### PR TITLE
Change how we namespace our attribute ids

### DIFF
--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -37,7 +37,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
 {
     if (clusterId == OnOff::Id)
     {
-        if (attributeId != OnOff::Attributes::Ids::OnOff)
+        if (attributeId != OnOff::Attributes::OnOff::Id)
         {
             ChipLogError(Zcl, "ON OFF attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
                          ChipLogValueMEI(attributeId), type, *value, size);

--- a/examples/lighting-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/k32w/main/ZclCallbacks.cpp
@@ -38,7 +38,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -51,7 +51,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -33,13 +33,13 @@ using namespace chip::app::Clusters;
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::Ids::OnOff)
+    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8, *value);
         LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION,
                                      AppEvent::kEventType_Lighting, size, value);
     }
-    else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::Ids::CurrentLevel)
+    else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::CurrentLevel::Id)
     {
         ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %" PRIu8, *value);
         LightingMgr().InitiateAction(LightingManager::LEVEL_ACTION, AppEvent::kEventType_Lighting, size, value);

--- a/examples/lighting-app/telink/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/telink/src/ZclCallbacks.cpp
@@ -37,7 +37,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
 
     if (clusterId == OnOff::Id)
     {
-        if (attributeId != OnOff::Attributes::Ids::OnOff)
+        if (attributeId != OnOff::Attributes::OnOff::Id)
         {
             ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             return;
@@ -48,7 +48,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
     else if (clusterId == LevelControl::Id)
     {
-        if (attributeId != LevelControl::Attributes::Ids::CurrentLevel)
+        if (attributeId != LevelControl::Attributes::CurrentLevel::Id)
         {
             ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             return;

--- a/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -39,7 +39,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -39,7 +39,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         EFR32_LOG("Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/lock-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lock-app/k32w/main/ZclCallbacks.cpp
@@ -38,7 +38,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -32,7 +32,7 @@ using namespace ::chip::app::Clusters;
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::Ids::OnOff)
+    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8, *value);
         BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);

--- a/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -40,7 +40,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/pump-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/pump-app/nrfconnect/main/ZclCallbacks.cpp
@@ -37,7 +37,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
         return;

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -40,7 +40,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;

--- a/examples/pump-controller-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/ZclCallbacks.cpp
@@ -37,7 +37,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         return;
     }
 
-    if (attributeId != OnOff::Attributes::Ids::OnOff)
+    if (attributeId != OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
         return;

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -57,7 +57,7 @@ EmberAfStatus writeAttribute(EndpointId endpoint, AttributeId attributeId, uint8
 EmberAfStatus writeClientServerAttribute(EndpointId endpoint, bool server)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
-    AttributeId attributeId = server ? Descriptor::Attributes::Ids::ServerList : Descriptor::Attributes::Ids::ClientList;
+    AttributeId attributeId = server ? Descriptor::Attributes::ServerList::Id : Descriptor::Attributes::ClientList::Id;
 
     uint16_t clusterCount = emberAfClusterCount(endpoint, server);
 
@@ -85,7 +85,7 @@ EmberAfStatus writeClientAttribute(EndpointId endpoint)
 EmberAfStatus writeDeviceAttribute(EndpointId endpoint, uint16_t index)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
-    AttributeId attributeId = Descriptor::Attributes::Ids::DeviceList;
+    AttributeId attributeId = Descriptor::Attributes::DeviceList::Id;
 
     uint16_t deviceTypeCount  = 1;
     DeviceTypeId deviceTypeId = emberAfDeviceIdFromIndex(index);
@@ -104,7 +104,7 @@ EmberAfStatus writeDeviceAttribute(EndpointId endpoint, uint16_t index)
 EmberAfStatus writePartsAttribute(EndpointId endpoint)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
-    AttributeId attributeId = Descriptor::Attributes::Ids::PartsList;
+    AttributeId attributeId = Descriptor::Attributes::PartsList::Id;
 
     uint16_t partsCount = 0;
 

--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -59,19 +59,19 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const 
     *aDataRead = true;
     switch (aClusterInfo.mFieldId)
     {
-    case Ids::PacketRxCount: {
+    case PacketRxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetEthPacketRxCount, aEncoder);
     }
-    case Ids::PacketTxCount: {
+    case PacketTxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetEthPacketTxCount, aEncoder);
     }
-    case Ids::TxErrCount: {
+    case TxErrCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetEthTxErrCount, aEncoder);
     }
-    case Ids::CollisionCount: {
+    case CollisionCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetEthCollisionCount, aEncoder);
     }
-    case Ids::OverrunCount: {
+    case OverrunCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetEthOverrunCount, aEncoder);
     }
     default: {

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -74,16 +74,16 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const A
     *aDataRead = true;
     switch (aClusterInfo.mFieldId)
     {
-    case Ids::RebootCount: {
+    case RebootCount::Id: {
         return ReadIfSupported(&PlatformManager::GetRebootCount, aEncoder);
     }
-    case Ids::UpTime: {
+    case UpTime::Id: {
         return ReadIfSupported(&PlatformManager::GetUpTime, aEncoder);
     }
-    case Ids::TotalOperationalHours: {
+    case TotalOperationalHours::Id: {
         return ReadIfSupported(&PlatformManager::GetTotalOperationalHours, aEncoder);
     }
-    case Ids::BootReasons: {
+    case BootReasons::Id: {
         return ReadIfSupported(&PlatformManager::GetBootReasons, aEncoder);
     }
     default: {

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -145,7 +145,7 @@ static inline void identify_deactivate(Identify * identify)
 
 void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId)
 {
-    if (attributeId == Clusters::Identify::Attributes::Ids::IdentifyTime)
+    if (attributeId == Clusters::Identify::Attributes::IdentifyTime::Id)
     {
         Identify * identify = inst(endpoint);
         uint16_t identifyTime;

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -59,13 +59,13 @@ CHIP_ERROR SoftwareDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const 
     *aDataRead = true;
     switch (aClusterInfo.mFieldId)
     {
-    case Ids::CurrentHeapFree: {
+    case CurrentHeapFree::Id: {
         return ReadIfSupported(&PlatformManager::GetCurrentHeapFree, aEncoder);
     }
-    case Ids::CurrentHeapUsed: {
+    case CurrentHeapUsed::Id: {
         return ReadIfSupported(&PlatformManager::GetCurrentHeapUsed, aEncoder);
     }
-    case Ids::CurrentHeapHighWatermark: {
+    case CurrentHeapHighWatermark::Id: {
         return ReadIfSupported(&PlatformManager::GetCurrentHeapHighWatermark, aEncoder);
     }
     default: {

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -72,7 +72,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
 
     switch (attributeId)
     {
-    case Ids::OccupiedHeatingSetpoint: {
+    case OccupiedHeatingSetpoint::Id: {
         int16_t AbsMinHeatSetpointLimit;
         int16_t AbsMaxHeatSetpointLimit;
         int16_t MinHeatSetpointLimit;
@@ -112,7 +112,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         break;
     }
 
-    case Ids::OccupiedCoolingSetpoint: {
+    case OccupiedCoolingSetpoint::Id: {
         int16_t AbsMinCoolSetpointLimit;
         int16_t AbsMaxCoolSetpointLimit;
         int16_t MinCoolSetpointLimit;
@@ -151,8 +151,8 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         break;
     }
 
-    case Ids::MinHeatSetpointLimit:
-    case Ids::MaxHeatSetpointLimit: {
+    case MinHeatSetpointLimit::Id:
+    case MaxHeatSetpointLimit::Id: {
         int16_t AbsMinHeatSetpointLimit;
         int16_t AbsMaxHeatSetpointLimit;
 
@@ -176,8 +176,8 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
 
         break;
     }
-    case Ids::MinCoolSetpointLimit:
-    case Ids::MaxCoolSetpointLimit: {
+    case MinCoolSetpointLimit::Id:
+    case MaxCoolSetpointLimit::Id: {
         int16_t AbsMinCoolSetpointLimit;
         int16_t AbsMaxCoolSetpointLimit;
 
@@ -202,7 +202,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         break;
     }
 
-    case Ids::ControlSequenceOfOperation: {
+    case ControlSequenceOfOperation::Id: {
         uint8_t requestedCSO;
         requestedCSO = *value;
         if (requestedCSO > EMBER_ZCL_THERMOSTAT_CONTROL_SEQUENCE_COOLING_AND_HEATING_WITH_REHEAT)
@@ -213,7 +213,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         break;
     }
 
-    case Ids::SystemMode: {
+    case SystemMode::Id: {
         uint8_t ControlSequenceOfOperation = kInvalidControlSequenceOfOperation;
         uint8_t RequestedSystemMode        = kInvalidRequestedSystemMode;
         GetControlSequenceOfOperation(endpoint, &ControlSequenceOfOperation);

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -78,40 +78,40 @@ CHIP_ERROR WiFiDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const Attr
     *aDataRead = true;
     switch (aClusterInfo.mFieldId)
     {
-    case Ids::SecurityType: {
+    case SecurityType::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiSecurityType, aEncoder);
     }
-    case Ids::WiFiVersion: {
+    case WiFiVersion::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiVersion, aEncoder);
     }
-    case Ids::ChannelNumber: {
+    case ChannelNumber::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiChannelNumber, aEncoder);
     }
-    case Ids::Rssi: {
+    case Rssi::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiRssi, aEncoder);
     }
-    case Ids::BeaconLostCount: {
+    case BeaconLostCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiBeaconLostCount, aEncoder);
     }
-    case Ids::BeaconRxCount: {
+    case BeaconRxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiBeaconRxCount, aEncoder);
     }
-    case Ids::PacketMulticastRxCount: {
+    case PacketMulticastRxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiPacketMulticastRxCount, aEncoder);
     }
-    case Ids::PacketMulticastTxCount: {
+    case PacketMulticastTxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiPacketMulticastTxCount, aEncoder);
     }
-    case Ids::PacketUnicastRxCount: {
+    case PacketUnicastRxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiPacketUnicastRxCount, aEncoder);
     }
-    case Ids::PacketUnicastTxCount: {
+    case PacketUnicastTxCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiPacketUnicastTxCount, aEncoder);
     }
-    case Ids::CurrentMaxRate: {
+    case CurrentMaxRate::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiCurrentMaxRate, aEncoder);
     }
-    case Ids::OverrunCount: {
+    case OverrunCount::Id: {
         return ReadIfSupported(&ConnectivityManager::GetWiFiOverrunCount, aEncoder);
     }
     default: {

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -116,14 +116,14 @@ CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::SubscribeAttribute{{asUpperC
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = {{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::Ids::{{asUpperCamelCase name}};
+    attributePath.mFieldId    = {{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::{{asUpperCamelCase name}}::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::ReportAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting({{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::Ids::{{asUpperCamelCase name}}, onReportCallback, BasicAttributeFilter<{{chipCallback.name}}AttributeCallback>);
+    return RequestAttributeReporting({{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::{{asUpperCamelCase name}}::Id, onReportCallback, BasicAttributeFilter<{{chipCallback.name}}AttributeCallback>);
 }
 
 {{/if}}

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -27,12 +27,12 @@ namespace Attributes {
 {{#if (canHaveSimpleAccessors type)}}
 EmberAfStatus Get{{asUpperCamelCase label}}(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}})
 {
-    return emberAfReadServerAttribute(endpoint, {{asUpperCamelCase parent.label}}::Id, Ids::{{asUpperCamelCase label}}, (uint8_t *) {{asLowerCamelCase label}}, sizeof(*{{asLowerCamelCase label}}));
+    return emberAfReadServerAttribute(endpoint, {{asUpperCamelCase parent.label}}::Id, {{asUpperCamelCase label}}::Id, (uint8_t *) {{asLowerCamelCase label}}, sizeof(*{{asLowerCamelCase label}}));
 
 }
 EmberAfStatus Set{{asUpperCamelCase label}}(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}})
 {
-    return emberAfWriteServerAttribute(endpoint, {{asUpperCamelCase parent.label}}::Id, Ids::{{asUpperCamelCase label}}, (uint8_t *) &{{asLowerCamelCase label}}, ZCL_{{asDelimitedMacro type}}_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, {{asUpperCamelCase parent.label}}::Id, {{asUpperCamelCase label}}::Id, (uint8_t *) &{{asLowerCamelCase label}}, ZCL_{{asDelimitedMacro type}}_ATTRIBUTE_TYPE);
 }
 {{/if}}
 {{/if}}

--- a/src/app/zap-templates/templates/app/ids/Attributes.zapt
+++ b/src/app/zap-templates/templates/app/ids/Attributes.zapt
@@ -10,13 +10,15 @@ namespace Clusters {
 
 namespace Globals {
 namespace Attributes {
-namespace Ids {
+
 {{#zcl_attributes_server}}
 {{#unless clusterRef}}
-static constexpr AttributeId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
+namespace {{asUpperCamelCase label}} {
+static constexpr AttributeId Id = {{asMEI manufacturerCode code}};
+} // namespace {{asUpperCamelCase label}}
+
 {{/unless}}
 {{/zcl_attributes_server}}
-} // namespace Ids
 } // namespace Attributes
 } // namespace Globals
 
@@ -27,13 +29,18 @@ static constexpr AttributeId {{asUpperCamelCase label}} = {{asMEI manufacturerCo
 {{#first}}
 namespace {{asUpperCamelCase parent.label}} {
 namespace Attributes {
-namespace Ids {
+
 {{/first}}
+{{#unless clusterRef}}
+namespace {{asUpperCamelCase label}} = Globals::Attributes::{{asUpperCamelCase label}};
+{{/unless}}
 {{#if clusterRef}}
-static constexpr AttributeId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
+namespace {{asUpperCamelCase label}} {
+static constexpr AttributeId Id = {{asMEI manufacturerCode code}};
+} // namespace {{asUpperCamelCase label}}
 {{/if}}
+
 {{#last}}
-} // namespace Ids
 } // namespace Attributes
 } // namespace {{asUpperCamelCase parent.label}}
 

--- a/src/app/zap-templates/templates/app/tests/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/tests/CHIPClusters-src.zapt
@@ -29,7 +29,7 @@ CHIP_ERROR {{asUpperCamelCase parent.name}}ClusterTest::WriteAttribute{{asUpperC
     attributePath.mNodeId         = mDevice->GetDeviceId();
     attributePath.mEndpointId     = mEndpoint;
     attributePath.mClusterId      = mClusterId;
-    attributePath.mFieldId        = {{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::Ids::{{asUpperCamelCase name}};
+    attributePath.mFieldId        = {{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::{{asUpperCamelCase name}}::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -838,37 +838,37 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
 
     switch (attributeId)
     {
-    case ThreadNetworkDiagnostics::Attributes::Ids::Channel: {
+    case ThreadNetworkDiagnostics::Attributes::Channel::Id: {
         uint16_t channel = otLinkGetChannel(mOTInst);
         err              = encoder.Encode(channel);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RoutingRole: {
+    case ThreadNetworkDiagnostics::Attributes::RoutingRole::Id: {
         otDeviceRole role = otThreadGetDeviceRole(mOTInst);
         err               = encoder.Encode(role);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::NetworkName: {
+    case ThreadNetworkDiagnostics::Attributes::NetworkName::Id: {
         const char * networkName = otThreadGetNetworkName(mOTInst);
         err                      = encoder.Encode(Span<const char>(networkName, strlen(networkName)));
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::PanId: {
+    case ThreadNetworkDiagnostics::Attributes::PanId::Id: {
         uint16_t panId = otLinkGetPanId(mOTInst);
         err            = encoder.Encode(panId);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::ExtendedPanId: {
+    case ThreadNetworkDiagnostics::Attributes::ExtendedPanId::Id: {
         const otExtendedPanId * pExtendedPanid = otThreadGetExtendedPanId(mOTInst);
         err                                    = encoder.Encode(Encoding::BigEndian::Get64(pExtendedPanid->m8));
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::MeshLocalPrefix: {
+    case ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::Id: {
         uint8_t meshLocaPrefix[OT_MESH_LOCAL_PREFIX_SIZE + 1] = { 0 }; // + 1  to encode prefix Len in the octstr
 
         const otMeshLocalPrefix * pMeshLocalPrefix = otThreadGetMeshLocalPrefix(mOTInst);
@@ -879,13 +879,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::OverrunCount: {
+    case ThreadNetworkDiagnostics::Attributes::OverrunCount::Id: {
         // TO DO
         err = CHIP_ERROR_NOT_IMPLEMENTED;
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::NeighborTableList: {
+    case ThreadNetworkDiagnostics::Attributes::NeighborTableList::Id: {
         // List and structure not yet functionnal
         err = CHIP_ERROR_NOT_IMPLEMENTED;
         // TO DO When list is functionnal.
@@ -913,295 +913,295 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RouteTableList: {
+    case ThreadNetworkDiagnostics::Attributes::RouteTableList::Id: {
         // List not yet functionnal
         err = CHIP_ERROR_NOT_IMPLEMENTED;
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::PartitionId: {
+    case ThreadNetworkDiagnostics::Attributes::PartitionId::Id: {
         uint32_t partitionId = otThreadGetPartitionId(mOTInst);
         err                  = encoder.Encode(partitionId);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::Weighting: {
+    case ThreadNetworkDiagnostics::Attributes::Weighting::Id: {
         uint8_t weight = otThreadGetLeaderWeight(mOTInst);
         err            = encoder.Encode(weight);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::DataVersion: {
+    case ThreadNetworkDiagnostics::Attributes::DataVersion::Id: {
         uint8_t dataVersion = otNetDataGetVersion(mOTInst);
         err                 = encoder.Encode(dataVersion);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::StableDataVersion: {
+    case ThreadNetworkDiagnostics::Attributes::StableDataVersion::Id: {
         uint8_t stableVersion = otNetDataGetStableVersion(mOTInst);
         err                   = encoder.Encode(stableVersion);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::LeaderRouterId: {
+    case ThreadNetworkDiagnostics::Attributes::LeaderRouterId::Id: {
         uint8_t leaderRouterId = otThreadGetLeaderRouterId(mOTInst);
         err                    = encoder.Encode(leaderRouterId);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::DetachedRoleCount: {
+    case ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::Id: {
         uint16_t detachedRole = otThreadGetMleCounters(mOTInst)->mDetachedRole;
         err                   = encoder.Encode(detachedRole);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::ChildRoleCount: {
+    case ThreadNetworkDiagnostics::Attributes::ChildRoleCount::Id: {
         uint16_t childRole = otThreadGetMleCounters(mOTInst)->mChildRole;
         err                = encoder.Encode(childRole);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RouterRoleCount: {
+    case ThreadNetworkDiagnostics::Attributes::RouterRoleCount::Id: {
         uint16_t routerRole = otThreadGetMleCounters(mOTInst)->mRouterRole;
         err                 = encoder.Encode(routerRole);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::LeaderRoleCount: {
+    case ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::Id: {
         uint16_t leaderRole = otThreadGetMleCounters(mOTInst)->mLeaderRole;
         err                 = encoder.Encode(leaderRole);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::AttachAttemptCount: {
+    case ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::Id: {
         uint16_t attachAttempts = otThreadGetMleCounters(mOTInst)->mAttachAttempts;
         err                     = encoder.Encode(attachAttempts);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::PartitionIdChangeCount: {
+    case ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::Id: {
         uint16_t partitionIdChanges = otThreadGetMleCounters(mOTInst)->mPartitionIdChanges;
         err                         = encoder.Encode(partitionIdChanges);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::BetterPartitionAttachAttemptCount: {
+    case ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::Id: {
         uint16_t betterPartitionAttachAttempts = otThreadGetMleCounters(mOTInst)->mBetterPartitionAttachAttempts;
         err                                    = encoder.Encode(betterPartitionAttachAttempts);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::ParentChangeCount: {
+    case ThreadNetworkDiagnostics::Attributes::ParentChangeCount::Id: {
         uint16_t parentChanges = otThreadGetMleCounters(mOTInst)->mParentChanges;
         err                    = encoder.Encode(parentChanges);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxTotalCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxTotalCount::Id: {
         uint32_t txTotal = otLinkGetCounters(mOTInst)->mTxTotal;
         err              = encoder.Encode(txTotal);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxUnicastCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxUnicastCount::Id: {
         uint32_t txUnicast = otLinkGetCounters(mOTInst)->mTxUnicast;
         err                = encoder.Encode(txUnicast);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxBroadcastCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::Id: {
         uint32_t txBroadcast = otLinkGetCounters(mOTInst)->mTxBroadcast;
         err                  = encoder.Encode(txBroadcast);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxAckRequestedCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::Id: {
         uint32_t txAckRequested = otLinkGetCounters(mOTInst)->mTxAckRequested;
         err                     = encoder.Encode(txAckRequested);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxAckedCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxAckedCount::Id: {
         uint32_t txAcked = otLinkGetCounters(mOTInst)->mTxAcked;
         err              = encoder.Encode(txAcked);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxNoAckRequestedCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::Id: {
         uint32_t txNoAckRequested = otLinkGetCounters(mOTInst)->mTxNoAckRequested;
         err                       = encoder.Encode(txNoAckRequested);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxDataCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxDataCount::Id: {
         uint32_t txData = otLinkGetCounters(mOTInst)->mTxData;
         err             = encoder.Encode(txData);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxDataPollCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxDataPollCount::Id: {
         uint32_t txDataPoll = otLinkGetCounters(mOTInst)->mTxDataPoll;
         err                 = encoder.Encode(txDataPoll);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxBeaconCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxBeaconCount::Id: {
         uint32_t txBeacon = otLinkGetCounters(mOTInst)->mTxBeacon;
         err               = encoder.Encode(txBeacon);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxBeaconRequestCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::Id: {
         uint32_t txBeaconRequest = otLinkGetCounters(mOTInst)->mTxBeaconRequest;
         err                      = encoder.Encode(txBeaconRequest);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxOtherCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxOtherCount::Id: {
         uint32_t txOther = otLinkGetCounters(mOTInst)->mTxOther;
         err              = encoder.Encode(txOther);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxRetryCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxRetryCount::Id: {
         uint32_t txRetry = otLinkGetCounters(mOTInst)->mTxRetry;
         err              = encoder.Encode(txRetry);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxDirectMaxRetryExpiryCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::Id: {
         uint32_t txDirectMaxRetryExpiry = otLinkGetCounters(mOTInst)->mTxDirectMaxRetryExpiry;
         err                             = encoder.Encode(txDirectMaxRetryExpiry);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxIndirectMaxRetryExpiryCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::Id: {
         uint32_t txIndirectMaxRetryExpiry = otLinkGetCounters(mOTInst)->mTxIndirectMaxRetryExpiry;
         err                               = encoder.Encode(txIndirectMaxRetryExpiry);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxErrCcaCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::Id: {
         uint32_t txErrCca = otLinkGetCounters(mOTInst)->mTxErrCca;
         err               = encoder.Encode(txErrCca);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxErrAbortCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::Id: {
         uint32_t TxErrAbort = otLinkGetCounters(mOTInst)->mTxErrAbort;
         err                 = encoder.Encode(TxErrAbort);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::TxErrBusyChannelCount: {
+    case ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::Id: {
         uint32_t TxErrBusyChannel = otLinkGetCounters(mOTInst)->mTxErrBusyChannel;
         err                       = encoder.Encode(TxErrBusyChannel);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxTotalCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxTotalCount::Id: {
         uint32_t rxTotal = otLinkGetCounters(mOTInst)->mRxTotal;
         err              = encoder.Encode(rxTotal);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxUnicastCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxUnicastCount::Id: {
         uint32_t rxUnicast = otLinkGetCounters(mOTInst)->mRxUnicast;
         err                = encoder.Encode(rxUnicast);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxBroadcastCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::Id: {
         uint32_t rxBroadcast = otLinkGetCounters(mOTInst)->mRxBroadcast;
         err                  = encoder.Encode(rxBroadcast);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxDataCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxDataCount::Id: {
         uint32_t rxData = otLinkGetCounters(mOTInst)->mRxData;
         err             = encoder.Encode(rxData);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxDataPollCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxDataPollCount::Id: {
         uint32_t rxDataPoll = otLinkGetCounters(mOTInst)->mRxDataPoll;
         err                 = encoder.Encode(rxDataPoll);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxBeaconCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxBeaconCount::Id: {
         uint32_t rxBeacon = otLinkGetCounters(mOTInst)->mRxBeacon;
         err               = encoder.Encode(rxBeacon);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxBeaconRequestCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::Id: {
         uint32_t rxBeaconRequest = otLinkGetCounters(mOTInst)->mRxBeaconRequest;
         err                      = encoder.Encode(rxBeaconRequest);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxOtherCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxOtherCount::Id: {
         uint32_t rxOther = otLinkGetCounters(mOTInst)->mRxOther;
         err              = encoder.Encode(rxOther);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxAddressFilteredCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::Id: {
         uint32_t rxAddressFiltered = otLinkGetCounters(mOTInst)->mRxAddressFiltered;
         err                        = encoder.Encode(rxAddressFiltered);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxDestAddrFilteredCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::Id: {
         uint32_t rxDestAddrFiltered = otLinkGetCounters(mOTInst)->mRxDestAddrFiltered;
         err                         = encoder.Encode(rxDestAddrFiltered);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxDuplicatedCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::Id: {
         uint32_t rxDuplicated = otLinkGetCounters(mOTInst)->mRxDuplicated;
         err                   = encoder.Encode(rxDuplicated);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxErrNoFrameCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::Id: {
         uint32_t rxErrNoFrame = otLinkGetCounters(mOTInst)->mRxErrNoFrame;
         err                   = encoder.Encode(rxErrNoFrame);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxErrUnknownNeighborCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::Id: {
         uint32_t rxErrUnknownNeighbor = otLinkGetCounters(mOTInst)->mRxErrUnknownNeighbor;
         err                           = encoder.Encode(rxErrUnknownNeighbor);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxErrInvalidSrcAddrCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::Id: {
         uint32_t rxErrInvalidSrcAddr = otLinkGetCounters(mOTInst)->mRxErrInvalidSrcAddr;
         err                          = encoder.Encode(rxErrInvalidSrcAddr);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxErrSecCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxErrSecCount::Id: {
         uint32_t rxErrSec = otLinkGetCounters(mOTInst)->mRxErrSec;
         err               = encoder.Encode(rxErrSec);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxErrFcsCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::Id: {
         uint32_t rxErrFcs = otLinkGetCounters(mOTInst)->mRxErrFcs;
         err               = encoder.Encode(rxErrFcs);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::RxErrOtherCount: {
+    case ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::Id: {
         uint32_t rxErrOther = otLinkGetCounters(mOTInst)->mRxErrOther;
         err                 = encoder.Encode(rxErrOther);
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::ActiveTimestamp: {
+    case ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::Id: {
         err = CHIP_ERROR_INCORRECT_STATE;
         if (otDatasetIsCommissioned(mOTInst))
         {
@@ -1214,7 +1214,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::PendingTimestamp: {
+    case ThreadNetworkDiagnostics::Attributes::PendingTimestamp::Id: {
         err = CHIP_ERROR_INCORRECT_STATE;
         if (otDatasetIsCommissioned(mOTInst))
         {
@@ -1227,7 +1227,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::Delay: {
+    case ThreadNetworkDiagnostics::Attributes::Delay::Id: {
         err = CHIP_ERROR_INCORRECT_STATE;
         if (otDatasetIsCommissioned(mOTInst))
         {
@@ -1240,7 +1240,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::SecurityPolicy: {
+    case ThreadNetworkDiagnostics::Attributes::SecurityPolicy::Id: {
         err = CHIP_ERROR_NOT_IMPLEMENTED;
         // Stuct type nopt yet supported
         // if (otDatasetIsCommissioned(mOTInst))
@@ -1253,7 +1253,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::ChannelMask: {
+    case ThreadNetworkDiagnostics::Attributes::ChannelMask::Id: {
         err = CHIP_ERROR_INCORRECT_STATE;
         if (otDatasetIsCommissioned(mOTInst))
         {
@@ -1276,7 +1276,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::OperationalDatasetComponents: {
+    case ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::Id: {
         // Structure not yet supported
         // if (otDatasetIsCommissioned(mOTInst))
         // {
@@ -1294,7 +1294,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
     }
     break;
 
-    case ThreadNetworkDiagnostics::Attributes::Ids::ActiveNetworkFaultsList: {
+    case ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::Id: {
         // List not yet supported
         err = CHIP_ERROR_NOT_IMPLEMENTED;
         break;

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -37,542 +37,542 @@ namespace PowerConfiguration {
 namespace Attributes {
 EmberAfStatus GetMainsVoltage(chip::EndpointId endpoint, uint16_t * mainsVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltage, (uint8_t *) mainsVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltage::Id, (uint8_t *) mainsVoltage,
                                       sizeof(*mainsVoltage));
 }
 EmberAfStatus SetMainsVoltage(chip::EndpointId endpoint, uint16_t mainsVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltage, (uint8_t *) &mainsVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltage::Id, (uint8_t *) &mainsVoltage,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMainsFrequency(chip::EndpointId endpoint, uint8_t * mainsFrequency)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsFrequency, (uint8_t *) mainsFrequency,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsFrequency::Id, (uint8_t *) mainsFrequency,
                                       sizeof(*mainsFrequency));
 }
 EmberAfStatus SetMainsFrequency(chip::EndpointId endpoint, uint8_t mainsFrequency)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsFrequency, (uint8_t *) &mainsFrequency,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsFrequency::Id, (uint8_t *) &mainsFrequency,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMainsAlarmMask(chip::EndpointId endpoint, uint8_t * mainsAlarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsAlarmMask, (uint8_t *) mainsAlarmMask,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsAlarmMask::Id, (uint8_t *) mainsAlarmMask,
                                       sizeof(*mainsAlarmMask));
 }
 EmberAfStatus SetMainsAlarmMask(chip::EndpointId endpoint, uint8_t mainsAlarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsAlarmMask, (uint8_t *) &mainsAlarmMask,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsAlarmMask::Id, (uint8_t *) &mainsAlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMainsVoltageMinThreshold(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMinThreshold::Id,
                                       (uint8_t *) mainsVoltageMinThreshold, sizeof(*mainsVoltageMinThreshold));
 }
 EmberAfStatus SetMainsVoltageMinThreshold(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMinThreshold::Id,
                                        (uint8_t *) &mainsVoltageMinThreshold, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMainsVoltageMaxThreshold(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltageMaxThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMaxThreshold::Id,
                                       (uint8_t *) mainsVoltageMaxThreshold, sizeof(*mainsVoltageMaxThreshold));
 }
 EmberAfStatus SetMainsVoltageMaxThreshold(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltageMaxThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMaxThreshold::Id,
                                        (uint8_t *) &mainsVoltageMaxThreshold, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMainsVoltageDwellTrip(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltageDwellTrip,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageDwellTrip::Id,
                                       (uint8_t *) mainsVoltageDwellTrip, sizeof(*mainsVoltageDwellTrip));
 }
 EmberAfStatus SetMainsVoltageDwellTrip(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::MainsVoltageDwellTrip,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageDwellTrip::Id,
                                        (uint8_t *) &mainsVoltageDwellTrip, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryVoltage(chip::EndpointId endpoint, uint8_t * batteryVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltage, (uint8_t *) batteryVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltage::Id, (uint8_t *) batteryVoltage,
                                       sizeof(*batteryVoltage));
 }
 EmberAfStatus SetBatteryVoltage(chip::EndpointId endpoint, uint8_t batteryVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltage, (uint8_t *) &batteryVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltage::Id, (uint8_t *) &batteryVoltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPercentageRemaining(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageRemaining,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageRemaining::Id,
                                       (uint8_t *) batteryPercentageRemaining, sizeof(*batteryPercentageRemaining));
 }
 EmberAfStatus SetBatteryPercentageRemaining(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageRemaining,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageRemaining::Id,
                                        (uint8_t *) &batteryPercentageRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatterySize(chip::EndpointId endpoint, uint8_t * batterySize)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatterySize, (uint8_t *) batterySize,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatterySize::Id, (uint8_t *) batterySize,
                                       sizeof(*batterySize));
 }
 EmberAfStatus SetBatterySize(chip::EndpointId endpoint, uint8_t batterySize)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatterySize, (uint8_t *) &batterySize,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatterySize::Id, (uint8_t *) &batterySize,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryAhrRating(chip::EndpointId endpoint, uint16_t * batteryAhrRating)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryAhrRating, (uint8_t *) batteryAhrRating,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryAhrRating::Id, (uint8_t *) batteryAhrRating,
                                       sizeof(*batteryAhrRating));
 }
 EmberAfStatus SetBatteryAhrRating(chip::EndpointId endpoint, uint16_t batteryAhrRating)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryAhrRating, (uint8_t *) &batteryAhrRating,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryAhrRating::Id, (uint8_t *) &batteryAhrRating,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryQuantity(chip::EndpointId endpoint, uint8_t * batteryQuantity)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryQuantity, (uint8_t *) batteryQuantity,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryQuantity::Id, (uint8_t *) batteryQuantity,
                                       sizeof(*batteryQuantity));
 }
 EmberAfStatus SetBatteryQuantity(chip::EndpointId endpoint, uint8_t batteryQuantity)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryQuantity, (uint8_t *) &batteryQuantity,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryQuantity::Id, (uint8_t *) &batteryQuantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryRatedVoltage(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryRatedVoltage, (uint8_t *) batteryRatedVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryRatedVoltage::Id, (uint8_t *) batteryRatedVoltage,
                                       sizeof(*batteryRatedVoltage));
 }
 EmberAfStatus SetBatteryRatedVoltage(chip::EndpointId endpoint, uint8_t batteryRatedVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryRatedVoltage, (uint8_t *) &batteryRatedVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryRatedVoltage::Id, (uint8_t *) &batteryRatedVoltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryAlarmMask(chip::EndpointId endpoint, uint8_t * batteryAlarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryAlarmMask, (uint8_t *) batteryAlarmMask,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmMask::Id, (uint8_t *) batteryAlarmMask,
                                       sizeof(*batteryAlarmMask));
 }
 EmberAfStatus SetBatteryAlarmMask(chip::EndpointId endpoint, uint8_t batteryAlarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryAlarmMask, (uint8_t *) &batteryAlarmMask,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmMask::Id, (uint8_t *) &batteryAlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryVoltageMinThreshold(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageMinThreshold::Id,
                                       (uint8_t *) batteryVoltageMinThreshold, sizeof(*batteryVoltageMinThreshold));
 }
 EmberAfStatus SetBatteryVoltageMinThreshold(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageMinThreshold::Id,
                                        (uint8_t *) &batteryVoltageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryVoltageThreshold1(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageThreshold1,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold1::Id,
                                       (uint8_t *) batteryVoltageThreshold1, sizeof(*batteryVoltageThreshold1));
 }
 EmberAfStatus SetBatteryVoltageThreshold1(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold1::Id,
                                        (uint8_t *) &batteryVoltageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryVoltageThreshold2(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageThreshold2,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold2::Id,
                                       (uint8_t *) batteryVoltageThreshold2, sizeof(*batteryVoltageThreshold2));
 }
 EmberAfStatus SetBatteryVoltageThreshold2(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold2::Id,
                                        (uint8_t *) &batteryVoltageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryVoltageThreshold3(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageThreshold3,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold3::Id,
                                       (uint8_t *) batteryVoltageThreshold3, sizeof(*batteryVoltageThreshold3));
 }
 EmberAfStatus SetBatteryVoltageThreshold3(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryVoltageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold3::Id,
                                        (uint8_t *) &batteryVoltageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPercentageMinThreshold(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageMinThreshold::Id,
                                       (uint8_t *) batteryPercentageMinThreshold, sizeof(*batteryPercentageMinThreshold));
 }
 EmberAfStatus SetBatteryPercentageMinThreshold(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageMinThreshold::Id,
                                        (uint8_t *) &batteryPercentageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPercentageThreshold1(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageThreshold1,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold1::Id,
                                       (uint8_t *) batteryPercentageThreshold1, sizeof(*batteryPercentageThreshold1));
 }
 EmberAfStatus SetBatteryPercentageThreshold1(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold1::Id,
                                        (uint8_t *) &batteryPercentageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPercentageThreshold2(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageThreshold2,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold2::Id,
                                       (uint8_t *) batteryPercentageThreshold2, sizeof(*batteryPercentageThreshold2));
 }
 EmberAfStatus SetBatteryPercentageThreshold2(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold2::Id,
                                        (uint8_t *) &batteryPercentageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPercentageThreshold3(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageThreshold3,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold3::Id,
                                       (uint8_t *) batteryPercentageThreshold3, sizeof(*batteryPercentageThreshold3));
 }
 EmberAfStatus SetBatteryPercentageThreshold3(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryPercentageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold3::Id,
                                        (uint8_t *) &batteryPercentageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryAlarmState(chip::EndpointId endpoint, uint32_t * batteryAlarmState)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryAlarmState, (uint8_t *) batteryAlarmState,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmState::Id, (uint8_t *) batteryAlarmState,
                                       sizeof(*batteryAlarmState));
 }
 EmberAfStatus SetBatteryAlarmState(chip::EndpointId endpoint, uint32_t batteryAlarmState)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::BatteryAlarmState, (uint8_t *) &batteryAlarmState,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmState::Id, (uint8_t *) &batteryAlarmState,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2Voltage(chip::EndpointId endpoint, uint8_t * battery2Voltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2Voltage, (uint8_t *) battery2Voltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2Voltage::Id, (uint8_t *) battery2Voltage,
                                       sizeof(*battery2Voltage));
 }
 EmberAfStatus SetBattery2Voltage(chip::EndpointId endpoint, uint8_t battery2Voltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2Voltage, (uint8_t *) &battery2Voltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2Voltage::Id, (uint8_t *) &battery2Voltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2PercentageRemaining(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageRemaining,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageRemaining::Id,
                                       (uint8_t *) battery2PercentageRemaining, sizeof(*battery2PercentageRemaining));
 }
 EmberAfStatus SetBattery2PercentageRemaining(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageRemaining,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageRemaining::Id,
                                        (uint8_t *) &battery2PercentageRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2Size(chip::EndpointId endpoint, uint8_t * battery2Size)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2Size, (uint8_t *) battery2Size,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2Size::Id, (uint8_t *) battery2Size,
                                       sizeof(*battery2Size));
 }
 EmberAfStatus SetBattery2Size(chip::EndpointId endpoint, uint8_t battery2Size)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2Size, (uint8_t *) &battery2Size,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2Size::Id, (uint8_t *) &battery2Size,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2AhrRating(chip::EndpointId endpoint, uint16_t * battery2AhrRating)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2AhrRating, (uint8_t *) battery2AhrRating,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2AhrRating::Id, (uint8_t *) battery2AhrRating,
                                       sizeof(*battery2AhrRating));
 }
 EmberAfStatus SetBattery2AhrRating(chip::EndpointId endpoint, uint16_t battery2AhrRating)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2AhrRating, (uint8_t *) &battery2AhrRating,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2AhrRating::Id, (uint8_t *) &battery2AhrRating,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2Quantity(chip::EndpointId endpoint, uint8_t * battery2Quantity)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2Quantity, (uint8_t *) battery2Quantity,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2Quantity::Id, (uint8_t *) battery2Quantity,
                                       sizeof(*battery2Quantity));
 }
 EmberAfStatus SetBattery2Quantity(chip::EndpointId endpoint, uint8_t battery2Quantity)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2Quantity, (uint8_t *) &battery2Quantity,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2Quantity::Id, (uint8_t *) &battery2Quantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2RatedVoltage(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2RatedVoltage, (uint8_t *) battery2RatedVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2RatedVoltage::Id, (uint8_t *) battery2RatedVoltage,
                                       sizeof(*battery2RatedVoltage));
 }
 EmberAfStatus SetBattery2RatedVoltage(chip::EndpointId endpoint, uint8_t battery2RatedVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2RatedVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2RatedVoltage::Id,
                                        (uint8_t *) &battery2RatedVoltage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2AlarmMask(chip::EndpointId endpoint, uint8_t * battery2AlarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2AlarmMask, (uint8_t *) battery2AlarmMask,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmMask::Id, (uint8_t *) battery2AlarmMask,
                                       sizeof(*battery2AlarmMask));
 }
 EmberAfStatus SetBattery2AlarmMask(chip::EndpointId endpoint, uint8_t battery2AlarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2AlarmMask, (uint8_t *) &battery2AlarmMask,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmMask::Id, (uint8_t *) &battery2AlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2VoltageMinThreshold(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageMinThreshold::Id,
                                       (uint8_t *) battery2VoltageMinThreshold, sizeof(*battery2VoltageMinThreshold));
 }
 EmberAfStatus SetBattery2VoltageMinThreshold(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageMinThreshold::Id,
                                        (uint8_t *) &battery2VoltageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2VoltageThreshold1(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageThreshold1,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold1::Id,
                                       (uint8_t *) battery2VoltageThreshold1, sizeof(*battery2VoltageThreshold1));
 }
 EmberAfStatus SetBattery2VoltageThreshold1(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold1::Id,
                                        (uint8_t *) &battery2VoltageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2VoltageThreshold2(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageThreshold2,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold2::Id,
                                       (uint8_t *) battery2VoltageThreshold2, sizeof(*battery2VoltageThreshold2));
 }
 EmberAfStatus SetBattery2VoltageThreshold2(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold2::Id,
                                        (uint8_t *) &battery2VoltageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2VoltageThreshold3(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageThreshold3,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold3::Id,
                                       (uint8_t *) battery2VoltageThreshold3, sizeof(*battery2VoltageThreshold3));
 }
 EmberAfStatus SetBattery2VoltageThreshold3(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2VoltageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold3::Id,
                                        (uint8_t *) &battery2VoltageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2PercentageMinThreshold(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageMinThreshold::Id,
                                       (uint8_t *) battery2PercentageMinThreshold, sizeof(*battery2PercentageMinThreshold));
 }
 EmberAfStatus SetBattery2PercentageMinThreshold(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageMinThreshold::Id,
                                        (uint8_t *) &battery2PercentageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2PercentageThreshold1(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageThreshold1,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold1::Id,
                                       (uint8_t *) battery2PercentageThreshold1, sizeof(*battery2PercentageThreshold1));
 }
 EmberAfStatus SetBattery2PercentageThreshold1(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold1::Id,
                                        (uint8_t *) &battery2PercentageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2PercentageThreshold2(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageThreshold2,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold2::Id,
                                       (uint8_t *) battery2PercentageThreshold2, sizeof(*battery2PercentageThreshold2));
 }
 EmberAfStatus SetBattery2PercentageThreshold2(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold2::Id,
                                        (uint8_t *) &battery2PercentageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2PercentageThreshold3(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageThreshold3,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold3::Id,
                                       (uint8_t *) battery2PercentageThreshold3, sizeof(*battery2PercentageThreshold3));
 }
 EmberAfStatus SetBattery2PercentageThreshold3(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2PercentageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold3::Id,
                                        (uint8_t *) &battery2PercentageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery2AlarmState(chip::EndpointId endpoint, uint32_t * battery2AlarmState)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2AlarmState, (uint8_t *) battery2AlarmState,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmState::Id, (uint8_t *) battery2AlarmState,
                                       sizeof(*battery2AlarmState));
 }
 EmberAfStatus SetBattery2AlarmState(chip::EndpointId endpoint, uint32_t battery2AlarmState)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery2AlarmState, (uint8_t *) &battery2AlarmState,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmState::Id, (uint8_t *) &battery2AlarmState,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3Voltage(chip::EndpointId endpoint, uint8_t * battery3Voltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3Voltage, (uint8_t *) battery3Voltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3Voltage::Id, (uint8_t *) battery3Voltage,
                                       sizeof(*battery3Voltage));
 }
 EmberAfStatus SetBattery3Voltage(chip::EndpointId endpoint, uint8_t battery3Voltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3Voltage, (uint8_t *) &battery3Voltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3Voltage::Id, (uint8_t *) &battery3Voltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3PercentageRemaining(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageRemaining,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageRemaining::Id,
                                       (uint8_t *) battery3PercentageRemaining, sizeof(*battery3PercentageRemaining));
 }
 EmberAfStatus SetBattery3PercentageRemaining(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageRemaining,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageRemaining::Id,
                                        (uint8_t *) &battery3PercentageRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3Size(chip::EndpointId endpoint, uint8_t * battery3Size)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3Size, (uint8_t *) battery3Size,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3Size::Id, (uint8_t *) battery3Size,
                                       sizeof(*battery3Size));
 }
 EmberAfStatus SetBattery3Size(chip::EndpointId endpoint, uint8_t battery3Size)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3Size, (uint8_t *) &battery3Size,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3Size::Id, (uint8_t *) &battery3Size,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3AhrRating(chip::EndpointId endpoint, uint16_t * battery3AhrRating)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3AhrRating, (uint8_t *) battery3AhrRating,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3AhrRating::Id, (uint8_t *) battery3AhrRating,
                                       sizeof(*battery3AhrRating));
 }
 EmberAfStatus SetBattery3AhrRating(chip::EndpointId endpoint, uint16_t battery3AhrRating)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3AhrRating, (uint8_t *) &battery3AhrRating,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3AhrRating::Id, (uint8_t *) &battery3AhrRating,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3Quantity(chip::EndpointId endpoint, uint8_t * battery3Quantity)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3Quantity, (uint8_t *) battery3Quantity,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3Quantity::Id, (uint8_t *) battery3Quantity,
                                       sizeof(*battery3Quantity));
 }
 EmberAfStatus SetBattery3Quantity(chip::EndpointId endpoint, uint8_t battery3Quantity)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3Quantity, (uint8_t *) &battery3Quantity,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3Quantity::Id, (uint8_t *) &battery3Quantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3RatedVoltage(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3RatedVoltage, (uint8_t *) battery3RatedVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3RatedVoltage::Id, (uint8_t *) battery3RatedVoltage,
                                       sizeof(*battery3RatedVoltage));
 }
 EmberAfStatus SetBattery3RatedVoltage(chip::EndpointId endpoint, uint8_t battery3RatedVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3RatedVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3RatedVoltage::Id,
                                        (uint8_t *) &battery3RatedVoltage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3AlarmMask(chip::EndpointId endpoint, uint8_t * battery3AlarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3AlarmMask, (uint8_t *) battery3AlarmMask,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmMask::Id, (uint8_t *) battery3AlarmMask,
                                       sizeof(*battery3AlarmMask));
 }
 EmberAfStatus SetBattery3AlarmMask(chip::EndpointId endpoint, uint8_t battery3AlarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3AlarmMask, (uint8_t *) &battery3AlarmMask,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmMask::Id, (uint8_t *) &battery3AlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3VoltageMinThreshold(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageMinThreshold::Id,
                                       (uint8_t *) battery3VoltageMinThreshold, sizeof(*battery3VoltageMinThreshold));
 }
 EmberAfStatus SetBattery3VoltageMinThreshold(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageMinThreshold::Id,
                                        (uint8_t *) &battery3VoltageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3VoltageThreshold1(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageThreshold1,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold1::Id,
                                       (uint8_t *) battery3VoltageThreshold1, sizeof(*battery3VoltageThreshold1));
 }
 EmberAfStatus SetBattery3VoltageThreshold1(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold1::Id,
                                        (uint8_t *) &battery3VoltageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3VoltageThreshold2(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageThreshold2,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold2::Id,
                                       (uint8_t *) battery3VoltageThreshold2, sizeof(*battery3VoltageThreshold2));
 }
 EmberAfStatus SetBattery3VoltageThreshold2(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold2::Id,
                                        (uint8_t *) &battery3VoltageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3VoltageThreshold3(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageThreshold3,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold3::Id,
                                       (uint8_t *) battery3VoltageThreshold3, sizeof(*battery3VoltageThreshold3));
 }
 EmberAfStatus SetBattery3VoltageThreshold3(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3VoltageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold3::Id,
                                        (uint8_t *) &battery3VoltageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3PercentageMinThreshold(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageMinThreshold,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageMinThreshold::Id,
                                       (uint8_t *) battery3PercentageMinThreshold, sizeof(*battery3PercentageMinThreshold));
 }
 EmberAfStatus SetBattery3PercentageMinThreshold(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageMinThreshold::Id,
                                        (uint8_t *) &battery3PercentageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3PercentageThreshold1(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageThreshold1,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold1::Id,
                                       (uint8_t *) battery3PercentageThreshold1, sizeof(*battery3PercentageThreshold1));
 }
 EmberAfStatus SetBattery3PercentageThreshold1(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold1::Id,
                                        (uint8_t *) &battery3PercentageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3PercentageThreshold2(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageThreshold2,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold2::Id,
                                       (uint8_t *) battery3PercentageThreshold2, sizeof(*battery3PercentageThreshold2));
 }
 EmberAfStatus SetBattery3PercentageThreshold2(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold2::Id,
                                        (uint8_t *) &battery3PercentageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3PercentageThreshold3(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageThreshold3,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold3::Id,
                                       (uint8_t *) battery3PercentageThreshold3, sizeof(*battery3PercentageThreshold3));
 }
 EmberAfStatus SetBattery3PercentageThreshold3(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3PercentageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold3::Id,
                                        (uint8_t *) &battery3PercentageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBattery3AlarmState(chip::EndpointId endpoint, uint32_t * battery3AlarmState)
 {
-    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3AlarmState, (uint8_t *) battery3AlarmState,
+    return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmState::Id, (uint8_t *) battery3AlarmState,
                                       sizeof(*battery3AlarmState));
 }
 EmberAfStatus SetBattery3AlarmState(chip::EndpointId endpoint, uint32_t battery3AlarmState)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Ids::Battery3AlarmState, (uint8_t *) &battery3AlarmState,
+    return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmState::Id, (uint8_t *) &battery3AlarmState,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -582,72 +582,72 @@ namespace DeviceTemperatureConfiguration {
 namespace Attributes {
 EmberAfStatus GetCurrentTemperature(chip::EndpointId endpoint, int16_t * currentTemperature)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::CurrentTemperature,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, CurrentTemperature::Id,
                                       (uint8_t *) currentTemperature, sizeof(*currentTemperature));
 }
 EmberAfStatus SetCurrentTemperature(chip::EndpointId endpoint, int16_t currentTemperature)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::CurrentTemperature,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, CurrentTemperature::Id,
                                        (uint8_t *) &currentTemperature, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinTempExperienced(chip::EndpointId endpoint, int16_t * minTempExperienced)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::MinTempExperienced,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MinTempExperienced::Id,
                                       (uint8_t *) minTempExperienced, sizeof(*minTempExperienced));
 }
 EmberAfStatus SetMinTempExperienced(chip::EndpointId endpoint, int16_t minTempExperienced)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::MinTempExperienced,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MinTempExperienced::Id,
                                        (uint8_t *) &minTempExperienced, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxTempExperienced(chip::EndpointId endpoint, int16_t * maxTempExperienced)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::MaxTempExperienced,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MaxTempExperienced::Id,
                                       (uint8_t *) maxTempExperienced, sizeof(*maxTempExperienced));
 }
 EmberAfStatus SetMaxTempExperienced(chip::EndpointId endpoint, int16_t maxTempExperienced)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::MaxTempExperienced,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MaxTempExperienced::Id,
                                        (uint8_t *) &maxTempExperienced, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOverTempTotalDwell(chip::EndpointId endpoint, uint16_t * overTempTotalDwell)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::OverTempTotalDwell,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, OverTempTotalDwell::Id,
                                       (uint8_t *) overTempTotalDwell, sizeof(*overTempTotalDwell));
 }
 EmberAfStatus SetOverTempTotalDwell(chip::EndpointId endpoint, uint16_t overTempTotalDwell)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::OverTempTotalDwell,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, OverTempTotalDwell::Id,
                                        (uint8_t *) &overTempTotalDwell, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDeviceTempAlarmMask(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::DeviceTempAlarmMask,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, DeviceTempAlarmMask::Id,
                                       (uint8_t *) deviceTempAlarmMask, sizeof(*deviceTempAlarmMask));
 }
 EmberAfStatus SetDeviceTempAlarmMask(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::DeviceTempAlarmMask,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, DeviceTempAlarmMask::Id,
                                        (uint8_t *) &deviceTempAlarmMask, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLowTempThreshold(chip::EndpointId endpoint, int16_t * lowTempThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::LowTempThreshold,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, LowTempThreshold::Id,
                                       (uint8_t *) lowTempThreshold, sizeof(*lowTempThreshold));
 }
 EmberAfStatus SetLowTempThreshold(chip::EndpointId endpoint, int16_t lowTempThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::LowTempThreshold,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, LowTempThreshold::Id,
                                        (uint8_t *) &lowTempThreshold, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetHighTempThreshold(chip::EndpointId endpoint, int16_t * highTempThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::HighTempThreshold,
+    return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, HighTempThreshold::Id,
                                       (uint8_t *) highTempThreshold, sizeof(*highTempThreshold));
 }
 EmberAfStatus SetHighTempThreshold(chip::EndpointId endpoint, int16_t highTempThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, Ids::HighTempThreshold,
+    return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, HighTempThreshold::Id,
                                        (uint8_t *) &highTempThreshold, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -657,20 +657,20 @@ namespace Identify {
 namespace Attributes {
 EmberAfStatus GetIdentifyTime(chip::EndpointId endpoint, uint16_t * identifyTime)
 {
-    return emberAfReadServerAttribute(endpoint, Identify::Id, Ids::IdentifyTime, (uint8_t *) identifyTime, sizeof(*identifyTime));
+    return emberAfReadServerAttribute(endpoint, Identify::Id, IdentifyTime::Id, (uint8_t *) identifyTime, sizeof(*identifyTime));
 }
 EmberAfStatus SetIdentifyTime(chip::EndpointId endpoint, uint16_t identifyTime)
 {
-    return emberAfWriteServerAttribute(endpoint, Identify::Id, Ids::IdentifyTime, (uint8_t *) &identifyTime,
+    return emberAfWriteServerAttribute(endpoint, Identify::Id, IdentifyTime::Id, (uint8_t *) &identifyTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetIdentifyType(chip::EndpointId endpoint, uint8_t * identifyType)
 {
-    return emberAfReadServerAttribute(endpoint, Identify::Id, Ids::IdentifyType, (uint8_t *) identifyType, sizeof(*identifyType));
+    return emberAfReadServerAttribute(endpoint, Identify::Id, IdentifyType::Id, (uint8_t *) identifyType, sizeof(*identifyType));
 }
 EmberAfStatus SetIdentifyType(chip::EndpointId endpoint, uint8_t identifyType)
 {
-    return emberAfWriteServerAttribute(endpoint, Identify::Id, Ids::IdentifyType, (uint8_t *) &identifyType,
+    return emberAfWriteServerAttribute(endpoint, Identify::Id, IdentifyType::Id, (uint8_t *) &identifyType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -680,12 +680,11 @@ namespace Groups {
 namespace Attributes {
 EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport)
 {
-    return emberAfReadServerAttribute(endpoint, Groups::Id, Ids::NameSupport, (uint8_t *) nameSupport, sizeof(*nameSupport));
+    return emberAfReadServerAttribute(endpoint, Groups::Id, NameSupport::Id, (uint8_t *) nameSupport, sizeof(*nameSupport));
 }
 EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport)
 {
-    return emberAfWriteServerAttribute(endpoint, Groups::Id, Ids::NameSupport, (uint8_t *) &nameSupport,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Groups::Id, NameSupport::Id, (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace Groups
@@ -694,46 +693,44 @@ namespace Scenes {
 namespace Attributes {
 EmberAfStatus GetSceneCount(chip::EndpointId endpoint, uint8_t * sceneCount)
 {
-    return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::SceneCount, (uint8_t *) sceneCount, sizeof(*sceneCount));
+    return emberAfReadServerAttribute(endpoint, Scenes::Id, SceneCount::Id, (uint8_t *) sceneCount, sizeof(*sceneCount));
 }
 EmberAfStatus SetSceneCount(chip::EndpointId endpoint, uint8_t sceneCount)
 {
-    return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::SceneCount, (uint8_t *) &sceneCount, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Scenes::Id, SceneCount::Id, (uint8_t *) &sceneCount, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentScene(chip::EndpointId endpoint, uint8_t * currentScene)
 {
-    return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::CurrentScene, (uint8_t *) currentScene, sizeof(*currentScene));
+    return emberAfReadServerAttribute(endpoint, Scenes::Id, CurrentScene::Id, (uint8_t *) currentScene, sizeof(*currentScene));
 }
 EmberAfStatus SetCurrentScene(chip::EndpointId endpoint, uint8_t currentScene)
 {
-    return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::CurrentScene, (uint8_t *) &currentScene,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Scenes::Id, CurrentScene::Id, (uint8_t *) &currentScene, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentGroup(chip::EndpointId endpoint, uint16_t * currentGroup)
 {
-    return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::CurrentGroup, (uint8_t *) currentGroup, sizeof(*currentGroup));
+    return emberAfReadServerAttribute(endpoint, Scenes::Id, CurrentGroup::Id, (uint8_t *) currentGroup, sizeof(*currentGroup));
 }
 EmberAfStatus SetCurrentGroup(chip::EndpointId endpoint, uint16_t currentGroup)
 {
-    return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::CurrentGroup, (uint8_t *) &currentGroup,
+    return emberAfWriteServerAttribute(endpoint, Scenes::Id, CurrentGroup::Id, (uint8_t *) &currentGroup,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSceneValid(chip::EndpointId endpoint, bool * sceneValid)
 {
-    return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::SceneValid, (uint8_t *) sceneValid, sizeof(*sceneValid));
+    return emberAfReadServerAttribute(endpoint, Scenes::Id, SceneValid::Id, (uint8_t *) sceneValid, sizeof(*sceneValid));
 }
 EmberAfStatus SetSceneValid(chip::EndpointId endpoint, bool sceneValid)
 {
-    return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::SceneValid, (uint8_t *) &sceneValid, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Scenes::Id, SceneValid::Id, (uint8_t *) &sceneValid, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport)
 {
-    return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::NameSupport, (uint8_t *) nameSupport, sizeof(*nameSupport));
+    return emberAfReadServerAttribute(endpoint, Scenes::Id, NameSupport::Id, (uint8_t *) nameSupport, sizeof(*nameSupport));
 }
 EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport)
 {
-    return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::NameSupport, (uint8_t *) &nameSupport,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Scenes::Id, NameSupport::Id, (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace Scenes
@@ -742,91 +739,91 @@ namespace OnOff {
 namespace Attributes {
 EmberAfStatus GetOnOff(chip::EndpointId endpoint, bool * onOff)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::OnOff, (uint8_t *) onOff, sizeof(*onOff));
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, OnOff::Id, (uint8_t *) onOff, sizeof(*onOff));
 }
 EmberAfStatus SetOnOff(chip::EndpointId endpoint, bool onOff)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::OnOff, (uint8_t *) &onOff, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, OnOff::Id, (uint8_t *) &onOff, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint,
                                                         uint16_t * sampleMfgSpecificAttribute0x00000x1002)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00000x1002,
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1002::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00000x1002,
                                       sizeof(*sampleMfgSpecificAttribute0x00000x1002));
 }
 EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00000x1002,
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1002::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00000x1002, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1049(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00000x1049)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00000x1049,
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1049::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00000x1049,
                                       sizeof(*sampleMfgSpecificAttribute0x00000x1049));
 }
 EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1049(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00000x1049,
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1049::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00000x1049, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00010x1002)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00010x1002,
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1002::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00010x1002,
                                       sizeof(*sampleMfgSpecificAttribute0x00010x1002));
 }
 EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00010x1002,
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1002::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00010x1002, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint,
                                                         uint16_t * sampleMfgSpecificAttribute0x00010x1040)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00010x1040,
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1040::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00010x1040,
                                       sizeof(*sampleMfgSpecificAttribute0x00010x1040));
 }
 EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00010x1040,
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1040::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00010x1040, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, bool * globalSceneControl)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::GlobalSceneControl, (uint8_t *) globalSceneControl,
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, GlobalSceneControl::Id, (uint8_t *) globalSceneControl,
                                       sizeof(*globalSceneControl));
 }
 EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, bool globalSceneControl)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::GlobalSceneControl, (uint8_t *) &globalSceneControl,
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, GlobalSceneControl::Id, (uint8_t *) &globalSceneControl,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOnTime(chip::EndpointId endpoint, uint16_t * onTime)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::OnTime, (uint8_t *) onTime, sizeof(*onTime));
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, OnTime::Id, (uint8_t *) onTime, sizeof(*onTime));
 }
 EmberAfStatus SetOnTime(chip::EndpointId endpoint, uint16_t onTime)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::OnTime, (uint8_t *) &onTime, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, OnTime::Id, (uint8_t *) &onTime, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOffWaitTime(chip::EndpointId endpoint, uint16_t * offWaitTime)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::OffWaitTime, (uint8_t *) offWaitTime, sizeof(*offWaitTime));
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, OffWaitTime::Id, (uint8_t *) offWaitTime, sizeof(*offWaitTime));
 }
 EmberAfStatus SetOffWaitTime(chip::EndpointId endpoint, uint16_t offWaitTime)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::OffWaitTime, (uint8_t *) &offWaitTime, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, OffWaitTime::Id, (uint8_t *) &offWaitTime, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStartUpOnOff(chip::EndpointId endpoint, uint8_t * startUpOnOff)
 {
-    return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::StartUpOnOff, (uint8_t *) startUpOnOff, sizeof(*startUpOnOff));
+    return emberAfReadServerAttribute(endpoint, OnOff::Id, StartUpOnOff::Id, (uint8_t *) startUpOnOff, sizeof(*startUpOnOff));
 }
 EmberAfStatus SetStartUpOnOff(chip::EndpointId endpoint, uint8_t startUpOnOff)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::StartUpOnOff, (uint8_t *) &startUpOnOff, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, OnOff::Id, StartUpOnOff::Id, (uint8_t *) &startUpOnOff, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace OnOff
@@ -835,22 +832,22 @@ namespace OnOffSwitchConfiguration {
 namespace Attributes {
 EmberAfStatus GetSwitchType(chip::EndpointId endpoint, uint8_t * switchType)
 {
-    return emberAfReadServerAttribute(endpoint, OnOffSwitchConfiguration::Id, Ids::SwitchType, (uint8_t *) switchType,
+    return emberAfReadServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchType::Id, (uint8_t *) switchType,
                                       sizeof(*switchType));
 }
 EmberAfStatus SetSwitchType(chip::EndpointId endpoint, uint8_t switchType)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOffSwitchConfiguration::Id, Ids::SwitchType, (uint8_t *) &switchType,
+    return emberAfWriteServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchType::Id, (uint8_t *) &switchType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSwitchActions(chip::EndpointId endpoint, uint8_t * switchActions)
 {
-    return emberAfReadServerAttribute(endpoint, OnOffSwitchConfiguration::Id, Ids::SwitchActions, (uint8_t *) switchActions,
+    return emberAfReadServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchActions::Id, (uint8_t *) switchActions,
                                       sizeof(*switchActions));
 }
 EmberAfStatus SetSwitchActions(chip::EndpointId endpoint, uint8_t switchActions)
 {
-    return emberAfWriteServerAttribute(endpoint, OnOffSwitchConfiguration::Id, Ids::SwitchActions, (uint8_t *) &switchActions,
+    return emberAfWriteServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchActions::Id, (uint8_t *) &switchActions,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -860,88 +857,88 @@ namespace LevelControl {
 namespace Attributes {
 EmberAfStatus GetCurrentLevel(chip::EndpointId endpoint, uint8_t * currentLevel)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::CurrentLevel, (uint8_t *) currentLevel,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, CurrentLevel::Id, (uint8_t *) currentLevel,
                                       sizeof(*currentLevel));
 }
 EmberAfStatus SetCurrentLevel(chip::EndpointId endpoint, uint8_t currentLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::CurrentLevel, (uint8_t *) &currentLevel,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, CurrentLevel::Id, (uint8_t *) &currentLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::RemainingTime, (uint8_t *) remainingTime,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, RemainingTime::Id, (uint8_t *) remainingTime,
                                       sizeof(*remainingTime));
 }
 EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::RemainingTime, (uint8_t *) &remainingTime,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, RemainingTime::Id, (uint8_t *) &remainingTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOptions(chip::EndpointId endpoint, uint8_t * options)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::Options, (uint8_t *) options, sizeof(*options));
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Options::Id, (uint8_t *) options, sizeof(*options));
 }
 EmberAfStatus SetOptions(chip::EndpointId endpoint, uint8_t options)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::Options, (uint8_t *) &options, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Options::Id, (uint8_t *) &options, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOnOffTransitionTime(chip::EndpointId endpoint, uint16_t * onOffTransitionTime)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::OnOffTransitionTime, (uint8_t *) onOffTransitionTime,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, OnOffTransitionTime::Id, (uint8_t *) onOffTransitionTime,
                                       sizeof(*onOffTransitionTime));
 }
 EmberAfStatus SetOnOffTransitionTime(chip::EndpointId endpoint, uint16_t onOffTransitionTime)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::OnOffTransitionTime, (uint8_t *) &onOffTransitionTime,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OnOffTransitionTime::Id, (uint8_t *) &onOffTransitionTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOnLevel(chip::EndpointId endpoint, uint8_t * onLevel)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::OnLevel, (uint8_t *) onLevel, sizeof(*onLevel));
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, OnLevel::Id, (uint8_t *) onLevel, sizeof(*onLevel));
 }
 EmberAfStatus SetOnLevel(chip::EndpointId endpoint, uint8_t onLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::OnLevel, (uint8_t *) &onLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OnLevel::Id, (uint8_t *) &onLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOnTransitionTime(chip::EndpointId endpoint, uint16_t * onTransitionTime)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::OnTransitionTime, (uint8_t *) onTransitionTime,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, OnTransitionTime::Id, (uint8_t *) onTransitionTime,
                                       sizeof(*onTransitionTime));
 }
 EmberAfStatus SetOnTransitionTime(chip::EndpointId endpoint, uint16_t onTransitionTime)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::OnTransitionTime, (uint8_t *) &onTransitionTime,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OnTransitionTime::Id, (uint8_t *) &onTransitionTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOffTransitionTime(chip::EndpointId endpoint, uint16_t * offTransitionTime)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::OffTransitionTime, (uint8_t *) offTransitionTime,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, OffTransitionTime::Id, (uint8_t *) offTransitionTime,
                                       sizeof(*offTransitionTime));
 }
 EmberAfStatus SetOffTransitionTime(chip::EndpointId endpoint, uint16_t offTransitionTime)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::OffTransitionTime, (uint8_t *) &offTransitionTime,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OffTransitionTime::Id, (uint8_t *) &offTransitionTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDefaultMoveRate(chip::EndpointId endpoint, uint8_t * defaultMoveRate)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::DefaultMoveRate, (uint8_t *) defaultMoveRate,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, DefaultMoveRate::Id, (uint8_t *) defaultMoveRate,
                                       sizeof(*defaultMoveRate));
 }
 EmberAfStatus SetDefaultMoveRate(chip::EndpointId endpoint, uint8_t defaultMoveRate)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::DefaultMoveRate, (uint8_t *) &defaultMoveRate,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, DefaultMoveRate::Id, (uint8_t *) &defaultMoveRate,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStartUpCurrentLevel(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel)
 {
-    return emberAfReadServerAttribute(endpoint, LevelControl::Id, Ids::StartUpCurrentLevel, (uint8_t *) startUpCurrentLevel,
+    return emberAfReadServerAttribute(endpoint, LevelControl::Id, StartUpCurrentLevel::Id, (uint8_t *) startUpCurrentLevel,
                                       sizeof(*startUpCurrentLevel));
 }
 EmberAfStatus SetStartUpCurrentLevel(chip::EndpointId endpoint, uint8_t startUpCurrentLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Ids::StartUpCurrentLevel, (uint8_t *) &startUpCurrentLevel,
+    return emberAfWriteServerAttribute(endpoint, LevelControl::Id, StartUpCurrentLevel::Id, (uint8_t *) &startUpCurrentLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -951,11 +948,11 @@ namespace Alarms {
 namespace Attributes {
 EmberAfStatus GetAlarmCount(chip::EndpointId endpoint, uint16_t * alarmCount)
 {
-    return emberAfReadServerAttribute(endpoint, Alarms::Id, Ids::AlarmCount, (uint8_t *) alarmCount, sizeof(*alarmCount));
+    return emberAfReadServerAttribute(endpoint, Alarms::Id, AlarmCount::Id, (uint8_t *) alarmCount, sizeof(*alarmCount));
 }
 EmberAfStatus SetAlarmCount(chip::EndpointId endpoint, uint16_t alarmCount)
 {
-    return emberAfWriteServerAttribute(endpoint, Alarms::Id, Ids::AlarmCount, (uint8_t *) &alarmCount, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Alarms::Id, AlarmCount::Id, (uint8_t *) &alarmCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace Alarms
@@ -964,84 +961,83 @@ namespace Time {
 namespace Attributes {
 EmberAfStatus GetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** time)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::Time, (uint8_t *) time, sizeof(*time));
+    return emberAfReadServerAttribute(endpoint, Time::Id, Time::Id, (uint8_t *) time, sizeof(*time));
 }
 EmberAfStatus SetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * time)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::Time, (uint8_t *) &time, ZCL_UTC_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, Time::Id, (uint8_t *) &time, ZCL_UTC_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTimeStatus(chip::EndpointId endpoint, uint8_t * timeStatus)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::TimeStatus, (uint8_t *) timeStatus, sizeof(*timeStatus));
+    return emberAfReadServerAttribute(endpoint, Time::Id, TimeStatus::Id, (uint8_t *) timeStatus, sizeof(*timeStatus));
 }
 EmberAfStatus SetTimeStatus(chip::EndpointId endpoint, uint8_t timeStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::TimeStatus, (uint8_t *) &timeStatus, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, TimeStatus::Id, (uint8_t *) &timeStatus, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTimeZone(chip::EndpointId endpoint, int32_t * timeZone)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::TimeZone, (uint8_t *) timeZone, sizeof(*timeZone));
+    return emberAfReadServerAttribute(endpoint, Time::Id, TimeZone::Id, (uint8_t *) timeZone, sizeof(*timeZone));
 }
 EmberAfStatus SetTimeZone(chip::EndpointId endpoint, int32_t timeZone)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::TimeZone, (uint8_t *) &timeZone, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, TimeZone::Id, (uint8_t *) &timeZone, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDstStart(chip::EndpointId endpoint, uint32_t * dstStart)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::DstStart, (uint8_t *) dstStart, sizeof(*dstStart));
+    return emberAfReadServerAttribute(endpoint, Time::Id, DstStart::Id, (uint8_t *) dstStart, sizeof(*dstStart));
 }
 EmberAfStatus SetDstStart(chip::EndpointId endpoint, uint32_t dstStart)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::DstStart, (uint8_t *) &dstStart, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, DstStart::Id, (uint8_t *) &dstStart, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDstEnd(chip::EndpointId endpoint, uint32_t * dstEnd)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::DstEnd, (uint8_t *) dstEnd, sizeof(*dstEnd));
+    return emberAfReadServerAttribute(endpoint, Time::Id, DstEnd::Id, (uint8_t *) dstEnd, sizeof(*dstEnd));
 }
 EmberAfStatus SetDstEnd(chip::EndpointId endpoint, uint32_t dstEnd)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::DstEnd, (uint8_t *) &dstEnd, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, DstEnd::Id, (uint8_t *) &dstEnd, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDstShift(chip::EndpointId endpoint, int32_t * dstShift)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::DstShift, (uint8_t *) dstShift, sizeof(*dstShift));
+    return emberAfReadServerAttribute(endpoint, Time::Id, DstShift::Id, (uint8_t *) dstShift, sizeof(*dstShift));
 }
 EmberAfStatus SetDstShift(chip::EndpointId endpoint, int32_t dstShift)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::DstShift, (uint8_t *) &dstShift, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, DstShift::Id, (uint8_t *) &dstShift, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStandardTime(chip::EndpointId endpoint, uint32_t * standardTime)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::StandardTime, (uint8_t *) standardTime, sizeof(*standardTime));
+    return emberAfReadServerAttribute(endpoint, Time::Id, StandardTime::Id, (uint8_t *) standardTime, sizeof(*standardTime));
 }
 EmberAfStatus SetStandardTime(chip::EndpointId endpoint, uint32_t standardTime)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::StandardTime, (uint8_t *) &standardTime, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, StandardTime::Id, (uint8_t *) &standardTime, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLocalTime(chip::EndpointId endpoint, uint32_t * localTime)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::LocalTime, (uint8_t *) localTime, sizeof(*localTime));
+    return emberAfReadServerAttribute(endpoint, Time::Id, LocalTime::Id, (uint8_t *) localTime, sizeof(*localTime));
 }
 EmberAfStatus SetLocalTime(chip::EndpointId endpoint, uint32_t localTime)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::LocalTime, (uint8_t *) &localTime, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, LocalTime::Id, (uint8_t *) &localTime, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLastSetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** lastSetTime)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::LastSetTime, (uint8_t *) lastSetTime, sizeof(*lastSetTime));
+    return emberAfReadServerAttribute(endpoint, Time::Id, LastSetTime::Id, (uint8_t *) lastSetTime, sizeof(*lastSetTime));
 }
 EmberAfStatus SetLastSetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * lastSetTime)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::LastSetTime, (uint8_t *) &lastSetTime, ZCL_UTC_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, LastSetTime::Id, (uint8_t *) &lastSetTime, ZCL_UTC_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** validUntilTime)
 {
-    return emberAfReadServerAttribute(endpoint, Time::Id, Ids::ValidUntilTime, (uint8_t *) validUntilTime, sizeof(*validUntilTime));
+    return emberAfReadServerAttribute(endpoint, Time::Id, ValidUntilTime::Id, (uint8_t *) validUntilTime, sizeof(*validUntilTime));
 }
 EmberAfStatus SetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * validUntilTime)
 {
-    return emberAfWriteServerAttribute(endpoint, Time::Id, Ids::ValidUntilTime, (uint8_t *) &validUntilTime,
-                                       ZCL_UTC_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Time::Id, ValidUntilTime::Id, (uint8_t *) &validUntilTime, ZCL_UTC_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace Time
@@ -1050,61 +1046,61 @@ namespace BinaryInputBasic {
 namespace Attributes {
 EmberAfStatus GetOutOfService(chip::EndpointId endpoint, bool * outOfService)
 {
-    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::OutOfService, (uint8_t *) outOfService,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, OutOfService::Id, (uint8_t *) outOfService,
                                       sizeof(*outOfService));
 }
 EmberAfStatus SetOutOfService(chip::EndpointId endpoint, bool outOfService)
 {
-    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::OutOfService, (uint8_t *) &outOfService,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, OutOfService::Id, (uint8_t *) &outOfService,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPolarity(chip::EndpointId endpoint, uint8_t * polarity)
 {
-    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::Polarity, (uint8_t *) polarity, sizeof(*polarity));
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Polarity::Id, (uint8_t *) polarity, sizeof(*polarity));
 }
 EmberAfStatus SetPolarity(chip::EndpointId endpoint, uint8_t polarity)
 {
-    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::Polarity, (uint8_t *) &polarity,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Polarity::Id, (uint8_t *) &polarity,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPresentValue(chip::EndpointId endpoint, bool * presentValue)
 {
-    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::PresentValue, (uint8_t *) presentValue,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, PresentValue::Id, (uint8_t *) presentValue,
                                       sizeof(*presentValue));
 }
 EmberAfStatus SetPresentValue(chip::EndpointId endpoint, bool presentValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::PresentValue, (uint8_t *) &presentValue,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, PresentValue::Id, (uint8_t *) &presentValue,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReliability(chip::EndpointId endpoint, uint8_t * reliability)
 {
-    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::Reliability, (uint8_t *) reliability,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Reliability::Id, (uint8_t *) reliability,
                                       sizeof(*reliability));
 }
 EmberAfStatus SetReliability(chip::EndpointId endpoint, uint8_t reliability)
 {
-    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::Reliability, (uint8_t *) &reliability,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Reliability::Id, (uint8_t *) &reliability,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStatusFlags(chip::EndpointId endpoint, uint8_t * statusFlags)
 {
-    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::StatusFlags, (uint8_t *) statusFlags,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, StatusFlags::Id, (uint8_t *) statusFlags,
                                       sizeof(*statusFlags));
 }
 EmberAfStatus SetStatusFlags(chip::EndpointId endpoint, uint8_t statusFlags)
 {
-    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::StatusFlags, (uint8_t *) &statusFlags,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, StatusFlags::Id, (uint8_t *) &statusFlags,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetApplicationType(chip::EndpointId endpoint, uint32_t * applicationType)
 {
-    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::ApplicationType, (uint8_t *) applicationType,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, ApplicationType::Id, (uint8_t *) applicationType,
                                       sizeof(*applicationType));
 }
 EmberAfStatus SetApplicationType(chip::EndpointId endpoint, uint32_t applicationType)
 {
-    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::ApplicationType, (uint8_t *) &applicationType,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, ApplicationType::Id, (uint8_t *) &applicationType,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1114,52 +1110,52 @@ namespace PowerProfile {
 namespace Attributes {
 EmberAfStatus GetTotalProfileNum(chip::EndpointId endpoint, uint8_t * totalProfileNum)
 {
-    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::TotalProfileNum, (uint8_t *) totalProfileNum,
+    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, TotalProfileNum::Id, (uint8_t *) totalProfileNum,
                                       sizeof(*totalProfileNum));
 }
 EmberAfStatus SetTotalProfileNum(chip::EndpointId endpoint, uint8_t totalProfileNum)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::TotalProfileNum, (uint8_t *) &totalProfileNum,
+    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, TotalProfileNum::Id, (uint8_t *) &totalProfileNum,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, bool * multipleScheduling)
 {
-    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::MultipleScheduling, (uint8_t *) multipleScheduling,
+    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, MultipleScheduling::Id, (uint8_t *) multipleScheduling,
                                       sizeof(*multipleScheduling));
 }
 EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, bool multipleScheduling)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::MultipleScheduling, (uint8_t *) &multipleScheduling,
+    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, MultipleScheduling::Id, (uint8_t *) &multipleScheduling,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnergyFormatting(chip::EndpointId endpoint, uint8_t * energyFormatting)
 {
-    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyFormatting, (uint8_t *) energyFormatting,
+    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, EnergyFormatting::Id, (uint8_t *) energyFormatting,
                                       sizeof(*energyFormatting));
 }
 EmberAfStatus SetEnergyFormatting(chip::EndpointId endpoint, uint8_t energyFormatting)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyFormatting, (uint8_t *) &energyFormatting,
+    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, EnergyFormatting::Id, (uint8_t *) &energyFormatting,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, bool * energyRemote)
 {
-    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyRemote, (uint8_t *) energyRemote,
+    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, EnergyRemote::Id, (uint8_t *) energyRemote,
                                       sizeof(*energyRemote));
 }
 EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, bool energyRemote)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyRemote, (uint8_t *) &energyRemote,
+    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, EnergyRemote::Id, (uint8_t *) &energyRemote,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetScheduleMode(chip::EndpointId endpoint, uint8_t * scheduleMode)
 {
-    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::ScheduleMode, (uint8_t *) scheduleMode,
+    return emberAfReadServerAttribute(endpoint, PowerProfile::Id, ScheduleMode::Id, (uint8_t *) scheduleMode,
                                       sizeof(*scheduleMode));
 }
 EmberAfStatus SetScheduleMode(chip::EndpointId endpoint, uint8_t scheduleMode)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::ScheduleMode, (uint8_t *) &scheduleMode,
+    return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, ScheduleMode::Id, (uint8_t *) &scheduleMode,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1169,30 +1165,30 @@ namespace ApplianceControl {
 namespace Attributes {
 EmberAfStatus GetStartTime(chip::EndpointId endpoint, uint16_t * startTime)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, Ids::StartTime, (uint8_t *) startTime, sizeof(*startTime));
+    return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, StartTime::Id, (uint8_t *) startTime, sizeof(*startTime));
 }
 EmberAfStatus SetStartTime(chip::EndpointId endpoint, uint16_t startTime)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, Ids::StartTime, (uint8_t *) &startTime,
+    return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, StartTime::Id, (uint8_t *) &startTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetFinishTime(chip::EndpointId endpoint, uint16_t * finishTime)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, Ids::FinishTime, (uint8_t *) finishTime, sizeof(*finishTime));
+    return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, FinishTime::Id, (uint8_t *) finishTime, sizeof(*finishTime));
 }
 EmberAfStatus SetFinishTime(chip::EndpointId endpoint, uint16_t finishTime)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, Ids::FinishTime, (uint8_t *) &finishTime,
+    return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, FinishTime::Id, (uint8_t *) &finishTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, Ids::RemainingTime, (uint8_t *) remainingTime,
+    return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, RemainingTime::Id, (uint8_t *) remainingTime,
                                       sizeof(*remainingTime));
 }
 EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, Ids::RemainingTime, (uint8_t *) &remainingTime,
+    return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, RemainingTime::Id, (uint8_t *) &remainingTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1207,72 +1203,72 @@ namespace PollControl {
 namespace Attributes {
 EmberAfStatus GetCheckInInterval(chip::EndpointId endpoint, uint32_t * checkInInterval)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::CheckInInterval, (uint8_t *) checkInInterval,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, CheckInInterval::Id, (uint8_t *) checkInInterval,
                                       sizeof(*checkInInterval));
 }
 EmberAfStatus SetCheckInInterval(chip::EndpointId endpoint, uint32_t checkInInterval)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::CheckInInterval, (uint8_t *) &checkInInterval,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, CheckInInterval::Id, (uint8_t *) &checkInInterval,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLongPollInterval(chip::EndpointId endpoint, uint32_t * longPollInterval)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::LongPollInterval, (uint8_t *) longPollInterval,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, LongPollInterval::Id, (uint8_t *) longPollInterval,
                                       sizeof(*longPollInterval));
 }
 EmberAfStatus SetLongPollInterval(chip::EndpointId endpoint, uint32_t longPollInterval)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::LongPollInterval, (uint8_t *) &longPollInterval,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, LongPollInterval::Id, (uint8_t *) &longPollInterval,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetShortPollInterval(chip::EndpointId endpoint, uint16_t * shortPollInterval)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::ShortPollInterval, (uint8_t *) shortPollInterval,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, ShortPollInterval::Id, (uint8_t *) shortPollInterval,
                                       sizeof(*shortPollInterval));
 }
 EmberAfStatus SetShortPollInterval(chip::EndpointId endpoint, uint16_t shortPollInterval)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::ShortPollInterval, (uint8_t *) &shortPollInterval,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, ShortPollInterval::Id, (uint8_t *) &shortPollInterval,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetFastPollTimeout(chip::EndpointId endpoint, uint16_t * fastPollTimeout)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::FastPollTimeout, (uint8_t *) fastPollTimeout,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, FastPollTimeout::Id, (uint8_t *) fastPollTimeout,
                                       sizeof(*fastPollTimeout));
 }
 EmberAfStatus SetFastPollTimeout(chip::EndpointId endpoint, uint16_t fastPollTimeout)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::FastPollTimeout, (uint8_t *) &fastPollTimeout,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, FastPollTimeout::Id, (uint8_t *) &fastPollTimeout,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCheckInIntervalMin(chip::EndpointId endpoint, uint32_t * checkInIntervalMin)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::CheckInIntervalMin, (uint8_t *) checkInIntervalMin,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, CheckInIntervalMin::Id, (uint8_t *) checkInIntervalMin,
                                       sizeof(*checkInIntervalMin));
 }
 EmberAfStatus SetCheckInIntervalMin(chip::EndpointId endpoint, uint32_t checkInIntervalMin)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::CheckInIntervalMin, (uint8_t *) &checkInIntervalMin,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, CheckInIntervalMin::Id, (uint8_t *) &checkInIntervalMin,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLongPollIntervalMin(chip::EndpointId endpoint, uint32_t * longPollIntervalMin)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::LongPollIntervalMin, (uint8_t *) longPollIntervalMin,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, LongPollIntervalMin::Id, (uint8_t *) longPollIntervalMin,
                                       sizeof(*longPollIntervalMin));
 }
 EmberAfStatus SetLongPollIntervalMin(chip::EndpointId endpoint, uint32_t longPollIntervalMin)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::LongPollIntervalMin, (uint8_t *) &longPollIntervalMin,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, LongPollIntervalMin::Id, (uint8_t *) &longPollIntervalMin,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetFastPollTimeoutMax(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax)
 {
-    return emberAfReadServerAttribute(endpoint, PollControl::Id, Ids::FastPollTimeoutMax, (uint8_t *) fastPollTimeoutMax,
+    return emberAfReadServerAttribute(endpoint, PollControl::Id, FastPollTimeoutMax::Id, (uint8_t *) fastPollTimeoutMax,
                                       sizeof(*fastPollTimeoutMax));
 }
 EmberAfStatus SetFastPollTimeoutMax(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax)
 {
-    return emberAfWriteServerAttribute(endpoint, PollControl::Id, Ids::FastPollTimeoutMax, (uint8_t *) &fastPollTimeoutMax,
+    return emberAfWriteServerAttribute(endpoint, PollControl::Id, FastPollTimeoutMax::Id, (uint8_t *) &fastPollTimeoutMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1282,67 +1278,67 @@ namespace Basic {
 namespace Attributes {
 EmberAfStatus GetInteractionModelVersion(chip::EndpointId endpoint, uint16_t * interactionModelVersion)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::InteractionModelVersion, (uint8_t *) interactionModelVersion,
+    return emberAfReadServerAttribute(endpoint, Basic::Id, InteractionModelVersion::Id, (uint8_t *) interactionModelVersion,
                                       sizeof(*interactionModelVersion));
 }
 EmberAfStatus SetInteractionModelVersion(chip::EndpointId endpoint, uint16_t interactionModelVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::InteractionModelVersion, (uint8_t *) &interactionModelVersion,
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, InteractionModelVersion::Id, (uint8_t *) &interactionModelVersion,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetVendorID(chip::EndpointId endpoint, uint16_t * vendorID)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::VendorID, (uint8_t *) vendorID, sizeof(*vendorID));
+    return emberAfReadServerAttribute(endpoint, Basic::Id, VendorID::Id, (uint8_t *) vendorID, sizeof(*vendorID));
 }
 EmberAfStatus SetVendorID(chip::EndpointId endpoint, uint16_t vendorID)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::VendorID, (uint8_t *) &vendorID, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, VendorID::Id, (uint8_t *) &vendorID, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetProductID(chip::EndpointId endpoint, uint16_t * productID)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::ProductID, (uint8_t *) productID, sizeof(*productID));
+    return emberAfReadServerAttribute(endpoint, Basic::Id, ProductID::Id, (uint8_t *) productID, sizeof(*productID));
 }
 EmberAfStatus SetProductID(chip::EndpointId endpoint, uint16_t productID)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::ProductID, (uint8_t *) &productID, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, ProductID::Id, (uint8_t *) &productID, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareVersion)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::HardwareVersion, (uint8_t *) hardwareVersion,
+    return emberAfReadServerAttribute(endpoint, Basic::Id, HardwareVersion::Id, (uint8_t *) hardwareVersion,
                                       sizeof(*hardwareVersion));
 }
 EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::HardwareVersion, (uint8_t *) &hardwareVersion,
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, HardwareVersion::Id, (uint8_t *) &hardwareVersion,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::SoftwareVersion, (uint8_t *) softwareVersion,
+    return emberAfReadServerAttribute(endpoint, Basic::Id, SoftwareVersion::Id, (uint8_t *) softwareVersion,
                                       sizeof(*softwareVersion));
 }
 EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::SoftwareVersion, (uint8_t *) &softwareVersion,
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, SoftwareVersion::Id, (uint8_t *) &softwareVersion,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, bool * localConfigDisabled)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::LocalConfigDisabled, (uint8_t *) localConfigDisabled,
+    return emberAfReadServerAttribute(endpoint, Basic::Id, LocalConfigDisabled::Id, (uint8_t *) localConfigDisabled,
                                       sizeof(*localConfigDisabled));
 }
 EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, bool localConfigDisabled)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::LocalConfigDisabled, (uint8_t *) &localConfigDisabled,
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, LocalConfigDisabled::Id, (uint8_t *) &localConfigDisabled,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable)
 {
-    return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::Reachable, (uint8_t *) reachable, sizeof(*reachable));
+    return emberAfReadServerAttribute(endpoint, Basic::Id, Reachable::Id, (uint8_t *) reachable, sizeof(*reachable));
 }
 EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable)
 {
-    return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::Reachable, (uint8_t *) &reachable, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Basic::Id, Reachable::Id, (uint8_t *) &reachable, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace Basic
@@ -1351,12 +1347,12 @@ namespace OtaSoftwareUpdateRequestor {
 namespace Attributes {
 EmberAfStatus GetUpdatePossible(chip::EndpointId endpoint, bool * updatePossible)
 {
-    return emberAfReadServerAttribute(endpoint, OtaSoftwareUpdateRequestor::Id, Ids::UpdatePossible, (uint8_t *) updatePossible,
+    return emberAfReadServerAttribute(endpoint, OtaSoftwareUpdateRequestor::Id, UpdatePossible::Id, (uint8_t *) updatePossible,
                                       sizeof(*updatePossible));
 }
 EmberAfStatus SetUpdatePossible(chip::EndpointId endpoint, bool updatePossible)
 {
-    return emberAfWriteServerAttribute(endpoint, OtaSoftwareUpdateRequestor::Id, Ids::UpdatePossible, (uint8_t *) &updatePossible,
+    return emberAfWriteServerAttribute(endpoint, OtaSoftwareUpdateRequestor::Id, UpdatePossible::Id, (uint8_t *) &updatePossible,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1366,238 +1362,237 @@ namespace PowerSource {
 namespace Attributes {
 EmberAfStatus GetStatus(chip::EndpointId endpoint, uint8_t * status)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::Status, (uint8_t *) status, sizeof(*status));
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Status::Id, (uint8_t *) status, sizeof(*status));
 }
 EmberAfStatus SetStatus(chip::EndpointId endpoint, uint8_t status)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::Status, (uint8_t *) &status, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Status::Id, (uint8_t *) &status, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOrder(chip::EndpointId endpoint, uint8_t * order)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::Order, (uint8_t *) order, sizeof(*order));
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Order::Id, (uint8_t *) order, sizeof(*order));
 }
 EmberAfStatus SetOrder(chip::EndpointId endpoint, uint8_t order)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::Order, (uint8_t *) &order, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Order::Id, (uint8_t *) &order, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredAssessedInputVoltage(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredAssessedInputVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputVoltage::Id,
                                       (uint8_t *) wiredAssessedInputVoltage, sizeof(*wiredAssessedInputVoltage));
 }
 EmberAfStatus SetWiredAssessedInputVoltage(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredAssessedInputVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputVoltage::Id,
                                        (uint8_t *) &wiredAssessedInputVoltage, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredAssessedInputFrequency(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredAssessedInputFrequency,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputFrequency::Id,
                                       (uint8_t *) wiredAssessedInputFrequency, sizeof(*wiredAssessedInputFrequency));
 }
 EmberAfStatus SetWiredAssessedInputFrequency(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredAssessedInputFrequency,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputFrequency::Id,
                                        (uint8_t *) &wiredAssessedInputFrequency, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredCurrentType(chip::EndpointId endpoint, uint8_t * wiredCurrentType)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredCurrentType, (uint8_t *) wiredCurrentType,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredCurrentType::Id, (uint8_t *) wiredCurrentType,
                                       sizeof(*wiredCurrentType));
 }
 EmberAfStatus SetWiredCurrentType(chip::EndpointId endpoint, uint8_t wiredCurrentType)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredCurrentType, (uint8_t *) &wiredCurrentType,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredCurrentType::Id, (uint8_t *) &wiredCurrentType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredAssessedCurrent(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredAssessedCurrent, (uint8_t *) wiredAssessedCurrent,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredAssessedCurrent::Id, (uint8_t *) wiredAssessedCurrent,
                                       sizeof(*wiredAssessedCurrent));
 }
 EmberAfStatus SetWiredAssessedCurrent(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredAssessedCurrent, (uint8_t *) &wiredAssessedCurrent,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredAssessedCurrent::Id, (uint8_t *) &wiredAssessedCurrent,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredNominalVoltage(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredNominalVoltage, (uint8_t *) wiredNominalVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredNominalVoltage::Id, (uint8_t *) wiredNominalVoltage,
                                       sizeof(*wiredNominalVoltage));
 }
 EmberAfStatus SetWiredNominalVoltage(chip::EndpointId endpoint, uint32_t wiredNominalVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredNominalVoltage, (uint8_t *) &wiredNominalVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredNominalVoltage::Id, (uint8_t *) &wiredNominalVoltage,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredMaximumCurrent(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredMaximumCurrent, (uint8_t *) wiredMaximumCurrent,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredMaximumCurrent::Id, (uint8_t *) wiredMaximumCurrent,
                                       sizeof(*wiredMaximumCurrent));
 }
 EmberAfStatus SetWiredMaximumCurrent(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredMaximumCurrent, (uint8_t *) &wiredMaximumCurrent,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredMaximumCurrent::Id, (uint8_t *) &wiredMaximumCurrent,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiredPresent(chip::EndpointId endpoint, bool * wiredPresent)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::WiredPresent, (uint8_t *) wiredPresent,
-                                      sizeof(*wiredPresent));
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredPresent::Id, (uint8_t *) wiredPresent, sizeof(*wiredPresent));
 }
 EmberAfStatus SetWiredPresent(chip::EndpointId endpoint, bool wiredPresent)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::WiredPresent, (uint8_t *) &wiredPresent,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredPresent::Id, (uint8_t *) &wiredPresent,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryVoltage(chip::EndpointId endpoint, uint32_t * batteryVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryVoltage, (uint8_t *) batteryVoltage,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryVoltage::Id, (uint8_t *) batteryVoltage,
                                       sizeof(*batteryVoltage));
 }
 EmberAfStatus SetBatteryVoltage(chip::EndpointId endpoint, uint32_t batteryVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryVoltage, (uint8_t *) &batteryVoltage,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryVoltage::Id, (uint8_t *) &batteryVoltage,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPercentRemaining(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryPercentRemaining, (uint8_t *) batteryPercentRemaining,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryPercentRemaining::Id, (uint8_t *) batteryPercentRemaining,
                                       sizeof(*batteryPercentRemaining));
 }
 EmberAfStatus SetBatteryPercentRemaining(chip::EndpointId endpoint, uint8_t batteryPercentRemaining)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryPercentRemaining,
-                                       (uint8_t *) &batteryPercentRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryPercentRemaining::Id, (uint8_t *) &batteryPercentRemaining,
+                                       ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryTimeRemaining(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryTimeRemaining, (uint8_t *) batteryTimeRemaining,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryTimeRemaining::Id, (uint8_t *) batteryTimeRemaining,
                                       sizeof(*batteryTimeRemaining));
 }
 EmberAfStatus SetBatteryTimeRemaining(chip::EndpointId endpoint, uint32_t batteryTimeRemaining)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryTimeRemaining, (uint8_t *) &batteryTimeRemaining,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryTimeRemaining::Id, (uint8_t *) &batteryTimeRemaining,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryChargeLevel(chip::EndpointId endpoint, uint8_t * batteryChargeLevel)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryChargeLevel, (uint8_t *) batteryChargeLevel,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryChargeLevel::Id, (uint8_t *) batteryChargeLevel,
                                       sizeof(*batteryChargeLevel));
 }
 EmberAfStatus SetBatteryChargeLevel(chip::EndpointId endpoint, uint8_t batteryChargeLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryChargeLevel, (uint8_t *) &batteryChargeLevel,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryChargeLevel::Id, (uint8_t *) &batteryChargeLevel,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryReplacementNeeded(chip::EndpointId endpoint, bool * batteryReplacementNeeded)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryReplacementNeeded,
-                                      (uint8_t *) batteryReplacementNeeded, sizeof(*batteryReplacementNeeded));
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryReplacementNeeded::Id, (uint8_t *) batteryReplacementNeeded,
+                                      sizeof(*batteryReplacementNeeded));
 }
 EmberAfStatus SetBatteryReplacementNeeded(chip::EndpointId endpoint, bool batteryReplacementNeeded)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryReplacementNeeded,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryReplacementNeeded::Id,
                                        (uint8_t *) &batteryReplacementNeeded, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryReplaceability(chip::EndpointId endpoint, uint8_t * batteryReplaceability)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryReplaceability, (uint8_t *) batteryReplaceability,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryReplaceability::Id, (uint8_t *) batteryReplaceability,
                                       sizeof(*batteryReplaceability));
 }
 EmberAfStatus SetBatteryReplaceability(chip::EndpointId endpoint, uint8_t batteryReplaceability)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryReplaceability, (uint8_t *) &batteryReplaceability,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryReplaceability::Id, (uint8_t *) &batteryReplaceability,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryPresent(chip::EndpointId endpoint, bool * batteryPresent)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryPresent, (uint8_t *) batteryPresent,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryPresent::Id, (uint8_t *) batteryPresent,
                                       sizeof(*batteryPresent));
 }
 EmberAfStatus SetBatteryPresent(chip::EndpointId endpoint, bool batteryPresent)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryPresent, (uint8_t *) &batteryPresent,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryPresent::Id, (uint8_t *) &batteryPresent,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryCommonDesignation(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryCommonDesignation,
-                                      (uint8_t *) batteryCommonDesignation, sizeof(*batteryCommonDesignation));
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryCommonDesignation::Id, (uint8_t *) batteryCommonDesignation,
+                                      sizeof(*batteryCommonDesignation));
 }
 EmberAfStatus SetBatteryCommonDesignation(chip::EndpointId endpoint, uint32_t batteryCommonDesignation)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryCommonDesignation,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryCommonDesignation::Id,
                                        (uint8_t *) &batteryCommonDesignation, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryApprovedChemistry(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryApprovedChemistry,
-                                      (uint8_t *) batteryApprovedChemistry, sizeof(*batteryApprovedChemistry));
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryApprovedChemistry::Id, (uint8_t *) batteryApprovedChemistry,
+                                      sizeof(*batteryApprovedChemistry));
 }
 EmberAfStatus SetBatteryApprovedChemistry(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryApprovedChemistry,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryApprovedChemistry::Id,
                                        (uint8_t *) &batteryApprovedChemistry, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryCapacity(chip::EndpointId endpoint, uint32_t * batteryCapacity)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryCapacity, (uint8_t *) batteryCapacity,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryCapacity::Id, (uint8_t *) batteryCapacity,
                                       sizeof(*batteryCapacity));
 }
 EmberAfStatus SetBatteryCapacity(chip::EndpointId endpoint, uint32_t batteryCapacity)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryCapacity, (uint8_t *) &batteryCapacity,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryCapacity::Id, (uint8_t *) &batteryCapacity,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryQuantity(chip::EndpointId endpoint, uint8_t * batteryQuantity)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryQuantity, (uint8_t *) batteryQuantity,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryQuantity::Id, (uint8_t *) batteryQuantity,
                                       sizeof(*batteryQuantity));
 }
 EmberAfStatus SetBatteryQuantity(chip::EndpointId endpoint, uint8_t batteryQuantity)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryQuantity, (uint8_t *) &batteryQuantity,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryQuantity::Id, (uint8_t *) &batteryQuantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryChargeState(chip::EndpointId endpoint, uint8_t * batteryChargeState)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryChargeState, (uint8_t *) batteryChargeState,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryChargeState::Id, (uint8_t *) batteryChargeState,
                                       sizeof(*batteryChargeState));
 }
 EmberAfStatus SetBatteryChargeState(chip::EndpointId endpoint, uint8_t batteryChargeState)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryChargeState, (uint8_t *) &batteryChargeState,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryChargeState::Id, (uint8_t *) &batteryChargeState,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryTimeToFullCharge(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryTimeToFullCharge, (uint8_t *) batteryTimeToFullCharge,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryTimeToFullCharge::Id, (uint8_t *) batteryTimeToFullCharge,
                                       sizeof(*batteryTimeToFullCharge));
 }
 EmberAfStatus SetBatteryTimeToFullCharge(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryTimeToFullCharge,
-                                       (uint8_t *) &batteryTimeToFullCharge, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryTimeToFullCharge::Id, (uint8_t *) &batteryTimeToFullCharge,
+                                       ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryFunctionalWhileCharging(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryFunctionalWhileCharging,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryFunctionalWhileCharging::Id,
                                       (uint8_t *) batteryFunctionalWhileCharging, sizeof(*batteryFunctionalWhileCharging));
 }
 EmberAfStatus SetBatteryFunctionalWhileCharging(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryFunctionalWhileCharging,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryFunctionalWhileCharging::Id,
                                        (uint8_t *) &batteryFunctionalWhileCharging, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBatteryChargingCurrent(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, PowerSource::Id, Ids::BatteryChargingCurrent, (uint8_t *) batteryChargingCurrent,
+    return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryChargingCurrent::Id, (uint8_t *) batteryChargingCurrent,
                                       sizeof(*batteryChargingCurrent));
 }
 EmberAfStatus SetBatteryChargingCurrent(chip::EndpointId endpoint, uint32_t batteryChargingCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Ids::BatteryChargingCurrent, (uint8_t *) &batteryChargingCurrent,
+    return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryChargingCurrent::Id, (uint8_t *) &batteryChargingCurrent,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1607,12 +1602,12 @@ namespace GeneralCommissioning {
 namespace Attributes {
 EmberAfStatus GetBreadcrumb(chip::EndpointId endpoint, uint64_t * breadcrumb)
 {
-    return emberAfReadServerAttribute(endpoint, GeneralCommissioning::Id, Ids::Breadcrumb, (uint8_t *) breadcrumb,
+    return emberAfReadServerAttribute(endpoint, GeneralCommissioning::Id, Breadcrumb::Id, (uint8_t *) breadcrumb,
                                       sizeof(*breadcrumb));
 }
 EmberAfStatus SetBreadcrumb(chip::EndpointId endpoint, uint64_t breadcrumb)
 {
-    return emberAfWriteServerAttribute(endpoint, GeneralCommissioning::Id, Ids::Breadcrumb, (uint8_t *) &breadcrumb,
+    return emberAfWriteServerAttribute(endpoint, GeneralCommissioning::Id, Breadcrumb::Id, (uint8_t *) &breadcrumb,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1622,41 +1617,41 @@ namespace GeneralDiagnostics {
 namespace Attributes {
 EmberAfStatus GetRebootCount(chip::EndpointId endpoint, uint16_t * rebootCount)
 {
-    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::RebootCount, (uint8_t *) rebootCount,
+    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, RebootCount::Id, (uint8_t *) rebootCount,
                                       sizeof(*rebootCount));
 }
 EmberAfStatus SetRebootCount(chip::EndpointId endpoint, uint16_t rebootCount)
 {
-    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::RebootCount, (uint8_t *) &rebootCount,
+    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, RebootCount::Id, (uint8_t *) &rebootCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUpTime(chip::EndpointId endpoint, uint64_t * upTime)
 {
-    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::UpTime, (uint8_t *) upTime, sizeof(*upTime));
+    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, UpTime::Id, (uint8_t *) upTime, sizeof(*upTime));
 }
 EmberAfStatus SetUpTime(chip::EndpointId endpoint, uint64_t upTime)
 {
-    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::UpTime, (uint8_t *) &upTime,
+    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, UpTime::Id, (uint8_t *) &upTime,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTotalOperationalHours(chip::EndpointId endpoint, uint32_t * totalOperationalHours)
 {
-    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::TotalOperationalHours,
+    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, TotalOperationalHours::Id,
                                       (uint8_t *) totalOperationalHours, sizeof(*totalOperationalHours));
 }
 EmberAfStatus SetTotalOperationalHours(chip::EndpointId endpoint, uint32_t totalOperationalHours)
 {
-    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::TotalOperationalHours,
+    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, TotalOperationalHours::Id,
                                        (uint8_t *) &totalOperationalHours, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBootReasons(chip::EndpointId endpoint, uint8_t * bootReasons)
 {
-    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::BootReasons, (uint8_t *) bootReasons,
+    return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, BootReasons::Id, (uint8_t *) bootReasons,
                                       sizeof(*bootReasons));
 }
 EmberAfStatus SetBootReasons(chip::EndpointId endpoint, uint8_t bootReasons)
 {
-    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, Ids::BootReasons, (uint8_t *) &bootReasons,
+    return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, BootReasons::Id, (uint8_t *) &bootReasons,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1666,32 +1661,32 @@ namespace SoftwareDiagnostics {
 namespace Attributes {
 EmberAfStatus GetCurrentHeapFree(chip::EndpointId endpoint, uint64_t * currentHeapFree)
 {
-    return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, Ids::CurrentHeapFree, (uint8_t *) currentHeapFree,
+    return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapFree::Id, (uint8_t *) currentHeapFree,
                                       sizeof(*currentHeapFree));
 }
 EmberAfStatus SetCurrentHeapFree(chip::EndpointId endpoint, uint64_t currentHeapFree)
 {
-    return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, Ids::CurrentHeapFree, (uint8_t *) &currentHeapFree,
+    return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapFree::Id, (uint8_t *) &currentHeapFree,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentHeapUsed(chip::EndpointId endpoint, uint64_t * currentHeapUsed)
 {
-    return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, Ids::CurrentHeapUsed, (uint8_t *) currentHeapUsed,
+    return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapUsed::Id, (uint8_t *) currentHeapUsed,
                                       sizeof(*currentHeapUsed));
 }
 EmberAfStatus SetCurrentHeapUsed(chip::EndpointId endpoint, uint64_t currentHeapUsed)
 {
-    return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, Ids::CurrentHeapUsed, (uint8_t *) &currentHeapUsed,
+    return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapUsed::Id, (uint8_t *) &currentHeapUsed,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentHeapHighWatermark(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark)
 {
-    return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, Ids::CurrentHeapHighWatermark,
+    return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapHighWatermark::Id,
                                       (uint8_t *) currentHeapHighWatermark, sizeof(*currentHeapHighWatermark));
 }
 EmberAfStatus SetCurrentHeapHighWatermark(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark)
 {
-    return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, Ids::CurrentHeapHighWatermark,
+    return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapHighWatermark::Id,
                                        (uint8_t *) &currentHeapHighWatermark, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -1701,549 +1696,549 @@ namespace ThreadNetworkDiagnostics {
 namespace Attributes {
 EmberAfStatus GetChannel(chip::EndpointId endpoint, uint8_t * channel)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::Channel, (uint8_t *) channel, sizeof(*channel));
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Channel::Id, (uint8_t *) channel, sizeof(*channel));
 }
 EmberAfStatus SetChannel(chip::EndpointId endpoint, uint8_t channel)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::Channel, (uint8_t *) &channel,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Channel::Id, (uint8_t *) &channel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRoutingRole(chip::EndpointId endpoint, uint8_t * routingRole)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RoutingRole, (uint8_t *) routingRole,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RoutingRole::Id, (uint8_t *) routingRole,
                                       sizeof(*routingRole));
 }
 EmberAfStatus SetRoutingRole(chip::EndpointId endpoint, uint8_t routingRole)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RoutingRole, (uint8_t *) &routingRole,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RoutingRole::Id, (uint8_t *) &routingRole,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPanId(chip::EndpointId endpoint, uint16_t * panId)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PanId, (uint8_t *) panId, sizeof(*panId));
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PanId::Id, (uint8_t *) panId, sizeof(*panId));
 }
 EmberAfStatus SetPanId(chip::EndpointId endpoint, uint16_t panId)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PanId, (uint8_t *) &panId,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PanId::Id, (uint8_t *) &panId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetExtendedPanId(chip::EndpointId endpoint, uint64_t * extendedPanId)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ExtendedPanId, (uint8_t *) extendedPanId,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ExtendedPanId::Id, (uint8_t *) extendedPanId,
                                       sizeof(*extendedPanId));
 }
 EmberAfStatus SetExtendedPanId(chip::EndpointId endpoint, uint64_t extendedPanId)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ExtendedPanId, (uint8_t *) &extendedPanId,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ExtendedPanId::Id, (uint8_t *) &extendedPanId,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) overrunCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) overrunCount,
                                       sizeof(*overrunCount));
 }
 EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) &overrunCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPartitionId(chip::EndpointId endpoint, uint32_t * partitionId)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PartitionId, (uint8_t *) partitionId,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionId::Id, (uint8_t *) partitionId,
                                       sizeof(*partitionId));
 }
 EmberAfStatus SetPartitionId(chip::EndpointId endpoint, uint32_t partitionId)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PartitionId, (uint8_t *) &partitionId,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionId::Id, (uint8_t *) &partitionId,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWeighting(chip::EndpointId endpoint, uint8_t * weighting)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::Weighting, (uint8_t *) weighting,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Weighting::Id, (uint8_t *) weighting,
                                       sizeof(*weighting));
 }
 EmberAfStatus SetWeighting(chip::EndpointId endpoint, uint8_t weighting)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::Weighting, (uint8_t *) &weighting,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Weighting::Id, (uint8_t *) &weighting,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDataVersion(chip::EndpointId endpoint, uint8_t * dataVersion)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::DataVersion, (uint8_t *) dataVersion,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DataVersion::Id, (uint8_t *) dataVersion,
                                       sizeof(*dataVersion));
 }
 EmberAfStatus SetDataVersion(chip::EndpointId endpoint, uint8_t dataVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::DataVersion, (uint8_t *) &dataVersion,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DataVersion::Id, (uint8_t *) &dataVersion,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStableDataVersion(chip::EndpointId endpoint, uint8_t * stableDataVersion)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::StableDataVersion, (uint8_t *) stableDataVersion,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, StableDataVersion::Id, (uint8_t *) stableDataVersion,
                                       sizeof(*stableDataVersion));
 }
 EmberAfStatus SetStableDataVersion(chip::EndpointId endpoint, uint8_t stableDataVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::StableDataVersion,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, StableDataVersion::Id,
                                        (uint8_t *) &stableDataVersion, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLeaderRouterId(chip::EndpointId endpoint, uint8_t * leaderRouterId)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::LeaderRouterId, (uint8_t *) leaderRouterId,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRouterId::Id, (uint8_t *) leaderRouterId,
                                       sizeof(*leaderRouterId));
 }
 EmberAfStatus SetLeaderRouterId(chip::EndpointId endpoint, uint8_t leaderRouterId)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::LeaderRouterId, (uint8_t *) &leaderRouterId,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRouterId::Id, (uint8_t *) &leaderRouterId,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDetachedRoleCount(chip::EndpointId endpoint, uint16_t * detachedRoleCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::DetachedRoleCount, (uint8_t *) detachedRoleCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DetachedRoleCount::Id, (uint8_t *) detachedRoleCount,
                                       sizeof(*detachedRoleCount));
 }
 EmberAfStatus SetDetachedRoleCount(chip::EndpointId endpoint, uint16_t detachedRoleCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::DetachedRoleCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DetachedRoleCount::Id,
                                        (uint8_t *) &detachedRoleCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetChildRoleCount(chip::EndpointId endpoint, uint16_t * childRoleCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ChildRoleCount, (uint8_t *) childRoleCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ChildRoleCount::Id, (uint8_t *) childRoleCount,
                                       sizeof(*childRoleCount));
 }
 EmberAfStatus SetChildRoleCount(chip::EndpointId endpoint, uint16_t childRoleCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ChildRoleCount, (uint8_t *) &childRoleCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ChildRoleCount::Id, (uint8_t *) &childRoleCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRouterRoleCount(chip::EndpointId endpoint, uint16_t * routerRoleCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RouterRoleCount, (uint8_t *) routerRoleCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RouterRoleCount::Id, (uint8_t *) routerRoleCount,
                                       sizeof(*routerRoleCount));
 }
 EmberAfStatus SetRouterRoleCount(chip::EndpointId endpoint, uint16_t routerRoleCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RouterRoleCount, (uint8_t *) &routerRoleCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RouterRoleCount::Id, (uint8_t *) &routerRoleCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLeaderRoleCount(chip::EndpointId endpoint, uint16_t * leaderRoleCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::LeaderRoleCount, (uint8_t *) leaderRoleCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRoleCount::Id, (uint8_t *) leaderRoleCount,
                                       sizeof(*leaderRoleCount));
 }
 EmberAfStatus SetLeaderRoleCount(chip::EndpointId endpoint, uint16_t leaderRoleCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::LeaderRoleCount, (uint8_t *) &leaderRoleCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRoleCount::Id, (uint8_t *) &leaderRoleCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAttachAttemptCount(chip::EndpointId endpoint, uint16_t * attachAttemptCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::AttachAttemptCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, AttachAttemptCount::Id,
                                       (uint8_t *) attachAttemptCount, sizeof(*attachAttemptCount));
 }
 EmberAfStatus SetAttachAttemptCount(chip::EndpointId endpoint, uint16_t attachAttemptCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::AttachAttemptCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, AttachAttemptCount::Id,
                                        (uint8_t *) &attachAttemptCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPartitionIdChangeCount(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PartitionIdChangeCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionIdChangeCount::Id,
                                       (uint8_t *) partitionIdChangeCount, sizeof(*partitionIdChangeCount));
 }
 EmberAfStatus SetPartitionIdChangeCount(chip::EndpointId endpoint, uint16_t partitionIdChangeCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PartitionIdChangeCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionIdChangeCount::Id,
                                        (uint8_t *) &partitionIdChangeCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBetterPartitionAttachAttemptCount(chip::EndpointId endpoint, uint16_t * betterPartitionAttachAttemptCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::BetterPartitionAttachAttemptCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, BetterPartitionAttachAttemptCount::Id,
                                       (uint8_t *) betterPartitionAttachAttemptCount, sizeof(*betterPartitionAttachAttemptCount));
 }
 EmberAfStatus SetBetterPartitionAttachAttemptCount(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::BetterPartitionAttachAttemptCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, BetterPartitionAttachAttemptCount::Id,
                                        (uint8_t *) &betterPartitionAttachAttemptCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetParentChangeCount(chip::EndpointId endpoint, uint16_t * parentChangeCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ParentChangeCount, (uint8_t *) parentChangeCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ParentChangeCount::Id, (uint8_t *) parentChangeCount,
                                       sizeof(*parentChangeCount));
 }
 EmberAfStatus SetParentChangeCount(chip::EndpointId endpoint, uint16_t parentChangeCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ParentChangeCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ParentChangeCount::Id,
                                        (uint8_t *) &parentChangeCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxTotalCount(chip::EndpointId endpoint, uint32_t * txTotalCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxTotalCount, (uint8_t *) txTotalCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxTotalCount::Id, (uint8_t *) txTotalCount,
                                       sizeof(*txTotalCount));
 }
 EmberAfStatus SetTxTotalCount(chip::EndpointId endpoint, uint32_t txTotalCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxTotalCount, (uint8_t *) &txTotalCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxTotalCount::Id, (uint8_t *) &txTotalCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxUnicastCount(chip::EndpointId endpoint, uint32_t * txUnicastCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxUnicastCount, (uint8_t *) txUnicastCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxUnicastCount::Id, (uint8_t *) txUnicastCount,
                                       sizeof(*txUnicastCount));
 }
 EmberAfStatus SetTxUnicastCount(chip::EndpointId endpoint, uint32_t txUnicastCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxUnicastCount, (uint8_t *) &txUnicastCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxUnicastCount::Id, (uint8_t *) &txUnicastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxBroadcastCount(chip::EndpointId endpoint, uint32_t * txBroadcastCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxBroadcastCount, (uint8_t *) txBroadcastCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBroadcastCount::Id, (uint8_t *) txBroadcastCount,
                                       sizeof(*txBroadcastCount));
 }
 EmberAfStatus SetTxBroadcastCount(chip::EndpointId endpoint, uint32_t txBroadcastCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxBroadcastCount, (uint8_t *) &txBroadcastCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBroadcastCount::Id, (uint8_t *) &txBroadcastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxAckRequestedCount(chip::EndpointId endpoint, uint32_t * txAckRequestedCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxAckRequestedCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckRequestedCount::Id,
                                       (uint8_t *) txAckRequestedCount, sizeof(*txAckRequestedCount));
 }
 EmberAfStatus SetTxAckRequestedCount(chip::EndpointId endpoint, uint32_t txAckRequestedCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxAckRequestedCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckRequestedCount::Id,
                                        (uint8_t *) &txAckRequestedCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxAckedCount(chip::EndpointId endpoint, uint32_t * txAckedCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxAckedCount, (uint8_t *) txAckedCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckedCount::Id, (uint8_t *) txAckedCount,
                                       sizeof(*txAckedCount));
 }
 EmberAfStatus SetTxAckedCount(chip::EndpointId endpoint, uint32_t txAckedCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxAckedCount, (uint8_t *) &txAckedCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckedCount::Id, (uint8_t *) &txAckedCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxNoAckRequestedCount(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxNoAckRequestedCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxNoAckRequestedCount::Id,
                                       (uint8_t *) txNoAckRequestedCount, sizeof(*txNoAckRequestedCount));
 }
 EmberAfStatus SetTxNoAckRequestedCount(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxNoAckRequestedCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxNoAckRequestedCount::Id,
                                        (uint8_t *) &txNoAckRequestedCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxDataCount(chip::EndpointId endpoint, uint32_t * txDataCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxDataCount, (uint8_t *) txDataCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataCount::Id, (uint8_t *) txDataCount,
                                       sizeof(*txDataCount));
 }
 EmberAfStatus SetTxDataCount(chip::EndpointId endpoint, uint32_t txDataCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxDataCount, (uint8_t *) &txDataCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataCount::Id, (uint8_t *) &txDataCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxDataPollCount(chip::EndpointId endpoint, uint32_t * txDataPollCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxDataPollCount, (uint8_t *) txDataPollCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataPollCount::Id, (uint8_t *) txDataPollCount,
                                       sizeof(*txDataPollCount));
 }
 EmberAfStatus SetTxDataPollCount(chip::EndpointId endpoint, uint32_t txDataPollCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxDataPollCount, (uint8_t *) &txDataPollCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataPollCount::Id, (uint8_t *) &txDataPollCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxBeaconCount(chip::EndpointId endpoint, uint32_t * txBeaconCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxBeaconCount, (uint8_t *) txBeaconCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconCount::Id, (uint8_t *) txBeaconCount,
                                       sizeof(*txBeaconCount));
 }
 EmberAfStatus SetTxBeaconCount(chip::EndpointId endpoint, uint32_t txBeaconCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxBeaconCount, (uint8_t *) &txBeaconCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconCount::Id, (uint8_t *) &txBeaconCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxBeaconRequestCount(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxBeaconRequestCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconRequestCount::Id,
                                       (uint8_t *) txBeaconRequestCount, sizeof(*txBeaconRequestCount));
 }
 EmberAfStatus SetTxBeaconRequestCount(chip::EndpointId endpoint, uint32_t txBeaconRequestCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxBeaconRequestCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconRequestCount::Id,
                                        (uint8_t *) &txBeaconRequestCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxOtherCount(chip::EndpointId endpoint, uint32_t * txOtherCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxOtherCount, (uint8_t *) txOtherCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxOtherCount::Id, (uint8_t *) txOtherCount,
                                       sizeof(*txOtherCount));
 }
 EmberAfStatus SetTxOtherCount(chip::EndpointId endpoint, uint32_t txOtherCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxOtherCount, (uint8_t *) &txOtherCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxOtherCount::Id, (uint8_t *) &txOtherCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxRetryCount(chip::EndpointId endpoint, uint32_t * txRetryCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxRetryCount, (uint8_t *) txRetryCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxRetryCount::Id, (uint8_t *) txRetryCount,
                                       sizeof(*txRetryCount));
 }
 EmberAfStatus SetTxRetryCount(chip::EndpointId endpoint, uint32_t txRetryCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxRetryCount, (uint8_t *) &txRetryCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxRetryCount::Id, (uint8_t *) &txRetryCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxDirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxDirectMaxRetryExpiryCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDirectMaxRetryExpiryCount::Id,
                                       (uint8_t *) txDirectMaxRetryExpiryCount, sizeof(*txDirectMaxRetryExpiryCount));
 }
 EmberAfStatus SetTxDirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxDirectMaxRetryExpiryCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDirectMaxRetryExpiryCount::Id,
                                        (uint8_t *) &txDirectMaxRetryExpiryCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxIndirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxIndirectMaxRetryExpiryCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxIndirectMaxRetryExpiryCount::Id,
                                       (uint8_t *) txIndirectMaxRetryExpiryCount, sizeof(*txIndirectMaxRetryExpiryCount));
 }
 EmberAfStatus SetTxIndirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxIndirectMaxRetryExpiryCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxIndirectMaxRetryExpiryCount::Id,
                                        (uint8_t *) &txIndirectMaxRetryExpiryCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxErrCcaCount(chip::EndpointId endpoint, uint32_t * txErrCcaCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxErrCcaCount, (uint8_t *) txErrCcaCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrCcaCount::Id, (uint8_t *) txErrCcaCount,
                                       sizeof(*txErrCcaCount));
 }
 EmberAfStatus SetTxErrCcaCount(chip::EndpointId endpoint, uint32_t txErrCcaCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxErrCcaCount, (uint8_t *) &txErrCcaCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrCcaCount::Id, (uint8_t *) &txErrCcaCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxErrAbortCount(chip::EndpointId endpoint, uint32_t * txErrAbortCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxErrAbortCount, (uint8_t *) txErrAbortCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrAbortCount::Id, (uint8_t *) txErrAbortCount,
                                       sizeof(*txErrAbortCount));
 }
 EmberAfStatus SetTxErrAbortCount(chip::EndpointId endpoint, uint32_t txErrAbortCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxErrAbortCount, (uint8_t *) &txErrAbortCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrAbortCount::Id, (uint8_t *) &txErrAbortCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxErrBusyChannelCount(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxErrBusyChannelCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrBusyChannelCount::Id,
                                       (uint8_t *) txErrBusyChannelCount, sizeof(*txErrBusyChannelCount));
 }
 EmberAfStatus SetTxErrBusyChannelCount(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::TxErrBusyChannelCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrBusyChannelCount::Id,
                                        (uint8_t *) &txErrBusyChannelCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxTotalCount(chip::EndpointId endpoint, uint32_t * rxTotalCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxTotalCount, (uint8_t *) rxTotalCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxTotalCount::Id, (uint8_t *) rxTotalCount,
                                       sizeof(*rxTotalCount));
 }
 EmberAfStatus SetRxTotalCount(chip::EndpointId endpoint, uint32_t rxTotalCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxTotalCount, (uint8_t *) &rxTotalCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxTotalCount::Id, (uint8_t *) &rxTotalCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxUnicastCount(chip::EndpointId endpoint, uint32_t * rxUnicastCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxUnicastCount, (uint8_t *) rxUnicastCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxUnicastCount::Id, (uint8_t *) rxUnicastCount,
                                       sizeof(*rxUnicastCount));
 }
 EmberAfStatus SetRxUnicastCount(chip::EndpointId endpoint, uint32_t rxUnicastCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxUnicastCount, (uint8_t *) &rxUnicastCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxUnicastCount::Id, (uint8_t *) &rxUnicastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxBroadcastCount(chip::EndpointId endpoint, uint32_t * rxBroadcastCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxBroadcastCount, (uint8_t *) rxBroadcastCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBroadcastCount::Id, (uint8_t *) rxBroadcastCount,
                                       sizeof(*rxBroadcastCount));
 }
 EmberAfStatus SetRxBroadcastCount(chip::EndpointId endpoint, uint32_t rxBroadcastCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxBroadcastCount, (uint8_t *) &rxBroadcastCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBroadcastCount::Id, (uint8_t *) &rxBroadcastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxDataCount(chip::EndpointId endpoint, uint32_t * rxDataCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDataCount, (uint8_t *) rxDataCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataCount::Id, (uint8_t *) rxDataCount,
                                       sizeof(*rxDataCount));
 }
 EmberAfStatus SetRxDataCount(chip::EndpointId endpoint, uint32_t rxDataCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDataCount, (uint8_t *) &rxDataCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataCount::Id, (uint8_t *) &rxDataCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxDataPollCount(chip::EndpointId endpoint, uint32_t * rxDataPollCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDataPollCount, (uint8_t *) rxDataPollCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataPollCount::Id, (uint8_t *) rxDataPollCount,
                                       sizeof(*rxDataPollCount));
 }
 EmberAfStatus SetRxDataPollCount(chip::EndpointId endpoint, uint32_t rxDataPollCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDataPollCount, (uint8_t *) &rxDataPollCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataPollCount::Id, (uint8_t *) &rxDataPollCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxBeaconCount(chip::EndpointId endpoint, uint32_t * rxBeaconCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxBeaconCount, (uint8_t *) rxBeaconCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconCount::Id, (uint8_t *) rxBeaconCount,
                                       sizeof(*rxBeaconCount));
 }
 EmberAfStatus SetRxBeaconCount(chip::EndpointId endpoint, uint32_t rxBeaconCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxBeaconCount, (uint8_t *) &rxBeaconCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconCount::Id, (uint8_t *) &rxBeaconCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxBeaconRequestCount(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxBeaconRequestCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconRequestCount::Id,
                                       (uint8_t *) rxBeaconRequestCount, sizeof(*rxBeaconRequestCount));
 }
 EmberAfStatus SetRxBeaconRequestCount(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxBeaconRequestCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconRequestCount::Id,
                                        (uint8_t *) &rxBeaconRequestCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxOtherCount(chip::EndpointId endpoint, uint32_t * rxOtherCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxOtherCount, (uint8_t *) rxOtherCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxOtherCount::Id, (uint8_t *) rxOtherCount,
                                       sizeof(*rxOtherCount));
 }
 EmberAfStatus SetRxOtherCount(chip::EndpointId endpoint, uint32_t rxOtherCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxOtherCount, (uint8_t *) &rxOtherCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxOtherCount::Id, (uint8_t *) &rxOtherCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxAddressFilteredCount(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxAddressFilteredCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxAddressFilteredCount::Id,
                                       (uint8_t *) rxAddressFilteredCount, sizeof(*rxAddressFilteredCount));
 }
 EmberAfStatus SetRxAddressFilteredCount(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxAddressFilteredCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxAddressFilteredCount::Id,
                                        (uint8_t *) &rxAddressFilteredCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxDestAddrFilteredCount(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDestAddrFilteredCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDestAddrFilteredCount::Id,
                                       (uint8_t *) rxDestAddrFilteredCount, sizeof(*rxDestAddrFilteredCount));
 }
 EmberAfStatus SetRxDestAddrFilteredCount(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDestAddrFilteredCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDestAddrFilteredCount::Id,
                                        (uint8_t *) &rxDestAddrFilteredCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxDuplicatedCount(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDuplicatedCount, (uint8_t *) rxDuplicatedCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDuplicatedCount::Id, (uint8_t *) rxDuplicatedCount,
                                       sizeof(*rxDuplicatedCount));
 }
 EmberAfStatus SetRxDuplicatedCount(chip::EndpointId endpoint, uint32_t rxDuplicatedCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxDuplicatedCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDuplicatedCount::Id,
                                        (uint8_t *) &rxDuplicatedCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxErrNoFrameCount(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrNoFrameCount, (uint8_t *) rxErrNoFrameCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrNoFrameCount::Id, (uint8_t *) rxErrNoFrameCount,
                                       sizeof(*rxErrNoFrameCount));
 }
 EmberAfStatus SetRxErrNoFrameCount(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrNoFrameCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrNoFrameCount::Id,
                                        (uint8_t *) &rxErrNoFrameCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxErrUnknownNeighborCount(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrUnknownNeighborCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrUnknownNeighborCount::Id,
                                       (uint8_t *) rxErrUnknownNeighborCount, sizeof(*rxErrUnknownNeighborCount));
 }
 EmberAfStatus SetRxErrUnknownNeighborCount(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrUnknownNeighborCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrUnknownNeighborCount::Id,
                                        (uint8_t *) &rxErrUnknownNeighborCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxErrInvalidSrcAddrCount(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrInvalidSrcAddrCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrInvalidSrcAddrCount::Id,
                                       (uint8_t *) rxErrInvalidSrcAddrCount, sizeof(*rxErrInvalidSrcAddrCount));
 }
 EmberAfStatus SetRxErrInvalidSrcAddrCount(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrInvalidSrcAddrCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrInvalidSrcAddrCount::Id,
                                        (uint8_t *) &rxErrInvalidSrcAddrCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxErrSecCount(chip::EndpointId endpoint, uint32_t * rxErrSecCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrSecCount, (uint8_t *) rxErrSecCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrSecCount::Id, (uint8_t *) rxErrSecCount,
                                       sizeof(*rxErrSecCount));
 }
 EmberAfStatus SetRxErrSecCount(chip::EndpointId endpoint, uint32_t rxErrSecCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrSecCount, (uint8_t *) &rxErrSecCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrSecCount::Id, (uint8_t *) &rxErrSecCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxErrFcsCount(chip::EndpointId endpoint, uint32_t * rxErrFcsCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrFcsCount, (uint8_t *) rxErrFcsCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrFcsCount::Id, (uint8_t *) rxErrFcsCount,
                                       sizeof(*rxErrFcsCount));
 }
 EmberAfStatus SetRxErrFcsCount(chip::EndpointId endpoint, uint32_t rxErrFcsCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrFcsCount, (uint8_t *) &rxErrFcsCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrFcsCount::Id, (uint8_t *) &rxErrFcsCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRxErrOtherCount(chip::EndpointId endpoint, uint32_t * rxErrOtherCount)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrOtherCount, (uint8_t *) rxErrOtherCount,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrOtherCount::Id, (uint8_t *) rxErrOtherCount,
                                       sizeof(*rxErrOtherCount));
 }
 EmberAfStatus SetRxErrOtherCount(chip::EndpointId endpoint, uint32_t rxErrOtherCount)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::RxErrOtherCount, (uint8_t *) &rxErrOtherCount,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrOtherCount::Id, (uint8_t *) &rxErrOtherCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActiveTimestamp(chip::EndpointId endpoint, uint64_t * activeTimestamp)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ActiveTimestamp, (uint8_t *) activeTimestamp,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ActiveTimestamp::Id, (uint8_t *) activeTimestamp,
                                       sizeof(*activeTimestamp));
 }
 EmberAfStatus SetActiveTimestamp(chip::EndpointId endpoint, uint64_t activeTimestamp)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::ActiveTimestamp, (uint8_t *) &activeTimestamp,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ActiveTimestamp::Id, (uint8_t *) &activeTimestamp,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPendingTimestamp(chip::EndpointId endpoint, uint64_t * pendingTimestamp)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PendingTimestamp, (uint8_t *) pendingTimestamp,
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PendingTimestamp::Id, (uint8_t *) pendingTimestamp,
                                       sizeof(*pendingTimestamp));
 }
 EmberAfStatus SetPendingTimestamp(chip::EndpointId endpoint, uint64_t pendingTimestamp)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::PendingTimestamp, (uint8_t *) &pendingTimestamp,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PendingTimestamp::Id, (uint8_t *) &pendingTimestamp,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDelay(chip::EndpointId endpoint, uint32_t * delay)
 {
-    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::Delay, (uint8_t *) delay, sizeof(*delay));
+    return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Delay::Id, (uint8_t *) delay, sizeof(*delay));
 }
 EmberAfStatus SetDelay(chip::EndpointId endpoint, uint32_t delay)
 {
-    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Ids::Delay, (uint8_t *) &delay,
+    return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Delay::Id, (uint8_t *) &delay,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -2253,121 +2248,120 @@ namespace WiFiNetworkDiagnostics {
 namespace Attributes {
 EmberAfStatus GetSecurityType(chip::EndpointId endpoint, uint8_t * securityType)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::SecurityType, (uint8_t *) securityType,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, SecurityType::Id, (uint8_t *) securityType,
                                       sizeof(*securityType));
 }
 EmberAfStatus SetSecurityType(chip::EndpointId endpoint, uint8_t securityType)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::SecurityType, (uint8_t *) &securityType,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, SecurityType::Id, (uint8_t *) &securityType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWiFiVersion(chip::EndpointId endpoint, uint8_t * wiFiVersion)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::WiFiVersion, (uint8_t *) wiFiVersion,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, WiFiVersion::Id, (uint8_t *) wiFiVersion,
                                       sizeof(*wiFiVersion));
 }
 EmberAfStatus SetWiFiVersion(chip::EndpointId endpoint, uint8_t wiFiVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::WiFiVersion, (uint8_t *) &wiFiVersion,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, WiFiVersion::Id, (uint8_t *) &wiFiVersion,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetChannelNumber(chip::EndpointId endpoint, uint16_t * channelNumber)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::ChannelNumber, (uint8_t *) channelNumber,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, ChannelNumber::Id, (uint8_t *) channelNumber,
                                       sizeof(*channelNumber));
 }
 EmberAfStatus SetChannelNumber(chip::EndpointId endpoint, uint16_t channelNumber)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::ChannelNumber, (uint8_t *) &channelNumber,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, ChannelNumber::Id, (uint8_t *) &channelNumber,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRssi(chip::EndpointId endpoint, int8_t * rssi)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::Rssi, (uint8_t *) rssi, sizeof(*rssi));
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Rssi::Id, (uint8_t *) rssi, sizeof(*rssi));
 }
 EmberAfStatus SetRssi(chip::EndpointId endpoint, int8_t rssi)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::Rssi, (uint8_t *) &rssi,
-                                       ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Rssi::Id, (uint8_t *) &rssi, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBeaconLostCount(chip::EndpointId endpoint, uint32_t * beaconLostCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::BeaconLostCount, (uint8_t *) beaconLostCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconLostCount::Id, (uint8_t *) beaconLostCount,
                                       sizeof(*beaconLostCount));
 }
 EmberAfStatus SetBeaconLostCount(chip::EndpointId endpoint, uint32_t beaconLostCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::BeaconLostCount, (uint8_t *) &beaconLostCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconLostCount::Id, (uint8_t *) &beaconLostCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBeaconRxCount(chip::EndpointId endpoint, uint32_t * beaconRxCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::BeaconRxCount, (uint8_t *) beaconRxCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconRxCount::Id, (uint8_t *) beaconRxCount,
                                       sizeof(*beaconRxCount));
 }
 EmberAfStatus SetBeaconRxCount(chip::EndpointId endpoint, uint32_t beaconRxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::BeaconRxCount, (uint8_t *) &beaconRxCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconRxCount::Id, (uint8_t *) &beaconRxCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPacketMulticastRxCount(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketMulticastRxCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastRxCount::Id,
                                       (uint8_t *) packetMulticastRxCount, sizeof(*packetMulticastRxCount));
 }
 EmberAfStatus SetPacketMulticastRxCount(chip::EndpointId endpoint, uint32_t packetMulticastRxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketMulticastRxCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastRxCount::Id,
                                        (uint8_t *) &packetMulticastRxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPacketMulticastTxCount(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketMulticastTxCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastTxCount::Id,
                                       (uint8_t *) packetMulticastTxCount, sizeof(*packetMulticastTxCount));
 }
 EmberAfStatus SetPacketMulticastTxCount(chip::EndpointId endpoint, uint32_t packetMulticastTxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketMulticastTxCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastTxCount::Id,
                                        (uint8_t *) &packetMulticastTxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPacketUnicastRxCount(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketUnicastRxCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastRxCount::Id,
                                       (uint8_t *) packetUnicastRxCount, sizeof(*packetUnicastRxCount));
 }
 EmberAfStatus SetPacketUnicastRxCount(chip::EndpointId endpoint, uint32_t packetUnicastRxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketUnicastRxCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastRxCount::Id,
                                        (uint8_t *) &packetUnicastRxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPacketUnicastTxCount(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketUnicastTxCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastTxCount::Id,
                                       (uint8_t *) packetUnicastTxCount, sizeof(*packetUnicastTxCount));
 }
 EmberAfStatus SetPacketUnicastTxCount(chip::EndpointId endpoint, uint32_t packetUnicastTxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::PacketUnicastTxCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastTxCount::Id,
                                        (uint8_t *) &packetUnicastTxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentMaxRate(chip::EndpointId endpoint, uint64_t * currentMaxRate)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::CurrentMaxRate, (uint8_t *) currentMaxRate,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, CurrentMaxRate::Id, (uint8_t *) currentMaxRate,
                                       sizeof(*currentMaxRate));
 }
 EmberAfStatus SetCurrentMaxRate(chip::EndpointId endpoint, uint64_t currentMaxRate)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::CurrentMaxRate, (uint8_t *) &currentMaxRate,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, CurrentMaxRate::Id, (uint8_t *) &currentMaxRate,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount)
 {
-    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) overrunCount,
+    return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) overrunCount,
                                       sizeof(*overrunCount));
 }
 EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
 {
-    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) &overrunCount,
+    return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -2377,92 +2371,91 @@ namespace EthernetNetworkDiagnostics {
 namespace Attributes {
 EmberAfStatus GetPHYRate(chip::EndpointId endpoint, uint8_t * pHYRate)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PHYRate, (uint8_t *) pHYRate,
-                                      sizeof(*pHYRate));
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) pHYRate, sizeof(*pHYRate));
 }
 EmberAfStatus SetPHYRate(chip::EndpointId endpoint, uint8_t pHYRate)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PHYRate, (uint8_t *) &pHYRate,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) &pHYRate,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, bool * fullDuplex)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::FullDuplex, (uint8_t *) fullDuplex,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, FullDuplex::Id, (uint8_t *) fullDuplex,
                                       sizeof(*fullDuplex));
 }
 EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, bool fullDuplex)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::FullDuplex, (uint8_t *) &fullDuplex,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, FullDuplex::Id, (uint8_t *) &fullDuplex,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPacketRxCount(chip::EndpointId endpoint, uint64_t * packetRxCount)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PacketRxCount, (uint8_t *) packetRxCount,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketRxCount::Id, (uint8_t *) packetRxCount,
                                       sizeof(*packetRxCount));
 }
 EmberAfStatus SetPacketRxCount(chip::EndpointId endpoint, uint64_t packetRxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PacketRxCount, (uint8_t *) &packetRxCount,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketRxCount::Id, (uint8_t *) &packetRxCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPacketTxCount(chip::EndpointId endpoint, uint64_t * packetTxCount)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PacketTxCount, (uint8_t *) packetTxCount,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketTxCount::Id, (uint8_t *) packetTxCount,
                                       sizeof(*packetTxCount));
 }
 EmberAfStatus SetPacketTxCount(chip::EndpointId endpoint, uint64_t packetTxCount)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PacketTxCount, (uint8_t *) &packetTxCount,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketTxCount::Id, (uint8_t *) &packetTxCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTxErrCount(chip::EndpointId endpoint, uint64_t * txErrCount)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::TxErrCount, (uint8_t *) txErrCount,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TxErrCount::Id, (uint8_t *) txErrCount,
                                       sizeof(*txErrCount));
 }
 EmberAfStatus SetTxErrCount(chip::EndpointId endpoint, uint64_t txErrCount)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::TxErrCount, (uint8_t *) &txErrCount,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TxErrCount::Id, (uint8_t *) &txErrCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCollisionCount(chip::EndpointId endpoint, uint64_t * collisionCount)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::CollisionCount, (uint8_t *) collisionCount,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CollisionCount::Id, (uint8_t *) collisionCount,
                                       sizeof(*collisionCount));
 }
 EmberAfStatus SetCollisionCount(chip::EndpointId endpoint, uint64_t collisionCount)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::CollisionCount, (uint8_t *) &collisionCount,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CollisionCount::Id, (uint8_t *) &collisionCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) overrunCount,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) overrunCount,
                                       sizeof(*overrunCount));
 }
 EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) &overrunCount,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, bool * carrierDetect)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::CarrierDetect, (uint8_t *) carrierDetect,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CarrierDetect::Id, (uint8_t *) carrierDetect,
                                       sizeof(*carrierDetect));
 }
 EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, bool carrierDetect)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::CarrierDetect, (uint8_t *) &carrierDetect,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CarrierDetect::Id, (uint8_t *) &carrierDetect,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTimeSinceReset(chip::EndpointId endpoint, uint64_t * timeSinceReset)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::TimeSinceReset, (uint8_t *) timeSinceReset,
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TimeSinceReset::Id, (uint8_t *) timeSinceReset,
                                       sizeof(*timeSinceReset));
 }
 EmberAfStatus SetTimeSinceReset(chip::EndpointId endpoint, uint64_t timeSinceReset)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::TimeSinceReset, (uint8_t *) &timeSinceReset,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TimeSinceReset::Id, (uint8_t *) &timeSinceReset,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -2472,40 +2465,40 @@ namespace BridgedDeviceBasic {
 namespace Attributes {
 EmberAfStatus GetVendorID(chip::EndpointId endpoint, uint16_t * vendorID)
 {
-    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::VendorID, (uint8_t *) vendorID, sizeof(*vendorID));
+    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, VendorID::Id, (uint8_t *) vendorID, sizeof(*vendorID));
 }
 EmberAfStatus SetVendorID(chip::EndpointId endpoint, uint16_t vendorID)
 {
-    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::VendorID, (uint8_t *) &vendorID,
+    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, VendorID::Id, (uint8_t *) &vendorID,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareVersion)
 {
-    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::HardwareVersion, (uint8_t *) hardwareVersion,
+    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, HardwareVersion::Id, (uint8_t *) hardwareVersion,
                                       sizeof(*hardwareVersion));
 }
 EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::HardwareVersion, (uint8_t *) &hardwareVersion,
+    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, HardwareVersion::Id, (uint8_t *) &hardwareVersion,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion)
 {
-    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::SoftwareVersion, (uint8_t *) softwareVersion,
+    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, SoftwareVersion::Id, (uint8_t *) softwareVersion,
                                       sizeof(*softwareVersion));
 }
 EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::SoftwareVersion, (uint8_t *) &softwareVersion,
+    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, SoftwareVersion::Id, (uint8_t *) &softwareVersion,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable)
 {
-    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::Reachable, (uint8_t *) reachable, sizeof(*reachable));
+    return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Reachable::Id, (uint8_t *) reachable, sizeof(*reachable));
 }
 EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable)
 {
-    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::Reachable, (uint8_t *) &reachable,
+    return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Reachable::Id, (uint8_t *) &reachable,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -2515,31 +2508,31 @@ namespace Switch {
 namespace Attributes {
 EmberAfStatus GetNumberOfPositions(chip::EndpointId endpoint, uint8_t * numberOfPositions)
 {
-    return emberAfReadServerAttribute(endpoint, Switch::Id, Ids::NumberOfPositions, (uint8_t *) numberOfPositions,
+    return emberAfReadServerAttribute(endpoint, Switch::Id, NumberOfPositions::Id, (uint8_t *) numberOfPositions,
                                       sizeof(*numberOfPositions));
 }
 EmberAfStatus SetNumberOfPositions(chip::EndpointId endpoint, uint8_t numberOfPositions)
 {
-    return emberAfWriteServerAttribute(endpoint, Switch::Id, Ids::NumberOfPositions, (uint8_t *) &numberOfPositions,
+    return emberAfWriteServerAttribute(endpoint, Switch::Id, NumberOfPositions::Id, (uint8_t *) &numberOfPositions,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPosition(chip::EndpointId endpoint, uint8_t * currentPosition)
 {
-    return emberAfReadServerAttribute(endpoint, Switch::Id, Ids::CurrentPosition, (uint8_t *) currentPosition,
+    return emberAfReadServerAttribute(endpoint, Switch::Id, CurrentPosition::Id, (uint8_t *) currentPosition,
                                       sizeof(*currentPosition));
 }
 EmberAfStatus SetCurrentPosition(chip::EndpointId endpoint, uint8_t currentPosition)
 {
-    return emberAfWriteServerAttribute(endpoint, Switch::Id, Ids::CurrentPosition, (uint8_t *) &currentPosition,
+    return emberAfWriteServerAttribute(endpoint, Switch::Id, CurrentPosition::Id, (uint8_t *) &currentPosition,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMultiPressMax(chip::EndpointId endpoint, uint8_t * multiPressMax)
 {
-    return emberAfReadServerAttribute(endpoint, Switch::Id, Ids::MultiPressMax, (uint8_t *) multiPressMax, sizeof(*multiPressMax));
+    return emberAfReadServerAttribute(endpoint, Switch::Id, MultiPressMax::Id, (uint8_t *) multiPressMax, sizeof(*multiPressMax));
 }
 EmberAfStatus SetMultiPressMax(chip::EndpointId endpoint, uint8_t multiPressMax)
 {
-    return emberAfWriteServerAttribute(endpoint, Switch::Id, Ids::MultiPressMax, (uint8_t *) &multiPressMax,
+    return emberAfWriteServerAttribute(endpoint, Switch::Id, MultiPressMax::Id, (uint8_t *) &multiPressMax,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -2549,22 +2542,22 @@ namespace OperationalCredentials {
 namespace Attributes {
 EmberAfStatus GetSupportedFabrics(chip::EndpointId endpoint, uint8_t * supportedFabrics)
 {
-    return emberAfReadServerAttribute(endpoint, OperationalCredentials::Id, Ids::SupportedFabrics, (uint8_t *) supportedFabrics,
+    return emberAfReadServerAttribute(endpoint, OperationalCredentials::Id, SupportedFabrics::Id, (uint8_t *) supportedFabrics,
                                       sizeof(*supportedFabrics));
 }
 EmberAfStatus SetSupportedFabrics(chip::EndpointId endpoint, uint8_t supportedFabrics)
 {
-    return emberAfWriteServerAttribute(endpoint, OperationalCredentials::Id, Ids::SupportedFabrics, (uint8_t *) &supportedFabrics,
+    return emberAfWriteServerAttribute(endpoint, OperationalCredentials::Id, SupportedFabrics::Id, (uint8_t *) &supportedFabrics,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCommissionedFabrics(chip::EndpointId endpoint, uint8_t * commissionedFabrics)
 {
-    return emberAfReadServerAttribute(endpoint, OperationalCredentials::Id, Ids::CommissionedFabrics,
+    return emberAfReadServerAttribute(endpoint, OperationalCredentials::Id, CommissionedFabrics::Id,
                                       (uint8_t *) commissionedFabrics, sizeof(*commissionedFabrics));
 }
 EmberAfStatus SetCommissionedFabrics(chip::EndpointId endpoint, uint8_t commissionedFabrics)
 {
-    return emberAfWriteServerAttribute(endpoint, OperationalCredentials::Id, Ids::CommissionedFabrics,
+    return emberAfWriteServerAttribute(endpoint, OperationalCredentials::Id, CommissionedFabrics::Id,
                                        (uint8_t *) &commissionedFabrics, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -2579,50 +2572,50 @@ namespace ShadeConfiguration {
 namespace Attributes {
 EmberAfStatus GetPhysicalClosedLimit(chip::EndpointId endpoint, uint16_t * physicalClosedLimit)
 {
-    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Ids::PhysicalClosedLimit, (uint8_t *) physicalClosedLimit,
+    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, PhysicalClosedLimit::Id, (uint8_t *) physicalClosedLimit,
                                       sizeof(*physicalClosedLimit));
 }
 EmberAfStatus SetPhysicalClosedLimit(chip::EndpointId endpoint, uint16_t physicalClosedLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Ids::PhysicalClosedLimit, (uint8_t *) &physicalClosedLimit,
+    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, PhysicalClosedLimit::Id, (uint8_t *) &physicalClosedLimit,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMotorStepSize(chip::EndpointId endpoint, uint8_t * motorStepSize)
 {
-    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Ids::MotorStepSize, (uint8_t *) motorStepSize,
+    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, MotorStepSize::Id, (uint8_t *) motorStepSize,
                                       sizeof(*motorStepSize));
 }
 EmberAfStatus SetMotorStepSize(chip::EndpointId endpoint, uint8_t motorStepSize)
 {
-    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Ids::MotorStepSize, (uint8_t *) &motorStepSize,
+    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, MotorStepSize::Id, (uint8_t *) &motorStepSize,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStatus(chip::EndpointId endpoint, uint8_t * status)
 {
-    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Ids::Status, (uint8_t *) status, sizeof(*status));
+    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Status::Id, (uint8_t *) status, sizeof(*status));
 }
 EmberAfStatus SetStatus(chip::EndpointId endpoint, uint8_t status)
 {
-    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Ids::Status, (uint8_t *) &status,
+    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Status::Id, (uint8_t *) &status,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetClosedLimit(chip::EndpointId endpoint, uint16_t * closedLimit)
 {
-    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Ids::ClosedLimit, (uint8_t *) closedLimit,
+    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, ClosedLimit::Id, (uint8_t *) closedLimit,
                                       sizeof(*closedLimit));
 }
 EmberAfStatus SetClosedLimit(chip::EndpointId endpoint, uint16_t closedLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Ids::ClosedLimit, (uint8_t *) &closedLimit,
+    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, ClosedLimit::Id, (uint8_t *) &closedLimit,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMode(chip::EndpointId endpoint, uint8_t * mode)
 {
-    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Ids::Mode, (uint8_t *) mode, sizeof(*mode));
+    return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Mode::Id, (uint8_t *) mode, sizeof(*mode));
 }
 EmberAfStatus SetMode(chip::EndpointId endpoint, uint8_t mode)
 {
-    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Ids::Mode, (uint8_t *) &mode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Mode::Id, (uint8_t *) &mode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace ShadeConfiguration
@@ -2631,411 +2624,407 @@ namespace DoorLock {
 namespace Attributes {
 EmberAfStatus GetLockState(chip::EndpointId endpoint, uint8_t * lockState)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::LockState, (uint8_t *) lockState, sizeof(*lockState));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, LockState::Id, (uint8_t *) lockState, sizeof(*lockState));
 }
 EmberAfStatus SetLockState(chip::EndpointId endpoint, uint8_t lockState)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::LockState, (uint8_t *) &lockState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, LockState::Id, (uint8_t *) &lockState, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLockType(chip::EndpointId endpoint, uint8_t * lockType)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::LockType, (uint8_t *) lockType, sizeof(*lockType));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, LockType::Id, (uint8_t *) lockType, sizeof(*lockType));
 }
 EmberAfStatus SetLockType(chip::EndpointId endpoint, uint8_t lockType)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::LockType, (uint8_t *) &lockType, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, LockType::Id, (uint8_t *) &lockType, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, bool * actuatorEnabled)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::ActuatorEnabled, (uint8_t *) actuatorEnabled,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, ActuatorEnabled::Id, (uint8_t *) actuatorEnabled,
                                       sizeof(*actuatorEnabled));
 }
 EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, bool actuatorEnabled)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::ActuatorEnabled, (uint8_t *) &actuatorEnabled,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, ActuatorEnabled::Id, (uint8_t *) &actuatorEnabled,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDoorState(chip::EndpointId endpoint, uint8_t * doorState)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::DoorState, (uint8_t *) doorState, sizeof(*doorState));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, DoorState::Id, (uint8_t *) doorState, sizeof(*doorState));
 }
 EmberAfStatus SetDoorState(chip::EndpointId endpoint, uint8_t doorState)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::DoorState, (uint8_t *) &doorState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DoorState::Id, (uint8_t *) &doorState, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDoorOpenEvents(chip::EndpointId endpoint, uint32_t * doorOpenEvents)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::DoorOpenEvents, (uint8_t *) doorOpenEvents,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, DoorOpenEvents::Id, (uint8_t *) doorOpenEvents,
                                       sizeof(*doorOpenEvents));
 }
 EmberAfStatus SetDoorOpenEvents(chip::EndpointId endpoint, uint32_t doorOpenEvents)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::DoorOpenEvents, (uint8_t *) &doorOpenEvents,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DoorOpenEvents::Id, (uint8_t *) &doorOpenEvents,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDoorClosedEvents(chip::EndpointId endpoint, uint32_t * doorClosedEvents)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::DoorClosedEvents, (uint8_t *) doorClosedEvents,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, DoorClosedEvents::Id, (uint8_t *) doorClosedEvents,
                                       sizeof(*doorClosedEvents));
 }
 EmberAfStatus SetDoorClosedEvents(chip::EndpointId endpoint, uint32_t doorClosedEvents)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::DoorClosedEvents, (uint8_t *) &doorClosedEvents,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DoorClosedEvents::Id, (uint8_t *) &doorClosedEvents,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOpenPeriod(chip::EndpointId endpoint, uint16_t * openPeriod)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::OpenPeriod, (uint8_t *) openPeriod, sizeof(*openPeriod));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, OpenPeriod::Id, (uint8_t *) openPeriod, sizeof(*openPeriod));
 }
 EmberAfStatus SetOpenPeriod(chip::EndpointId endpoint, uint16_t openPeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::OpenPeriod, (uint8_t *) &openPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, OpenPeriod::Id, (uint8_t *) &openPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumLockRecordsSupported(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumLockRecordsSupported, (uint8_t *) numLockRecordsSupported,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumLockRecordsSupported::Id, (uint8_t *) numLockRecordsSupported,
                                       sizeof(*numLockRecordsSupported));
 }
 EmberAfStatus SetNumLockRecordsSupported(chip::EndpointId endpoint, uint16_t numLockRecordsSupported)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumLockRecordsSupported, (uint8_t *) &numLockRecordsSupported,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumLockRecordsSupported::Id, (uint8_t *) &numLockRecordsSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumTotalUsersSupported(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumTotalUsersSupported, (uint8_t *) numTotalUsersSupported,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumTotalUsersSupported::Id, (uint8_t *) numTotalUsersSupported,
                                       sizeof(*numTotalUsersSupported));
 }
 EmberAfStatus SetNumTotalUsersSupported(chip::EndpointId endpoint, uint16_t numTotalUsersSupported)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumTotalUsersSupported, (uint8_t *) &numTotalUsersSupported,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumTotalUsersSupported::Id, (uint8_t *) &numTotalUsersSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumPinUsersSupported(chip::EndpointId endpoint, uint16_t * numPinUsersSupported)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumPinUsersSupported, (uint8_t *) numPinUsersSupported,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumPinUsersSupported::Id, (uint8_t *) numPinUsersSupported,
                                       sizeof(*numPinUsersSupported));
 }
 EmberAfStatus SetNumPinUsersSupported(chip::EndpointId endpoint, uint16_t numPinUsersSupported)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumPinUsersSupported, (uint8_t *) &numPinUsersSupported,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumPinUsersSupported::Id, (uint8_t *) &numPinUsersSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumRfidUsersSupported(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumRfidUsersSupported, (uint8_t *) numRfidUsersSupported,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumRfidUsersSupported::Id, (uint8_t *) numRfidUsersSupported,
                                       sizeof(*numRfidUsersSupported));
 }
 EmberAfStatus SetNumRfidUsersSupported(chip::EndpointId endpoint, uint16_t numRfidUsersSupported)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumRfidUsersSupported, (uint8_t *) &numRfidUsersSupported,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumRfidUsersSupported::Id, (uint8_t *) &numRfidUsersSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumWeekdaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t * numWeekdaySchedulesSupportedPerUser)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumWeekdaySchedulesSupportedPerUser,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumWeekdaySchedulesSupportedPerUser::Id,
                                       (uint8_t *) numWeekdaySchedulesSupportedPerUser,
                                       sizeof(*numWeekdaySchedulesSupportedPerUser));
 }
 EmberAfStatus SetNumWeekdaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumWeekdaySchedulesSupportedPerUser,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumWeekdaySchedulesSupportedPerUser::Id,
                                        (uint8_t *) &numWeekdaySchedulesSupportedPerUser, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumYeardaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t * numYeardaySchedulesSupportedPerUser)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumYeardaySchedulesSupportedPerUser,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumYeardaySchedulesSupportedPerUser::Id,
                                       (uint8_t *) numYeardaySchedulesSupportedPerUser,
                                       sizeof(*numYeardaySchedulesSupportedPerUser));
 }
 EmberAfStatus SetNumYeardaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumYeardaySchedulesSupportedPerUser,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumYeardaySchedulesSupportedPerUser::Id,
                                        (uint8_t *) &numYeardaySchedulesSupportedPerUser, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumHolidaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t * numHolidaySchedulesSupportedPerUser)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::NumHolidaySchedulesSupportedPerUser,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumHolidaySchedulesSupportedPerUser::Id,
                                       (uint8_t *) numHolidaySchedulesSupportedPerUser,
                                       sizeof(*numHolidaySchedulesSupportedPerUser));
 }
 EmberAfStatus SetNumHolidaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::NumHolidaySchedulesSupportedPerUser,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumHolidaySchedulesSupportedPerUser::Id,
                                        (uint8_t *) &numHolidaySchedulesSupportedPerUser, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxPinLength(chip::EndpointId endpoint, uint8_t * maxPinLength)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::MaxPinLength, (uint8_t *) maxPinLength, sizeof(*maxPinLength));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, MaxPinLength::Id, (uint8_t *) maxPinLength, sizeof(*maxPinLength));
 }
 EmberAfStatus SetMaxPinLength(chip::EndpointId endpoint, uint8_t maxPinLength)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::MaxPinLength, (uint8_t *) &maxPinLength,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MaxPinLength::Id, (uint8_t *) &maxPinLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinPinLength(chip::EndpointId endpoint, uint8_t * minPinLength)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::MinPinLength, (uint8_t *) minPinLength, sizeof(*minPinLength));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, MinPinLength::Id, (uint8_t *) minPinLength, sizeof(*minPinLength));
 }
 EmberAfStatus SetMinPinLength(chip::EndpointId endpoint, uint8_t minPinLength)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::MinPinLength, (uint8_t *) &minPinLength,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MinPinLength::Id, (uint8_t *) &minPinLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::MaxRfidCodeLength, (uint8_t *) maxRfidCodeLength,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, MaxRfidCodeLength::Id, (uint8_t *) maxRfidCodeLength,
                                       sizeof(*maxRfidCodeLength));
 }
 EmberAfStatus SetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t maxRfidCodeLength)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::MaxRfidCodeLength, (uint8_t *) &maxRfidCodeLength,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MaxRfidCodeLength::Id, (uint8_t *) &maxRfidCodeLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t * minRfidCodeLength)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::MinRfidCodeLength, (uint8_t *) minRfidCodeLength,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, MinRfidCodeLength::Id, (uint8_t *) minRfidCodeLength,
                                       sizeof(*minRfidCodeLength));
 }
 EmberAfStatus SetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t minRfidCodeLength)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::MinRfidCodeLength, (uint8_t *) &minRfidCodeLength,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MinRfidCodeLength::Id, (uint8_t *) &minRfidCodeLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, bool * enableLogging)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableLogging, (uint8_t *) enableLogging,
-                                      sizeof(*enableLogging));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableLogging::Id, (uint8_t *) enableLogging, sizeof(*enableLogging));
 }
 EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, bool enableLogging)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableLogging, (uint8_t *) &enableLogging,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableLogging::Id, (uint8_t *) &enableLogging,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLedSettings(chip::EndpointId endpoint, uint8_t * ledSettings)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::LedSettings, (uint8_t *) ledSettings, sizeof(*ledSettings));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, LedSettings::Id, (uint8_t *) ledSettings, sizeof(*ledSettings));
 }
 EmberAfStatus SetLedSettings(chip::EndpointId endpoint, uint8_t ledSettings)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::LedSettings, (uint8_t *) &ledSettings,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, LedSettings::Id, (uint8_t *) &ledSettings, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAutoRelockTime(chip::EndpointId endpoint, uint32_t * autoRelockTime)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::AutoRelockTime, (uint8_t *) autoRelockTime,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, AutoRelockTime::Id, (uint8_t *) autoRelockTime,
                                       sizeof(*autoRelockTime));
 }
 EmberAfStatus SetAutoRelockTime(chip::EndpointId endpoint, uint32_t autoRelockTime)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::AutoRelockTime, (uint8_t *) &autoRelockTime,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, AutoRelockTime::Id, (uint8_t *) &autoRelockTime,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSoundVolume(chip::EndpointId endpoint, uint8_t * soundVolume)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::SoundVolume, (uint8_t *) soundVolume, sizeof(*soundVolume));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, SoundVolume::Id, (uint8_t *) soundVolume, sizeof(*soundVolume));
 }
 EmberAfStatus SetSoundVolume(chip::EndpointId endpoint, uint8_t soundVolume)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::SoundVolume, (uint8_t *) &soundVolume,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, SoundVolume::Id, (uint8_t *) &soundVolume, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOperatingMode(chip::EndpointId endpoint, uint8_t * operatingMode)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::OperatingMode, (uint8_t *) operatingMode,
-                                      sizeof(*operatingMode));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, OperatingMode::Id, (uint8_t *) operatingMode, sizeof(*operatingMode));
 }
 EmberAfStatus SetOperatingMode(chip::EndpointId endpoint, uint8_t operatingMode)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::OperatingMode, (uint8_t *) &operatingMode,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, OperatingMode::Id, (uint8_t *) &operatingMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t * supportedOperatingModes)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::SupportedOperatingModes, (uint8_t *) supportedOperatingModes,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, SupportedOperatingModes::Id, (uint8_t *) supportedOperatingModes,
                                       sizeof(*supportedOperatingModes));
 }
 EmberAfStatus SetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t supportedOperatingModes)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::SupportedOperatingModes, (uint8_t *) &supportedOperatingModes,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, SupportedOperatingModes::Id, (uint8_t *) &supportedOperatingModes,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::DefaultConfigurationRegister,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, DefaultConfigurationRegister::Id,
                                       (uint8_t *) defaultConfigurationRegister, sizeof(*defaultConfigurationRegister));
 }
 EmberAfStatus SetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::DefaultConfigurationRegister,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DefaultConfigurationRegister::Id,
                                        (uint8_t *) &defaultConfigurationRegister, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, bool * enableLocalProgramming)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableLocalProgramming, (uint8_t *) enableLocalProgramming,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableLocalProgramming::Id, (uint8_t *) enableLocalProgramming,
                                       sizeof(*enableLocalProgramming));
 }
 EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, bool enableLocalProgramming)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableLocalProgramming, (uint8_t *) &enableLocalProgramming,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableLocalProgramming::Id, (uint8_t *) &enableLocalProgramming,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, bool * enableOneTouchLocking)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableOneTouchLocking, (uint8_t *) enableOneTouchLocking,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableOneTouchLocking::Id, (uint8_t *) enableOneTouchLocking,
                                       sizeof(*enableOneTouchLocking));
 }
 EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, bool enableOneTouchLocking)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableOneTouchLocking, (uint8_t *) &enableOneTouchLocking,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableOneTouchLocking::Id, (uint8_t *) &enableOneTouchLocking,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, bool * enableInsideStatusLed)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableInsideStatusLed, (uint8_t *) enableInsideStatusLed,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableInsideStatusLed::Id, (uint8_t *) enableInsideStatusLed,
                                       sizeof(*enableInsideStatusLed));
 }
 EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, bool enableInsideStatusLed)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableInsideStatusLed, (uint8_t *) &enableInsideStatusLed,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableInsideStatusLed::Id, (uint8_t *) &enableInsideStatusLed,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, bool * enablePrivacyModeButton)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnablePrivacyModeButton, (uint8_t *) enablePrivacyModeButton,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnablePrivacyModeButton::Id, (uint8_t *) enablePrivacyModeButton,
                                       sizeof(*enablePrivacyModeButton));
 }
 EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, bool enablePrivacyModeButton)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnablePrivacyModeButton, (uint8_t *) &enablePrivacyModeButton,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnablePrivacyModeButton::Id, (uint8_t *) &enablePrivacyModeButton,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::WrongCodeEntryLimit, (uint8_t *) wrongCodeEntryLimit,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, WrongCodeEntryLimit::Id, (uint8_t *) wrongCodeEntryLimit,
                                       sizeof(*wrongCodeEntryLimit));
 }
 EmberAfStatus SetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::WrongCodeEntryLimit, (uint8_t *) &wrongCodeEntryLimit,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, WrongCodeEntryLimit::Id, (uint8_t *) &wrongCodeEntryLimit,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::UserCodeTemporaryDisableTime,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, UserCodeTemporaryDisableTime::Id,
                                       (uint8_t *) userCodeTemporaryDisableTime, sizeof(*userCodeTemporaryDisableTime));
 }
 EmberAfStatus SetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::UserCodeTemporaryDisableTime,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, UserCodeTemporaryDisableTime::Id,
                                        (uint8_t *) &userCodeTemporaryDisableTime, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, bool * sendPinOverTheAir)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::SendPinOverTheAir, (uint8_t *) sendPinOverTheAir,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, SendPinOverTheAir::Id, (uint8_t *) sendPinOverTheAir,
                                       sizeof(*sendPinOverTheAir));
 }
 EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, bool sendPinOverTheAir)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::SendPinOverTheAir, (uint8_t *) &sendPinOverTheAir,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, SendPinOverTheAir::Id, (uint8_t *) &sendPinOverTheAir,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, bool * requirePinForRfOperation)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::RequirePinForRfOperation, (uint8_t *) requirePinForRfOperation,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, RequirePinForRfOperation::Id, (uint8_t *) requirePinForRfOperation,
                                       sizeof(*requirePinForRfOperation));
 }
 EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, bool requirePinForRfOperation)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::RequirePinForRfOperation, (uint8_t *) &requirePinForRfOperation,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RequirePinForRfOperation::Id, (uint8_t *) &requirePinForRfOperation,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::ZigbeeSecurityLevel, (uint8_t *) zigbeeSecurityLevel,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, ZigbeeSecurityLevel::Id, (uint8_t *) zigbeeSecurityLevel,
                                       sizeof(*zigbeeSecurityLevel));
 }
 EmberAfStatus SetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::ZigbeeSecurityLevel, (uint8_t *) &zigbeeSecurityLevel,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, ZigbeeSecurityLevel::Id, (uint8_t *) &zigbeeSecurityLevel,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::AlarmMask, (uint8_t *) alarmMask, sizeof(*alarmMask));
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, AlarmMask::Id, (uint8_t *) alarmMask, sizeof(*alarmMask));
 }
 EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint16_t alarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::AlarmMask, (uint8_t *) &alarmMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, AlarmMask::Id, (uint8_t *) &alarmMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetKeypadOperationEventMask(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::KeypadOperationEventMask, (uint8_t *) keypadOperationEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, KeypadOperationEventMask::Id, (uint8_t *) keypadOperationEventMask,
                                       sizeof(*keypadOperationEventMask));
 }
 EmberAfStatus SetKeypadOperationEventMask(chip::EndpointId endpoint, uint16_t keypadOperationEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::KeypadOperationEventMask, (uint8_t *) &keypadOperationEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, KeypadOperationEventMask::Id, (uint8_t *) &keypadOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRfOperationEventMask(chip::EndpointId endpoint, uint16_t * rfOperationEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::RfOperationEventMask, (uint8_t *) rfOperationEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfOperationEventMask::Id, (uint8_t *) rfOperationEventMask,
                                       sizeof(*rfOperationEventMask));
 }
 EmberAfStatus SetRfOperationEventMask(chip::EndpointId endpoint, uint16_t rfOperationEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::RfOperationEventMask, (uint8_t *) &rfOperationEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfOperationEventMask::Id, (uint8_t *) &rfOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetManualOperationEventMask(chip::EndpointId endpoint, uint16_t * manualOperationEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::ManualOperationEventMask, (uint8_t *) manualOperationEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, ManualOperationEventMask::Id, (uint8_t *) manualOperationEventMask,
                                       sizeof(*manualOperationEventMask));
 }
 EmberAfStatus SetManualOperationEventMask(chip::EndpointId endpoint, uint16_t manualOperationEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::ManualOperationEventMask, (uint8_t *) &manualOperationEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, ManualOperationEventMask::Id, (uint8_t *) &manualOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRfidOperationEventMask(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::RfidOperationEventMask, (uint8_t *) rfidOperationEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfidOperationEventMask::Id, (uint8_t *) rfidOperationEventMask,
                                       sizeof(*rfidOperationEventMask));
 }
 EmberAfStatus SetRfidOperationEventMask(chip::EndpointId endpoint, uint16_t rfidOperationEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::RfidOperationEventMask, (uint8_t *) &rfidOperationEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfidOperationEventMask::Id, (uint8_t *) &rfidOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetKeypadProgrammingEventMask(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::KeypadProgrammingEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, KeypadProgrammingEventMask::Id,
                                       (uint8_t *) keypadProgrammingEventMask, sizeof(*keypadProgrammingEventMask));
 }
 EmberAfStatus SetKeypadProgrammingEventMask(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::KeypadProgrammingEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, KeypadProgrammingEventMask::Id,
                                        (uint8_t *) &keypadProgrammingEventMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRfProgrammingEventMask(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::RfProgrammingEventMask, (uint8_t *) rfProgrammingEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfProgrammingEventMask::Id, (uint8_t *) rfProgrammingEventMask,
                                       sizeof(*rfProgrammingEventMask));
 }
 EmberAfStatus SetRfProgrammingEventMask(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::RfProgrammingEventMask, (uint8_t *) &rfProgrammingEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfProgrammingEventMask::Id, (uint8_t *) &rfProgrammingEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRfidProgrammingEventMask(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask)
 {
-    return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::RfidProgrammingEventMask, (uint8_t *) rfidProgrammingEventMask,
+    return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfidProgrammingEventMask::Id, (uint8_t *) rfidProgrammingEventMask,
                                       sizeof(*rfidProgrammingEventMask));
 }
 EmberAfStatus SetRfidProgrammingEventMask(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask)
 {
-    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::RfidProgrammingEventMask, (uint8_t *) &rfidProgrammingEventMask,
+    return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfidProgrammingEventMask::Id, (uint8_t *) &rfidProgrammingEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -3045,248 +3034,248 @@ namespace WindowCovering {
 namespace Attributes {
 EmberAfStatus GetType(chip::EndpointId endpoint, uint8_t * type)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::Type, (uint8_t *) type, sizeof(*type));
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Type::Id, (uint8_t *) type, sizeof(*type));
 }
 EmberAfStatus SetType(chip::EndpointId endpoint, uint8_t type)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::Type, (uint8_t *) &type, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Type::Id, (uint8_t *) &type, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhysicalClosedLimitLift(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::PhysicalClosedLimitLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitLift::Id,
                                       (uint8_t *) physicalClosedLimitLift, sizeof(*physicalClosedLimitLift));
 }
 EmberAfStatus SetPhysicalClosedLimitLift(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::PhysicalClosedLimitLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitLift::Id,
                                        (uint8_t *) &physicalClosedLimitLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhysicalClosedLimitTilt(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::PhysicalClosedLimitTilt,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitTilt::Id,
                                       (uint8_t *) physicalClosedLimitTilt, sizeof(*physicalClosedLimitTilt));
 }
 EmberAfStatus SetPhysicalClosedLimitTilt(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::PhysicalClosedLimitTilt,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitTilt::Id,
                                        (uint8_t *) &physicalClosedLimitTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPositionLift(chip::EndpointId endpoint, uint16_t * currentPositionLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionLift, (uint8_t *) currentPositionLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLift::Id, (uint8_t *) currentPositionLift,
                                       sizeof(*currentPositionLift));
 }
 EmberAfStatus SetCurrentPositionLift(chip::EndpointId endpoint, uint16_t currentPositionLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionLift, (uint8_t *) &currentPositionLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLift::Id, (uint8_t *) &currentPositionLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPositionTilt(chip::EndpointId endpoint, uint16_t * currentPositionTilt)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionTilt, (uint8_t *) currentPositionTilt,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTilt::Id, (uint8_t *) currentPositionTilt,
                                       sizeof(*currentPositionTilt));
 }
 EmberAfStatus SetCurrentPositionTilt(chip::EndpointId endpoint, uint16_t currentPositionTilt)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionTilt, (uint8_t *) &currentPositionTilt,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTilt::Id, (uint8_t *) &currentPositionTilt,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumberOfActuationsLift(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::NumberOfActuationsLift, (uint8_t *) numberOfActuationsLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsLift::Id, (uint8_t *) numberOfActuationsLift,
                                       sizeof(*numberOfActuationsLift));
 }
 EmberAfStatus SetNumberOfActuationsLift(chip::EndpointId endpoint, uint16_t numberOfActuationsLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::NumberOfActuationsLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsLift::Id,
                                        (uint8_t *) &numberOfActuationsLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumberOfActuationsTilt(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::NumberOfActuationsTilt, (uint8_t *) numberOfActuationsTilt,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsTilt::Id, (uint8_t *) numberOfActuationsTilt,
                                       sizeof(*numberOfActuationsTilt));
 }
 EmberAfStatus SetNumberOfActuationsTilt(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::NumberOfActuationsTilt,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsTilt::Id,
                                        (uint8_t *) &numberOfActuationsTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetConfigStatus(chip::EndpointId endpoint, uint8_t * configStatus)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::ConfigStatus, (uint8_t *) configStatus,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, ConfigStatus::Id, (uint8_t *) configStatus,
                                       sizeof(*configStatus));
 }
 EmberAfStatus SetConfigStatus(chip::EndpointId endpoint, uint8_t configStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::ConfigStatus, (uint8_t *) &configStatus,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, ConfigStatus::Id, (uint8_t *) &configStatus,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPositionLiftPercentage(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionLiftPercentage,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercentage::Id,
                                       (uint8_t *) currentPositionLiftPercentage, sizeof(*currentPositionLiftPercentage));
 }
 EmberAfStatus SetCurrentPositionLiftPercentage(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionLiftPercentage,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercentage::Id,
                                        (uint8_t *) &currentPositionLiftPercentage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPositionTiltPercentage(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionTiltPercentage,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercentage::Id,
                                       (uint8_t *) currentPositionTiltPercentage, sizeof(*currentPositionTiltPercentage));
 }
 EmberAfStatus SetCurrentPositionTiltPercentage(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionTiltPercentage,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercentage::Id,
                                        (uint8_t *) &currentPositionTiltPercentage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOperationalStatus(chip::EndpointId endpoint, uint8_t * operationalStatus)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::OperationalStatus, (uint8_t *) operationalStatus,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, OperationalStatus::Id, (uint8_t *) operationalStatus,
                                       sizeof(*operationalStatus));
 }
 EmberAfStatus SetOperationalStatus(chip::EndpointId endpoint, uint8_t operationalStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::OperationalStatus, (uint8_t *) &operationalStatus,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, OperationalStatus::Id, (uint8_t *) &operationalStatus,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTargetPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::TargetPositionLiftPercent100ths,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, TargetPositionLiftPercent100ths::Id,
                                       (uint8_t *) targetPositionLiftPercent100ths, sizeof(*targetPositionLiftPercent100ths));
 }
 EmberAfStatus SetTargetPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::TargetPositionLiftPercent100ths,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, TargetPositionLiftPercent100ths::Id,
                                        (uint8_t *) &targetPositionLiftPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTargetPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::TargetPositionTiltPercent100ths,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, TargetPositionTiltPercent100ths::Id,
                                       (uint8_t *) targetPositionTiltPercent100ths, sizeof(*targetPositionTiltPercent100ths));
 }
 EmberAfStatus SetTargetPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::TargetPositionTiltPercent100ths,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, TargetPositionTiltPercent100ths::Id,
                                        (uint8_t *) &targetPositionTiltPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEndProductType(chip::EndpointId endpoint, uint8_t * endProductType)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::EndProductType, (uint8_t *) endProductType,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, EndProductType::Id, (uint8_t *) endProductType,
                                       sizeof(*endProductType));
 }
 EmberAfStatus SetEndProductType(chip::EndpointId endpoint, uint8_t endProductType)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::EndProductType, (uint8_t *) &endProductType,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, EndProductType::Id, (uint8_t *) &endProductType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionLiftPercent100ths,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercent100ths::Id,
                                       (uint8_t *) currentPositionLiftPercent100ths, sizeof(*currentPositionLiftPercent100ths));
 }
 EmberAfStatus SetCurrentPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionLiftPercent100ths,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercent100ths::Id,
                                        (uint8_t *) &currentPositionLiftPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionTiltPercent100ths,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercent100ths::Id,
                                       (uint8_t *) currentPositionTiltPercent100ths, sizeof(*currentPositionTiltPercent100ths));
 }
 EmberAfStatus SetCurrentPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::CurrentPositionTiltPercent100ths,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercent100ths::Id,
                                        (uint8_t *) &currentPositionTiltPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstalledOpenLimitLift(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledOpenLimitLift, (uint8_t *) installedOpenLimitLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitLift::Id, (uint8_t *) installedOpenLimitLift,
                                       sizeof(*installedOpenLimitLift));
 }
 EmberAfStatus SetInstalledOpenLimitLift(chip::EndpointId endpoint, uint16_t installedOpenLimitLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledOpenLimitLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitLift::Id,
                                        (uint8_t *) &installedOpenLimitLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstalledClosedLimitLift(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledClosedLimitLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitLift::Id,
                                       (uint8_t *) installedClosedLimitLift, sizeof(*installedClosedLimitLift));
 }
 EmberAfStatus SetInstalledClosedLimitLift(chip::EndpointId endpoint, uint16_t installedClosedLimitLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledClosedLimitLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitLift::Id,
                                        (uint8_t *) &installedClosedLimitLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstalledOpenLimitTilt(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledOpenLimitTilt, (uint8_t *) installedOpenLimitTilt,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitTilt::Id, (uint8_t *) installedOpenLimitTilt,
                                       sizeof(*installedOpenLimitTilt));
 }
 EmberAfStatus SetInstalledOpenLimitTilt(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledOpenLimitTilt,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitTilt::Id,
                                        (uint8_t *) &installedOpenLimitTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstalledClosedLimitTilt(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledClosedLimitTilt,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitTilt::Id,
                                       (uint8_t *) installedClosedLimitTilt, sizeof(*installedClosedLimitTilt));
 }
 EmberAfStatus SetInstalledClosedLimitTilt(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::InstalledClosedLimitTilt,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitTilt::Id,
                                        (uint8_t *) &installedClosedLimitTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetVelocityLift(chip::EndpointId endpoint, uint16_t * velocityLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::VelocityLift, (uint8_t *) velocityLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, VelocityLift::Id, (uint8_t *) velocityLift,
                                       sizeof(*velocityLift));
 }
 EmberAfStatus SetVelocityLift(chip::EndpointId endpoint, uint16_t velocityLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::VelocityLift, (uint8_t *) &velocityLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, VelocityLift::Id, (uint8_t *) &velocityLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAccelerationTimeLift(chip::EndpointId endpoint, uint16_t * accelerationTimeLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::AccelerationTimeLift, (uint8_t *) accelerationTimeLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, AccelerationTimeLift::Id, (uint8_t *) accelerationTimeLift,
                                       sizeof(*accelerationTimeLift));
 }
 EmberAfStatus SetAccelerationTimeLift(chip::EndpointId endpoint, uint16_t accelerationTimeLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::AccelerationTimeLift, (uint8_t *) &accelerationTimeLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, AccelerationTimeLift::Id, (uint8_t *) &accelerationTimeLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDecelerationTimeLift(chip::EndpointId endpoint, uint16_t * decelerationTimeLift)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::DecelerationTimeLift, (uint8_t *) decelerationTimeLift,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, DecelerationTimeLift::Id, (uint8_t *) decelerationTimeLift,
                                       sizeof(*decelerationTimeLift));
 }
 EmberAfStatus SetDecelerationTimeLift(chip::EndpointId endpoint, uint16_t decelerationTimeLift)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::DecelerationTimeLift, (uint8_t *) &decelerationTimeLift,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, DecelerationTimeLift::Id, (uint8_t *) &decelerationTimeLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMode(chip::EndpointId endpoint, uint8_t * mode)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::Mode, (uint8_t *) mode, sizeof(*mode));
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Mode::Id, (uint8_t *) mode, sizeof(*mode));
 }
 EmberAfStatus SetMode(chip::EndpointId endpoint, uint8_t mode)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::Mode, (uint8_t *) &mode, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Mode::Id, (uint8_t *) &mode, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSafetyStatus(chip::EndpointId endpoint, uint16_t * safetyStatus)
 {
-    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Ids::SafetyStatus, (uint8_t *) safetyStatus,
+    return emberAfReadServerAttribute(endpoint, WindowCovering::Id, SafetyStatus::Id, (uint8_t *) safetyStatus,
                                       sizeof(*safetyStatus));
 }
 EmberAfStatus SetSafetyStatus(chip::EndpointId endpoint, uint16_t safetyStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Ids::SafetyStatus, (uint8_t *) &safetyStatus,
+    return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, SafetyStatus::Id, (uint8_t *) &safetyStatus,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -3296,102 +3285,102 @@ namespace BarrierControl {
 namespace Attributes {
 EmberAfStatus GetBarrierMovingState(chip::EndpointId endpoint, uint8_t * barrierMovingState)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierMovingState, (uint8_t *) barrierMovingState,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierMovingState::Id, (uint8_t *) barrierMovingState,
                                       sizeof(*barrierMovingState));
 }
 EmberAfStatus SetBarrierMovingState(chip::EndpointId endpoint, uint8_t barrierMovingState)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierMovingState, (uint8_t *) &barrierMovingState,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierMovingState::Id, (uint8_t *) &barrierMovingState,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierSafetyStatus(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierSafetyStatus, (uint8_t *) barrierSafetyStatus,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierSafetyStatus::Id, (uint8_t *) barrierSafetyStatus,
                                       sizeof(*barrierSafetyStatus));
 }
 EmberAfStatus SetBarrierSafetyStatus(chip::EndpointId endpoint, uint16_t barrierSafetyStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierSafetyStatus, (uint8_t *) &barrierSafetyStatus,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierSafetyStatus::Id, (uint8_t *) &barrierSafetyStatus,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierCapabilities(chip::EndpointId endpoint, uint8_t * barrierCapabilities)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCapabilities, (uint8_t *) barrierCapabilities,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCapabilities::Id, (uint8_t *) barrierCapabilities,
                                       sizeof(*barrierCapabilities));
 }
 EmberAfStatus SetBarrierCapabilities(chip::EndpointId endpoint, uint8_t barrierCapabilities)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCapabilities, (uint8_t *) &barrierCapabilities,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCapabilities::Id, (uint8_t *) &barrierCapabilities,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierOpenEvents(chip::EndpointId endpoint, uint16_t * barrierOpenEvents)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierOpenEvents, (uint8_t *) barrierOpenEvents,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierOpenEvents::Id, (uint8_t *) barrierOpenEvents,
                                       sizeof(*barrierOpenEvents));
 }
 EmberAfStatus SetBarrierOpenEvents(chip::EndpointId endpoint, uint16_t barrierOpenEvents)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierOpenEvents, (uint8_t *) &barrierOpenEvents,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierOpenEvents::Id, (uint8_t *) &barrierOpenEvents,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierCloseEvents(chip::EndpointId endpoint, uint16_t * barrierCloseEvents)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCloseEvents, (uint8_t *) barrierCloseEvents,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCloseEvents::Id, (uint8_t *) barrierCloseEvents,
                                       sizeof(*barrierCloseEvents));
 }
 EmberAfStatus SetBarrierCloseEvents(chip::EndpointId endpoint, uint16_t barrierCloseEvents)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCloseEvents, (uint8_t *) &barrierCloseEvents,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCloseEvents::Id, (uint8_t *) &barrierCloseEvents,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierCommandOpenEvents(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCommandOpenEvents,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCommandOpenEvents::Id,
                                       (uint8_t *) barrierCommandOpenEvents, sizeof(*barrierCommandOpenEvents));
 }
 EmberAfStatus SetBarrierCommandOpenEvents(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCommandOpenEvents,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCommandOpenEvents::Id,
                                        (uint8_t *) &barrierCommandOpenEvents, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierCommandCloseEvents(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCommandCloseEvents,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCommandCloseEvents::Id,
                                       (uint8_t *) barrierCommandCloseEvents, sizeof(*barrierCommandCloseEvents));
 }
 EmberAfStatus SetBarrierCommandCloseEvents(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierCommandCloseEvents,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCommandCloseEvents::Id,
                                        (uint8_t *) &barrierCommandCloseEvents, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierOpenPeriod(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierOpenPeriod, (uint8_t *) barrierOpenPeriod,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierOpenPeriod::Id, (uint8_t *) barrierOpenPeriod,
                                       sizeof(*barrierOpenPeriod));
 }
 EmberAfStatus SetBarrierOpenPeriod(chip::EndpointId endpoint, uint16_t barrierOpenPeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierOpenPeriod, (uint8_t *) &barrierOpenPeriod,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierOpenPeriod::Id, (uint8_t *) &barrierOpenPeriod,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierClosePeriod(chip::EndpointId endpoint, uint16_t * barrierClosePeriod)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierClosePeriod, (uint8_t *) barrierClosePeriod,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierClosePeriod::Id, (uint8_t *) barrierClosePeriod,
                                       sizeof(*barrierClosePeriod));
 }
 EmberAfStatus SetBarrierClosePeriod(chip::EndpointId endpoint, uint16_t barrierClosePeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierClosePeriod, (uint8_t *) &barrierClosePeriod,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierClosePeriod::Id, (uint8_t *) &barrierClosePeriod,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBarrierPosition(chip::EndpointId endpoint, uint8_t * barrierPosition)
 {
-    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierPosition, (uint8_t *) barrierPosition,
+    return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierPosition::Id, (uint8_t *) barrierPosition,
                                       sizeof(*barrierPosition));
 }
 EmberAfStatus SetBarrierPosition(chip::EndpointId endpoint, uint8_t barrierPosition)
 {
-    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, Ids::BarrierPosition, (uint8_t *) &barrierPosition,
+    return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierPosition::Id, (uint8_t *) &barrierPosition,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -3401,221 +3390,221 @@ namespace PumpConfigurationAndControl {
 namespace Attributes {
 EmberAfStatus GetMaxPressure(chip::EndpointId endpoint, int16_t * maxPressure)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxPressure, (uint8_t *) maxPressure,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxPressure::Id, (uint8_t *) maxPressure,
                                       sizeof(*maxPressure));
 }
 EmberAfStatus SetMaxPressure(chip::EndpointId endpoint, int16_t maxPressure)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxPressure, (uint8_t *) &maxPressure,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxPressure::Id, (uint8_t *) &maxPressure,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxSpeed(chip::EndpointId endpoint, uint16_t * maxSpeed)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxSpeed, (uint8_t *) maxSpeed,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxSpeed::Id, (uint8_t *) maxSpeed,
                                       sizeof(*maxSpeed));
 }
 EmberAfStatus SetMaxSpeed(chip::EndpointId endpoint, uint16_t maxSpeed)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxSpeed, (uint8_t *) &maxSpeed,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxSpeed::Id, (uint8_t *) &maxSpeed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxFlow(chip::EndpointId endpoint, uint16_t * maxFlow)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxFlow, (uint8_t *) maxFlow,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxFlow::Id, (uint8_t *) maxFlow,
                                       sizeof(*maxFlow));
 }
 EmberAfStatus SetMaxFlow(chip::EndpointId endpoint, uint16_t maxFlow)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxFlow, (uint8_t *) &maxFlow,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxFlow::Id, (uint8_t *) &maxFlow,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinConstPressure(chip::EndpointId endpoint, int16_t * minConstPressure)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstPressure,
-                                      (uint8_t *) minConstPressure, sizeof(*minConstPressure));
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstPressure::Id, (uint8_t *) minConstPressure,
+                                      sizeof(*minConstPressure));
 }
 EmberAfStatus SetMinConstPressure(chip::EndpointId endpoint, int16_t minConstPressure)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstPressure,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstPressure::Id,
                                        (uint8_t *) &minConstPressure, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxConstPressure(chip::EndpointId endpoint, int16_t * maxConstPressure)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstPressure,
-                                      (uint8_t *) maxConstPressure, sizeof(*maxConstPressure));
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstPressure::Id, (uint8_t *) maxConstPressure,
+                                      sizeof(*maxConstPressure));
 }
 EmberAfStatus SetMaxConstPressure(chip::EndpointId endpoint, int16_t maxConstPressure)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstPressure,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstPressure::Id,
                                        (uint8_t *) &maxConstPressure, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinCompPressure(chip::EndpointId endpoint, int16_t * minCompPressure)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinCompPressure, (uint8_t *) minCompPressure,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinCompPressure::Id, (uint8_t *) minCompPressure,
                                       sizeof(*minCompPressure));
 }
 EmberAfStatus SetMinCompPressure(chip::EndpointId endpoint, int16_t minCompPressure)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinCompPressure,
-                                       (uint8_t *) &minCompPressure, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinCompPressure::Id, (uint8_t *) &minCompPressure,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxCompPressure(chip::EndpointId endpoint, int16_t * maxCompPressure)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxCompPressure, (uint8_t *) maxCompPressure,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxCompPressure::Id, (uint8_t *) maxCompPressure,
                                       sizeof(*maxCompPressure));
 }
 EmberAfStatus SetMaxCompPressure(chip::EndpointId endpoint, int16_t maxCompPressure)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxCompPressure,
-                                       (uint8_t *) &maxCompPressure, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxCompPressure::Id, (uint8_t *) &maxCompPressure,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinConstSpeed(chip::EndpointId endpoint, uint16_t * minConstSpeed)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstSpeed, (uint8_t *) minConstSpeed,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstSpeed::Id, (uint8_t *) minConstSpeed,
                                       sizeof(*minConstSpeed));
 }
 EmberAfStatus SetMinConstSpeed(chip::EndpointId endpoint, uint16_t minConstSpeed)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstSpeed, (uint8_t *) &minConstSpeed,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstSpeed::Id, (uint8_t *) &minConstSpeed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxConstSpeed(chip::EndpointId endpoint, uint16_t * maxConstSpeed)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstSpeed, (uint8_t *) maxConstSpeed,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstSpeed::Id, (uint8_t *) maxConstSpeed,
                                       sizeof(*maxConstSpeed));
 }
 EmberAfStatus SetMaxConstSpeed(chip::EndpointId endpoint, uint16_t maxConstSpeed)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstSpeed, (uint8_t *) &maxConstSpeed,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstSpeed::Id, (uint8_t *) &maxConstSpeed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinConstFlow(chip::EndpointId endpoint, uint16_t * minConstFlow)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstFlow, (uint8_t *) minConstFlow,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstFlow::Id, (uint8_t *) minConstFlow,
                                       sizeof(*minConstFlow));
 }
 EmberAfStatus SetMinConstFlow(chip::EndpointId endpoint, uint16_t minConstFlow)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstFlow, (uint8_t *) &minConstFlow,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstFlow::Id, (uint8_t *) &minConstFlow,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxConstFlow(chip::EndpointId endpoint, uint16_t * maxConstFlow)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstFlow, (uint8_t *) maxConstFlow,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstFlow::Id, (uint8_t *) maxConstFlow,
                                       sizeof(*maxConstFlow));
 }
 EmberAfStatus SetMaxConstFlow(chip::EndpointId endpoint, uint16_t maxConstFlow)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstFlow, (uint8_t *) &maxConstFlow,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstFlow::Id, (uint8_t *) &maxConstFlow,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinConstTemp(chip::EndpointId endpoint, int16_t * minConstTemp)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstTemp, (uint8_t *) minConstTemp,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstTemp::Id, (uint8_t *) minConstTemp,
                                       sizeof(*minConstTemp));
 }
 EmberAfStatus SetMinConstTemp(chip::EndpointId endpoint, int16_t minConstTemp)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MinConstTemp, (uint8_t *) &minConstTemp,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstTemp::Id, (uint8_t *) &minConstTemp,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxConstTemp(chip::EndpointId endpoint, int16_t * maxConstTemp)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstTemp, (uint8_t *) maxConstTemp,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstTemp::Id, (uint8_t *) maxConstTemp,
                                       sizeof(*maxConstTemp));
 }
 EmberAfStatus SetMaxConstTemp(chip::EndpointId endpoint, int16_t maxConstTemp)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::MaxConstTemp, (uint8_t *) &maxConstTemp,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstTemp::Id, (uint8_t *) &maxConstTemp,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPumpStatus(chip::EndpointId endpoint, uint16_t * pumpStatus)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::PumpStatus, (uint8_t *) pumpStatus,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, PumpStatus::Id, (uint8_t *) pumpStatus,
                                       sizeof(*pumpStatus));
 }
 EmberAfStatus SetPumpStatus(chip::EndpointId endpoint, uint16_t pumpStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::PumpStatus, (uint8_t *) &pumpStatus,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, PumpStatus::Id, (uint8_t *) &pumpStatus,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEffectiveOperationMode(chip::EndpointId endpoint, uint8_t * effectiveOperationMode)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::EffectiveOperationMode,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveOperationMode::Id,
                                       (uint8_t *) effectiveOperationMode, sizeof(*effectiveOperationMode));
 }
 EmberAfStatus SetEffectiveOperationMode(chip::EndpointId endpoint, uint8_t effectiveOperationMode)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::EffectiveOperationMode,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveOperationMode::Id,
                                        (uint8_t *) &effectiveOperationMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEffectiveControlMode(chip::EndpointId endpoint, uint8_t * effectiveControlMode)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::EffectiveControlMode,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveControlMode::Id,
                                       (uint8_t *) effectiveControlMode, sizeof(*effectiveControlMode));
 }
 EmberAfStatus SetEffectiveControlMode(chip::EndpointId endpoint, uint8_t effectiveControlMode)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::EffectiveControlMode,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveControlMode::Id,
                                        (uint8_t *) &effectiveControlMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCapacity(chip::EndpointId endpoint, int16_t * capacity)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::Capacity, (uint8_t *) capacity,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Capacity::Id, (uint8_t *) capacity,
                                       sizeof(*capacity));
 }
 EmberAfStatus SetCapacity(chip::EndpointId endpoint, int16_t capacity)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::Capacity, (uint8_t *) &capacity,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Capacity::Id, (uint8_t *) &capacity,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSpeed(chip::EndpointId endpoint, uint16_t * speed)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::Speed, (uint8_t *) speed, sizeof(*speed));
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Speed::Id, (uint8_t *) speed, sizeof(*speed));
 }
 EmberAfStatus SetSpeed(chip::EndpointId endpoint, uint16_t speed)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::Speed, (uint8_t *) &speed,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Speed::Id, (uint8_t *) &speed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLifetimeEnergyConsumed(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::LifetimeEnergyConsumed,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, LifetimeEnergyConsumed::Id,
                                       (uint8_t *) lifetimeEnergyConsumed, sizeof(*lifetimeEnergyConsumed));
 }
 EmberAfStatus SetLifetimeEnergyConsumed(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::LifetimeEnergyConsumed,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, LifetimeEnergyConsumed::Id,
                                        (uint8_t *) &lifetimeEnergyConsumed, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOperationMode(chip::EndpointId endpoint, uint8_t * operationMode)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::OperationMode, (uint8_t *) operationMode,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, OperationMode::Id, (uint8_t *) operationMode,
                                       sizeof(*operationMode));
 }
 EmberAfStatus SetOperationMode(chip::EndpointId endpoint, uint8_t operationMode)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::OperationMode, (uint8_t *) &operationMode,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, OperationMode::Id, (uint8_t *) &operationMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetControlMode(chip::EndpointId endpoint, uint8_t * controlMode)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::ControlMode, (uint8_t *) controlMode,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, ControlMode::Id, (uint8_t *) controlMode,
                                       sizeof(*controlMode));
 }
 EmberAfStatus SetControlMode(chip::EndpointId endpoint, uint8_t controlMode)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::ControlMode, (uint8_t *) &controlMode,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, ControlMode::Id, (uint8_t *) &controlMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::AlarmMask, (uint8_t *) alarmMask,
+    return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, AlarmMask::Id, (uint8_t *) alarmMask,
                                       sizeof(*alarmMask));
 }
 EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint16_t alarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Ids::AlarmMask, (uint8_t *) &alarmMask,
+    return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, AlarmMask::Id, (uint8_t *) &alarmMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -3625,425 +3614,422 @@ namespace Thermostat {
 namespace Attributes {
 EmberAfStatus GetLocalTemperature(chip::EndpointId endpoint, int16_t * localTemperature)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::LocalTemperature, (uint8_t *) localTemperature,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, LocalTemperature::Id, (uint8_t *) localTemperature,
                                       sizeof(*localTemperature));
 }
 EmberAfStatus SetLocalTemperature(chip::EndpointId endpoint, int16_t localTemperature)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::LocalTemperature, (uint8_t *) &localTemperature,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, LocalTemperature::Id, (uint8_t *) &localTemperature,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOutdoorTemperature(chip::EndpointId endpoint, int16_t * outdoorTemperature)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::OutdoorTemperature, (uint8_t *) outdoorTemperature,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, OutdoorTemperature::Id, (uint8_t *) outdoorTemperature,
                                       sizeof(*outdoorTemperature));
 }
 EmberAfStatus SetOutdoorTemperature(chip::EndpointId endpoint, int16_t outdoorTemperature)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::OutdoorTemperature, (uint8_t *) &outdoorTemperature,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, OutdoorTemperature::Id, (uint8_t *) &outdoorTemperature,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOccupancy(chip::EndpointId endpoint, uint8_t * occupancy)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::Occupancy, (uint8_t *) occupancy, sizeof(*occupancy));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Occupancy::Id, (uint8_t *) occupancy, sizeof(*occupancy));
 }
 EmberAfStatus SetOccupancy(chip::EndpointId endpoint, uint8_t occupancy)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::Occupancy, (uint8_t *) &occupancy,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Occupancy::Id, (uint8_t *) &occupancy, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAbsMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AbsMinHeatSetpointLimit, (uint8_t *) absMinHeatSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMinHeatSetpointLimit::Id, (uint8_t *) absMinHeatSetpointLimit,
                                       sizeof(*absMinHeatSetpointLimit));
 }
 EmberAfStatus SetAbsMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AbsMinHeatSetpointLimit, (uint8_t *) &absMinHeatSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMinHeatSetpointLimit::Id, (uint8_t *) &absMinHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAbsMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AbsMaxHeatSetpointLimit, (uint8_t *) absMaxHeatSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMaxHeatSetpointLimit::Id, (uint8_t *) absMaxHeatSetpointLimit,
                                       sizeof(*absMaxHeatSetpointLimit));
 }
 EmberAfStatus SetAbsMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AbsMaxHeatSetpointLimit, (uint8_t *) &absMaxHeatSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMaxHeatSetpointLimit::Id, (uint8_t *) &absMaxHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAbsMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AbsMinCoolSetpointLimit, (uint8_t *) absMinCoolSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMinCoolSetpointLimit::Id, (uint8_t *) absMinCoolSetpointLimit,
                                       sizeof(*absMinCoolSetpointLimit));
 }
 EmberAfStatus SetAbsMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AbsMinCoolSetpointLimit, (uint8_t *) &absMinCoolSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMinCoolSetpointLimit::Id, (uint8_t *) &absMinCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAbsMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AbsMaxCoolSetpointLimit, (uint8_t *) absMaxCoolSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMaxCoolSetpointLimit::Id, (uint8_t *) absMaxCoolSetpointLimit,
                                       sizeof(*absMaxCoolSetpointLimit));
 }
 EmberAfStatus SetAbsMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AbsMaxCoolSetpointLimit, (uint8_t *) &absMaxCoolSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMaxCoolSetpointLimit::Id, (uint8_t *) &absMaxCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPiCoolingDemand(chip::EndpointId endpoint, uint8_t * piCoolingDemand)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::PiCoolingDemand, (uint8_t *) piCoolingDemand,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, PiCoolingDemand::Id, (uint8_t *) piCoolingDemand,
                                       sizeof(*piCoolingDemand));
 }
 EmberAfStatus SetPiCoolingDemand(chip::EndpointId endpoint, uint8_t piCoolingDemand)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::PiCoolingDemand, (uint8_t *) &piCoolingDemand,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, PiCoolingDemand::Id, (uint8_t *) &piCoolingDemand,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPiHeatingDemand(chip::EndpointId endpoint, uint8_t * piHeatingDemand)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::PiHeatingDemand, (uint8_t *) piHeatingDemand,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, PiHeatingDemand::Id, (uint8_t *) piHeatingDemand,
                                       sizeof(*piHeatingDemand));
 }
 EmberAfStatus SetPiHeatingDemand(chip::EndpointId endpoint, uint8_t piHeatingDemand)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::PiHeatingDemand, (uint8_t *) &piHeatingDemand,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, PiHeatingDemand::Id, (uint8_t *) &piHeatingDemand,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetHvacSystemTypeConfiguration(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::HvacSystemTypeConfiguration,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, HvacSystemTypeConfiguration::Id,
                                       (uint8_t *) hvacSystemTypeConfiguration, sizeof(*hvacSystemTypeConfiguration));
 }
 EmberAfStatus SetHvacSystemTypeConfiguration(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::HvacSystemTypeConfiguration,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, HvacSystemTypeConfiguration::Id,
                                        (uint8_t *) &hvacSystemTypeConfiguration, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLocalTemperatureCalibration(chip::EndpointId endpoint, int8_t * localTemperatureCalibration)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::LocalTemperatureCalibration,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, LocalTemperatureCalibration::Id,
                                       (uint8_t *) localTemperatureCalibration, sizeof(*localTemperatureCalibration));
 }
 EmberAfStatus SetLocalTemperatureCalibration(chip::EndpointId endpoint, int8_t localTemperatureCalibration)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::LocalTemperatureCalibration,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, LocalTemperatureCalibration::Id,
                                        (uint8_t *) &localTemperatureCalibration, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::OccupiedCoolingSetpoint, (uint8_t *) occupiedCoolingSetpoint,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id, (uint8_t *) occupiedCoolingSetpoint,
                                       sizeof(*occupiedCoolingSetpoint));
 }
 EmberAfStatus SetOccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::OccupiedCoolingSetpoint, (uint8_t *) &occupiedCoolingSetpoint,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id, (uint8_t *) &occupiedCoolingSetpoint,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::OccupiedHeatingSetpoint, (uint8_t *) occupiedHeatingSetpoint,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id, (uint8_t *) occupiedHeatingSetpoint,
                                       sizeof(*occupiedHeatingSetpoint));
 }
 EmberAfStatus SetOccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::OccupiedHeatingSetpoint, (uint8_t *) &occupiedHeatingSetpoint,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id, (uint8_t *) &occupiedHeatingSetpoint,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUnoccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::UnoccupiedCoolingSetpoint,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, UnoccupiedCoolingSetpoint::Id,
                                       (uint8_t *) unoccupiedCoolingSetpoint, sizeof(*unoccupiedCoolingSetpoint));
 }
 EmberAfStatus SetUnoccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::UnoccupiedCoolingSetpoint,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, UnoccupiedCoolingSetpoint::Id,
                                        (uint8_t *) &unoccupiedCoolingSetpoint, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUnoccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::UnoccupiedHeatingSetpoint,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, UnoccupiedHeatingSetpoint::Id,
                                       (uint8_t *) unoccupiedHeatingSetpoint, sizeof(*unoccupiedHeatingSetpoint));
 }
 EmberAfStatus SetUnoccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::UnoccupiedHeatingSetpoint,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, UnoccupiedHeatingSetpoint::Id,
                                        (uint8_t *) &unoccupiedHeatingSetpoint, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::MinHeatSetpointLimit, (uint8_t *) minHeatSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, MinHeatSetpointLimit::Id, (uint8_t *) minHeatSetpointLimit,
                                       sizeof(*minHeatSetpointLimit));
 }
 EmberAfStatus SetMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t minHeatSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::MinHeatSetpointLimit, (uint8_t *) &minHeatSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MinHeatSetpointLimit::Id, (uint8_t *) &minHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::MaxHeatSetpointLimit, (uint8_t *) maxHeatSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, MaxHeatSetpointLimit::Id, (uint8_t *) maxHeatSetpointLimit,
                                       sizeof(*maxHeatSetpointLimit));
 }
 EmberAfStatus SetMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::MaxHeatSetpointLimit, (uint8_t *) &maxHeatSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MaxHeatSetpointLimit::Id, (uint8_t *) &maxHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::MinCoolSetpointLimit, (uint8_t *) minCoolSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, MinCoolSetpointLimit::Id, (uint8_t *) minCoolSetpointLimit,
                                       sizeof(*minCoolSetpointLimit));
 }
 EmberAfStatus SetMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t minCoolSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::MinCoolSetpointLimit, (uint8_t *) &minCoolSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MinCoolSetpointLimit::Id, (uint8_t *) &minCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::MaxCoolSetpointLimit, (uint8_t *) maxCoolSetpointLimit,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, MaxCoolSetpointLimit::Id, (uint8_t *) maxCoolSetpointLimit,
                                       sizeof(*maxCoolSetpointLimit));
 }
 EmberAfStatus SetMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::MaxCoolSetpointLimit, (uint8_t *) &maxCoolSetpointLimit,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MaxCoolSetpointLimit::Id, (uint8_t *) &maxCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinSetpointDeadBand(chip::EndpointId endpoint, int8_t * minSetpointDeadBand)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::MinSetpointDeadBand, (uint8_t *) minSetpointDeadBand,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, MinSetpointDeadBand::Id, (uint8_t *) minSetpointDeadBand,
                                       sizeof(*minSetpointDeadBand));
 }
 EmberAfStatus SetMinSetpointDeadBand(chip::EndpointId endpoint, int8_t minSetpointDeadBand)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::MinSetpointDeadBand, (uint8_t *) &minSetpointDeadBand,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MinSetpointDeadBand::Id, (uint8_t *) &minSetpointDeadBand,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRemoteSensing(chip::EndpointId endpoint, uint8_t * remoteSensing)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::RemoteSensing, (uint8_t *) remoteSensing,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, RemoteSensing::Id, (uint8_t *) remoteSensing,
                                       sizeof(*remoteSensing));
 }
 EmberAfStatus SetRemoteSensing(chip::EndpointId endpoint, uint8_t remoteSensing)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::RemoteSensing, (uint8_t *) &remoteSensing,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, RemoteSensing::Id, (uint8_t *) &remoteSensing,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetControlSequenceOfOperation(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::ControlSequenceOfOperation,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, ControlSequenceOfOperation::Id,
                                       (uint8_t *) controlSequenceOfOperation, sizeof(*controlSequenceOfOperation));
 }
 EmberAfStatus SetControlSequenceOfOperation(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::ControlSequenceOfOperation,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, ControlSequenceOfOperation::Id,
                                        (uint8_t *) &controlSequenceOfOperation, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSystemMode(chip::EndpointId endpoint, uint8_t * systemMode)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::SystemMode, (uint8_t *) systemMode, sizeof(*systemMode));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, SystemMode::Id, (uint8_t *) systemMode, sizeof(*systemMode));
 }
 EmberAfStatus SetSystemMode(chip::EndpointId endpoint, uint8_t systemMode)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::SystemMode, (uint8_t *) &systemMode,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SystemMode::Id, (uint8_t *) &systemMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint8_t * alarmMask)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AlarmMask, (uint8_t *) alarmMask, sizeof(*alarmMask));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AlarmMask::Id, (uint8_t *) alarmMask, sizeof(*alarmMask));
 }
 EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint8_t alarmMask)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AlarmMask, (uint8_t *) &alarmMask,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AlarmMask::Id, (uint8_t *) &alarmMask, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetThermostatRunningMode(chip::EndpointId endpoint, uint8_t * thermostatRunningMode)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::ThermostatRunningMode, (uint8_t *) thermostatRunningMode,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, ThermostatRunningMode::Id, (uint8_t *) thermostatRunningMode,
                                       sizeof(*thermostatRunningMode));
 }
 EmberAfStatus SetThermostatRunningMode(chip::EndpointId endpoint, uint8_t thermostatRunningMode)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::ThermostatRunningMode, (uint8_t *) &thermostatRunningMode,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, ThermostatRunningMode::Id, (uint8_t *) &thermostatRunningMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStartOfWeek(chip::EndpointId endpoint, uint8_t * startOfWeek)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::StartOfWeek, (uint8_t *) startOfWeek, sizeof(*startOfWeek));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, StartOfWeek::Id, (uint8_t *) startOfWeek, sizeof(*startOfWeek));
 }
 EmberAfStatus SetStartOfWeek(chip::EndpointId endpoint, uint8_t startOfWeek)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::StartOfWeek, (uint8_t *) &startOfWeek,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, StartOfWeek::Id, (uint8_t *) &startOfWeek,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumberOfWeeklyTransitions(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::NumberOfWeeklyTransitions,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, NumberOfWeeklyTransitions::Id,
                                       (uint8_t *) numberOfWeeklyTransitions, sizeof(*numberOfWeeklyTransitions));
 }
 EmberAfStatus SetNumberOfWeeklyTransitions(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::NumberOfWeeklyTransitions,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, NumberOfWeeklyTransitions::Id,
                                        (uint8_t *) &numberOfWeeklyTransitions, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumberOfDailyTransitions(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::NumberOfDailyTransitions, (uint8_t *) numberOfDailyTransitions,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, NumberOfDailyTransitions::Id, (uint8_t *) numberOfDailyTransitions,
                                       sizeof(*numberOfDailyTransitions));
 }
 EmberAfStatus SetNumberOfDailyTransitions(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::NumberOfDailyTransitions,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, NumberOfDailyTransitions::Id,
                                        (uint8_t *) &numberOfDailyTransitions, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTemperatureSetpointHold(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::TemperatureSetpointHold, (uint8_t *) temperatureSetpointHold,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHold::Id, (uint8_t *) temperatureSetpointHold,
                                       sizeof(*temperatureSetpointHold));
 }
 EmberAfStatus SetTemperatureSetpointHold(chip::EndpointId endpoint, uint8_t temperatureSetpointHold)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::TemperatureSetpointHold, (uint8_t *) &temperatureSetpointHold,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHold::Id, (uint8_t *) &temperatureSetpointHold,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTemperatureSetpointHoldDuration(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::TemperatureSetpointHoldDuration,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHoldDuration::Id,
                                       (uint8_t *) temperatureSetpointHoldDuration, sizeof(*temperatureSetpointHoldDuration));
 }
 EmberAfStatus SetTemperatureSetpointHoldDuration(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::TemperatureSetpointHoldDuration,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHoldDuration::Id,
                                        (uint8_t *) &temperatureSetpointHoldDuration, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetThermostatProgrammingOperationMode(chip::EndpointId endpoint, uint8_t * thermostatProgrammingOperationMode)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::ThermostatProgrammingOperationMode,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, ThermostatProgrammingOperationMode::Id,
                                       (uint8_t *) thermostatProgrammingOperationMode, sizeof(*thermostatProgrammingOperationMode));
 }
 EmberAfStatus SetThermostatProgrammingOperationMode(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::ThermostatProgrammingOperationMode,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, ThermostatProgrammingOperationMode::Id,
                                        (uint8_t *) &thermostatProgrammingOperationMode, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetHvacRelayState(chip::EndpointId endpoint, uint16_t * hvacRelayState)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::HvacRelayState, (uint8_t *) hvacRelayState,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, HvacRelayState::Id, (uint8_t *) hvacRelayState,
                                       sizeof(*hvacRelayState));
 }
 EmberAfStatus SetHvacRelayState(chip::EndpointId endpoint, uint16_t hvacRelayState)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::HvacRelayState, (uint8_t *) &hvacRelayState,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, HvacRelayState::Id, (uint8_t *) &hvacRelayState,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSetpointChangeSource(chip::EndpointId endpoint, uint8_t * setpointChangeSource)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::SetpointChangeSource, (uint8_t *) setpointChangeSource,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, SetpointChangeSource::Id, (uint8_t *) setpointChangeSource,
                                       sizeof(*setpointChangeSource));
 }
 EmberAfStatus SetSetpointChangeSource(chip::EndpointId endpoint, uint8_t setpointChangeSource)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::SetpointChangeSource, (uint8_t *) &setpointChangeSource,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SetpointChangeSource::Id, (uint8_t *) &setpointChangeSource,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSetpointChangeAmount(chip::EndpointId endpoint, int16_t * setpointChangeAmount)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::SetpointChangeAmount, (uint8_t *) setpointChangeAmount,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, SetpointChangeAmount::Id, (uint8_t *) setpointChangeAmount,
                                       sizeof(*setpointChangeAmount));
 }
 EmberAfStatus SetSetpointChangeAmount(chip::EndpointId endpoint, int16_t setpointChangeAmount)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::SetpointChangeAmount, (uint8_t *) &setpointChangeAmount,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SetpointChangeAmount::Id, (uint8_t *) &setpointChangeAmount,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSetpointChangeSourceTimestamp(chip::EndpointId endpoint,
                                                /* TYPE WARNING: utc defaults to */ uint8_t ** setpointChangeSourceTimestamp)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::SetpointChangeSourceTimestamp,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, SetpointChangeSourceTimestamp::Id,
                                       (uint8_t *) setpointChangeSourceTimestamp, sizeof(*setpointChangeSourceTimestamp));
 }
 EmberAfStatus SetSetpointChangeSourceTimestamp(chip::EndpointId endpoint,
                                                /* TYPE WARNING: utc defaults to */ uint8_t * setpointChangeSourceTimestamp)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::SetpointChangeSourceTimestamp,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SetpointChangeSourceTimestamp::Id,
                                        (uint8_t *) &setpointChangeSourceTimestamp, ZCL_UTC_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcType(chip::EndpointId endpoint, uint8_t * acType)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcType, (uint8_t *) acType, sizeof(*acType));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcType::Id, (uint8_t *) acType, sizeof(*acType));
 }
 EmberAfStatus SetAcType(chip::EndpointId endpoint, uint8_t acType)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcType, (uint8_t *) &acType, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcType::Id, (uint8_t *) &acType, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCapacity(chip::EndpointId endpoint, uint16_t * acCapacity)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcCapacity, (uint8_t *) acCapacity, sizeof(*acCapacity));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCapacity::Id, (uint8_t *) acCapacity, sizeof(*acCapacity));
 }
 EmberAfStatus SetAcCapacity(chip::EndpointId endpoint, uint16_t acCapacity)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcCapacity, (uint8_t *) &acCapacity,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCapacity::Id, (uint8_t *) &acCapacity,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcRefrigerantType(chip::EndpointId endpoint, uint8_t * acRefrigerantType)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcRefrigerantType, (uint8_t *) acRefrigerantType,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcRefrigerantType::Id, (uint8_t *) acRefrigerantType,
                                       sizeof(*acRefrigerantType));
 }
 EmberAfStatus SetAcRefrigerantType(chip::EndpointId endpoint, uint8_t acRefrigerantType)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcRefrigerantType, (uint8_t *) &acRefrigerantType,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcRefrigerantType::Id, (uint8_t *) &acRefrigerantType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCompressor(chip::EndpointId endpoint, uint8_t * acCompressor)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcCompressor, (uint8_t *) acCompressor, sizeof(*acCompressor));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCompressor::Id, (uint8_t *) acCompressor, sizeof(*acCompressor));
 }
 EmberAfStatus SetAcCompressor(chip::EndpointId endpoint, uint8_t acCompressor)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcCompressor, (uint8_t *) &acCompressor,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCompressor::Id, (uint8_t *) &acCompressor,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcErrorCode(chip::EndpointId endpoint, uint32_t * acErrorCode)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcErrorCode, (uint8_t *) acErrorCode, sizeof(*acErrorCode));
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcErrorCode::Id, (uint8_t *) acErrorCode, sizeof(*acErrorCode));
 }
 EmberAfStatus SetAcErrorCode(chip::EndpointId endpoint, uint32_t acErrorCode)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcErrorCode, (uint8_t *) &acErrorCode,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcErrorCode::Id, (uint8_t *) &acErrorCode,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcLouverPosition(chip::EndpointId endpoint, uint8_t * acLouverPosition)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcLouverPosition, (uint8_t *) acLouverPosition,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcLouverPosition::Id, (uint8_t *) acLouverPosition,
                                       sizeof(*acLouverPosition));
 }
 EmberAfStatus SetAcLouverPosition(chip::EndpointId endpoint, uint8_t acLouverPosition)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcLouverPosition, (uint8_t *) &acLouverPosition,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcLouverPosition::Id, (uint8_t *) &acLouverPosition,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCoilTemperature(chip::EndpointId endpoint, int16_t * acCoilTemperature)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcCoilTemperature, (uint8_t *) acCoilTemperature,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCoilTemperature::Id, (uint8_t *) acCoilTemperature,
                                       sizeof(*acCoilTemperature));
 }
 EmberAfStatus SetAcCoilTemperature(chip::EndpointId endpoint, int16_t acCoilTemperature)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcCoilTemperature, (uint8_t *) &acCoilTemperature,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCoilTemperature::Id, (uint8_t *) &acCoilTemperature,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCapacityFormat(chip::EndpointId endpoint, uint8_t * acCapacityFormat)
 {
-    return emberAfReadServerAttribute(endpoint, Thermostat::Id, Ids::AcCapacityFormat, (uint8_t *) acCapacityFormat,
+    return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCapacityFormat::Id, (uint8_t *) acCapacityFormat,
                                       sizeof(*acCapacityFormat));
 }
 EmberAfStatus SetAcCapacityFormat(chip::EndpointId endpoint, uint8_t acCapacityFormat)
 {
-    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Ids::AcCapacityFormat, (uint8_t *) &acCapacityFormat,
+    return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCapacityFormat::Id, (uint8_t *) &acCapacityFormat,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4053,20 +4039,20 @@ namespace FanControl {
 namespace Attributes {
 EmberAfStatus GetFanMode(chip::EndpointId endpoint, uint8_t * fanMode)
 {
-    return emberAfReadServerAttribute(endpoint, FanControl::Id, Ids::FanMode, (uint8_t *) fanMode, sizeof(*fanMode));
+    return emberAfReadServerAttribute(endpoint, FanControl::Id, FanMode::Id, (uint8_t *) fanMode, sizeof(*fanMode));
 }
 EmberAfStatus SetFanMode(chip::EndpointId endpoint, uint8_t fanMode)
 {
-    return emberAfWriteServerAttribute(endpoint, FanControl::Id, Ids::FanMode, (uint8_t *) &fanMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, FanControl::Id, FanMode::Id, (uint8_t *) &fanMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetFanModeSequence(chip::EndpointId endpoint, uint8_t * fanModeSequence)
 {
-    return emberAfReadServerAttribute(endpoint, FanControl::Id, Ids::FanModeSequence, (uint8_t *) fanModeSequence,
+    return emberAfReadServerAttribute(endpoint, FanControl::Id, FanModeSequence::Id, (uint8_t *) fanModeSequence,
                                       sizeof(*fanModeSequence));
 }
 EmberAfStatus SetFanModeSequence(chip::EndpointId endpoint, uint8_t fanModeSequence)
 {
-    return emberAfWriteServerAttribute(endpoint, FanControl::Id, Ids::FanModeSequence, (uint8_t *) &fanModeSequence,
+    return emberAfWriteServerAttribute(endpoint, FanControl::Id, FanModeSequence::Id, (uint8_t *) &fanModeSequence,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4076,82 +4062,82 @@ namespace DehumidificationControl {
 namespace Attributes {
 EmberAfStatus GetRelativeHumidity(chip::EndpointId endpoint, uint8_t * relativeHumidity)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::RelativeHumidity, (uint8_t *) relativeHumidity,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidity::Id, (uint8_t *) relativeHumidity,
                                       sizeof(*relativeHumidity));
 }
 EmberAfStatus SetRelativeHumidity(chip::EndpointId endpoint, uint8_t relativeHumidity)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::RelativeHumidity, (uint8_t *) &relativeHumidity,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidity::Id, (uint8_t *) &relativeHumidity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDehumidificationCooling(chip::EndpointId endpoint, uint8_t * dehumidificationCooling)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationCooling,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationCooling::Id,
                                       (uint8_t *) dehumidificationCooling, sizeof(*dehumidificationCooling));
 }
 EmberAfStatus SetDehumidificationCooling(chip::EndpointId endpoint, uint8_t dehumidificationCooling)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationCooling,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationCooling::Id,
                                        (uint8_t *) &dehumidificationCooling, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRhDehumidificationSetpoint(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::RhDehumidificationSetpoint,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RhDehumidificationSetpoint::Id,
                                       (uint8_t *) rhDehumidificationSetpoint, sizeof(*rhDehumidificationSetpoint));
 }
 EmberAfStatus SetRhDehumidificationSetpoint(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::RhDehumidificationSetpoint,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RhDehumidificationSetpoint::Id,
                                        (uint8_t *) &rhDehumidificationSetpoint, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRelativeHumidityMode(chip::EndpointId endpoint, uint8_t * relativeHumidityMode)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::RelativeHumidityMode,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityMode::Id,
                                       (uint8_t *) relativeHumidityMode, sizeof(*relativeHumidityMode));
 }
 EmberAfStatus SetRelativeHumidityMode(chip::EndpointId endpoint, uint8_t relativeHumidityMode)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::RelativeHumidityMode,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityMode::Id,
                                        (uint8_t *) &relativeHumidityMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDehumidificationLockout(chip::EndpointId endpoint, uint8_t * dehumidificationLockout)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationLockout,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationLockout::Id,
                                       (uint8_t *) dehumidificationLockout, sizeof(*dehumidificationLockout));
 }
 EmberAfStatus SetDehumidificationLockout(chip::EndpointId endpoint, uint8_t dehumidificationLockout)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationLockout,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationLockout::Id,
                                        (uint8_t *) &dehumidificationLockout, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDehumidificationHysteresis(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationHysteresis,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationHysteresis::Id,
                                       (uint8_t *) dehumidificationHysteresis, sizeof(*dehumidificationHysteresis));
 }
 EmberAfStatus SetDehumidificationHysteresis(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationHysteresis,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationHysteresis::Id,
                                        (uint8_t *) &dehumidificationHysteresis, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDehumidificationMaxCool(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationMaxCool,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationMaxCool::Id,
                                       (uint8_t *) dehumidificationMaxCool, sizeof(*dehumidificationMaxCool));
 }
 EmberAfStatus SetDehumidificationMaxCool(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::DehumidificationMaxCool,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationMaxCool::Id,
                                        (uint8_t *) &dehumidificationMaxCool, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRelativeHumidityDisplay(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay)
 {
-    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, Ids::RelativeHumidityDisplay,
+    return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityDisplay::Id,
                                       (uint8_t *) relativeHumidityDisplay, sizeof(*relativeHumidityDisplay));
 }
 EmberAfStatus SetRelativeHumidityDisplay(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay)
 {
-    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, Ids::RelativeHumidityDisplay,
+    return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityDisplay::Id,
                                        (uint8_t *) &relativeHumidityDisplay, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4161,32 +4147,32 @@ namespace ThermostatUserInterfaceConfiguration {
 namespace Attributes {
 EmberAfStatus GetTemperatureDisplayMode(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode)
 {
-    return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, Ids::TemperatureDisplayMode,
+    return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, TemperatureDisplayMode::Id,
                                       (uint8_t *) temperatureDisplayMode, sizeof(*temperatureDisplayMode));
 }
 EmberAfStatus SetTemperatureDisplayMode(chip::EndpointId endpoint, uint8_t temperatureDisplayMode)
 {
-    return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, Ids::TemperatureDisplayMode,
+    return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, TemperatureDisplayMode::Id,
                                        (uint8_t *) &temperatureDisplayMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetKeypadLockout(chip::EndpointId endpoint, uint8_t * keypadLockout)
 {
-    return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, Ids::KeypadLockout,
+    return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, KeypadLockout::Id,
                                       (uint8_t *) keypadLockout, sizeof(*keypadLockout));
 }
 EmberAfStatus SetKeypadLockout(chip::EndpointId endpoint, uint8_t keypadLockout)
 {
-    return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, Ids::KeypadLockout,
+    return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, KeypadLockout::Id,
                                        (uint8_t *) &keypadLockout, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetScheduleProgrammingVisibility(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility)
 {
-    return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, Ids::ScheduleProgrammingVisibility,
+    return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, ScheduleProgrammingVisibility::Id,
                                       (uint8_t *) scheduleProgrammingVisibility, sizeof(*scheduleProgrammingVisibility));
 }
 EmberAfStatus SetScheduleProgrammingVisibility(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility)
 {
-    return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, Ids::ScheduleProgrammingVisibility,
+    return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, ScheduleProgrammingVisibility::Id,
                                        (uint8_t *) &scheduleProgrammingVisibility, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4196,492 +4182,491 @@ namespace ColorControl {
 namespace Attributes {
 EmberAfStatus GetCurrentHue(chip::EndpointId endpoint, uint8_t * currentHue)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::CurrentHue, (uint8_t *) currentHue, sizeof(*currentHue));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentHue::Id, (uint8_t *) currentHue, sizeof(*currentHue));
 }
 EmberAfStatus SetCurrentHue(chip::EndpointId endpoint, uint8_t currentHue)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::CurrentHue, (uint8_t *) &currentHue,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentHue::Id, (uint8_t *) &currentHue,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentSaturation(chip::EndpointId endpoint, uint8_t * currentSaturation)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::CurrentSaturation, (uint8_t *) currentSaturation,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentSaturation::Id, (uint8_t *) currentSaturation,
                                       sizeof(*currentSaturation));
 }
 EmberAfStatus SetCurrentSaturation(chip::EndpointId endpoint, uint8_t currentSaturation)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::CurrentSaturation, (uint8_t *) &currentSaturation,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentSaturation::Id, (uint8_t *) &currentSaturation,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::RemainingTime, (uint8_t *) remainingTime,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, RemainingTime::Id, (uint8_t *) remainingTime,
                                       sizeof(*remainingTime));
 }
 EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::RemainingTime, (uint8_t *) &remainingTime,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, RemainingTime::Id, (uint8_t *) &remainingTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentX(chip::EndpointId endpoint, uint16_t * currentX)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::CurrentX, (uint8_t *) currentX, sizeof(*currentX));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentX::Id, (uint8_t *) currentX, sizeof(*currentX));
 }
 EmberAfStatus SetCurrentX(chip::EndpointId endpoint, uint16_t currentX)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::CurrentX, (uint8_t *) &currentX, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentX::Id, (uint8_t *) &currentX, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentY(chip::EndpointId endpoint, uint16_t * currentY)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::CurrentY, (uint8_t *) currentY, sizeof(*currentY));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentY::Id, (uint8_t *) currentY, sizeof(*currentY));
 }
 EmberAfStatus SetCurrentY(chip::EndpointId endpoint, uint16_t currentY)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::CurrentY, (uint8_t *) &currentY, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentY::Id, (uint8_t *) &currentY, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDriftCompensation(chip::EndpointId endpoint, uint8_t * driftCompensation)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::DriftCompensation, (uint8_t *) driftCompensation,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, DriftCompensation::Id, (uint8_t *) driftCompensation,
                                       sizeof(*driftCompensation));
 }
 EmberAfStatus SetDriftCompensation(chip::EndpointId endpoint, uint8_t driftCompensation)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::DriftCompensation, (uint8_t *) &driftCompensation,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, DriftCompensation::Id, (uint8_t *) &driftCompensation,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorTemperature(chip::EndpointId endpoint, uint16_t * colorTemperature)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorTemperature, (uint8_t *) colorTemperature,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorTemperature::Id, (uint8_t *) colorTemperature,
                                       sizeof(*colorTemperature));
 }
 EmberAfStatus SetColorTemperature(chip::EndpointId endpoint, uint16_t colorTemperature)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorTemperature, (uint8_t *) &colorTemperature,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorTemperature::Id, (uint8_t *) &colorTemperature,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorMode(chip::EndpointId endpoint, uint8_t * colorMode)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorMode, (uint8_t *) colorMode, sizeof(*colorMode));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorMode::Id, (uint8_t *) colorMode, sizeof(*colorMode));
 }
 EmberAfStatus SetColorMode(chip::EndpointId endpoint, uint8_t colorMode)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorMode, (uint8_t *) &colorMode,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorMode::Id, (uint8_t *) &colorMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorControlOptions(chip::EndpointId endpoint, uint8_t * colorControlOptions)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorControlOptions, (uint8_t *) colorControlOptions,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorControlOptions::Id, (uint8_t *) colorControlOptions,
                                       sizeof(*colorControlOptions));
 }
 EmberAfStatus SetColorControlOptions(chip::EndpointId endpoint, uint8_t colorControlOptions)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorControlOptions, (uint8_t *) &colorControlOptions,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorControlOptions::Id, (uint8_t *) &colorControlOptions,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumberOfPrimaries(chip::EndpointId endpoint, uint8_t * numberOfPrimaries)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::NumberOfPrimaries, (uint8_t *) numberOfPrimaries,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, NumberOfPrimaries::Id, (uint8_t *) numberOfPrimaries,
                                       sizeof(*numberOfPrimaries));
 }
 EmberAfStatus SetNumberOfPrimaries(chip::EndpointId endpoint, uint8_t numberOfPrimaries)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::NumberOfPrimaries, (uint8_t *) &numberOfPrimaries,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, NumberOfPrimaries::Id, (uint8_t *) &numberOfPrimaries,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary1X(chip::EndpointId endpoint, uint16_t * primary1X)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary1X, (uint8_t *) primary1X, sizeof(*primary1X));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary1X::Id, (uint8_t *) primary1X, sizeof(*primary1X));
 }
 EmberAfStatus SetPrimary1X(chip::EndpointId endpoint, uint16_t primary1X)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary1X, (uint8_t *) &primary1X,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary1X::Id, (uint8_t *) &primary1X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary1Y(chip::EndpointId endpoint, uint16_t * primary1Y)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary1Y, (uint8_t *) primary1Y, sizeof(*primary1Y));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary1Y::Id, (uint8_t *) primary1Y, sizeof(*primary1Y));
 }
 EmberAfStatus SetPrimary1Y(chip::EndpointId endpoint, uint16_t primary1Y)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary1Y, (uint8_t *) &primary1Y,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary1Y::Id, (uint8_t *) &primary1Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary1Intensity(chip::EndpointId endpoint, uint8_t * primary1Intensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary1Intensity, (uint8_t *) primary1Intensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary1Intensity::Id, (uint8_t *) primary1Intensity,
                                       sizeof(*primary1Intensity));
 }
 EmberAfStatus SetPrimary1Intensity(chip::EndpointId endpoint, uint8_t primary1Intensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary1Intensity, (uint8_t *) &primary1Intensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary1Intensity::Id, (uint8_t *) &primary1Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary2X(chip::EndpointId endpoint, uint16_t * primary2X)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary2X, (uint8_t *) primary2X, sizeof(*primary2X));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary2X::Id, (uint8_t *) primary2X, sizeof(*primary2X));
 }
 EmberAfStatus SetPrimary2X(chip::EndpointId endpoint, uint16_t primary2X)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary2X, (uint8_t *) &primary2X,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary2X::Id, (uint8_t *) &primary2X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary2Y(chip::EndpointId endpoint, uint16_t * primary2Y)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary2Y, (uint8_t *) primary2Y, sizeof(*primary2Y));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary2Y::Id, (uint8_t *) primary2Y, sizeof(*primary2Y));
 }
 EmberAfStatus SetPrimary2Y(chip::EndpointId endpoint, uint16_t primary2Y)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary2Y, (uint8_t *) &primary2Y,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary2Y::Id, (uint8_t *) &primary2Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary2Intensity(chip::EndpointId endpoint, uint8_t * primary2Intensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary2Intensity, (uint8_t *) primary2Intensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary2Intensity::Id, (uint8_t *) primary2Intensity,
                                       sizeof(*primary2Intensity));
 }
 EmberAfStatus SetPrimary2Intensity(chip::EndpointId endpoint, uint8_t primary2Intensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary2Intensity, (uint8_t *) &primary2Intensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary2Intensity::Id, (uint8_t *) &primary2Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary3X(chip::EndpointId endpoint, uint16_t * primary3X)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary3X, (uint8_t *) primary3X, sizeof(*primary3X));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary3X::Id, (uint8_t *) primary3X, sizeof(*primary3X));
 }
 EmberAfStatus SetPrimary3X(chip::EndpointId endpoint, uint16_t primary3X)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary3X, (uint8_t *) &primary3X,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary3X::Id, (uint8_t *) &primary3X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary3Y(chip::EndpointId endpoint, uint16_t * primary3Y)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary3Y, (uint8_t *) primary3Y, sizeof(*primary3Y));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary3Y::Id, (uint8_t *) primary3Y, sizeof(*primary3Y));
 }
 EmberAfStatus SetPrimary3Y(chip::EndpointId endpoint, uint16_t primary3Y)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary3Y, (uint8_t *) &primary3Y,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary3Y::Id, (uint8_t *) &primary3Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary3Intensity(chip::EndpointId endpoint, uint8_t * primary3Intensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary3Intensity, (uint8_t *) primary3Intensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary3Intensity::Id, (uint8_t *) primary3Intensity,
                                       sizeof(*primary3Intensity));
 }
 EmberAfStatus SetPrimary3Intensity(chip::EndpointId endpoint, uint8_t primary3Intensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary3Intensity, (uint8_t *) &primary3Intensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary3Intensity::Id, (uint8_t *) &primary3Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary4X(chip::EndpointId endpoint, uint16_t * primary4X)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary4X, (uint8_t *) primary4X, sizeof(*primary4X));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary4X::Id, (uint8_t *) primary4X, sizeof(*primary4X));
 }
 EmberAfStatus SetPrimary4X(chip::EndpointId endpoint, uint16_t primary4X)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary4X, (uint8_t *) &primary4X,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary4X::Id, (uint8_t *) &primary4X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary4Y(chip::EndpointId endpoint, uint16_t * primary4Y)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary4Y, (uint8_t *) primary4Y, sizeof(*primary4Y));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary4Y::Id, (uint8_t *) primary4Y, sizeof(*primary4Y));
 }
 EmberAfStatus SetPrimary4Y(chip::EndpointId endpoint, uint16_t primary4Y)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary4Y, (uint8_t *) &primary4Y,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary4Y::Id, (uint8_t *) &primary4Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary4Intensity(chip::EndpointId endpoint, uint8_t * primary4Intensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary4Intensity, (uint8_t *) primary4Intensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary4Intensity::Id, (uint8_t *) primary4Intensity,
                                       sizeof(*primary4Intensity));
 }
 EmberAfStatus SetPrimary4Intensity(chip::EndpointId endpoint, uint8_t primary4Intensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary4Intensity, (uint8_t *) &primary4Intensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary4Intensity::Id, (uint8_t *) &primary4Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary5X(chip::EndpointId endpoint, uint16_t * primary5X)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary5X, (uint8_t *) primary5X, sizeof(*primary5X));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary5X::Id, (uint8_t *) primary5X, sizeof(*primary5X));
 }
 EmberAfStatus SetPrimary5X(chip::EndpointId endpoint, uint16_t primary5X)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary5X, (uint8_t *) &primary5X,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary5X::Id, (uint8_t *) &primary5X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary5Y(chip::EndpointId endpoint, uint16_t * primary5Y)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary5Y, (uint8_t *) primary5Y, sizeof(*primary5Y));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary5Y::Id, (uint8_t *) primary5Y, sizeof(*primary5Y));
 }
 EmberAfStatus SetPrimary5Y(chip::EndpointId endpoint, uint16_t primary5Y)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary5Y, (uint8_t *) &primary5Y,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary5Y::Id, (uint8_t *) &primary5Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary5Intensity(chip::EndpointId endpoint, uint8_t * primary5Intensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary5Intensity, (uint8_t *) primary5Intensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary5Intensity::Id, (uint8_t *) primary5Intensity,
                                       sizeof(*primary5Intensity));
 }
 EmberAfStatus SetPrimary5Intensity(chip::EndpointId endpoint, uint8_t primary5Intensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary5Intensity, (uint8_t *) &primary5Intensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary5Intensity::Id, (uint8_t *) &primary5Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary6X(chip::EndpointId endpoint, uint16_t * primary6X)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary6X, (uint8_t *) primary6X, sizeof(*primary6X));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary6X::Id, (uint8_t *) primary6X, sizeof(*primary6X));
 }
 EmberAfStatus SetPrimary6X(chip::EndpointId endpoint, uint16_t primary6X)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary6X, (uint8_t *) &primary6X,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary6X::Id, (uint8_t *) &primary6X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary6Y(chip::EndpointId endpoint, uint16_t * primary6Y)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary6Y, (uint8_t *) primary6Y, sizeof(*primary6Y));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary6Y::Id, (uint8_t *) primary6Y, sizeof(*primary6Y));
 }
 EmberAfStatus SetPrimary6Y(chip::EndpointId endpoint, uint16_t primary6Y)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary6Y, (uint8_t *) &primary6Y,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary6Y::Id, (uint8_t *) &primary6Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPrimary6Intensity(chip::EndpointId endpoint, uint8_t * primary6Intensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::Primary6Intensity, (uint8_t *) primary6Intensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary6Intensity::Id, (uint8_t *) primary6Intensity,
                                       sizeof(*primary6Intensity));
 }
 EmberAfStatus SetPrimary6Intensity(chip::EndpointId endpoint, uint8_t primary6Intensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::Primary6Intensity, (uint8_t *) &primary6Intensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary6Intensity::Id, (uint8_t *) &primary6Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWhitePointX(chip::EndpointId endpoint, uint16_t * whitePointX)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::WhitePointX, (uint8_t *) whitePointX, sizeof(*whitePointX));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, WhitePointX::Id, (uint8_t *) whitePointX, sizeof(*whitePointX));
 }
 EmberAfStatus SetWhitePointX(chip::EndpointId endpoint, uint16_t whitePointX)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::WhitePointX, (uint8_t *) &whitePointX,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, WhitePointX::Id, (uint8_t *) &whitePointX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetWhitePointY(chip::EndpointId endpoint, uint16_t * whitePointY)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::WhitePointY, (uint8_t *) whitePointY, sizeof(*whitePointY));
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, WhitePointY::Id, (uint8_t *) whitePointY, sizeof(*whitePointY));
 }
 EmberAfStatus SetWhitePointY(chip::EndpointId endpoint, uint16_t whitePointY)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::WhitePointY, (uint8_t *) &whitePointY,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, WhitePointY::Id, (uint8_t *) &whitePointY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointRX(chip::EndpointId endpoint, uint16_t * colorPointRX)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointRX, (uint8_t *) colorPointRX,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointRX::Id, (uint8_t *) colorPointRX,
                                       sizeof(*colorPointRX));
 }
 EmberAfStatus SetColorPointRX(chip::EndpointId endpoint, uint16_t colorPointRX)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointRX, (uint8_t *) &colorPointRX,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointRX::Id, (uint8_t *) &colorPointRX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointRY(chip::EndpointId endpoint, uint16_t * colorPointRY)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointRY, (uint8_t *) colorPointRY,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointRY::Id, (uint8_t *) colorPointRY,
                                       sizeof(*colorPointRY));
 }
 EmberAfStatus SetColorPointRY(chip::EndpointId endpoint, uint16_t colorPointRY)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointRY, (uint8_t *) &colorPointRY,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointRY::Id, (uint8_t *) &colorPointRY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointRIntensity(chip::EndpointId endpoint, uint8_t * colorPointRIntensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointRIntensity, (uint8_t *) colorPointRIntensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointRIntensity::Id, (uint8_t *) colorPointRIntensity,
                                       sizeof(*colorPointRIntensity));
 }
 EmberAfStatus SetColorPointRIntensity(chip::EndpointId endpoint, uint8_t colorPointRIntensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointRIntensity, (uint8_t *) &colorPointRIntensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointRIntensity::Id, (uint8_t *) &colorPointRIntensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointGX(chip::EndpointId endpoint, uint16_t * colorPointGX)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointGX, (uint8_t *) colorPointGX,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointGX::Id, (uint8_t *) colorPointGX,
                                       sizeof(*colorPointGX));
 }
 EmberAfStatus SetColorPointGX(chip::EndpointId endpoint, uint16_t colorPointGX)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointGX, (uint8_t *) &colorPointGX,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointGX::Id, (uint8_t *) &colorPointGX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointGY(chip::EndpointId endpoint, uint16_t * colorPointGY)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointGY, (uint8_t *) colorPointGY,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointGY::Id, (uint8_t *) colorPointGY,
                                       sizeof(*colorPointGY));
 }
 EmberAfStatus SetColorPointGY(chip::EndpointId endpoint, uint16_t colorPointGY)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointGY, (uint8_t *) &colorPointGY,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointGY::Id, (uint8_t *) &colorPointGY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointGIntensity(chip::EndpointId endpoint, uint8_t * colorPointGIntensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointGIntensity, (uint8_t *) colorPointGIntensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointGIntensity::Id, (uint8_t *) colorPointGIntensity,
                                       sizeof(*colorPointGIntensity));
 }
 EmberAfStatus SetColorPointGIntensity(chip::EndpointId endpoint, uint8_t colorPointGIntensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointGIntensity, (uint8_t *) &colorPointGIntensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointGIntensity::Id, (uint8_t *) &colorPointGIntensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointBX(chip::EndpointId endpoint, uint16_t * colorPointBX)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointBX, (uint8_t *) colorPointBX,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointBX::Id, (uint8_t *) colorPointBX,
                                       sizeof(*colorPointBX));
 }
 EmberAfStatus SetColorPointBX(chip::EndpointId endpoint, uint16_t colorPointBX)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointBX, (uint8_t *) &colorPointBX,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointBX::Id, (uint8_t *) &colorPointBX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointBY(chip::EndpointId endpoint, uint16_t * colorPointBY)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointBY, (uint8_t *) colorPointBY,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointBY::Id, (uint8_t *) colorPointBY,
                                       sizeof(*colorPointBY));
 }
 EmberAfStatus SetColorPointBY(chip::EndpointId endpoint, uint16_t colorPointBY)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointBY, (uint8_t *) &colorPointBY,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointBY::Id, (uint8_t *) &colorPointBY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorPointBIntensity(chip::EndpointId endpoint, uint8_t * colorPointBIntensity)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointBIntensity, (uint8_t *) colorPointBIntensity,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointBIntensity::Id, (uint8_t *) colorPointBIntensity,
                                       sizeof(*colorPointBIntensity));
 }
 EmberAfStatus SetColorPointBIntensity(chip::EndpointId endpoint, uint8_t colorPointBIntensity)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorPointBIntensity, (uint8_t *) &colorPointBIntensity,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointBIntensity::Id, (uint8_t *) &colorPointBIntensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnhancedCurrentHue(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::EnhancedCurrentHue, (uint8_t *) enhancedCurrentHue,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, EnhancedCurrentHue::Id, (uint8_t *) enhancedCurrentHue,
                                       sizeof(*enhancedCurrentHue));
 }
 EmberAfStatus SetEnhancedCurrentHue(chip::EndpointId endpoint, uint16_t enhancedCurrentHue)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::EnhancedCurrentHue, (uint8_t *) &enhancedCurrentHue,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, EnhancedCurrentHue::Id, (uint8_t *) &enhancedCurrentHue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnhancedColorMode(chip::EndpointId endpoint, uint8_t * enhancedColorMode)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::EnhancedColorMode, (uint8_t *) enhancedColorMode,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, EnhancedColorMode::Id, (uint8_t *) enhancedColorMode,
                                       sizeof(*enhancedColorMode));
 }
 EmberAfStatus SetEnhancedColorMode(chip::EndpointId endpoint, uint8_t enhancedColorMode)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::EnhancedColorMode, (uint8_t *) &enhancedColorMode,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, EnhancedColorMode::Id, (uint8_t *) &enhancedColorMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorLoopActive(chip::EndpointId endpoint, uint8_t * colorLoopActive)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopActive, (uint8_t *) colorLoopActive,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopActive::Id, (uint8_t *) colorLoopActive,
                                       sizeof(*colorLoopActive));
 }
 EmberAfStatus SetColorLoopActive(chip::EndpointId endpoint, uint8_t colorLoopActive)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopActive, (uint8_t *) &colorLoopActive,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopActive::Id, (uint8_t *) &colorLoopActive,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorLoopDirection(chip::EndpointId endpoint, uint8_t * colorLoopDirection)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopDirection, (uint8_t *) colorLoopDirection,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopDirection::Id, (uint8_t *) colorLoopDirection,
                                       sizeof(*colorLoopDirection));
 }
 EmberAfStatus SetColorLoopDirection(chip::EndpointId endpoint, uint8_t colorLoopDirection)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopDirection, (uint8_t *) &colorLoopDirection,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopDirection::Id, (uint8_t *) &colorLoopDirection,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorLoopTime(chip::EndpointId endpoint, uint16_t * colorLoopTime)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopTime, (uint8_t *) colorLoopTime,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopTime::Id, (uint8_t *) colorLoopTime,
                                       sizeof(*colorLoopTime));
 }
 EmberAfStatus SetColorLoopTime(chip::EndpointId endpoint, uint16_t colorLoopTime)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopTime, (uint8_t *) &colorLoopTime,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopTime::Id, (uint8_t *) &colorLoopTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorLoopStartEnhancedHue(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopStartEnhancedHue,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopStartEnhancedHue::Id,
                                       (uint8_t *) colorLoopStartEnhancedHue, sizeof(*colorLoopStartEnhancedHue));
 }
 EmberAfStatus SetColorLoopStartEnhancedHue(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopStartEnhancedHue,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopStartEnhancedHue::Id,
                                        (uint8_t *) &colorLoopStartEnhancedHue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorLoopStoredEnhancedHue(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopStoredEnhancedHue,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopStoredEnhancedHue::Id,
                                       (uint8_t *) colorLoopStoredEnhancedHue, sizeof(*colorLoopStoredEnhancedHue));
 }
 EmberAfStatus SetColorLoopStoredEnhancedHue(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorLoopStoredEnhancedHue,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopStoredEnhancedHue::Id,
                                        (uint8_t *) &colorLoopStoredEnhancedHue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorCapabilities(chip::EndpointId endpoint, uint16_t * colorCapabilities)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorCapabilities, (uint8_t *) colorCapabilities,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorCapabilities::Id, (uint8_t *) colorCapabilities,
                                       sizeof(*colorCapabilities));
 }
 EmberAfStatus SetColorCapabilities(chip::EndpointId endpoint, uint16_t colorCapabilities)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorCapabilities, (uint8_t *) &colorCapabilities,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorCapabilities::Id, (uint8_t *) &colorCapabilities,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorTempPhysicalMin(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorTempPhysicalMin, (uint8_t *) colorTempPhysicalMin,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMin::Id, (uint8_t *) colorTempPhysicalMin,
                                       sizeof(*colorTempPhysicalMin));
 }
 EmberAfStatus SetColorTempPhysicalMin(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorTempPhysicalMin, (uint8_t *) &colorTempPhysicalMin,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMin::Id, (uint8_t *) &colorTempPhysicalMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetColorTempPhysicalMax(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::ColorTempPhysicalMax, (uint8_t *) colorTempPhysicalMax,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMax::Id, (uint8_t *) colorTempPhysicalMax,
                                       sizeof(*colorTempPhysicalMax));
 }
 EmberAfStatus SetColorTempPhysicalMax(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::ColorTempPhysicalMax, (uint8_t *) &colorTempPhysicalMax,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMax::Id, (uint8_t *) &colorTempPhysicalMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCoupleColorTempToLevelMinMireds(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::CoupleColorTempToLevelMinMireds,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, CoupleColorTempToLevelMinMireds::Id,
                                       (uint8_t *) coupleColorTempToLevelMinMireds, sizeof(*coupleColorTempToLevelMinMireds));
 }
 EmberAfStatus SetCoupleColorTempToLevelMinMireds(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::CoupleColorTempToLevelMinMireds,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CoupleColorTempToLevelMinMireds::Id,
                                        (uint8_t *) &coupleColorTempToLevelMinMireds, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStartUpColorTemperatureMireds(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds)
 {
-    return emberAfReadServerAttribute(endpoint, ColorControl::Id, Ids::StartUpColorTemperatureMireds,
+    return emberAfReadServerAttribute(endpoint, ColorControl::Id, StartUpColorTemperatureMireds::Id,
                                       (uint8_t *) startUpColorTemperatureMireds, sizeof(*startUpColorTemperatureMireds));
 }
 EmberAfStatus SetStartUpColorTemperatureMireds(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds)
 {
-    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Ids::StartUpColorTemperatureMireds,
+    return emberAfWriteServerAttribute(endpoint, ColorControl::Id, StartUpColorTemperatureMireds::Id,
                                        (uint8_t *) &startUpColorTemperatureMireds, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4691,110 +4676,110 @@ namespace BallastConfiguration {
 namespace Attributes {
 EmberAfStatus GetPhysicalMinLevel(chip::EndpointId endpoint, uint8_t * physicalMinLevel)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::PhysicalMinLevel, (uint8_t *) physicalMinLevel,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMinLevel::Id, (uint8_t *) physicalMinLevel,
                                       sizeof(*physicalMinLevel));
 }
 EmberAfStatus SetPhysicalMinLevel(chip::EndpointId endpoint, uint8_t physicalMinLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::PhysicalMinLevel, (uint8_t *) &physicalMinLevel,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMinLevel::Id, (uint8_t *) &physicalMinLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhysicalMaxLevel(chip::EndpointId endpoint, uint8_t * physicalMaxLevel)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::PhysicalMaxLevel, (uint8_t *) physicalMaxLevel,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMaxLevel::Id, (uint8_t *) physicalMaxLevel,
                                       sizeof(*physicalMaxLevel));
 }
 EmberAfStatus SetPhysicalMaxLevel(chip::EndpointId endpoint, uint8_t physicalMaxLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::PhysicalMaxLevel, (uint8_t *) &physicalMaxLevel,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMaxLevel::Id, (uint8_t *) &physicalMaxLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBallastStatus(chip::EndpointId endpoint, uint8_t * ballastStatus)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::BallastStatus, (uint8_t *) ballastStatus,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, BallastStatus::Id, (uint8_t *) ballastStatus,
                                       sizeof(*ballastStatus));
 }
 EmberAfStatus SetBallastStatus(chip::EndpointId endpoint, uint8_t ballastStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::BallastStatus, (uint8_t *) &ballastStatus,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, BallastStatus::Id, (uint8_t *) &ballastStatus,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinLevel(chip::EndpointId endpoint, uint8_t * minLevel)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::MinLevel, (uint8_t *) minLevel, sizeof(*minLevel));
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, MinLevel::Id, (uint8_t *) minLevel, sizeof(*minLevel));
 }
 EmberAfStatus SetMinLevel(chip::EndpointId endpoint, uint8_t minLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::MinLevel, (uint8_t *) &minLevel,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, MinLevel::Id, (uint8_t *) &minLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxLevel(chip::EndpointId endpoint, uint8_t * maxLevel)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::MaxLevel, (uint8_t *) maxLevel, sizeof(*maxLevel));
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, MaxLevel::Id, (uint8_t *) maxLevel, sizeof(*maxLevel));
 }
 EmberAfStatus SetMaxLevel(chip::EndpointId endpoint, uint8_t maxLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::MaxLevel, (uint8_t *) &maxLevel,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, MaxLevel::Id, (uint8_t *) &maxLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerOnLevel(chip::EndpointId endpoint, uint8_t * powerOnLevel)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::PowerOnLevel, (uint8_t *) powerOnLevel,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PowerOnLevel::Id, (uint8_t *) powerOnLevel,
                                       sizeof(*powerOnLevel));
 }
 EmberAfStatus SetPowerOnLevel(chip::EndpointId endpoint, uint8_t powerOnLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::PowerOnLevel, (uint8_t *) &powerOnLevel,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PowerOnLevel::Id, (uint8_t *) &powerOnLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerOnFadeTime(chip::EndpointId endpoint, uint16_t * powerOnFadeTime)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::PowerOnFadeTime, (uint8_t *) powerOnFadeTime,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PowerOnFadeTime::Id, (uint8_t *) powerOnFadeTime,
                                       sizeof(*powerOnFadeTime));
 }
 EmberAfStatus SetPowerOnFadeTime(chip::EndpointId endpoint, uint16_t powerOnFadeTime)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::PowerOnFadeTime, (uint8_t *) &powerOnFadeTime,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PowerOnFadeTime::Id, (uint8_t *) &powerOnFadeTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetIntrinsicBallastFactor(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::IntrinsicBallastFactor,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, IntrinsicBallastFactor::Id,
                                       (uint8_t *) intrinsicBallastFactor, sizeof(*intrinsicBallastFactor));
 }
 EmberAfStatus SetIntrinsicBallastFactor(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::IntrinsicBallastFactor,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, IntrinsicBallastFactor::Id,
                                        (uint8_t *) &intrinsicBallastFactor, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBallastFactorAdjustment(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::BallastFactorAdjustment,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, BallastFactorAdjustment::Id,
                                       (uint8_t *) ballastFactorAdjustment, sizeof(*ballastFactorAdjustment));
 }
 EmberAfStatus SetBallastFactorAdjustment(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::BallastFactorAdjustment,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, BallastFactorAdjustment::Id,
                                        (uint8_t *) &ballastFactorAdjustment, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLampQuality(chip::EndpointId endpoint, uint8_t * lampQuality)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::LampQuality, (uint8_t *) lampQuality,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, LampQuality::Id, (uint8_t *) lampQuality,
                                       sizeof(*lampQuality));
 }
 EmberAfStatus SetLampQuality(chip::EndpointId endpoint, uint8_t lampQuality)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::LampQuality, (uint8_t *) &lampQuality,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, LampQuality::Id, (uint8_t *) &lampQuality,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLampAlarmMode(chip::EndpointId endpoint, uint8_t * lampAlarmMode)
 {
-    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, Ids::LampAlarmMode, (uint8_t *) lampAlarmMode,
+    return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, LampAlarmMode::Id, (uint8_t *) lampAlarmMode,
                                       sizeof(*lampAlarmMode));
 }
 EmberAfStatus SetLampAlarmMode(chip::EndpointId endpoint, uint8_t lampAlarmMode)
 {
-    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, Ids::LampAlarmMode, (uint8_t *) &lampAlarmMode,
+    return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, LampAlarmMode::Id, (uint8_t *) &lampAlarmMode,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4804,52 +4789,52 @@ namespace IlluminanceMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, uint16_t measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) minMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, uint16_t minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) maxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLightSensorType(chip::EndpointId endpoint, uint8_t * lightSensorType)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::LightSensorType, (uint8_t *) lightSensorType,
+    return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, LightSensorType::Id, (uint8_t *) lightSensorType,
                                       sizeof(*lightSensorType));
 }
 EmberAfStatus SetLightSensorType(chip::EndpointId endpoint, uint8_t lightSensorType)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Ids::LightSensorType, (uint8_t *) &lightSensorType,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, LightSensorType::Id, (uint8_t *) &lightSensorType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4859,32 +4844,32 @@ namespace IlluminanceLevelSensing {
 namespace Attributes {
 EmberAfStatus GetLevelStatus(chip::EndpointId endpoint, uint8_t * levelStatus)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, Ids::LevelStatus, (uint8_t *) levelStatus,
+    return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, LevelStatus::Id, (uint8_t *) levelStatus,
                                       sizeof(*levelStatus));
 }
 EmberAfStatus SetLevelStatus(chip::EndpointId endpoint, uint8_t levelStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, Ids::LevelStatus, (uint8_t *) &levelStatus,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, LevelStatus::Id, (uint8_t *) &levelStatus,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLightSensorType(chip::EndpointId endpoint, uint8_t * lightSensorType)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, Ids::LightSensorType, (uint8_t *) lightSensorType,
+    return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, LightSensorType::Id, (uint8_t *) lightSensorType,
                                       sizeof(*lightSensorType));
 }
 EmberAfStatus SetLightSensorType(chip::EndpointId endpoint, uint8_t lightSensorType)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, Ids::LightSensorType, (uint8_t *) &lightSensorType,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, LightSensorType::Id, (uint8_t *) &lightSensorType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetIlluminanceLevelTarget(chip::EndpointId endpoint, uint16_t * illuminanceLevelTarget)
 {
-    return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, Ids::IlluminanceLevelTarget,
+    return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, IlluminanceLevelTarget::Id,
                                       (uint8_t *) illuminanceLevelTarget, sizeof(*illuminanceLevelTarget));
 }
 EmberAfStatus SetIlluminanceLevelTarget(chip::EndpointId endpoint, uint16_t illuminanceLevelTarget)
 {
-    return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, Ids::IlluminanceLevelTarget,
+    return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, IlluminanceLevelTarget::Id,
                                        (uint8_t *) &illuminanceLevelTarget, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4894,42 +4879,42 @@ namespace TemperatureMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) minMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) maxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -4939,90 +4924,90 @@ namespace PressureMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) minMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) maxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetScaledValue(chip::EndpointId endpoint, int16_t * scaledValue)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::ScaledValue, (uint8_t *) scaledValue,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, ScaledValue::Id, (uint8_t *) scaledValue,
                                       sizeof(*scaledValue));
 }
 EmberAfStatus SetScaledValue(chip::EndpointId endpoint, int16_t scaledValue)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::ScaledValue, (uint8_t *) &scaledValue,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, ScaledValue::Id, (uint8_t *) &scaledValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinScaledValue(chip::EndpointId endpoint, int16_t * minScaledValue)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::MinScaledValue, (uint8_t *) minScaledValue,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MinScaledValue::Id, (uint8_t *) minScaledValue,
                                       sizeof(*minScaledValue));
 }
 EmberAfStatus SetMinScaledValue(chip::EndpointId endpoint, int16_t minScaledValue)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::MinScaledValue, (uint8_t *) &minScaledValue,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MinScaledValue::Id, (uint8_t *) &minScaledValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxScaledValue(chip::EndpointId endpoint, int16_t * maxScaledValue)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::MaxScaledValue, (uint8_t *) maxScaledValue,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MaxScaledValue::Id, (uint8_t *) maxScaledValue,
                                       sizeof(*maxScaledValue));
 }
 EmberAfStatus SetMaxScaledValue(chip::EndpointId endpoint, int16_t maxScaledValue)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::MaxScaledValue, (uint8_t *) &maxScaledValue,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MaxScaledValue::Id, (uint8_t *) &maxScaledValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetScaledTolerance(chip::EndpointId endpoint, uint16_t * scaledTolerance)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::ScaledTolerance, (uint8_t *) scaledTolerance,
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, ScaledTolerance::Id, (uint8_t *) scaledTolerance,
                                       sizeof(*scaledTolerance));
 }
 EmberAfStatus SetScaledTolerance(chip::EndpointId endpoint, uint16_t scaledTolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::ScaledTolerance, (uint8_t *) &scaledTolerance,
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, ScaledTolerance::Id, (uint8_t *) &scaledTolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetScale(chip::EndpointId endpoint, int8_t * scale)
 {
-    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Ids::Scale, (uint8_t *) scale, sizeof(*scale));
+    return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Scale::Id, (uint8_t *) scale, sizeof(*scale));
 }
 EmberAfStatus SetScale(chip::EndpointId endpoint, int8_t scale)
 {
-    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Ids::Scale, (uint8_t *) &scale, ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Scale::Id, (uint8_t *) &scale, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace PressureMeasurement
@@ -5031,41 +5016,41 @@ namespace FlowMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) minMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, Ids::MinMeasuredValue, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) maxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, Ids::MaxMeasuredValue, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5075,42 +5060,42 @@ namespace RelativeHumidityMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, uint16_t measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::MinMeasuredValue,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
+                                      sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, uint16_t minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::MaxMeasuredValue,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
+                                      sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5120,134 +5105,134 @@ namespace OccupancySensing {
 namespace Attributes {
 EmberAfStatus GetOccupancy(chip::EndpointId endpoint, uint8_t * occupancy)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::Occupancy, (uint8_t *) occupancy, sizeof(*occupancy));
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Occupancy::Id, (uint8_t *) occupancy, sizeof(*occupancy));
 }
 EmberAfStatus SetOccupancy(chip::EndpointId endpoint, uint8_t occupancy)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::Occupancy, (uint8_t *) &occupancy,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Occupancy::Id, (uint8_t *) &occupancy,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOccupancySensorType(chip::EndpointId endpoint, uint8_t * occupancySensorType)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::OccupancySensorType, (uint8_t *) occupancySensorType,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorType::Id, (uint8_t *) occupancySensorType,
                                       sizeof(*occupancySensorType));
 }
 EmberAfStatus SetOccupancySensorType(chip::EndpointId endpoint, uint8_t occupancySensorType)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::OccupancySensorType, (uint8_t *) &occupancySensorType,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorType::Id, (uint8_t *) &occupancySensorType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOccupancySensorTypeBitmap(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::OccupancySensorTypeBitmap,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorTypeBitmap::Id,
                                       (uint8_t *) occupancySensorTypeBitmap, sizeof(*occupancySensorTypeBitmap));
 }
 EmberAfStatus SetOccupancySensorTypeBitmap(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::OccupancySensorTypeBitmap,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorTypeBitmap::Id,
                                        (uint8_t *) &occupancySensorTypeBitmap, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPirOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::PirOccupiedToUnoccupiedDelay,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PirOccupiedToUnoccupiedDelay::Id,
                                       (uint8_t *) pirOccupiedToUnoccupiedDelay, sizeof(*pirOccupiedToUnoccupiedDelay));
 }
 EmberAfStatus SetPirOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::PirOccupiedToUnoccupiedDelay,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PirOccupiedToUnoccupiedDelay::Id,
                                        (uint8_t *) &pirOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPirUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::PirUnoccupiedToOccupiedDelay,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedDelay::Id,
                                       (uint8_t *) pirUnoccupiedToOccupiedDelay, sizeof(*pirUnoccupiedToOccupiedDelay));
 }
 EmberAfStatus SetPirUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::PirUnoccupiedToOccupiedDelay,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedDelay::Id,
                                        (uint8_t *) &pirUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPirUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::PirUnoccupiedToOccupiedThreshold,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedThreshold::Id,
                                       (uint8_t *) pirUnoccupiedToOccupiedThreshold, sizeof(*pirUnoccupiedToOccupiedThreshold));
 }
 EmberAfStatus SetPirUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::PirUnoccupiedToOccupiedThreshold,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedThreshold::Id,
                                        (uint8_t *) &pirUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUltrasonicOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t * ultrasonicOccupiedToUnoccupiedDelay)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::UltrasonicOccupiedToUnoccupiedDelay,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, UltrasonicOccupiedToUnoccupiedDelay::Id,
                                       (uint8_t *) ultrasonicOccupiedToUnoccupiedDelay,
                                       sizeof(*ultrasonicOccupiedToUnoccupiedDelay));
 }
 EmberAfStatus SetUltrasonicOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::UltrasonicOccupiedToUnoccupiedDelay,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, UltrasonicOccupiedToUnoccupiedDelay::Id,
                                        (uint8_t *) &ultrasonicOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUltrasonicUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t * ultrasonicUnoccupiedToOccupiedDelay)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::UltrasonicUnoccupiedToOccupiedDelay,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedDelay::Id,
                                       (uint8_t *) ultrasonicUnoccupiedToOccupiedDelay,
                                       sizeof(*ultrasonicUnoccupiedToOccupiedDelay));
 }
 EmberAfStatus SetUltrasonicUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::UltrasonicUnoccupiedToOccupiedDelay,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedDelay::Id,
                                        (uint8_t *) &ultrasonicUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUltrasonicUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
                                                          uint8_t * ultrasonicUnoccupiedToOccupiedThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::UltrasonicUnoccupiedToOccupiedThreshold,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedThreshold::Id,
                                       (uint8_t *) ultrasonicUnoccupiedToOccupiedThreshold,
                                       sizeof(*ultrasonicUnoccupiedToOccupiedThreshold));
 }
 EmberAfStatus SetUltrasonicUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t ultrasonicUnoccupiedToOccupiedThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::UltrasonicUnoccupiedToOccupiedThreshold,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedThreshold::Id,
                                        (uint8_t *) &ultrasonicUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhysicalContactOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
                                                           uint16_t * physicalContactOccupiedToUnoccupiedDelay)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::PhysicalContactOccupiedToUnoccupiedDelay,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactOccupiedToUnoccupiedDelay::Id,
                                       (uint8_t *) physicalContactOccupiedToUnoccupiedDelay,
                                       sizeof(*physicalContactOccupiedToUnoccupiedDelay));
 }
 EmberAfStatus SetPhysicalContactOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
                                                           uint16_t physicalContactOccupiedToUnoccupiedDelay)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::PhysicalContactOccupiedToUnoccupiedDelay,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactOccupiedToUnoccupiedDelay::Id,
                                        (uint8_t *) &physicalContactOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhysicalContactUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
                                                           uint16_t * physicalContactUnoccupiedToOccupiedDelay)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::PhysicalContactUnoccupiedToOccupiedDelay,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedDelay::Id,
                                       (uint8_t *) physicalContactUnoccupiedToOccupiedDelay,
                                       sizeof(*physicalContactUnoccupiedToOccupiedDelay));
 }
 EmberAfStatus SetPhysicalContactUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
                                                           uint16_t physicalContactUnoccupiedToOccupiedDelay)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::PhysicalContactUnoccupiedToOccupiedDelay,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedDelay::Id,
                                        (uint8_t *) &physicalContactUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhysicalContactUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
                                                               uint8_t * physicalContactUnoccupiedToOccupiedThreshold)
 {
-    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Ids::PhysicalContactUnoccupiedToOccupiedThreshold,
+    return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedThreshold::Id,
                                       (uint8_t *) physicalContactUnoccupiedToOccupiedThreshold,
                                       sizeof(*physicalContactUnoccupiedToOccupiedThreshold));
 }
 EmberAfStatus SetPhysicalContactUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
                                                               uint8_t physicalContactUnoccupiedToOccupiedThreshold)
 {
-    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Ids::PhysicalContactUnoccupiedToOccupiedThreshold,
+    return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedThreshold::Id,
                                        (uint8_t *) &physicalContactUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5257,42 +5242,42 @@ namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5302,42 +5287,42 @@ namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5347,42 +5332,42 @@ namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5392,42 +5377,42 @@ namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5437,42 +5422,42 @@ namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5482,42 +5467,42 @@ namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5527,42 +5512,42 @@ namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5572,43 +5557,43 @@ namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Ids::Tolerance,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace NitrogenDioxideConcentrationMeasurement
@@ -5617,42 +5602,42 @@ namespace OxygenConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5662,42 +5647,42 @@ namespace OzoneConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5707,42 +5692,42 @@ namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5752,43 +5737,43 @@ namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Ids::Tolerance,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace DissolvedOxygenConcentrationMeasurement
@@ -5797,42 +5782,42 @@ namespace BromateConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::MeasuredValue,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5842,42 +5827,42 @@ namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5887,42 +5872,42 @@ namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5932,42 +5917,42 @@ namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -5977,42 +5962,42 @@ namespace FluorideConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6022,43 +6007,43 @@ namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Ids::Tolerance,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace HaloaceticAcidsConcentrationMeasurement
@@ -6067,42 +6052,42 @@ namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6112,42 +6097,42 @@ namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6157,42 +6142,42 @@ namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::MeasuredValue,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
+                                      sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6202,42 +6187,42 @@ namespace CopperConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6247,42 +6232,42 @@ namespace LeadConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6292,42 +6277,42 @@ namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::MeasuredValue,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
+                                      sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6337,42 +6322,42 @@ namespace SulfateConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::MeasuredValue,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6382,42 +6367,42 @@ namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6427,42 +6412,42 @@ namespace BromoformConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::MeasuredValue,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
+                                      sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6472,42 +6457,42 @@ namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Ids::Tolerance,
+    return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6517,42 +6502,42 @@ namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::MeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6562,42 +6547,42 @@ namespace SodiumConcentrationMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) measuredValue,
+    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::MeasuredValue, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::MinMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
-    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
-    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::MaxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
-    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) tolerance,
+    return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
 EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
-    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Ids::Tolerance, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6607,65 +6592,64 @@ namespace IasZone {
 namespace Attributes {
 EmberAfStatus GetZoneState(chip::EndpointId endpoint, uint8_t * zoneState)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::ZoneState, (uint8_t *) zoneState, sizeof(*zoneState));
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneState::Id, (uint8_t *) zoneState, sizeof(*zoneState));
 }
 EmberAfStatus SetZoneState(chip::EndpointId endpoint, uint8_t zoneState)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::ZoneState, (uint8_t *) &zoneState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneState::Id, (uint8_t *) &zoneState, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetZoneType(chip::EndpointId endpoint, uint16_t * zoneType)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::ZoneType, (uint8_t *) zoneType, sizeof(*zoneType));
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneType::Id, (uint8_t *) zoneType, sizeof(*zoneType));
 }
 EmberAfStatus SetZoneType(chip::EndpointId endpoint, uint16_t zoneType)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::ZoneType, (uint8_t *) &zoneType, ZCL_ENUM16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneType::Id, (uint8_t *) &zoneType, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetZoneStatus(chip::EndpointId endpoint, uint16_t * zoneStatus)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::ZoneStatus, (uint8_t *) zoneStatus, sizeof(*zoneStatus));
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneStatus::Id, (uint8_t *) zoneStatus, sizeof(*zoneStatus));
 }
 EmberAfStatus SetZoneStatus(chip::EndpointId endpoint, uint16_t zoneStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::ZoneStatus, (uint8_t *) &zoneStatus,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneStatus::Id, (uint8_t *) &zoneStatus, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetIasCieAddress(chip::EndpointId endpoint, chip::NodeId * iasCieAddress)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::IasCieAddress, (uint8_t *) iasCieAddress, sizeof(*iasCieAddress));
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, IasCieAddress::Id, (uint8_t *) iasCieAddress, sizeof(*iasCieAddress));
 }
 EmberAfStatus SetIasCieAddress(chip::EndpointId endpoint, chip::NodeId iasCieAddress)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::IasCieAddress, (uint8_t *) &iasCieAddress,
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, IasCieAddress::Id, (uint8_t *) &iasCieAddress,
                                        ZCL_NODE_ID_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetZoneId(chip::EndpointId endpoint, uint8_t * zoneId)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::ZoneId, (uint8_t *) zoneId, sizeof(*zoneId));
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneId::Id, (uint8_t *) zoneId, sizeof(*zoneId));
 }
 EmberAfStatus SetZoneId(chip::EndpointId endpoint, uint8_t zoneId)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::ZoneId, (uint8_t *) &zoneId, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneId::Id, (uint8_t *) &zoneId, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNumberOfZoneSensitivityLevelsSupported(chip::EndpointId endpoint, uint8_t * numberOfZoneSensitivityLevelsSupported)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::NumberOfZoneSensitivityLevelsSupported,
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, NumberOfZoneSensitivityLevelsSupported::Id,
                                       (uint8_t *) numberOfZoneSensitivityLevelsSupported,
                                       sizeof(*numberOfZoneSensitivityLevelsSupported));
 }
 EmberAfStatus SetNumberOfZoneSensitivityLevelsSupported(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::NumberOfZoneSensitivityLevelsSupported,
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, NumberOfZoneSensitivityLevelsSupported::Id,
                                        (uint8_t *) &numberOfZoneSensitivityLevelsSupported, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentZoneSensitivityLevel(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel)
 {
-    return emberAfReadServerAttribute(endpoint, IasZone::Id, Ids::CurrentZoneSensitivityLevel,
+    return emberAfReadServerAttribute(endpoint, IasZone::Id, CurrentZoneSensitivityLevel::Id,
                                       (uint8_t *) currentZoneSensitivityLevel, sizeof(*currentZoneSensitivityLevel));
 }
 EmberAfStatus SetCurrentZoneSensitivityLevel(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel)
 {
-    return emberAfWriteServerAttribute(endpoint, IasZone::Id, Ids::CurrentZoneSensitivityLevel,
+    return emberAfWriteServerAttribute(endpoint, IasZone::Id, CurrentZoneSensitivityLevel::Id,
                                        (uint8_t *) &currentZoneSensitivityLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6675,11 +6659,11 @@ namespace IasWd {
 namespace Attributes {
 EmberAfStatus GetMaxDuration(chip::EndpointId endpoint, uint16_t * maxDuration)
 {
-    return emberAfReadServerAttribute(endpoint, IasWd::Id, Ids::MaxDuration, (uint8_t *) maxDuration, sizeof(*maxDuration));
+    return emberAfReadServerAttribute(endpoint, IasWd::Id, MaxDuration::Id, (uint8_t *) maxDuration, sizeof(*maxDuration));
 }
 EmberAfStatus SetMaxDuration(chip::EndpointId endpoint, uint16_t maxDuration)
 {
-    return emberAfWriteServerAttribute(endpoint, IasWd::Id, Ids::MaxDuration, (uint8_t *) &maxDuration, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, IasWd::Id, MaxDuration::Id, (uint8_t *) &maxDuration, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace IasWd
@@ -6698,12 +6682,12 @@ namespace TargetNavigator {
 namespace Attributes {
 EmberAfStatus GetCurrentNavigatorTarget(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget)
 {
-    return emberAfReadServerAttribute(endpoint, TargetNavigator::Id, Ids::CurrentNavigatorTarget,
-                                      (uint8_t *) currentNavigatorTarget, sizeof(*currentNavigatorTarget));
+    return emberAfReadServerAttribute(endpoint, TargetNavigator::Id, CurrentNavigatorTarget::Id, (uint8_t *) currentNavigatorTarget,
+                                      sizeof(*currentNavigatorTarget));
 }
 EmberAfStatus SetCurrentNavigatorTarget(chip::EndpointId endpoint, uint8_t currentNavigatorTarget)
 {
-    return emberAfWriteServerAttribute(endpoint, TargetNavigator::Id, Ids::CurrentNavigatorTarget,
+    return emberAfWriteServerAttribute(endpoint, TargetNavigator::Id, CurrentNavigatorTarget::Id,
                                        (uint8_t *) &currentNavigatorTarget, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6713,79 +6697,77 @@ namespace MediaPlayback {
 namespace Attributes {
 EmberAfStatus GetPlaybackState(chip::EndpointId endpoint, uint8_t * playbackState)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::PlaybackState, (uint8_t *) playbackState,
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, PlaybackState::Id, (uint8_t *) playbackState,
                                       sizeof(*playbackState));
 }
 EmberAfStatus SetPlaybackState(chip::EndpointId endpoint, uint8_t playbackState)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::PlaybackState, (uint8_t *) &playbackState,
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, PlaybackState::Id, (uint8_t *) &playbackState,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetStartTime(chip::EndpointId endpoint, uint64_t * startTime)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::StartTime, (uint8_t *) startTime, sizeof(*startTime));
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, StartTime::Id, (uint8_t *) startTime, sizeof(*startTime));
 }
 EmberAfStatus SetStartTime(chip::EndpointId endpoint, uint64_t startTime)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::StartTime, (uint8_t *) &startTime,
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, StartTime::Id, (uint8_t *) &startTime,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDuration(chip::EndpointId endpoint, uint64_t * duration)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::Duration, (uint8_t *) duration, sizeof(*duration));
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Duration::Id, (uint8_t *) duration, sizeof(*duration));
 }
 EmberAfStatus SetDuration(chip::EndpointId endpoint, uint64_t duration)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::Duration, (uint8_t *) &duration,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Duration::Id, (uint8_t *) &duration, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPositionUpdatedAt(chip::EndpointId endpoint, uint64_t * positionUpdatedAt)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::PositionUpdatedAt, (uint8_t *) positionUpdatedAt,
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, PositionUpdatedAt::Id, (uint8_t *) positionUpdatedAt,
                                       sizeof(*positionUpdatedAt));
 }
 EmberAfStatus SetPositionUpdatedAt(chip::EndpointId endpoint, uint64_t positionUpdatedAt)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::PositionUpdatedAt, (uint8_t *) &positionUpdatedAt,
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, PositionUpdatedAt::Id, (uint8_t *) &positionUpdatedAt,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPosition(chip::EndpointId endpoint, uint64_t * position)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::Position, (uint8_t *) position, sizeof(*position));
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Position::Id, (uint8_t *) position, sizeof(*position));
 }
 EmberAfStatus SetPosition(chip::EndpointId endpoint, uint64_t position)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::Position, (uint8_t *) &position,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Position::Id, (uint8_t *) &position, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPlaybackSpeed(chip::EndpointId endpoint, uint64_t * playbackSpeed)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::PlaybackSpeed, (uint8_t *) playbackSpeed,
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, PlaybackSpeed::Id, (uint8_t *) playbackSpeed,
                                       sizeof(*playbackSpeed));
 }
 EmberAfStatus SetPlaybackSpeed(chip::EndpointId endpoint, uint64_t playbackSpeed)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::PlaybackSpeed, (uint8_t *) &playbackSpeed,
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, PlaybackSpeed::Id, (uint8_t *) &playbackSpeed,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSeekRangeEnd(chip::EndpointId endpoint, uint64_t * seekRangeEnd)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::SeekRangeEnd, (uint8_t *) seekRangeEnd,
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, SeekRangeEnd::Id, (uint8_t *) seekRangeEnd,
                                       sizeof(*seekRangeEnd));
 }
 EmberAfStatus SetSeekRangeEnd(chip::EndpointId endpoint, uint64_t seekRangeEnd)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::SeekRangeEnd, (uint8_t *) &seekRangeEnd,
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, SeekRangeEnd::Id, (uint8_t *) &seekRangeEnd,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetSeekRangeStart(chip::EndpointId endpoint, uint64_t * seekRangeStart)
 {
-    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Ids::SeekRangeStart, (uint8_t *) seekRangeStart,
+    return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, SeekRangeStart::Id, (uint8_t *) seekRangeStart,
                                       sizeof(*seekRangeStart));
 }
 EmberAfStatus SetSeekRangeStart(chip::EndpointId endpoint, uint64_t seekRangeStart)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Ids::SeekRangeStart, (uint8_t *) &seekRangeStart,
+    return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, SeekRangeStart::Id, (uint8_t *) &seekRangeStart,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6795,12 +6777,12 @@ namespace MediaInput {
 namespace Attributes {
 EmberAfStatus GetCurrentMediaInput(chip::EndpointId endpoint, uint8_t * currentMediaInput)
 {
-    return emberAfReadServerAttribute(endpoint, MediaInput::Id, Ids::CurrentMediaInput, (uint8_t *) currentMediaInput,
+    return emberAfReadServerAttribute(endpoint, MediaInput::Id, CurrentMediaInput::Id, (uint8_t *) currentMediaInput,
                                       sizeof(*currentMediaInput));
 }
 EmberAfStatus SetCurrentMediaInput(chip::EndpointId endpoint, uint8_t currentMediaInput)
 {
-    return emberAfWriteServerAttribute(endpoint, MediaInput::Id, Ids::CurrentMediaInput, (uint8_t *) &currentMediaInput,
+    return emberAfWriteServerAttribute(endpoint, MediaInput::Id, CurrentMediaInput::Id, (uint8_t *) &currentMediaInput,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6815,12 +6797,12 @@ namespace AudioOutput {
 namespace Attributes {
 EmberAfStatus GetCurrentAudioOutput(chip::EndpointId endpoint, uint8_t * currentAudioOutput)
 {
-    return emberAfReadServerAttribute(endpoint, AudioOutput::Id, Ids::CurrentAudioOutput, (uint8_t *) currentAudioOutput,
+    return emberAfReadServerAttribute(endpoint, AudioOutput::Id, CurrentAudioOutput::Id, (uint8_t *) currentAudioOutput,
                                       sizeof(*currentAudioOutput));
 }
 EmberAfStatus SetCurrentAudioOutput(chip::EndpointId endpoint, uint8_t currentAudioOutput)
 {
-    return emberAfWriteServerAttribute(endpoint, AudioOutput::Id, Ids::CurrentAudioOutput, (uint8_t *) &currentAudioOutput,
+    return emberAfWriteServerAttribute(endpoint, AudioOutput::Id, CurrentAudioOutput::Id, (uint8_t *) &currentAudioOutput,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6830,22 +6812,22 @@ namespace ApplicationLauncher {
 namespace Attributes {
 EmberAfStatus GetCatalogVendorId(chip::EndpointId endpoint, uint8_t * catalogVendorId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplicationLauncher::Id, Ids::CatalogVendorId, (uint8_t *) catalogVendorId,
+    return emberAfReadServerAttribute(endpoint, ApplicationLauncher::Id, CatalogVendorId::Id, (uint8_t *) catalogVendorId,
                                       sizeof(*catalogVendorId));
 }
 EmberAfStatus SetCatalogVendorId(chip::EndpointId endpoint, uint8_t catalogVendorId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplicationLauncher::Id, Ids::CatalogVendorId, (uint8_t *) &catalogVendorId,
+    return emberAfWriteServerAttribute(endpoint, ApplicationLauncher::Id, CatalogVendorId::Id, (uint8_t *) &catalogVendorId,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetApplicationId(chip::EndpointId endpoint, uint8_t * applicationId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplicationLauncher::Id, Ids::ApplicationId, (uint8_t *) applicationId,
+    return emberAfReadServerAttribute(endpoint, ApplicationLauncher::Id, ApplicationId::Id, (uint8_t *) applicationId,
                                       sizeof(*applicationId));
 }
 EmberAfStatus SetApplicationId(chip::EndpointId endpoint, uint8_t applicationId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplicationLauncher::Id, Ids::ApplicationId, (uint8_t *) &applicationId,
+    return emberAfWriteServerAttribute(endpoint, ApplicationLauncher::Id, ApplicationId::Id, (uint8_t *) &applicationId,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6855,40 +6837,40 @@ namespace ApplicationBasic {
 namespace Attributes {
 EmberAfStatus GetVendorId(chip::EndpointId endpoint, uint16_t * vendorId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, Ids::VendorId, (uint8_t *) vendorId, sizeof(*vendorId));
+    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, VendorId::Id, (uint8_t *) vendorId, sizeof(*vendorId));
 }
 EmberAfStatus SetVendorId(chip::EndpointId endpoint, uint16_t vendorId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, Ids::VendorId, (uint8_t *) &vendorId,
+    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, VendorId::Id, (uint8_t *) &vendorId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetProductId(chip::EndpointId endpoint, uint16_t * productId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, Ids::ProductId, (uint8_t *) productId, sizeof(*productId));
+    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, ProductId::Id, (uint8_t *) productId, sizeof(*productId));
 }
 EmberAfStatus SetProductId(chip::EndpointId endpoint, uint16_t productId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, Ids::ProductId, (uint8_t *) &productId,
+    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, ProductId::Id, (uint8_t *) &productId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCatalogVendorId(chip::EndpointId endpoint, uint16_t * catalogVendorId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, Ids::CatalogVendorId, (uint8_t *) catalogVendorId,
+    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, CatalogVendorId::Id, (uint8_t *) catalogVendorId,
                                       sizeof(*catalogVendorId));
 }
 EmberAfStatus SetCatalogVendorId(chip::EndpointId endpoint, uint16_t catalogVendorId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, Ids::CatalogVendorId, (uint8_t *) &catalogVendorId,
+    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, CatalogVendorId::Id, (uint8_t *) &catalogVendorId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetApplicationStatus(chip::EndpointId endpoint, uint8_t * applicationStatus)
 {
-    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, Ids::ApplicationStatus, (uint8_t *) applicationStatus,
+    return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, ApplicationStatus::Id, (uint8_t *) applicationStatus,
                                       sizeof(*applicationStatus));
 }
 EmberAfStatus SetApplicationStatus(chip::EndpointId endpoint, uint8_t applicationStatus)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, Ids::ApplicationStatus, (uint8_t *) &applicationStatus,
+    return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, ApplicationStatus::Id, (uint8_t *) &applicationStatus,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -6898,150 +6880,147 @@ namespace TestCluster {
 namespace Attributes {
 EmberAfStatus GetBoolean(chip::EndpointId endpoint, bool * boolean)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Boolean, (uint8_t *) boolean, sizeof(*boolean));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Boolean::Id, (uint8_t *) boolean, sizeof(*boolean));
 }
 EmberAfStatus SetBoolean(chip::EndpointId endpoint, bool boolean)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Boolean, (uint8_t *) &boolean, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Boolean::Id, (uint8_t *) &boolean, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBitmap8(chip::EndpointId endpoint, uint8_t * bitmap8)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap8, (uint8_t *) bitmap8, sizeof(*bitmap8));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap8::Id, (uint8_t *) bitmap8, sizeof(*bitmap8));
 }
 EmberAfStatus SetBitmap8(chip::EndpointId endpoint, uint8_t bitmap8)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap8, (uint8_t *) &bitmap8, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap8::Id, (uint8_t *) &bitmap8, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBitmap16(chip::EndpointId endpoint, uint16_t * bitmap16)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap16, (uint8_t *) bitmap16, sizeof(*bitmap16));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap16::Id, (uint8_t *) bitmap16, sizeof(*bitmap16));
 }
 EmberAfStatus SetBitmap16(chip::EndpointId endpoint, uint16_t bitmap16)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap16, (uint8_t *) &bitmap16,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap16::Id, (uint8_t *) &bitmap16, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBitmap32(chip::EndpointId endpoint, uint32_t * bitmap32)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap32, (uint8_t *) bitmap32, sizeof(*bitmap32));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap32::Id, (uint8_t *) bitmap32, sizeof(*bitmap32));
 }
 EmberAfStatus SetBitmap32(chip::EndpointId endpoint, uint32_t bitmap32)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap32, (uint8_t *) &bitmap32,
-                                       ZCL_BITMAP32_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap32::Id, (uint8_t *) &bitmap32, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBitmap64(chip::EndpointId endpoint, uint64_t * bitmap64)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap64, (uint8_t *) bitmap64, sizeof(*bitmap64));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap64::Id, (uint8_t *) bitmap64, sizeof(*bitmap64));
 }
 EmberAfStatus SetBitmap64(chip::EndpointId endpoint, uint64_t bitmap64)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Bitmap64, (uint8_t *) &bitmap64,
-                                       ZCL_BITMAP64_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap64::Id, (uint8_t *) &bitmap64, ZCL_BITMAP64_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt8u(chip::EndpointId endpoint, uint8_t * int8u)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int8u, (uint8_t *) int8u, sizeof(*int8u));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int8u::Id, (uint8_t *) int8u, sizeof(*int8u));
 }
 EmberAfStatus SetInt8u(chip::EndpointId endpoint, uint8_t int8u)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int8u, (uint8_t *) &int8u, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int8u::Id, (uint8_t *) &int8u, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt16u(chip::EndpointId endpoint, uint16_t * int16u)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int16u, (uint8_t *) int16u, sizeof(*int16u));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int16u::Id, (uint8_t *) int16u, sizeof(*int16u));
 }
 EmberAfStatus SetInt16u(chip::EndpointId endpoint, uint16_t int16u)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int16u, (uint8_t *) &int16u, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int16u::Id, (uint8_t *) &int16u, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt32u(chip::EndpointId endpoint, uint32_t * int32u)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int32u, (uint8_t *) int32u, sizeof(*int32u));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int32u::Id, (uint8_t *) int32u, sizeof(*int32u));
 }
 EmberAfStatus SetInt32u(chip::EndpointId endpoint, uint32_t int32u)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int32u, (uint8_t *) &int32u, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int32u::Id, (uint8_t *) &int32u, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt64u(chip::EndpointId endpoint, uint64_t * int64u)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int64u, (uint8_t *) int64u, sizeof(*int64u));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int64u::Id, (uint8_t *) int64u, sizeof(*int64u));
 }
 EmberAfStatus SetInt64u(chip::EndpointId endpoint, uint64_t int64u)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int64u, (uint8_t *) &int64u, ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int64u::Id, (uint8_t *) &int64u, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt8s(chip::EndpointId endpoint, int8_t * int8s)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int8s, (uint8_t *) int8s, sizeof(*int8s));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int8s::Id, (uint8_t *) int8s, sizeof(*int8s));
 }
 EmberAfStatus SetInt8s(chip::EndpointId endpoint, int8_t int8s)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int8s, (uint8_t *) &int8s, ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int8s::Id, (uint8_t *) &int8s, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt16s(chip::EndpointId endpoint, int16_t * int16s)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int16s, (uint8_t *) int16s, sizeof(*int16s));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int16s::Id, (uint8_t *) int16s, sizeof(*int16s));
 }
 EmberAfStatus SetInt16s(chip::EndpointId endpoint, int16_t int16s)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int16s, (uint8_t *) &int16s, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int16s::Id, (uint8_t *) &int16s, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt32s(chip::EndpointId endpoint, int32_t * int32s)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int32s, (uint8_t *) int32s, sizeof(*int32s));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int32s::Id, (uint8_t *) int32s, sizeof(*int32s));
 }
 EmberAfStatus SetInt32s(chip::EndpointId endpoint, int32_t int32s)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int32s, (uint8_t *) &int32s, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int32s::Id, (uint8_t *) &int32s, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInt64s(chip::EndpointId endpoint, int64_t * int64s)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Int64s, (uint8_t *) int64s, sizeof(*int64s));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int64s::Id, (uint8_t *) int64s, sizeof(*int64s));
 }
 EmberAfStatus SetInt64s(chip::EndpointId endpoint, int64_t int64s)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Int64s, (uint8_t *) &int64s, ZCL_INT64S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int64s::Id, (uint8_t *) &int64s, ZCL_INT64S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnum8(chip::EndpointId endpoint, uint8_t * enum8)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Enum8, (uint8_t *) enum8, sizeof(*enum8));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Enum8::Id, (uint8_t *) enum8, sizeof(*enum8));
 }
 EmberAfStatus SetEnum8(chip::EndpointId endpoint, uint8_t enum8)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Enum8, (uint8_t *) &enum8, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Enum8::Id, (uint8_t *) &enum8, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEnum16(chip::EndpointId endpoint, uint16_t * enum16)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Enum16, (uint8_t *) enum16, sizeof(*enum16));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Enum16::Id, (uint8_t *) enum16, sizeof(*enum16));
 }
 EmberAfStatus SetEnum16(chip::EndpointId endpoint, uint16_t enum16)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Enum16, (uint8_t *) &enum16, ZCL_ENUM16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Enum16::Id, (uint8_t *) &enum16, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEpochUs(chip::EndpointId endpoint, uint64_t * epochUs)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::EpochUs, (uint8_t *) epochUs, sizeof(*epochUs));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, EpochUs::Id, (uint8_t *) epochUs, sizeof(*epochUs));
 }
 EmberAfStatus SetEpochUs(chip::EndpointId endpoint, uint64_t epochUs)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::EpochUs, (uint8_t *) &epochUs, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, EpochUs::Id, (uint8_t *) &epochUs, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEpochS(chip::EndpointId endpoint, uint32_t * epochS)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::EpochS, (uint8_t *) epochS, sizeof(*epochS));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, EpochS::Id, (uint8_t *) epochS, sizeof(*epochS));
 }
 EmberAfStatus SetEpochS(chip::EndpointId endpoint, uint32_t epochS)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::EpochS, (uint8_t *) &epochS, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, EpochS::Id, (uint8_t *) &epochS, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetUnsupported(chip::EndpointId endpoint, bool * unsupported)
 {
-    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Unsupported, (uint8_t *) unsupported, sizeof(*unsupported));
+    return emberAfReadServerAttribute(endpoint, TestCluster::Id, Unsupported::Id, (uint8_t *) unsupported, sizeof(*unsupported));
 }
 EmberAfStatus SetUnsupported(chip::EndpointId endpoint, bool unsupported)
 {
-    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Unsupported, (uint8_t *) &unsupported,
+    return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Unsupported::Id, (uint8_t *) &unsupported,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -7051,41 +7030,41 @@ namespace ApplianceIdentification {
 namespace Attributes {
 EmberAfStatus GetCompanyId(chip::EndpointId endpoint, uint16_t * companyId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, Ids::CompanyId, (uint8_t *) companyId,
+    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, CompanyId::Id, (uint8_t *) companyId,
                                       sizeof(*companyId));
 }
 EmberAfStatus SetCompanyId(chip::EndpointId endpoint, uint16_t companyId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, Ids::CompanyId, (uint8_t *) &companyId,
+    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, CompanyId::Id, (uint8_t *) &companyId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetBrandId(chip::EndpointId endpoint, uint16_t * brandId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, Ids::BrandId, (uint8_t *) brandId, sizeof(*brandId));
+    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, BrandId::Id, (uint8_t *) brandId, sizeof(*brandId));
 }
 EmberAfStatus SetBrandId(chip::EndpointId endpoint, uint16_t brandId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, Ids::BrandId, (uint8_t *) &brandId,
+    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, BrandId::Id, (uint8_t *) &brandId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetProductTypeId(chip::EndpointId endpoint, uint16_t * productTypeId)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, Ids::ProductTypeId, (uint8_t *) productTypeId,
+    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, ProductTypeId::Id, (uint8_t *) productTypeId,
                                       sizeof(*productTypeId));
 }
 EmberAfStatus SetProductTypeId(chip::EndpointId endpoint, uint16_t productTypeId)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, Ids::ProductTypeId, (uint8_t *) &productTypeId,
+    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, ProductTypeId::Id, (uint8_t *) &productTypeId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCecedSpecificationVersion(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, Ids::CecedSpecificationVersion,
+    return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, CecedSpecificationVersion::Id,
                                       (uint8_t *) cecedSpecificationVersion, sizeof(*cecedSpecificationVersion));
 }
 EmberAfStatus SetCecedSpecificationVersion(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, Ids::CecedSpecificationVersion,
+    return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, CecedSpecificationVersion::Id,
                                        (uint8_t *) &cecedSpecificationVersion, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -7095,22 +7074,22 @@ namespace MeterIdentification {
 namespace Attributes {
 EmberAfStatus GetMeterTypeId(chip::EndpointId endpoint, uint16_t * meterTypeId)
 {
-    return emberAfReadServerAttribute(endpoint, MeterIdentification::Id, Ids::MeterTypeId, (uint8_t *) meterTypeId,
+    return emberAfReadServerAttribute(endpoint, MeterIdentification::Id, MeterTypeId::Id, (uint8_t *) meterTypeId,
                                       sizeof(*meterTypeId));
 }
 EmberAfStatus SetMeterTypeId(chip::EndpointId endpoint, uint16_t meterTypeId)
 {
-    return emberAfWriteServerAttribute(endpoint, MeterIdentification::Id, Ids::MeterTypeId, (uint8_t *) &meterTypeId,
+    return emberAfWriteServerAttribute(endpoint, MeterIdentification::Id, MeterTypeId::Id, (uint8_t *) &meterTypeId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDataQualityId(chip::EndpointId endpoint, uint16_t * dataQualityId)
 {
-    return emberAfReadServerAttribute(endpoint, MeterIdentification::Id, Ids::DataQualityId, (uint8_t *) dataQualityId,
+    return emberAfReadServerAttribute(endpoint, MeterIdentification::Id, DataQualityId::Id, (uint8_t *) dataQualityId,
                                       sizeof(*dataQualityId));
 }
 EmberAfStatus SetDataQualityId(chip::EndpointId endpoint, uint16_t dataQualityId)
 {
-    return emberAfWriteServerAttribute(endpoint, MeterIdentification::Id, Ids::DataQualityId, (uint8_t *) &dataQualityId,
+    return emberAfWriteServerAttribute(endpoint, MeterIdentification::Id, DataQualityId::Id, (uint8_t *) &dataQualityId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -7120,22 +7099,22 @@ namespace ApplianceStatistics {
 namespace Attributes {
 EmberAfStatus GetLogMaxSize(chip::EndpointId endpoint, uint32_t * logMaxSize)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceStatistics::Id, Ids::LogMaxSize, (uint8_t *) logMaxSize,
+    return emberAfReadServerAttribute(endpoint, ApplianceStatistics::Id, LogMaxSize::Id, (uint8_t *) logMaxSize,
                                       sizeof(*logMaxSize));
 }
 EmberAfStatus SetLogMaxSize(chip::EndpointId endpoint, uint32_t logMaxSize)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceStatistics::Id, Ids::LogMaxSize, (uint8_t *) &logMaxSize,
+    return emberAfWriteServerAttribute(endpoint, ApplianceStatistics::Id, LogMaxSize::Id, (uint8_t *) &logMaxSize,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLogQueueMaxSize(chip::EndpointId endpoint, uint8_t * logQueueMaxSize)
 {
-    return emberAfReadServerAttribute(endpoint, ApplianceStatistics::Id, Ids::LogQueueMaxSize, (uint8_t *) logQueueMaxSize,
+    return emberAfReadServerAttribute(endpoint, ApplianceStatistics::Id, LogQueueMaxSize::Id, (uint8_t *) logQueueMaxSize,
                                       sizeof(*logQueueMaxSize));
 }
 EmberAfStatus SetLogQueueMaxSize(chip::EndpointId endpoint, uint8_t logQueueMaxSize)
 {
-    return emberAfWriteServerAttribute(endpoint, ApplianceStatistics::Id, Ids::LogQueueMaxSize, (uint8_t *) &logQueueMaxSize,
+    return emberAfWriteServerAttribute(endpoint, ApplianceStatistics::Id, LogQueueMaxSize::Id, (uint8_t *) &logQueueMaxSize,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -7145,1289 +7124,1289 @@ namespace ElectricalMeasurement {
 namespace Attributes {
 EmberAfStatus GetMeasurementType(chip::EndpointId endpoint, uint32_t * measurementType)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasurementType, (uint8_t *) measurementType,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasurementType::Id, (uint8_t *) measurementType,
                                       sizeof(*measurementType));
 }
 EmberAfStatus SetMeasurementType(chip::EndpointId endpoint, uint32_t measurementType)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasurementType, (uint8_t *) &measurementType,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasurementType::Id, (uint8_t *) &measurementType,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcVoltage(chip::EndpointId endpoint, int16_t * dcVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltage, (uint8_t *) dcVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltage::Id, (uint8_t *) dcVoltage,
                                       sizeof(*dcVoltage));
 }
 EmberAfStatus SetDcVoltage(chip::EndpointId endpoint, int16_t dcVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltage, (uint8_t *) &dcVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltage::Id, (uint8_t *) &dcVoltage,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcVoltageMin(chip::EndpointId endpoint, int16_t * dcVoltageMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageMin, (uint8_t *) dcVoltageMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMin::Id, (uint8_t *) dcVoltageMin,
                                       sizeof(*dcVoltageMin));
 }
 EmberAfStatus SetDcVoltageMin(chip::EndpointId endpoint, int16_t dcVoltageMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageMin, (uint8_t *) &dcVoltageMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMin::Id, (uint8_t *) &dcVoltageMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcVoltageMax(chip::EndpointId endpoint, int16_t * dcVoltageMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageMax, (uint8_t *) dcVoltageMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMax::Id, (uint8_t *) dcVoltageMax,
                                       sizeof(*dcVoltageMax));
 }
 EmberAfStatus SetDcVoltageMax(chip::EndpointId endpoint, int16_t dcVoltageMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageMax, (uint8_t *) &dcVoltageMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMax::Id, (uint8_t *) &dcVoltageMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcCurrent(chip::EndpointId endpoint, int16_t * dcCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrent, (uint8_t *) dcCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrent::Id, (uint8_t *) dcCurrent,
                                       sizeof(*dcCurrent));
 }
 EmberAfStatus SetDcCurrent(chip::EndpointId endpoint, int16_t dcCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrent, (uint8_t *) &dcCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrent::Id, (uint8_t *) &dcCurrent,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcCurrentMin(chip::EndpointId endpoint, int16_t * dcCurrentMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentMin, (uint8_t *) dcCurrentMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMin::Id, (uint8_t *) dcCurrentMin,
                                       sizeof(*dcCurrentMin));
 }
 EmberAfStatus SetDcCurrentMin(chip::EndpointId endpoint, int16_t dcCurrentMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentMin, (uint8_t *) &dcCurrentMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMin::Id, (uint8_t *) &dcCurrentMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcCurrentMax(chip::EndpointId endpoint, int16_t * dcCurrentMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentMax, (uint8_t *) dcCurrentMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMax::Id, (uint8_t *) dcCurrentMax,
                                       sizeof(*dcCurrentMax));
 }
 EmberAfStatus SetDcCurrentMax(chip::EndpointId endpoint, int16_t dcCurrentMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentMax, (uint8_t *) &dcCurrentMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMax::Id, (uint8_t *) &dcCurrentMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcPower(chip::EndpointId endpoint, int16_t * dcPower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPower, (uint8_t *) dcPower, sizeof(*dcPower));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPower::Id, (uint8_t *) dcPower, sizeof(*dcPower));
 }
 EmberAfStatus SetDcPower(chip::EndpointId endpoint, int16_t dcPower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPower, (uint8_t *) &dcPower,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPower::Id, (uint8_t *) &dcPower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcPowerMin(chip::EndpointId endpoint, int16_t * dcPowerMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerMin, (uint8_t *) dcPowerMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMin::Id, (uint8_t *) dcPowerMin,
                                       sizeof(*dcPowerMin));
 }
 EmberAfStatus SetDcPowerMin(chip::EndpointId endpoint, int16_t dcPowerMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerMin, (uint8_t *) &dcPowerMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMin::Id, (uint8_t *) &dcPowerMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcPowerMax(chip::EndpointId endpoint, int16_t * dcPowerMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerMax, (uint8_t *) dcPowerMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMax::Id, (uint8_t *) dcPowerMax,
                                       sizeof(*dcPowerMax));
 }
 EmberAfStatus SetDcPowerMax(chip::EndpointId endpoint, int16_t dcPowerMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerMax, (uint8_t *) &dcPowerMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMax::Id, (uint8_t *) &dcPowerMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcVoltageMultiplier(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageMultiplier,
-                                      (uint8_t *) dcVoltageMultiplier, sizeof(*dcVoltageMultiplier));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMultiplier::Id, (uint8_t *) dcVoltageMultiplier,
+                                      sizeof(*dcVoltageMultiplier));
 }
 EmberAfStatus SetDcVoltageMultiplier(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMultiplier::Id,
                                        (uint8_t *) &dcVoltageMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcVoltageDivisor(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageDivisor, (uint8_t *) dcVoltageDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageDivisor::Id, (uint8_t *) dcVoltageDivisor,
                                       sizeof(*dcVoltageDivisor));
 }
 EmberAfStatus SetDcVoltageDivisor(chip::EndpointId endpoint, uint16_t dcVoltageDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcVoltageDivisor, (uint8_t *) &dcVoltageDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageDivisor::Id, (uint8_t *) &dcVoltageDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcCurrentMultiplier(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentMultiplier,
-                                      (uint8_t *) dcCurrentMultiplier, sizeof(*dcCurrentMultiplier));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMultiplier::Id, (uint8_t *) dcCurrentMultiplier,
+                                      sizeof(*dcCurrentMultiplier));
 }
 EmberAfStatus SetDcCurrentMultiplier(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMultiplier::Id,
                                        (uint8_t *) &dcCurrentMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcCurrentDivisor(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentDivisor, (uint8_t *) dcCurrentDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentDivisor::Id, (uint8_t *) dcCurrentDivisor,
                                       sizeof(*dcCurrentDivisor));
 }
 EmberAfStatus SetDcCurrentDivisor(chip::EndpointId endpoint, uint16_t dcCurrentDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcCurrentDivisor, (uint8_t *) &dcCurrentDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentDivisor::Id, (uint8_t *) &dcCurrentDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcPowerMultiplier(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerMultiplier, (uint8_t *) dcPowerMultiplier,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMultiplier::Id, (uint8_t *) dcPowerMultiplier,
                                       sizeof(*dcPowerMultiplier));
 }
 EmberAfStatus SetDcPowerMultiplier(chip::EndpointId endpoint, uint16_t dcPowerMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerMultiplier, (uint8_t *) &dcPowerMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMultiplier::Id, (uint8_t *) &dcPowerMultiplier,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetDcPowerDivisor(chip::EndpointId endpoint, uint16_t * dcPowerDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerDivisor, (uint8_t *) dcPowerDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerDivisor::Id, (uint8_t *) dcPowerDivisor,
                                       sizeof(*dcPowerDivisor));
 }
 EmberAfStatus SetDcPowerDivisor(chip::EndpointId endpoint, uint16_t dcPowerDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::DcPowerDivisor, (uint8_t *) &dcPowerDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerDivisor::Id, (uint8_t *) &dcPowerDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcFrequency(chip::EndpointId endpoint, uint16_t * acFrequency)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequency, (uint8_t *) acFrequency,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequency::Id, (uint8_t *) acFrequency,
                                       sizeof(*acFrequency));
 }
 EmberAfStatus SetAcFrequency(chip::EndpointId endpoint, uint16_t acFrequency)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequency, (uint8_t *) &acFrequency,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequency::Id, (uint8_t *) &acFrequency,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcFrequencyMin(chip::EndpointId endpoint, uint16_t * acFrequencyMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyMin, (uint8_t *) acFrequencyMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMin::Id, (uint8_t *) acFrequencyMin,
                                       sizeof(*acFrequencyMin));
 }
 EmberAfStatus SetAcFrequencyMin(chip::EndpointId endpoint, uint16_t acFrequencyMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyMin, (uint8_t *) &acFrequencyMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMin::Id, (uint8_t *) &acFrequencyMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcFrequencyMax(chip::EndpointId endpoint, uint16_t * acFrequencyMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyMax, (uint8_t *) acFrequencyMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMax::Id, (uint8_t *) acFrequencyMax,
                                       sizeof(*acFrequencyMax));
 }
 EmberAfStatus SetAcFrequencyMax(chip::EndpointId endpoint, uint16_t acFrequencyMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyMax, (uint8_t *) &acFrequencyMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMax::Id, (uint8_t *) &acFrequencyMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetNeutralCurrent(chip::EndpointId endpoint, uint16_t * neutralCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::NeutralCurrent, (uint8_t *) neutralCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, NeutralCurrent::Id, (uint8_t *) neutralCurrent,
                                       sizeof(*neutralCurrent));
 }
 EmberAfStatus SetNeutralCurrent(chip::EndpointId endpoint, uint16_t neutralCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::NeutralCurrent, (uint8_t *) &neutralCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, NeutralCurrent::Id, (uint8_t *) &neutralCurrent,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTotalActivePower(chip::EndpointId endpoint, int32_t * totalActivePower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::TotalActivePower, (uint8_t *) totalActivePower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, TotalActivePower::Id, (uint8_t *) totalActivePower,
                                       sizeof(*totalActivePower));
 }
 EmberAfStatus SetTotalActivePower(chip::EndpointId endpoint, int32_t totalActivePower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::TotalActivePower, (uint8_t *) &totalActivePower,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, TotalActivePower::Id, (uint8_t *) &totalActivePower,
                                        ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTotalReactivePower(chip::EndpointId endpoint, int32_t * totalReactivePower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::TotalReactivePower, (uint8_t *) totalReactivePower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, TotalReactivePower::Id, (uint8_t *) totalReactivePower,
                                       sizeof(*totalReactivePower));
 }
 EmberAfStatus SetTotalReactivePower(chip::EndpointId endpoint, int32_t totalReactivePower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::TotalReactivePower,
-                                       (uint8_t *) &totalReactivePower, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, TotalReactivePower::Id, (uint8_t *) &totalReactivePower,
+                                       ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetTotalApparentPower(chip::EndpointId endpoint, uint32_t * totalApparentPower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::TotalApparentPower, (uint8_t *) totalApparentPower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, TotalApparentPower::Id, (uint8_t *) totalApparentPower,
                                       sizeof(*totalApparentPower));
 }
 EmberAfStatus SetTotalApparentPower(chip::EndpointId endpoint, uint32_t totalApparentPower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::TotalApparentPower,
-                                       (uint8_t *) &totalApparentPower, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, TotalApparentPower::Id, (uint8_t *) &totalApparentPower,
+                                       ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasured1stHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured1stHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured1stHarmonicCurrent::Id,
                                       (uint8_t *) measured1stHarmonicCurrent, sizeof(*measured1stHarmonicCurrent));
 }
 EmberAfStatus SetMeasured1stHarmonicCurrent(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured1stHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured1stHarmonicCurrent::Id,
                                        (uint8_t *) &measured1stHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasured3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured3rdHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured3rdHarmonicCurrent::Id,
                                       (uint8_t *) measured3rdHarmonicCurrent, sizeof(*measured3rdHarmonicCurrent));
 }
 EmberAfStatus SetMeasured3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured3rdHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured3rdHarmonicCurrent::Id,
                                        (uint8_t *) &measured3rdHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasured5thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured5thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured5thHarmonicCurrent::Id,
                                       (uint8_t *) measured5thHarmonicCurrent, sizeof(*measured5thHarmonicCurrent));
 }
 EmberAfStatus SetMeasured5thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured5thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured5thHarmonicCurrent::Id,
                                        (uint8_t *) &measured5thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasured7thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured7thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured7thHarmonicCurrent::Id,
                                       (uint8_t *) measured7thHarmonicCurrent, sizeof(*measured7thHarmonicCurrent));
 }
 EmberAfStatus SetMeasured7thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured7thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured7thHarmonicCurrent::Id,
                                        (uint8_t *) &measured7thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasured9thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured9thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured9thHarmonicCurrent::Id,
                                       (uint8_t *) measured9thHarmonicCurrent, sizeof(*measured9thHarmonicCurrent));
 }
 EmberAfStatus SetMeasured9thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured9thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured9thHarmonicCurrent::Id,
                                        (uint8_t *) &measured9thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasured11thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured11thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured11thHarmonicCurrent::Id,
                                       (uint8_t *) measured11thHarmonicCurrent, sizeof(*measured11thHarmonicCurrent));
 }
 EmberAfStatus SetMeasured11thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::Measured11thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured11thHarmonicCurrent::Id,
                                        (uint8_t *) &measured11thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasuredPhase1stHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase1stHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase1stHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase1stHarmonicCurrent, sizeof(*measuredPhase1stHarmonicCurrent));
 }
 EmberAfStatus SetMeasuredPhase1stHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase1stHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase1stHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase1stHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasuredPhase3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase3rdHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase3rdHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase3rdHarmonicCurrent, sizeof(*measuredPhase3rdHarmonicCurrent));
 }
 EmberAfStatus SetMeasuredPhase3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase3rdHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase3rdHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase3rdHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasuredPhase5thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase5thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase5thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase5thHarmonicCurrent, sizeof(*measuredPhase5thHarmonicCurrent));
 }
 EmberAfStatus SetMeasuredPhase5thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase5thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase5thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase5thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasuredPhase7thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase7thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase7thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase7thHarmonicCurrent, sizeof(*measuredPhase7thHarmonicCurrent));
 }
 EmberAfStatus SetMeasuredPhase7thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase7thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase7thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase7thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasuredPhase9thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase9thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase9thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase9thHarmonicCurrent, sizeof(*measuredPhase9thHarmonicCurrent));
 }
 EmberAfStatus SetMeasuredPhase9thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase9thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase9thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase9thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetMeasuredPhase11thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase11thHarmonicCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase11thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase11thHarmonicCurrent, sizeof(*measuredPhase11thHarmonicCurrent));
 }
 EmberAfStatus SetMeasuredPhase11thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::MeasuredPhase11thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase11thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase11thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcFrequencyMultiplier(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyMultiplier,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMultiplier::Id,
                                       (uint8_t *) acFrequencyMultiplier, sizeof(*acFrequencyMultiplier));
 }
 EmberAfStatus SetAcFrequencyMultiplier(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMultiplier::Id,
                                        (uint8_t *) &acFrequencyMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcFrequencyDivisor(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyDivisor, (uint8_t *) acFrequencyDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyDivisor::Id, (uint8_t *) acFrequencyDivisor,
                                       sizeof(*acFrequencyDivisor));
 }
 EmberAfStatus SetAcFrequencyDivisor(chip::EndpointId endpoint, uint16_t acFrequencyDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcFrequencyDivisor,
-                                       (uint8_t *) &acFrequencyDivisor, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyDivisor::Id, (uint8_t *) &acFrequencyDivisor,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerMultiplier(chip::EndpointId endpoint, uint32_t * powerMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerMultiplier, (uint8_t *) powerMultiplier,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerMultiplier::Id, (uint8_t *) powerMultiplier,
                                       sizeof(*powerMultiplier));
 }
 EmberAfStatus SetPowerMultiplier(chip::EndpointId endpoint, uint32_t powerMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerMultiplier, (uint8_t *) &powerMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerMultiplier::Id, (uint8_t *) &powerMultiplier,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerDivisor(chip::EndpointId endpoint, uint32_t * powerDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerDivisor, (uint8_t *) powerDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerDivisor::Id, (uint8_t *) powerDivisor,
                                       sizeof(*powerDivisor));
 }
 EmberAfStatus SetPowerDivisor(chip::EndpointId endpoint, uint32_t powerDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerDivisor, (uint8_t *) &powerDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerDivisor::Id, (uint8_t *) &powerDivisor,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::HarmonicCurrentMultiplier,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, HarmonicCurrentMultiplier::Id,
                                       (uint8_t *) harmonicCurrentMultiplier, sizeof(*harmonicCurrentMultiplier));
 }
 EmberAfStatus SetHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::HarmonicCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, HarmonicCurrentMultiplier::Id,
                                        (uint8_t *) &harmonicCurrentMultiplier, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPhaseHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PhaseHarmonicCurrentMultiplier,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PhaseHarmonicCurrentMultiplier::Id,
                                       (uint8_t *) phaseHarmonicCurrentMultiplier, sizeof(*phaseHarmonicCurrentMultiplier));
 }
 EmberAfStatus SetPhaseHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PhaseHarmonicCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PhaseHarmonicCurrentMultiplier::Id,
                                        (uint8_t *) &phaseHarmonicCurrentMultiplier, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstantaneousVoltage(chip::EndpointId endpoint, int16_t * instantaneousVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousVoltage::Id,
                                       (uint8_t *) instantaneousVoltage, sizeof(*instantaneousVoltage));
 }
 EmberAfStatus SetInstantaneousVoltage(chip::EndpointId endpoint, int16_t instantaneousVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousVoltage::Id,
                                        (uint8_t *) &instantaneousVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstantaneousLineCurrent(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousLineCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousLineCurrent::Id,
                                       (uint8_t *) instantaneousLineCurrent, sizeof(*instantaneousLineCurrent));
 }
 EmberAfStatus SetInstantaneousLineCurrent(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousLineCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousLineCurrent::Id,
                                        (uint8_t *) &instantaneousLineCurrent, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstantaneousActiveCurrent(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousActiveCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousActiveCurrent::Id,
                                       (uint8_t *) instantaneousActiveCurrent, sizeof(*instantaneousActiveCurrent));
 }
 EmberAfStatus SetInstantaneousActiveCurrent(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousActiveCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousActiveCurrent::Id,
                                        (uint8_t *) &instantaneousActiveCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstantaneousReactiveCurrent(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousReactiveCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousReactiveCurrent::Id,
                                       (uint8_t *) instantaneousReactiveCurrent, sizeof(*instantaneousReactiveCurrent));
 }
 EmberAfStatus SetInstantaneousReactiveCurrent(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousReactiveCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousReactiveCurrent::Id,
                                        (uint8_t *) &instantaneousReactiveCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetInstantaneousPower(chip::EndpointId endpoint, int16_t * instantaneousPower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousPower, (uint8_t *) instantaneousPower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousPower::Id, (uint8_t *) instantaneousPower,
                                       sizeof(*instantaneousPower));
 }
 EmberAfStatus SetInstantaneousPower(chip::EndpointId endpoint, int16_t instantaneousPower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::InstantaneousPower,
-                                       (uint8_t *) &instantaneousPower, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousPower::Id, (uint8_t *) &instantaneousPower,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltage(chip::EndpointId endpoint, uint16_t * rmsVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltage, (uint8_t *) rmsVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltage::Id, (uint8_t *) rmsVoltage,
                                       sizeof(*rmsVoltage));
 }
 EmberAfStatus SetRmsVoltage(chip::EndpointId endpoint, uint16_t rmsVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltage, (uint8_t *) &rmsVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltage::Id, (uint8_t *) &rmsVoltage,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageMin(chip::EndpointId endpoint, uint16_t * rmsVoltageMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMin, (uint8_t *) rmsVoltageMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMin::Id, (uint8_t *) rmsVoltageMin,
                                       sizeof(*rmsVoltageMin));
 }
 EmberAfStatus SetRmsVoltageMin(chip::EndpointId endpoint, uint16_t rmsVoltageMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMin, (uint8_t *) &rmsVoltageMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMin::Id, (uint8_t *) &rmsVoltageMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageMax(chip::EndpointId endpoint, uint16_t * rmsVoltageMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMax, (uint8_t *) rmsVoltageMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMax::Id, (uint8_t *) rmsVoltageMax,
                                       sizeof(*rmsVoltageMax));
 }
 EmberAfStatus SetRmsVoltageMax(chip::EndpointId endpoint, uint16_t rmsVoltageMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMax, (uint8_t *) &rmsVoltageMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMax::Id, (uint8_t *) &rmsVoltageMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrent(chip::EndpointId endpoint, uint16_t * rmsCurrent)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrent, (uint8_t *) rmsCurrent,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrent::Id, (uint8_t *) rmsCurrent,
                                       sizeof(*rmsCurrent));
 }
 EmberAfStatus SetRmsCurrent(chip::EndpointId endpoint, uint16_t rmsCurrent)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrent, (uint8_t *) &rmsCurrent,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrent::Id, (uint8_t *) &rmsCurrent,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentMin(chip::EndpointId endpoint, uint16_t * rmsCurrentMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMin, (uint8_t *) rmsCurrentMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMin::Id, (uint8_t *) rmsCurrentMin,
                                       sizeof(*rmsCurrentMin));
 }
 EmberAfStatus SetRmsCurrentMin(chip::EndpointId endpoint, uint16_t rmsCurrentMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMin, (uint8_t *) &rmsCurrentMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMin::Id, (uint8_t *) &rmsCurrentMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentMax(chip::EndpointId endpoint, uint16_t * rmsCurrentMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMax, (uint8_t *) rmsCurrentMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMax::Id, (uint8_t *) rmsCurrentMax,
                                       sizeof(*rmsCurrentMax));
 }
 EmberAfStatus SetRmsCurrentMax(chip::EndpointId endpoint, uint16_t rmsCurrentMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMax, (uint8_t *) &rmsCurrentMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMax::Id, (uint8_t *) &rmsCurrentMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePower(chip::EndpointId endpoint, int16_t * activePower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePower, (uint8_t *) activePower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePower::Id, (uint8_t *) activePower,
                                       sizeof(*activePower));
 }
 EmberAfStatus SetActivePower(chip::EndpointId endpoint, int16_t activePower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePower, (uint8_t *) &activePower,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePower::Id, (uint8_t *) &activePower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerMin(chip::EndpointId endpoint, int16_t * activePowerMin)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMin, (uint8_t *) activePowerMin,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMin::Id, (uint8_t *) activePowerMin,
                                       sizeof(*activePowerMin));
 }
 EmberAfStatus SetActivePowerMin(chip::EndpointId endpoint, int16_t activePowerMin)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMin, (uint8_t *) &activePowerMin,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMin::Id, (uint8_t *) &activePowerMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerMax(chip::EndpointId endpoint, int16_t * activePowerMax)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMax, (uint8_t *) activePowerMax,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMax::Id, (uint8_t *) activePowerMax,
                                       sizeof(*activePowerMax));
 }
 EmberAfStatus SetActivePowerMax(chip::EndpointId endpoint, int16_t activePowerMax)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMax, (uint8_t *) &activePowerMax,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMax::Id, (uint8_t *) &activePowerMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReactivePower(chip::EndpointId endpoint, int16_t * reactivePower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactivePower, (uint8_t *) reactivePower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePower::Id, (uint8_t *) reactivePower,
                                       sizeof(*reactivePower));
 }
 EmberAfStatus SetReactivePower(chip::EndpointId endpoint, int16_t reactivePower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactivePower, (uint8_t *) &reactivePower,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePower::Id, (uint8_t *) &reactivePower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetApparentPower(chip::EndpointId endpoint, uint16_t * apparentPower)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ApparentPower, (uint8_t *) apparentPower,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPower::Id, (uint8_t *) apparentPower,
                                       sizeof(*apparentPower));
 }
 EmberAfStatus SetApparentPower(chip::EndpointId endpoint, uint16_t apparentPower)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ApparentPower, (uint8_t *) &apparentPower,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPower::Id, (uint8_t *) &apparentPower,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerFactor(chip::EndpointId endpoint, int8_t * powerFactor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerFactor, (uint8_t *) powerFactor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactor::Id, (uint8_t *) powerFactor,
                                       sizeof(*powerFactor));
 }
 EmberAfStatus SetPowerFactor(chip::EndpointId endpoint, int8_t powerFactor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerFactor, (uint8_t *) &powerFactor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactor::Id, (uint8_t *) &powerFactor,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsVoltageMeasurementPeriod(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriod)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsVoltageMeasurementPeriod,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriod::Id,
                                       (uint8_t *) averageRmsVoltageMeasurementPeriod, sizeof(*averageRmsVoltageMeasurementPeriod));
 }
 EmberAfStatus SetAverageRmsVoltageMeasurementPeriod(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsVoltageMeasurementPeriod,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriod::Id,
                                        (uint8_t *) &averageRmsVoltageMeasurementPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsUnderVoltageCounter(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltageCounter,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounter::Id,
                                       (uint8_t *) averageRmsUnderVoltageCounter, sizeof(*averageRmsUnderVoltageCounter));
 }
 EmberAfStatus SetAverageRmsUnderVoltageCounter(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltageCounter,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounter::Id,
                                        (uint8_t *) &averageRmsUnderVoltageCounter, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeOverVoltagePeriod(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltagePeriod,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriod::Id,
                                       (uint8_t *) rmsExtremeOverVoltagePeriod, sizeof(*rmsExtremeOverVoltagePeriod));
 }
 EmberAfStatus SetRmsExtremeOverVoltagePeriod(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltagePeriod,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriod::Id,
                                        (uint8_t *) &rmsExtremeOverVoltagePeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeUnderVoltagePeriod(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltagePeriod,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriod::Id,
                                       (uint8_t *) rmsExtremeUnderVoltagePeriod, sizeof(*rmsExtremeUnderVoltagePeriod));
 }
 EmberAfStatus SetRmsExtremeUnderVoltagePeriod(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltagePeriod,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriod::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltagePeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSagPeriod(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSagPeriod,
-                                      (uint8_t *) rmsVoltageSagPeriod, sizeof(*rmsVoltageSagPeriod));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriod::Id, (uint8_t *) rmsVoltageSagPeriod,
+                                      sizeof(*rmsVoltageSagPeriod));
 }
 EmberAfStatus SetRmsVoltageSagPeriod(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSagPeriod,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriod::Id,
                                        (uint8_t *) &rmsVoltageSagPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSwellPeriod(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwellPeriod,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriod::Id,
                                       (uint8_t *) rmsVoltageSwellPeriod, sizeof(*rmsVoltageSwellPeriod));
 }
 EmberAfStatus SetRmsVoltageSwellPeriod(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwellPeriod,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriod::Id,
                                        (uint8_t *) &rmsVoltageSwellPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcVoltageMultiplier(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcVoltageMultiplier,
-                                      (uint8_t *) acVoltageMultiplier, sizeof(*acVoltageMultiplier));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageMultiplier::Id, (uint8_t *) acVoltageMultiplier,
+                                      sizeof(*acVoltageMultiplier));
 }
 EmberAfStatus SetAcVoltageMultiplier(chip::EndpointId endpoint, uint16_t acVoltageMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcVoltageMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageMultiplier::Id,
                                        (uint8_t *) &acVoltageMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcVoltageDivisor(chip::EndpointId endpoint, uint16_t * acVoltageDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcVoltageDivisor, (uint8_t *) acVoltageDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageDivisor::Id, (uint8_t *) acVoltageDivisor,
                                       sizeof(*acVoltageDivisor));
 }
 EmberAfStatus SetAcVoltageDivisor(chip::EndpointId endpoint, uint16_t acVoltageDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcVoltageDivisor, (uint8_t *) &acVoltageDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageDivisor::Id, (uint8_t *) &acVoltageDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCurrentMultiplier(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcCurrentMultiplier,
-                                      (uint8_t *) acCurrentMultiplier, sizeof(*acCurrentMultiplier));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentMultiplier::Id, (uint8_t *) acCurrentMultiplier,
+                                      sizeof(*acCurrentMultiplier));
 }
 EmberAfStatus SetAcCurrentMultiplier(chip::EndpointId endpoint, uint16_t acCurrentMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentMultiplier::Id,
                                        (uint8_t *) &acCurrentMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCurrentDivisor(chip::EndpointId endpoint, uint16_t * acCurrentDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcCurrentDivisor, (uint8_t *) acCurrentDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentDivisor::Id, (uint8_t *) acCurrentDivisor,
                                       sizeof(*acCurrentDivisor));
 }
 EmberAfStatus SetAcCurrentDivisor(chip::EndpointId endpoint, uint16_t acCurrentDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcCurrentDivisor, (uint8_t *) &acCurrentDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentDivisor::Id, (uint8_t *) &acCurrentDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcPowerMultiplier(chip::EndpointId endpoint, uint16_t * acPowerMultiplier)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcPowerMultiplier, (uint8_t *) acPowerMultiplier,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerMultiplier::Id, (uint8_t *) acPowerMultiplier,
                                       sizeof(*acPowerMultiplier));
 }
 EmberAfStatus SetAcPowerMultiplier(chip::EndpointId endpoint, uint16_t acPowerMultiplier)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcPowerMultiplier, (uint8_t *) &acPowerMultiplier,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerMultiplier::Id, (uint8_t *) &acPowerMultiplier,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcPowerDivisor(chip::EndpointId endpoint, uint16_t * acPowerDivisor)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcPowerDivisor, (uint8_t *) acPowerDivisor,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerDivisor::Id, (uint8_t *) acPowerDivisor,
                                       sizeof(*acPowerDivisor));
 }
 EmberAfStatus SetAcPowerDivisor(chip::EndpointId endpoint, uint16_t acPowerDivisor)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcPowerDivisor, (uint8_t *) &acPowerDivisor,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerDivisor::Id, (uint8_t *) &acPowerDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetOverloadAlarmsMask(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::OverloadAlarmsMask, (uint8_t *) overloadAlarmsMask,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, OverloadAlarmsMask::Id, (uint8_t *) overloadAlarmsMask,
                                       sizeof(*overloadAlarmsMask));
 }
 EmberAfStatus SetOverloadAlarmsMask(chip::EndpointId endpoint, uint8_t overloadAlarmsMask)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::OverloadAlarmsMask,
-                                       (uint8_t *) &overloadAlarmsMask, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, OverloadAlarmsMask::Id, (uint8_t *) &overloadAlarmsMask,
+                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetVoltageOverload(chip::EndpointId endpoint, int16_t * voltageOverload)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::VoltageOverload, (uint8_t *) voltageOverload,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, VoltageOverload::Id, (uint8_t *) voltageOverload,
                                       sizeof(*voltageOverload));
 }
 EmberAfStatus SetVoltageOverload(chip::EndpointId endpoint, int16_t voltageOverload)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::VoltageOverload, (uint8_t *) &voltageOverload,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, VoltageOverload::Id, (uint8_t *) &voltageOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetCurrentOverload(chip::EndpointId endpoint, int16_t * currentOverload)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::CurrentOverload, (uint8_t *) currentOverload,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, CurrentOverload::Id, (uint8_t *) currentOverload,
                                       sizeof(*currentOverload));
 }
 EmberAfStatus SetCurrentOverload(chip::EndpointId endpoint, int16_t currentOverload)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::CurrentOverload, (uint8_t *) &currentOverload,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, CurrentOverload::Id, (uint8_t *) &currentOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcOverloadAlarmsMask(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcOverloadAlarmsMask,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcOverloadAlarmsMask::Id,
                                       (uint8_t *) acOverloadAlarmsMask, sizeof(*acOverloadAlarmsMask));
 }
 EmberAfStatus SetAcOverloadAlarmsMask(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcOverloadAlarmsMask,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcOverloadAlarmsMask::Id,
                                        (uint8_t *) &acOverloadAlarmsMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcVoltageOverload(chip::EndpointId endpoint, int16_t * acVoltageOverload)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcVoltageOverload, (uint8_t *) acVoltageOverload,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageOverload::Id, (uint8_t *) acVoltageOverload,
                                       sizeof(*acVoltageOverload));
 }
 EmberAfStatus SetAcVoltageOverload(chip::EndpointId endpoint, int16_t acVoltageOverload)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcVoltageOverload, (uint8_t *) &acVoltageOverload,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageOverload::Id, (uint8_t *) &acVoltageOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcCurrentOverload(chip::EndpointId endpoint, int16_t * acCurrentOverload)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcCurrentOverload, (uint8_t *) acCurrentOverload,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentOverload::Id, (uint8_t *) acCurrentOverload,
                                       sizeof(*acCurrentOverload));
 }
 EmberAfStatus SetAcCurrentOverload(chip::EndpointId endpoint, int16_t acCurrentOverload)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcCurrentOverload, (uint8_t *) &acCurrentOverload,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentOverload::Id, (uint8_t *) &acCurrentOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcActivePowerOverload(chip::EndpointId endpoint, int16_t * acActivePowerOverload)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcActivePowerOverload,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcActivePowerOverload::Id,
                                       (uint8_t *) acActivePowerOverload, sizeof(*acActivePowerOverload));
 }
 EmberAfStatus SetAcActivePowerOverload(chip::EndpointId endpoint, int16_t acActivePowerOverload)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcActivePowerOverload,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcActivePowerOverload::Id,
                                        (uint8_t *) &acActivePowerOverload, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAcReactivePowerOverload(chip::EndpointId endpoint, int16_t * acReactivePowerOverload)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcReactivePowerOverload,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcReactivePowerOverload::Id,
                                       (uint8_t *) acReactivePowerOverload, sizeof(*acReactivePowerOverload));
 }
 EmberAfStatus SetAcReactivePowerOverload(chip::EndpointId endpoint, int16_t acReactivePowerOverload)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AcReactivePowerOverload,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcReactivePowerOverload::Id,
                                        (uint8_t *) &acReactivePowerOverload, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsOverVoltage(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsOverVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltage::Id,
                                       (uint8_t *) averageRmsOverVoltage, sizeof(*averageRmsOverVoltage));
 }
 EmberAfStatus SetAverageRmsOverVoltage(chip::EndpointId endpoint, int16_t averageRmsOverVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsOverVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltage::Id,
                                        (uint8_t *) &averageRmsOverVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsUnderVoltage(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltage::Id,
                                       (uint8_t *) averageRmsUnderVoltage, sizeof(*averageRmsUnderVoltage));
 }
 EmberAfStatus SetAverageRmsUnderVoltage(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltage::Id,
                                        (uint8_t *) &averageRmsUnderVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeOverVoltage(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltage::Id,
                                       (uint8_t *) rmsExtremeOverVoltage, sizeof(*rmsExtremeOverVoltage));
 }
 EmberAfStatus SetRmsExtremeOverVoltage(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltage::Id,
                                        (uint8_t *) &rmsExtremeOverVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeUnderVoltage(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltage,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltage::Id,
                                       (uint8_t *) rmsExtremeUnderVoltage, sizeof(*rmsExtremeUnderVoltage));
 }
 EmberAfStatus SetRmsExtremeUnderVoltage(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltage,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltage::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSag(chip::EndpointId endpoint, int16_t * rmsVoltageSag)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSag, (uint8_t *) rmsVoltageSag,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSag::Id, (uint8_t *) rmsVoltageSag,
                                       sizeof(*rmsVoltageSag));
 }
 EmberAfStatus SetRmsVoltageSag(chip::EndpointId endpoint, int16_t rmsVoltageSag)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSag, (uint8_t *) &rmsVoltageSag,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSag::Id, (uint8_t *) &rmsVoltageSag,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSwell(chip::EndpointId endpoint, int16_t * rmsVoltageSwell)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwell, (uint8_t *) rmsVoltageSwell,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwell::Id, (uint8_t *) rmsVoltageSwell,
                                       sizeof(*rmsVoltageSwell));
 }
 EmberAfStatus SetRmsVoltageSwell(chip::EndpointId endpoint, int16_t rmsVoltageSwell)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwell, (uint8_t *) &rmsVoltageSwell,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwell::Id, (uint8_t *) &rmsVoltageSwell,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLineCurrentPhaseB(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::LineCurrentPhaseB, (uint8_t *) lineCurrentPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseB::Id, (uint8_t *) lineCurrentPhaseB,
                                       sizeof(*lineCurrentPhaseB));
 }
 EmberAfStatus SetLineCurrentPhaseB(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::LineCurrentPhaseB, (uint8_t *) &lineCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseB::Id, (uint8_t *) &lineCurrentPhaseB,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActiveCurrentPhaseB(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActiveCurrentPhaseB,
-                                      (uint8_t *) activeCurrentPhaseB, sizeof(*activeCurrentPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseB::Id, (uint8_t *) activeCurrentPhaseB,
+                                      sizeof(*activeCurrentPhaseB));
 }
 EmberAfStatus SetActiveCurrentPhaseB(chip::EndpointId endpoint, int16_t activeCurrentPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActiveCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseB::Id,
                                        (uint8_t *) &activeCurrentPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReactiveCurrentPhaseB(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactiveCurrentPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseB::Id,
                                       (uint8_t *) reactiveCurrentPhaseB, sizeof(*reactiveCurrentPhaseB));
 }
 EmberAfStatus SetReactiveCurrentPhaseB(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactiveCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseB::Id,
                                        (uint8_t *) &reactiveCurrentPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltagePhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltagePhaseB, (uint8_t *) rmsVoltagePhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseB::Id, (uint8_t *) rmsVoltagePhaseB,
                                       sizeof(*rmsVoltagePhaseB));
 }
 EmberAfStatus SetRmsVoltagePhaseB(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltagePhaseB, (uint8_t *) &rmsVoltagePhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseB::Id, (uint8_t *) &rmsVoltagePhaseB,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageMinPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMinPhaseB,
-                                      (uint8_t *) rmsVoltageMinPhaseB, sizeof(*rmsVoltageMinPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseB::Id, (uint8_t *) rmsVoltageMinPhaseB,
+                                      sizeof(*rmsVoltageMinPhaseB));
 }
 EmberAfStatus SetRmsVoltageMinPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMinPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseB::Id,
                                        (uint8_t *) &rmsVoltageMinPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageMaxPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMaxPhaseB,
-                                      (uint8_t *) rmsVoltageMaxPhaseB, sizeof(*rmsVoltageMaxPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseB::Id, (uint8_t *) rmsVoltageMaxPhaseB,
+                                      sizeof(*rmsVoltageMaxPhaseB));
 }
 EmberAfStatus SetRmsVoltageMaxPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMaxPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseB::Id,
                                        (uint8_t *) &rmsVoltageMaxPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentPhaseB, (uint8_t *) rmsCurrentPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseB::Id, (uint8_t *) rmsCurrentPhaseB,
                                       sizeof(*rmsCurrentPhaseB));
 }
 EmberAfStatus SetRmsCurrentPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentPhaseB, (uint8_t *) &rmsCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseB::Id, (uint8_t *) &rmsCurrentPhaseB,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentMinPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMinPhaseB,
-                                      (uint8_t *) rmsCurrentMinPhaseB, sizeof(*rmsCurrentMinPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseB::Id, (uint8_t *) rmsCurrentMinPhaseB,
+                                      sizeof(*rmsCurrentMinPhaseB));
 }
 EmberAfStatus SetRmsCurrentMinPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMinPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseB::Id,
                                        (uint8_t *) &rmsCurrentMinPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentMaxPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMaxPhaseB,
-                                      (uint8_t *) rmsCurrentMaxPhaseB, sizeof(*rmsCurrentMaxPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseB::Id, (uint8_t *) rmsCurrentMaxPhaseB,
+                                      sizeof(*rmsCurrentMaxPhaseB));
 }
 EmberAfStatus SetRmsCurrentMaxPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMaxPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseB::Id,
                                        (uint8_t *) &rmsCurrentMaxPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerPhaseB(chip::EndpointId endpoint, int16_t * activePowerPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerPhaseB, (uint8_t *) activePowerPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseB::Id, (uint8_t *) activePowerPhaseB,
                                       sizeof(*activePowerPhaseB));
 }
 EmberAfStatus SetActivePowerPhaseB(chip::EndpointId endpoint, int16_t activePowerPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerPhaseB, (uint8_t *) &activePowerPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseB::Id, (uint8_t *) &activePowerPhaseB,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerMinPhaseB(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMinPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseB::Id,
                                       (uint8_t *) activePowerMinPhaseB, sizeof(*activePowerMinPhaseB));
 }
 EmberAfStatus SetActivePowerMinPhaseB(chip::EndpointId endpoint, int16_t activePowerMinPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMinPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseB::Id,
                                        (uint8_t *) &activePowerMinPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerMaxPhaseB(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMaxPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseB::Id,
                                       (uint8_t *) activePowerMaxPhaseB, sizeof(*activePowerMaxPhaseB));
 }
 EmberAfStatus SetActivePowerMaxPhaseB(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMaxPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseB::Id,
                                        (uint8_t *) &activePowerMaxPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReactivePowerPhaseB(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactivePowerPhaseB,
-                                      (uint8_t *) reactivePowerPhaseB, sizeof(*reactivePowerPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseB::Id, (uint8_t *) reactivePowerPhaseB,
+                                      sizeof(*reactivePowerPhaseB));
 }
 EmberAfStatus SetReactivePowerPhaseB(chip::EndpointId endpoint, int16_t reactivePowerPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactivePowerPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseB::Id,
                                        (uint8_t *) &reactivePowerPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetApparentPowerPhaseB(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ApparentPowerPhaseB,
-                                      (uint8_t *) apparentPowerPhaseB, sizeof(*apparentPowerPhaseB));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseB::Id, (uint8_t *) apparentPowerPhaseB,
+                                      sizeof(*apparentPowerPhaseB));
 }
 EmberAfStatus SetApparentPowerPhaseB(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ApparentPowerPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseB::Id,
                                        (uint8_t *) &apparentPowerPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerFactorPhaseB(chip::EndpointId endpoint, int8_t * powerFactorPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerFactorPhaseB, (uint8_t *) powerFactorPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseB::Id, (uint8_t *) powerFactorPhaseB,
                                       sizeof(*powerFactorPhaseB));
 }
 EmberAfStatus SetPowerFactorPhaseB(chip::EndpointId endpoint, int8_t powerFactorPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerFactorPhaseB, (uint8_t *) &powerFactorPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseB::Id, (uint8_t *) &powerFactorPhaseB,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsVoltageMeasurementPeriodPhaseB(chip::EndpointId endpoint,
                                                           uint16_t * averageRmsVoltageMeasurementPeriodPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsVoltageMeasurementPeriodPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseB::Id,
                                       (uint8_t *) averageRmsVoltageMeasurementPeriodPhaseB,
                                       sizeof(*averageRmsVoltageMeasurementPeriodPhaseB));
 }
 EmberAfStatus SetAverageRmsVoltageMeasurementPeriodPhaseB(chip::EndpointId endpoint,
                                                           uint16_t averageRmsVoltageMeasurementPeriodPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsVoltageMeasurementPeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseB::Id,
                                        (uint8_t *) &averageRmsVoltageMeasurementPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsOverVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsOverVoltageCounterPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseB::Id,
                                       (uint8_t *) averageRmsOverVoltageCounterPhaseB, sizeof(*averageRmsOverVoltageCounterPhaseB));
 }
 EmberAfStatus SetAverageRmsOverVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsOverVoltageCounterPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseB::Id,
                                        (uint8_t *) &averageRmsOverVoltageCounterPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsUnderVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltageCounterPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseB::Id,
                                       (uint8_t *) averageRmsUnderVoltageCounterPhaseB,
                                       sizeof(*averageRmsUnderVoltageCounterPhaseB));
 }
 EmberAfStatus SetAverageRmsUnderVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltageCounterPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseB::Id,
                                        (uint8_t *) &averageRmsUnderVoltageCounterPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeOverVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltagePeriodPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseB::Id,
                                       (uint8_t *) rmsExtremeOverVoltagePeriodPhaseB, sizeof(*rmsExtremeOverVoltagePeriodPhaseB));
 }
 EmberAfStatus SetRmsExtremeOverVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltagePeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseB::Id,
                                        (uint8_t *) &rmsExtremeOverVoltagePeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeUnderVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltagePeriodPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseB::Id,
                                       (uint8_t *) rmsExtremeUnderVoltagePeriodPhaseB, sizeof(*rmsExtremeUnderVoltagePeriodPhaseB));
 }
 EmberAfStatus SetRmsExtremeUnderVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltagePeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseB::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltagePeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSagPeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSagPeriodPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseB::Id,
                                       (uint8_t *) rmsVoltageSagPeriodPhaseB, sizeof(*rmsVoltageSagPeriodPhaseB));
 }
 EmberAfStatus SetRmsVoltageSagPeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSagPeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseB::Id,
                                        (uint8_t *) &rmsVoltageSagPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSwellPeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwellPeriodPhaseB,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseB::Id,
                                       (uint8_t *) rmsVoltageSwellPeriodPhaseB, sizeof(*rmsVoltageSwellPeriodPhaseB));
 }
 EmberAfStatus SetRmsVoltageSwellPeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwellPeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseB::Id,
                                        (uint8_t *) &rmsVoltageSwellPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetLineCurrentPhaseC(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::LineCurrentPhaseC, (uint8_t *) lineCurrentPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseC::Id, (uint8_t *) lineCurrentPhaseC,
                                       sizeof(*lineCurrentPhaseC));
 }
 EmberAfStatus SetLineCurrentPhaseC(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::LineCurrentPhaseC, (uint8_t *) &lineCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseC::Id, (uint8_t *) &lineCurrentPhaseC,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActiveCurrentPhaseC(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActiveCurrentPhaseC,
-                                      (uint8_t *) activeCurrentPhaseC, sizeof(*activeCurrentPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseC::Id, (uint8_t *) activeCurrentPhaseC,
+                                      sizeof(*activeCurrentPhaseC));
 }
 EmberAfStatus SetActiveCurrentPhaseC(chip::EndpointId endpoint, int16_t activeCurrentPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActiveCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseC::Id,
                                        (uint8_t *) &activeCurrentPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReactiveCurrentPhaseC(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactiveCurrentPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseC::Id,
                                       (uint8_t *) reactiveCurrentPhaseC, sizeof(*reactiveCurrentPhaseC));
 }
 EmberAfStatus SetReactiveCurrentPhaseC(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactiveCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseC::Id,
                                        (uint8_t *) &reactiveCurrentPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltagePhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltagePhaseC, (uint8_t *) rmsVoltagePhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseC::Id, (uint8_t *) rmsVoltagePhaseC,
                                       sizeof(*rmsVoltagePhaseC));
 }
 EmberAfStatus SetRmsVoltagePhaseC(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltagePhaseC, (uint8_t *) &rmsVoltagePhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseC::Id, (uint8_t *) &rmsVoltagePhaseC,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageMinPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMinPhaseC,
-                                      (uint8_t *) rmsVoltageMinPhaseC, sizeof(*rmsVoltageMinPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseC::Id, (uint8_t *) rmsVoltageMinPhaseC,
+                                      sizeof(*rmsVoltageMinPhaseC));
 }
 EmberAfStatus SetRmsVoltageMinPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMinPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseC::Id,
                                        (uint8_t *) &rmsVoltageMinPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageMaxPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMaxPhaseC,
-                                      (uint8_t *) rmsVoltageMaxPhaseC, sizeof(*rmsVoltageMaxPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseC::Id, (uint8_t *) rmsVoltageMaxPhaseC,
+                                      sizeof(*rmsVoltageMaxPhaseC));
 }
 EmberAfStatus SetRmsVoltageMaxPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageMaxPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseC::Id,
                                        (uint8_t *) &rmsVoltageMaxPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentPhaseC, (uint8_t *) rmsCurrentPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseC::Id, (uint8_t *) rmsCurrentPhaseC,
                                       sizeof(*rmsCurrentPhaseC));
 }
 EmberAfStatus SetRmsCurrentPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentPhaseC, (uint8_t *) &rmsCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseC::Id, (uint8_t *) &rmsCurrentPhaseC,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentMinPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMinPhaseC,
-                                      (uint8_t *) rmsCurrentMinPhaseC, sizeof(*rmsCurrentMinPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseC::Id, (uint8_t *) rmsCurrentMinPhaseC,
+                                      sizeof(*rmsCurrentMinPhaseC));
 }
 EmberAfStatus SetRmsCurrentMinPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMinPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseC::Id,
                                        (uint8_t *) &rmsCurrentMinPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsCurrentMaxPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMaxPhaseC,
-                                      (uint8_t *) rmsCurrentMaxPhaseC, sizeof(*rmsCurrentMaxPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseC::Id, (uint8_t *) rmsCurrentMaxPhaseC,
+                                      sizeof(*rmsCurrentMaxPhaseC));
 }
 EmberAfStatus SetRmsCurrentMaxPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsCurrentMaxPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseC::Id,
                                        (uint8_t *) &rmsCurrentMaxPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerPhaseC(chip::EndpointId endpoint, int16_t * activePowerPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerPhaseC, (uint8_t *) activePowerPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseC::Id, (uint8_t *) activePowerPhaseC,
                                       sizeof(*activePowerPhaseC));
 }
 EmberAfStatus SetActivePowerPhaseC(chip::EndpointId endpoint, int16_t activePowerPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerPhaseC, (uint8_t *) &activePowerPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseC::Id, (uint8_t *) &activePowerPhaseC,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerMinPhaseC(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMinPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseC::Id,
                                       (uint8_t *) activePowerMinPhaseC, sizeof(*activePowerMinPhaseC));
 }
 EmberAfStatus SetActivePowerMinPhaseC(chip::EndpointId endpoint, int16_t activePowerMinPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMinPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseC::Id,
                                        (uint8_t *) &activePowerMinPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetActivePowerMaxPhaseC(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMaxPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseC::Id,
                                       (uint8_t *) activePowerMaxPhaseC, sizeof(*activePowerMaxPhaseC));
 }
 EmberAfStatus SetActivePowerMaxPhaseC(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ActivePowerMaxPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseC::Id,
                                        (uint8_t *) &activePowerMaxPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetReactivePowerPhaseC(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactivePowerPhaseC,
-                                      (uint8_t *) reactivePowerPhaseC, sizeof(*reactivePowerPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseC::Id, (uint8_t *) reactivePowerPhaseC,
+                                      sizeof(*reactivePowerPhaseC));
 }
 EmberAfStatus SetReactivePowerPhaseC(chip::EndpointId endpoint, int16_t reactivePowerPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ReactivePowerPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseC::Id,
                                        (uint8_t *) &reactivePowerPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetApparentPowerPhaseC(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ApparentPowerPhaseC,
-                                      (uint8_t *) apparentPowerPhaseC, sizeof(*apparentPowerPhaseC));
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseC::Id, (uint8_t *) apparentPowerPhaseC,
+                                      sizeof(*apparentPowerPhaseC));
 }
 EmberAfStatus SetApparentPowerPhaseC(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::ApparentPowerPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseC::Id,
                                        (uint8_t *) &apparentPowerPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetPowerFactorPhaseC(chip::EndpointId endpoint, int8_t * powerFactorPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerFactorPhaseC, (uint8_t *) powerFactorPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseC::Id, (uint8_t *) powerFactorPhaseC,
                                       sizeof(*powerFactorPhaseC));
 }
 EmberAfStatus SetPowerFactorPhaseC(chip::EndpointId endpoint, int8_t powerFactorPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::PowerFactorPhaseC, (uint8_t *) &powerFactorPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseC::Id, (uint8_t *) &powerFactorPhaseC,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsVoltageMeasurementPeriodPhaseC(chip::EndpointId endpoint,
                                                           uint16_t * averageRmsVoltageMeasurementPeriodPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsVoltageMeasurementPeriodPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseC::Id,
                                       (uint8_t *) averageRmsVoltageMeasurementPeriodPhaseC,
                                       sizeof(*averageRmsVoltageMeasurementPeriodPhaseC));
 }
 EmberAfStatus SetAverageRmsVoltageMeasurementPeriodPhaseC(chip::EndpointId endpoint,
                                                           uint16_t averageRmsVoltageMeasurementPeriodPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsVoltageMeasurementPeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseC::Id,
                                        (uint8_t *) &averageRmsVoltageMeasurementPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsOverVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsOverVoltageCounterPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseC::Id,
                                       (uint8_t *) averageRmsOverVoltageCounterPhaseC, sizeof(*averageRmsOverVoltageCounterPhaseC));
 }
 EmberAfStatus SetAverageRmsOverVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsOverVoltageCounterPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseC::Id,
                                        (uint8_t *) &averageRmsOverVoltageCounterPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetAverageRmsUnderVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltageCounterPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseC::Id,
                                       (uint8_t *) averageRmsUnderVoltageCounterPhaseC,
                                       sizeof(*averageRmsUnderVoltageCounterPhaseC));
 }
 EmberAfStatus SetAverageRmsUnderVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::AverageRmsUnderVoltageCounterPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseC::Id,
                                        (uint8_t *) &averageRmsUnderVoltageCounterPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeOverVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltagePeriodPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseC::Id,
                                       (uint8_t *) rmsExtremeOverVoltagePeriodPhaseC, sizeof(*rmsExtremeOverVoltagePeriodPhaseC));
 }
 EmberAfStatus SetRmsExtremeOverVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeOverVoltagePeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseC::Id,
                                        (uint8_t *) &rmsExtremeOverVoltagePeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsExtremeUnderVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltagePeriodPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseC::Id,
                                       (uint8_t *) rmsExtremeUnderVoltagePeriodPhaseC, sizeof(*rmsExtremeUnderVoltagePeriodPhaseC));
 }
 EmberAfStatus SetRmsExtremeUnderVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsExtremeUnderVoltagePeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseC::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltagePeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSagPeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSagPeriodPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseC::Id,
                                       (uint8_t *) rmsVoltageSagPeriodPhaseC, sizeof(*rmsVoltageSagPeriodPhaseC));
 }
 EmberAfStatus SetRmsVoltageSagPeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSagPeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseC::Id,
                                        (uint8_t *) &rmsVoltageSagPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetRmsVoltageSwellPeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC)
 {
-    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwellPeriodPhaseC,
+    return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseC::Id,
                                       (uint8_t *) rmsVoltageSwellPeriodPhaseC, sizeof(*rmsVoltageSwellPeriodPhaseC));
 }
 EmberAfStatus SetRmsVoltageSwellPeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC)
 {
-    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Ids::RmsVoltageSwellPeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseC::Id,
                                        (uint8_t *) &rmsVoltageSwellPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -8442,22 +8421,22 @@ namespace SampleMfgSpecificCluster {
 namespace Attributes {
 EmberAfStatus GetEmberSampleAttribute(chip::EndpointId endpoint, uint8_t * emberSampleAttribute)
 {
-    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster::Id, Ids::EmberSampleAttribute,
+    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute::Id,
                                       (uint8_t *) emberSampleAttribute, sizeof(*emberSampleAttribute));
 }
 EmberAfStatus SetEmberSampleAttribute(chip::EndpointId endpoint, uint8_t emberSampleAttribute)
 {
-    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster::Id, Ids::EmberSampleAttribute,
+    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute::Id,
                                        (uint8_t *) &emberSampleAttribute, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEmberSampleAttribute2(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2)
 {
-    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster::Id, Ids::EmberSampleAttribute2,
+    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute2::Id,
                                       (uint8_t *) emberSampleAttribute2, sizeof(*emberSampleAttribute2));
 }
 EmberAfStatus SetEmberSampleAttribute2(chip::EndpointId endpoint, uint8_t emberSampleAttribute2)
 {
-    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster::Id, Ids::EmberSampleAttribute2,
+    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute2::Id,
                                        (uint8_t *) &emberSampleAttribute2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
@@ -8467,22 +8446,22 @@ namespace SampleMfgSpecificCluster2 {
 namespace Attributes {
 EmberAfStatus GetEmberSampleAttribute3(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3)
 {
-    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, Ids::EmberSampleAttribute3,
+    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute3::Id,
                                       (uint8_t *) emberSampleAttribute3, sizeof(*emberSampleAttribute3));
 }
 EmberAfStatus SetEmberSampleAttribute3(chip::EndpointId endpoint, uint16_t emberSampleAttribute3)
 {
-    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, Ids::EmberSampleAttribute3,
+    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute3::Id,
                                        (uint8_t *) &emberSampleAttribute3, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 EmberAfStatus GetEmberSampleAttribute4(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4)
 {
-    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, Ids::EmberSampleAttribute4,
+    return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute4::Id,
                                       (uint8_t *) emberSampleAttribute4, sizeof(*emberSampleAttribute4));
 }
 EmberAfStatus SetEmberSampleAttribute4(chip::EndpointId endpoint, uint16_t emberSampleAttribute4)
 {
-    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, Ids::EmberSampleAttribute4,
+    return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute4::Id,
                                        (uint8_t *) &emberSampleAttribute4, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h
@@ -27,1600 +27,4665 @@ namespace Clusters {
 
 namespace Globals {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId FeatureMap      = 0x0000FFFC;
-static constexpr AttributeId ClusterRevision = 0x0000FFFD;
-} // namespace Ids
+
+namespace FeatureMap {
+static constexpr AttributeId Id = 0x0000FFFC;
+} // namespace FeatureMap
+
+namespace ClusterRevision {
+static constexpr AttributeId Id = 0x0000FFFD;
+} // namespace ClusterRevision
+
 } // namespace Attributes
 } // namespace Globals
 
 namespace PowerConfiguration {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MainsVoltage                   = 0x00000000;
-static constexpr AttributeId MainsFrequency                 = 0x00000001;
-static constexpr AttributeId MainsAlarmMask                 = 0x00000010;
-static constexpr AttributeId MainsVoltageMinThreshold       = 0x00000011;
-static constexpr AttributeId MainsVoltageMaxThreshold       = 0x00000012;
-static constexpr AttributeId MainsVoltageDwellTrip          = 0x00000013;
-static constexpr AttributeId BatteryVoltage                 = 0x00000020;
-static constexpr AttributeId BatteryPercentageRemaining     = 0x00000021;
-static constexpr AttributeId BatteryManufacturer            = 0x00000030;
-static constexpr AttributeId BatterySize                    = 0x00000031;
-static constexpr AttributeId BatteryAhrRating               = 0x00000032;
-static constexpr AttributeId BatteryQuantity                = 0x00000033;
-static constexpr AttributeId BatteryRatedVoltage            = 0x00000034;
-static constexpr AttributeId BatteryAlarmMask               = 0x00000035;
-static constexpr AttributeId BatteryVoltageMinThreshold     = 0x00000036;
-static constexpr AttributeId BatteryVoltageThreshold1       = 0x00000037;
-static constexpr AttributeId BatteryVoltageThreshold2       = 0x00000038;
-static constexpr AttributeId BatteryVoltageThreshold3       = 0x00000039;
-static constexpr AttributeId BatteryPercentageMinThreshold  = 0x0000003A;
-static constexpr AttributeId BatteryPercentageThreshold1    = 0x0000003B;
-static constexpr AttributeId BatteryPercentageThreshold2    = 0x0000003C;
-static constexpr AttributeId BatteryPercentageThreshold3    = 0x0000003D;
-static constexpr AttributeId BatteryAlarmState              = 0x0000003E;
-static constexpr AttributeId Battery2Voltage                = 0x00000040;
-static constexpr AttributeId Battery2PercentageRemaining    = 0x00000041;
-static constexpr AttributeId Battery2Manufacturer           = 0x00000050;
-static constexpr AttributeId Battery2Size                   = 0x00000051;
-static constexpr AttributeId Battery2AhrRating              = 0x00000052;
-static constexpr AttributeId Battery2Quantity               = 0x00000053;
-static constexpr AttributeId Battery2RatedVoltage           = 0x00000054;
-static constexpr AttributeId Battery2AlarmMask              = 0x00000055;
-static constexpr AttributeId Battery2VoltageMinThreshold    = 0x00000056;
-static constexpr AttributeId Battery2VoltageThreshold1      = 0x00000057;
-static constexpr AttributeId Battery2VoltageThreshold2      = 0x00000058;
-static constexpr AttributeId Battery2VoltageThreshold3      = 0x00000059;
-static constexpr AttributeId Battery2PercentageMinThreshold = 0x0000005A;
-static constexpr AttributeId Battery2PercentageThreshold1   = 0x0000005B;
-static constexpr AttributeId Battery2PercentageThreshold2   = 0x0000005C;
-static constexpr AttributeId Battery2PercentageThreshold3   = 0x0000005D;
-static constexpr AttributeId Battery2AlarmState             = 0x0000005E;
-static constexpr AttributeId Battery3Voltage                = 0x00000060;
-static constexpr AttributeId Battery3PercentageRemaining    = 0x00000061;
-static constexpr AttributeId Battery3Manufacturer           = 0x00000070;
-static constexpr AttributeId Battery3Size                   = 0x00000071;
-static constexpr AttributeId Battery3AhrRating              = 0x00000072;
-static constexpr AttributeId Battery3Quantity               = 0x00000073;
-static constexpr AttributeId Battery3RatedVoltage           = 0x00000074;
-static constexpr AttributeId Battery3AlarmMask              = 0x00000075;
-static constexpr AttributeId Battery3VoltageMinThreshold    = 0x00000076;
-static constexpr AttributeId Battery3VoltageThreshold1      = 0x00000077;
-static constexpr AttributeId Battery3VoltageThreshold2      = 0x00000078;
-static constexpr AttributeId Battery3VoltageThreshold3      = 0x00000079;
-static constexpr AttributeId Battery3PercentageMinThreshold = 0x0000007A;
-static constexpr AttributeId Battery3PercentageThreshold1   = 0x0000007B;
-static constexpr AttributeId Battery3PercentageThreshold2   = 0x0000007C;
-static constexpr AttributeId Battery3PercentageThreshold3   = 0x0000007D;
-static constexpr AttributeId Battery3AlarmState             = 0x0000007E;
-} // namespace Ids
+
+namespace MainsVoltage {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MainsVoltage
+
+namespace MainsFrequency {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MainsFrequency
+
+namespace MainsAlarmMask {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace MainsAlarmMask
+
+namespace MainsVoltageMinThreshold {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace MainsVoltageMinThreshold
+
+namespace MainsVoltageMaxThreshold {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace MainsVoltageMaxThreshold
+
+namespace MainsVoltageDwellTrip {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace MainsVoltageDwellTrip
+
+namespace BatteryVoltage {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace BatteryVoltage
+
+namespace BatteryPercentageRemaining {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace BatteryPercentageRemaining
+
+namespace BatteryManufacturer {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace BatteryManufacturer
+
+namespace BatterySize {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace BatterySize
+
+namespace BatteryAhrRating {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace BatteryAhrRating
+
+namespace BatteryQuantity {
+static constexpr AttributeId Id = 0x00000033;
+} // namespace BatteryQuantity
+
+namespace BatteryRatedVoltage {
+static constexpr AttributeId Id = 0x00000034;
+} // namespace BatteryRatedVoltage
+
+namespace BatteryAlarmMask {
+static constexpr AttributeId Id = 0x00000035;
+} // namespace BatteryAlarmMask
+
+namespace BatteryVoltageMinThreshold {
+static constexpr AttributeId Id = 0x00000036;
+} // namespace BatteryVoltageMinThreshold
+
+namespace BatteryVoltageThreshold1 {
+static constexpr AttributeId Id = 0x00000037;
+} // namespace BatteryVoltageThreshold1
+
+namespace BatteryVoltageThreshold2 {
+static constexpr AttributeId Id = 0x00000038;
+} // namespace BatteryVoltageThreshold2
+
+namespace BatteryVoltageThreshold3 {
+static constexpr AttributeId Id = 0x00000039;
+} // namespace BatteryVoltageThreshold3
+
+namespace BatteryPercentageMinThreshold {
+static constexpr AttributeId Id = 0x0000003A;
+} // namespace BatteryPercentageMinThreshold
+
+namespace BatteryPercentageThreshold1 {
+static constexpr AttributeId Id = 0x0000003B;
+} // namespace BatteryPercentageThreshold1
+
+namespace BatteryPercentageThreshold2 {
+static constexpr AttributeId Id = 0x0000003C;
+} // namespace BatteryPercentageThreshold2
+
+namespace BatteryPercentageThreshold3 {
+static constexpr AttributeId Id = 0x0000003D;
+} // namespace BatteryPercentageThreshold3
+
+namespace BatteryAlarmState {
+static constexpr AttributeId Id = 0x0000003E;
+} // namespace BatteryAlarmState
+
+namespace Battery2Voltage {
+static constexpr AttributeId Id = 0x00000040;
+} // namespace Battery2Voltage
+
+namespace Battery2PercentageRemaining {
+static constexpr AttributeId Id = 0x00000041;
+} // namespace Battery2PercentageRemaining
+
+namespace Battery2Manufacturer {
+static constexpr AttributeId Id = 0x00000050;
+} // namespace Battery2Manufacturer
+
+namespace Battery2Size {
+static constexpr AttributeId Id = 0x00000051;
+} // namespace Battery2Size
+
+namespace Battery2AhrRating {
+static constexpr AttributeId Id = 0x00000052;
+} // namespace Battery2AhrRating
+
+namespace Battery2Quantity {
+static constexpr AttributeId Id = 0x00000053;
+} // namespace Battery2Quantity
+
+namespace Battery2RatedVoltage {
+static constexpr AttributeId Id = 0x00000054;
+} // namespace Battery2RatedVoltage
+
+namespace Battery2AlarmMask {
+static constexpr AttributeId Id = 0x00000055;
+} // namespace Battery2AlarmMask
+
+namespace Battery2VoltageMinThreshold {
+static constexpr AttributeId Id = 0x00000056;
+} // namespace Battery2VoltageMinThreshold
+
+namespace Battery2VoltageThreshold1 {
+static constexpr AttributeId Id = 0x00000057;
+} // namespace Battery2VoltageThreshold1
+
+namespace Battery2VoltageThreshold2 {
+static constexpr AttributeId Id = 0x00000058;
+} // namespace Battery2VoltageThreshold2
+
+namespace Battery2VoltageThreshold3 {
+static constexpr AttributeId Id = 0x00000059;
+} // namespace Battery2VoltageThreshold3
+
+namespace Battery2PercentageMinThreshold {
+static constexpr AttributeId Id = 0x0000005A;
+} // namespace Battery2PercentageMinThreshold
+
+namespace Battery2PercentageThreshold1 {
+static constexpr AttributeId Id = 0x0000005B;
+} // namespace Battery2PercentageThreshold1
+
+namespace Battery2PercentageThreshold2 {
+static constexpr AttributeId Id = 0x0000005C;
+} // namespace Battery2PercentageThreshold2
+
+namespace Battery2PercentageThreshold3 {
+static constexpr AttributeId Id = 0x0000005D;
+} // namespace Battery2PercentageThreshold3
+
+namespace Battery2AlarmState {
+static constexpr AttributeId Id = 0x0000005E;
+} // namespace Battery2AlarmState
+
+namespace Battery3Voltage {
+static constexpr AttributeId Id = 0x00000060;
+} // namespace Battery3Voltage
+
+namespace Battery3PercentageRemaining {
+static constexpr AttributeId Id = 0x00000061;
+} // namespace Battery3PercentageRemaining
+
+namespace Battery3Manufacturer {
+static constexpr AttributeId Id = 0x00000070;
+} // namespace Battery3Manufacturer
+
+namespace Battery3Size {
+static constexpr AttributeId Id = 0x00000071;
+} // namespace Battery3Size
+
+namespace Battery3AhrRating {
+static constexpr AttributeId Id = 0x00000072;
+} // namespace Battery3AhrRating
+
+namespace Battery3Quantity {
+static constexpr AttributeId Id = 0x00000073;
+} // namespace Battery3Quantity
+
+namespace Battery3RatedVoltage {
+static constexpr AttributeId Id = 0x00000074;
+} // namespace Battery3RatedVoltage
+
+namespace Battery3AlarmMask {
+static constexpr AttributeId Id = 0x00000075;
+} // namespace Battery3AlarmMask
+
+namespace Battery3VoltageMinThreshold {
+static constexpr AttributeId Id = 0x00000076;
+} // namespace Battery3VoltageMinThreshold
+
+namespace Battery3VoltageThreshold1 {
+static constexpr AttributeId Id = 0x00000077;
+} // namespace Battery3VoltageThreshold1
+
+namespace Battery3VoltageThreshold2 {
+static constexpr AttributeId Id = 0x00000078;
+} // namespace Battery3VoltageThreshold2
+
+namespace Battery3VoltageThreshold3 {
+static constexpr AttributeId Id = 0x00000079;
+} // namespace Battery3VoltageThreshold3
+
+namespace Battery3PercentageMinThreshold {
+static constexpr AttributeId Id = 0x0000007A;
+} // namespace Battery3PercentageMinThreshold
+
+namespace Battery3PercentageThreshold1 {
+static constexpr AttributeId Id = 0x0000007B;
+} // namespace Battery3PercentageThreshold1
+
+namespace Battery3PercentageThreshold2 {
+static constexpr AttributeId Id = 0x0000007C;
+} // namespace Battery3PercentageThreshold2
+
+namespace Battery3PercentageThreshold3 {
+static constexpr AttributeId Id = 0x0000007D;
+} // namespace Battery3PercentageThreshold3
+
+namespace Battery3AlarmState {
+static constexpr AttributeId Id = 0x0000007E;
+} // namespace Battery3AlarmState
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace PowerConfiguration
 
 namespace DeviceTemperatureConfiguration {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId CurrentTemperature     = 0x00000000;
-static constexpr AttributeId MinTempExperienced     = 0x00000001;
-static constexpr AttributeId MaxTempExperienced     = 0x00000002;
-static constexpr AttributeId OverTempTotalDwell     = 0x00000003;
-static constexpr AttributeId DeviceTempAlarmMask    = 0x00000010;
-static constexpr AttributeId LowTempThreshold       = 0x00000011;
-static constexpr AttributeId HighTempThreshold      = 0x00000012;
-static constexpr AttributeId LowTempDwellTripPoint  = 0x00000013;
-static constexpr AttributeId HighTempDwellTripPoint = 0x00000014;
-} // namespace Ids
+
+namespace CurrentTemperature {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace CurrentTemperature
+
+namespace MinTempExperienced {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinTempExperienced
+
+namespace MaxTempExperienced {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxTempExperienced
+
+namespace OverTempTotalDwell {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace OverTempTotalDwell
+
+namespace DeviceTempAlarmMask {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace DeviceTempAlarmMask
+
+namespace LowTempThreshold {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace LowTempThreshold
+
+namespace HighTempThreshold {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace HighTempThreshold
+
+namespace LowTempDwellTripPoint {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace LowTempDwellTripPoint
+
+namespace HighTempDwellTripPoint {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace HighTempDwellTripPoint
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace DeviceTemperatureConfiguration
 
 namespace Identify {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId IdentifyTime = 0x00000000;
-static constexpr AttributeId IdentifyType = 0x00000001;
-} // namespace Ids
+
+namespace IdentifyTime {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace IdentifyTime
+
+namespace IdentifyType {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace IdentifyType
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Identify
 
 namespace Groups {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId NameSupport = 0x00000000;
-} // namespace Ids
+
+namespace NameSupport {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace NameSupport
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Groups
 
 namespace Scenes {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId SceneCount       = 0x00000000;
-static constexpr AttributeId CurrentScene     = 0x00000001;
-static constexpr AttributeId CurrentGroup     = 0x00000002;
-static constexpr AttributeId SceneValid       = 0x00000003;
-static constexpr AttributeId NameSupport      = 0x00000004;
-static constexpr AttributeId LastConfiguredBy = 0x00000005;
-} // namespace Ids
+
+namespace SceneCount {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace SceneCount
+
+namespace CurrentScene {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentScene
+
+namespace CurrentGroup {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace CurrentGroup
+
+namespace SceneValid {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace SceneValid
+
+namespace NameSupport {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace NameSupport
+
+namespace LastConfiguredBy {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace LastConfiguredBy
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Scenes
 
 namespace OnOff {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId OnOff                                  = 0x00000000;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00000x1002 = 0x10020000;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00000x1049 = 0x10490000;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00010x1002 = 0x10020001;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00010x1040 = 0x10490001;
-static constexpr AttributeId GlobalSceneControl                     = 0x00004000;
-static constexpr AttributeId OnTime                                 = 0x00004001;
-static constexpr AttributeId OffWaitTime                            = 0x00004002;
-static constexpr AttributeId StartUpOnOff                           = 0x00004003;
-} // namespace Ids
+
+namespace OnOff {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace OnOff
+
+namespace SampleMfgSpecificAttribute0x00000x1002 {
+static constexpr AttributeId Id = 0x10020000;
+} // namespace SampleMfgSpecificAttribute0x00000x1002
+
+namespace SampleMfgSpecificAttribute0x00000x1049 {
+static constexpr AttributeId Id = 0x10490000;
+} // namespace SampleMfgSpecificAttribute0x00000x1049
+
+namespace SampleMfgSpecificAttribute0x00010x1002 {
+static constexpr AttributeId Id = 0x10020001;
+} // namespace SampleMfgSpecificAttribute0x00010x1002
+
+namespace SampleMfgSpecificAttribute0x00010x1040 {
+static constexpr AttributeId Id = 0x10490001;
+} // namespace SampleMfgSpecificAttribute0x00010x1040
+
+namespace GlobalSceneControl {
+static constexpr AttributeId Id = 0x00004000;
+} // namespace GlobalSceneControl
+
+namespace OnTime {
+static constexpr AttributeId Id = 0x00004001;
+} // namespace OnTime
+
+namespace OffWaitTime {
+static constexpr AttributeId Id = 0x00004002;
+} // namespace OffWaitTime
+
+namespace StartUpOnOff {
+static constexpr AttributeId Id = 0x00004003;
+} // namespace StartUpOnOff
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OnOff
 
 namespace OnOffSwitchConfiguration {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId SwitchType    = 0x00000000;
-static constexpr AttributeId SwitchActions = 0x00000010;
-} // namespace Ids
+
+namespace SwitchType {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace SwitchType
+
+namespace SwitchActions {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace SwitchActions
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OnOffSwitchConfiguration
 
 namespace LevelControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId CurrentLevel        = 0x00000000;
-static constexpr AttributeId RemainingTime       = 0x00000001;
-static constexpr AttributeId Options             = 0x0000000F;
-static constexpr AttributeId OnOffTransitionTime = 0x00000010;
-static constexpr AttributeId OnLevel             = 0x00000011;
-static constexpr AttributeId OnTransitionTime    = 0x00000012;
-static constexpr AttributeId OffTransitionTime   = 0x00000013;
-static constexpr AttributeId DefaultMoveRate     = 0x00000014;
-static constexpr AttributeId StartUpCurrentLevel = 0x00004000;
-} // namespace Ids
+
+namespace CurrentLevel {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace CurrentLevel
+
+namespace RemainingTime {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace RemainingTime
+
+namespace Options {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace Options
+
+namespace OnOffTransitionTime {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace OnOffTransitionTime
+
+namespace OnLevel {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace OnLevel
+
+namespace OnTransitionTime {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace OnTransitionTime
+
+namespace OffTransitionTime {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace OffTransitionTime
+
+namespace DefaultMoveRate {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace DefaultMoveRate
+
+namespace StartUpCurrentLevel {
+static constexpr AttributeId Id = 0x00004000;
+} // namespace StartUpCurrentLevel
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace LevelControl
 
 namespace Alarms {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId AlarmCount = 0x00000000;
-} // namespace Ids
+
+namespace AlarmCount {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace AlarmCount
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Alarms
 
 namespace Time {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Time           = 0x00000000;
-static constexpr AttributeId TimeStatus     = 0x00000001;
-static constexpr AttributeId TimeZone       = 0x00000002;
-static constexpr AttributeId DstStart       = 0x00000003;
-static constexpr AttributeId DstEnd         = 0x00000004;
-static constexpr AttributeId DstShift       = 0x00000005;
-static constexpr AttributeId StandardTime   = 0x00000006;
-static constexpr AttributeId LocalTime      = 0x00000007;
-static constexpr AttributeId LastSetTime    = 0x00000008;
-static constexpr AttributeId ValidUntilTime = 0x00000009;
-} // namespace Ids
+
+namespace Time {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Time
+
+namespace TimeStatus {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace TimeStatus
+
+namespace TimeZone {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace TimeZone
+
+namespace DstStart {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace DstStart
+
+namespace DstEnd {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace DstEnd
+
+namespace DstShift {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace DstShift
+
+namespace StandardTime {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace StandardTime
+
+namespace LocalTime {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace LocalTime
+
+namespace LastSetTime {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace LastSetTime
+
+namespace ValidUntilTime {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace ValidUntilTime
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Time
 
 namespace BinaryInputBasic {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId ActiveText      = 0x00000004;
-static constexpr AttributeId Description     = 0x0000001C;
-static constexpr AttributeId InactiveText    = 0x0000002E;
-static constexpr AttributeId OutOfService    = 0x00000051;
-static constexpr AttributeId Polarity        = 0x00000054;
-static constexpr AttributeId PresentValue    = 0x00000055;
-static constexpr AttributeId Reliability     = 0x00000067;
-static constexpr AttributeId StatusFlags     = 0x0000006F;
-static constexpr AttributeId ApplicationType = 0x00000100;
-} // namespace Ids
+
+namespace ActiveText {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace ActiveText
+
+namespace Description {
+static constexpr AttributeId Id = 0x0000001C;
+} // namespace Description
+
+namespace InactiveText {
+static constexpr AttributeId Id = 0x0000002E;
+} // namespace InactiveText
+
+namespace OutOfService {
+static constexpr AttributeId Id = 0x00000051;
+} // namespace OutOfService
+
+namespace Polarity {
+static constexpr AttributeId Id = 0x00000054;
+} // namespace Polarity
+
+namespace PresentValue {
+static constexpr AttributeId Id = 0x00000055;
+} // namespace PresentValue
+
+namespace Reliability {
+static constexpr AttributeId Id = 0x00000067;
+} // namespace Reliability
+
+namespace StatusFlags {
+static constexpr AttributeId Id = 0x0000006F;
+} // namespace StatusFlags
+
+namespace ApplicationType {
+static constexpr AttributeId Id = 0x00000100;
+} // namespace ApplicationType
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BinaryInputBasic
 
 namespace PowerProfile {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId TotalProfileNum    = 0x00000000;
-static constexpr AttributeId MultipleScheduling = 0x00000001;
-static constexpr AttributeId EnergyFormatting   = 0x00000002;
-static constexpr AttributeId EnergyRemote       = 0x00000003;
-static constexpr AttributeId ScheduleMode       = 0x00000004;
-} // namespace Ids
+
+namespace TotalProfileNum {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace TotalProfileNum
+
+namespace MultipleScheduling {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MultipleScheduling
+
+namespace EnergyFormatting {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace EnergyFormatting
+
+namespace EnergyRemote {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace EnergyRemote
+
+namespace ScheduleMode {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace ScheduleMode
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace PowerProfile
 
 namespace ApplianceControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId StartTime     = 0x00000000;
-static constexpr AttributeId FinishTime    = 0x00000001;
-static constexpr AttributeId RemainingTime = 0x00000002;
-} // namespace Ids
+
+namespace StartTime {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace StartTime
+
+namespace FinishTime {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace FinishTime
+
+namespace RemainingTime {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace RemainingTime
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ApplianceControl
 
 namespace Descriptor {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId DeviceList = 0x00000000;
-static constexpr AttributeId ServerList = 0x00000001;
-static constexpr AttributeId ClientList = 0x00000002;
-static constexpr AttributeId PartsList  = 0x00000003;
-} // namespace Ids
+
+namespace DeviceList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace DeviceList
+
+namespace ServerList {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace ServerList
+
+namespace ClientList {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ClientList
+
+namespace PartsList {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace PartsList
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Descriptor
 
 namespace PollControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId CheckInInterval     = 0x00000000;
-static constexpr AttributeId LongPollInterval    = 0x00000001;
-static constexpr AttributeId ShortPollInterval   = 0x00000002;
-static constexpr AttributeId FastPollTimeout     = 0x00000003;
-static constexpr AttributeId CheckInIntervalMin  = 0x00000004;
-static constexpr AttributeId LongPollIntervalMin = 0x00000005;
-static constexpr AttributeId FastPollTimeoutMax  = 0x00000006;
-} // namespace Ids
+
+namespace CheckInInterval {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace CheckInInterval
+
+namespace LongPollInterval {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace LongPollInterval
+
+namespace ShortPollInterval {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ShortPollInterval
+
+namespace FastPollTimeout {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace FastPollTimeout
+
+namespace CheckInIntervalMin {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace CheckInIntervalMin
+
+namespace LongPollIntervalMin {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace LongPollIntervalMin
+
+namespace FastPollTimeoutMax {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace FastPollTimeoutMax
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace PollControl
 
 namespace Basic {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId InteractionModelVersion = 0x00000000;
-static constexpr AttributeId VendorName              = 0x00000001;
-static constexpr AttributeId VendorID                = 0x00000002;
-static constexpr AttributeId ProductName             = 0x00000003;
-static constexpr AttributeId ProductID               = 0x00000004;
-static constexpr AttributeId UserLabel               = 0x00000005;
-static constexpr AttributeId Location                = 0x00000006;
-static constexpr AttributeId HardwareVersion         = 0x00000007;
-static constexpr AttributeId HardwareVersionString   = 0x00000008;
-static constexpr AttributeId SoftwareVersion         = 0x00000009;
-static constexpr AttributeId SoftwareVersionString   = 0x0000000A;
-static constexpr AttributeId ManufacturingDate       = 0x0000000B;
-static constexpr AttributeId PartNumber              = 0x0000000C;
-static constexpr AttributeId ProductURL              = 0x0000000D;
-static constexpr AttributeId ProductLabel            = 0x0000000E;
-static constexpr AttributeId SerialNumber            = 0x0000000F;
-static constexpr AttributeId LocalConfigDisabled     = 0x00000010;
-static constexpr AttributeId Reachable               = 0x00000011;
-} // namespace Ids
+
+namespace InteractionModelVersion {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace InteractionModelVersion
+
+namespace VendorName {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace VendorName
+
+namespace VendorID {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace VendorID
+
+namespace ProductName {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace ProductName
+
+namespace ProductID {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace ProductID
+
+namespace UserLabel {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace UserLabel
+
+namespace Location {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace Location
+
+namespace HardwareVersion {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace HardwareVersion
+
+namespace HardwareVersionString {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace HardwareVersionString
+
+namespace SoftwareVersion {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace SoftwareVersion
+
+namespace SoftwareVersionString {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace SoftwareVersionString
+
+namespace ManufacturingDate {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace ManufacturingDate
+
+namespace PartNumber {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace PartNumber
+
+namespace ProductURL {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace ProductURL
+
+namespace ProductLabel {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace ProductLabel
+
+namespace SerialNumber {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace SerialNumber
+
+namespace LocalConfigDisabled {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace LocalConfigDisabled
+
+namespace Reachable {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace Reachable
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Basic
 
 namespace OtaSoftwareUpdateRequestor {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId DefaultOtaProvider = 0x00000001;
-static constexpr AttributeId UpdatePossible     = 0x00000002;
-} // namespace Ids
+
+namespace DefaultOtaProvider {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace DefaultOtaProvider
+
+namespace UpdatePossible {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace UpdatePossible
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OtaSoftwareUpdateRequestor
 
 namespace PowerSource {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Status                         = 0x00000000;
-static constexpr AttributeId Order                          = 0x00000001;
-static constexpr AttributeId Description                    = 0x00000002;
-static constexpr AttributeId WiredAssessedInputVoltage      = 0x00000003;
-static constexpr AttributeId WiredAssessedInputFrequency    = 0x00000004;
-static constexpr AttributeId WiredCurrentType               = 0x00000005;
-static constexpr AttributeId WiredAssessedCurrent           = 0x00000006;
-static constexpr AttributeId WiredNominalVoltage            = 0x00000007;
-static constexpr AttributeId WiredMaximumCurrent            = 0x00000008;
-static constexpr AttributeId WiredPresent                   = 0x00000009;
-static constexpr AttributeId ActiveWiredFaults              = 0x0000000A;
-static constexpr AttributeId BatteryVoltage                 = 0x0000000B;
-static constexpr AttributeId BatteryPercentRemaining        = 0x0000000C;
-static constexpr AttributeId BatteryTimeRemaining           = 0x0000000D;
-static constexpr AttributeId BatteryChargeLevel             = 0x0000000E;
-static constexpr AttributeId BatteryReplacementNeeded       = 0x0000000F;
-static constexpr AttributeId BatteryReplaceability          = 0x00000010;
-static constexpr AttributeId BatteryPresent                 = 0x00000011;
-static constexpr AttributeId ActiveBatteryFaults            = 0x00000012;
-static constexpr AttributeId BatteryReplacementDescription  = 0x00000013;
-static constexpr AttributeId BatteryCommonDesignation       = 0x00000014;
-static constexpr AttributeId BatteryANSIDesignation         = 0x00000015;
-static constexpr AttributeId BatteryIECDesignation          = 0x00000016;
-static constexpr AttributeId BatteryApprovedChemistry       = 0x00000017;
-static constexpr AttributeId BatteryCapacity                = 0x00000018;
-static constexpr AttributeId BatteryQuantity                = 0x00000019;
-static constexpr AttributeId BatteryChargeState             = 0x0000001A;
-static constexpr AttributeId BatteryTimeToFullCharge        = 0x0000001B;
-static constexpr AttributeId BatteryFunctionalWhileCharging = 0x0000001C;
-static constexpr AttributeId BatteryChargingCurrent         = 0x0000001D;
-static constexpr AttributeId ActiveBatteryChargeFaults      = 0x0000001E;
-} // namespace Ids
+
+namespace Status {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Status
+
+namespace Order {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace Order
+
+namespace Description {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace Description
+
+namespace WiredAssessedInputVoltage {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace WiredAssessedInputVoltage
+
+namespace WiredAssessedInputFrequency {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace WiredAssessedInputFrequency
+
+namespace WiredCurrentType {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace WiredCurrentType
+
+namespace WiredAssessedCurrent {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace WiredAssessedCurrent
+
+namespace WiredNominalVoltage {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace WiredNominalVoltage
+
+namespace WiredMaximumCurrent {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace WiredMaximumCurrent
+
+namespace WiredPresent {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace WiredPresent
+
+namespace ActiveWiredFaults {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace ActiveWiredFaults
+
+namespace BatteryVoltage {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace BatteryVoltage
+
+namespace BatteryPercentRemaining {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace BatteryPercentRemaining
+
+namespace BatteryTimeRemaining {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace BatteryTimeRemaining
+
+namespace BatteryChargeLevel {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace BatteryChargeLevel
+
+namespace BatteryReplacementNeeded {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace BatteryReplacementNeeded
+
+namespace BatteryReplaceability {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace BatteryReplaceability
+
+namespace BatteryPresent {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace BatteryPresent
+
+namespace ActiveBatteryFaults {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace ActiveBatteryFaults
+
+namespace BatteryReplacementDescription {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace BatteryReplacementDescription
+
+namespace BatteryCommonDesignation {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace BatteryCommonDesignation
+
+namespace BatteryANSIDesignation {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace BatteryANSIDesignation
+
+namespace BatteryIECDesignation {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace BatteryIECDesignation
+
+namespace BatteryApprovedChemistry {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace BatteryApprovedChemistry
+
+namespace BatteryCapacity {
+static constexpr AttributeId Id = 0x00000018;
+} // namespace BatteryCapacity
+
+namespace BatteryQuantity {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace BatteryQuantity
+
+namespace BatteryChargeState {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace BatteryChargeState
+
+namespace BatteryTimeToFullCharge {
+static constexpr AttributeId Id = 0x0000001B;
+} // namespace BatteryTimeToFullCharge
+
+namespace BatteryFunctionalWhileCharging {
+static constexpr AttributeId Id = 0x0000001C;
+} // namespace BatteryFunctionalWhileCharging
+
+namespace BatteryChargingCurrent {
+static constexpr AttributeId Id = 0x0000001D;
+} // namespace BatteryChargingCurrent
+
+namespace ActiveBatteryChargeFaults {
+static constexpr AttributeId Id = 0x0000001E;
+} // namespace ActiveBatteryChargeFaults
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace PowerSource
 
 namespace GeneralCommissioning {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Breadcrumb                 = 0x00000000;
-static constexpr AttributeId BasicCommissioningInfoList = 0x00000001;
-static constexpr AttributeId RegulatoryConfigList       = 0x00000002;
-static constexpr AttributeId LocationCapabilityList     = 0x00000003;
-} // namespace Ids
+
+namespace Breadcrumb {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Breadcrumb
+
+namespace BasicCommissioningInfoList {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace BasicCommissioningInfoList
+
+namespace RegulatoryConfigList {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace RegulatoryConfigList
+
+namespace LocationCapabilityList {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace LocationCapabilityList
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace GeneralCommissioning
 
 namespace GeneralDiagnostics {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId NetworkInterfaces     = 0x00000000;
-static constexpr AttributeId RebootCount           = 0x00000001;
-static constexpr AttributeId UpTime                = 0x00000002;
-static constexpr AttributeId TotalOperationalHours = 0x00000003;
-static constexpr AttributeId BootReasons           = 0x00000004;
-static constexpr AttributeId ActiveHardwareFaults  = 0x00000005;
-static constexpr AttributeId ActiveRadioFaults     = 0x00000006;
-static constexpr AttributeId ActiveNetworkFaults   = 0x00000007;
-} // namespace Ids
+
+namespace NetworkInterfaces {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace NetworkInterfaces
+
+namespace RebootCount {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace RebootCount
+
+namespace UpTime {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace UpTime
+
+namespace TotalOperationalHours {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace TotalOperationalHours
+
+namespace BootReasons {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace BootReasons
+
+namespace ActiveHardwareFaults {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace ActiveHardwareFaults
+
+namespace ActiveRadioFaults {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace ActiveRadioFaults
+
+namespace ActiveNetworkFaults {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace ActiveNetworkFaults
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace GeneralDiagnostics
 
 namespace SoftwareDiagnostics {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId ThreadMetrics            = 0x00000000;
-static constexpr AttributeId CurrentHeapFree          = 0x00000001;
-static constexpr AttributeId CurrentHeapUsed          = 0x00000002;
-static constexpr AttributeId CurrentHeapHighWatermark = 0x00000003;
-} // namespace Ids
+
+namespace ThreadMetrics {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace ThreadMetrics
+
+namespace CurrentHeapFree {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentHeapFree
+
+namespace CurrentHeapUsed {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace CurrentHeapUsed
+
+namespace CurrentHeapHighWatermark {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace CurrentHeapHighWatermark
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace SoftwareDiagnostics
 
 namespace ThreadNetworkDiagnostics {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Channel                           = 0x00000000;
-static constexpr AttributeId RoutingRole                       = 0x00000001;
-static constexpr AttributeId NetworkName                       = 0x00000002;
-static constexpr AttributeId PanId                             = 0x00000003;
-static constexpr AttributeId ExtendedPanId                     = 0x00000004;
-static constexpr AttributeId MeshLocalPrefix                   = 0x00000005;
-static constexpr AttributeId OverrunCount                      = 0x00000006;
-static constexpr AttributeId NeighborTableList                 = 0x00000007;
-static constexpr AttributeId RouteTableList                    = 0x00000008;
-static constexpr AttributeId PartitionId                       = 0x00000009;
-static constexpr AttributeId Weighting                         = 0x0000000A;
-static constexpr AttributeId DataVersion                       = 0x0000000B;
-static constexpr AttributeId StableDataVersion                 = 0x0000000C;
-static constexpr AttributeId LeaderRouterId                    = 0x0000000D;
-static constexpr AttributeId DetachedRoleCount                 = 0x0000000E;
-static constexpr AttributeId ChildRoleCount                    = 0x0000000F;
-static constexpr AttributeId RouterRoleCount                   = 0x00000010;
-static constexpr AttributeId LeaderRoleCount                   = 0x00000011;
-static constexpr AttributeId AttachAttemptCount                = 0x00000012;
-static constexpr AttributeId PartitionIdChangeCount            = 0x00000013;
-static constexpr AttributeId BetterPartitionAttachAttemptCount = 0x00000014;
-static constexpr AttributeId ParentChangeCount                 = 0x00000015;
-static constexpr AttributeId TxTotalCount                      = 0x00000016;
-static constexpr AttributeId TxUnicastCount                    = 0x00000017;
-static constexpr AttributeId TxBroadcastCount                  = 0x00000018;
-static constexpr AttributeId TxAckRequestedCount               = 0x00000019;
-static constexpr AttributeId TxAckedCount                      = 0x0000001A;
-static constexpr AttributeId TxNoAckRequestedCount             = 0x0000001B;
-static constexpr AttributeId TxDataCount                       = 0x0000001C;
-static constexpr AttributeId TxDataPollCount                   = 0x0000001D;
-static constexpr AttributeId TxBeaconCount                     = 0x0000001E;
-static constexpr AttributeId TxBeaconRequestCount              = 0x0000001F;
-static constexpr AttributeId TxOtherCount                      = 0x00000020;
-static constexpr AttributeId TxRetryCount                      = 0x00000021;
-static constexpr AttributeId TxDirectMaxRetryExpiryCount       = 0x00000022;
-static constexpr AttributeId TxIndirectMaxRetryExpiryCount     = 0x00000023;
-static constexpr AttributeId TxErrCcaCount                     = 0x00000024;
-static constexpr AttributeId TxErrAbortCount                   = 0x00000025;
-static constexpr AttributeId TxErrBusyChannelCount             = 0x00000026;
-static constexpr AttributeId RxTotalCount                      = 0x00000027;
-static constexpr AttributeId RxUnicastCount                    = 0x00000028;
-static constexpr AttributeId RxBroadcastCount                  = 0x00000029;
-static constexpr AttributeId RxDataCount                       = 0x0000002A;
-static constexpr AttributeId RxDataPollCount                   = 0x0000002B;
-static constexpr AttributeId RxBeaconCount                     = 0x0000002C;
-static constexpr AttributeId RxBeaconRequestCount              = 0x0000002D;
-static constexpr AttributeId RxOtherCount                      = 0x0000002E;
-static constexpr AttributeId RxAddressFilteredCount            = 0x0000002F;
-static constexpr AttributeId RxDestAddrFilteredCount           = 0x00000030;
-static constexpr AttributeId RxDuplicatedCount                 = 0x00000031;
-static constexpr AttributeId RxErrNoFrameCount                 = 0x00000032;
-static constexpr AttributeId RxErrUnknownNeighborCount         = 0x00000033;
-static constexpr AttributeId RxErrInvalidSrcAddrCount          = 0x00000034;
-static constexpr AttributeId RxErrSecCount                     = 0x00000035;
-static constexpr AttributeId RxErrFcsCount                     = 0x00000036;
-static constexpr AttributeId RxErrOtherCount                   = 0x00000037;
-static constexpr AttributeId ActiveTimestamp                   = 0x00000038;
-static constexpr AttributeId PendingTimestamp                  = 0x00000039;
-static constexpr AttributeId Delay                             = 0x0000003A;
-static constexpr AttributeId SecurityPolicy                    = 0x0000003B;
-static constexpr AttributeId ChannelMask                       = 0x0000003C;
-static constexpr AttributeId OperationalDatasetComponents      = 0x0000003D;
-static constexpr AttributeId ActiveNetworkFaultsList           = 0x0000003E;
-} // namespace Ids
+
+namespace Channel {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Channel
+
+namespace RoutingRole {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace RoutingRole
+
+namespace NetworkName {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace NetworkName
+
+namespace PanId {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace PanId
+
+namespace ExtendedPanId {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace ExtendedPanId
+
+namespace MeshLocalPrefix {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace MeshLocalPrefix
+
+namespace OverrunCount {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace OverrunCount
+
+namespace NeighborTableList {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace NeighborTableList
+
+namespace RouteTableList {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace RouteTableList
+
+namespace PartitionId {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace PartitionId
+
+namespace Weighting {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace Weighting
+
+namespace DataVersion {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace DataVersion
+
+namespace StableDataVersion {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace StableDataVersion
+
+namespace LeaderRouterId {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace LeaderRouterId
+
+namespace DetachedRoleCount {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace DetachedRoleCount
+
+namespace ChildRoleCount {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace ChildRoleCount
+
+namespace RouterRoleCount {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace RouterRoleCount
+
+namespace LeaderRoleCount {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace LeaderRoleCount
+
+namespace AttachAttemptCount {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace AttachAttemptCount
+
+namespace PartitionIdChangeCount {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace PartitionIdChangeCount
+
+namespace BetterPartitionAttachAttemptCount {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace BetterPartitionAttachAttemptCount
+
+namespace ParentChangeCount {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace ParentChangeCount
+
+namespace TxTotalCount {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace TxTotalCount
+
+namespace TxUnicastCount {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace TxUnicastCount
+
+namespace TxBroadcastCount {
+static constexpr AttributeId Id = 0x00000018;
+} // namespace TxBroadcastCount
+
+namespace TxAckRequestedCount {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace TxAckRequestedCount
+
+namespace TxAckedCount {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace TxAckedCount
+
+namespace TxNoAckRequestedCount {
+static constexpr AttributeId Id = 0x0000001B;
+} // namespace TxNoAckRequestedCount
+
+namespace TxDataCount {
+static constexpr AttributeId Id = 0x0000001C;
+} // namespace TxDataCount
+
+namespace TxDataPollCount {
+static constexpr AttributeId Id = 0x0000001D;
+} // namespace TxDataPollCount
+
+namespace TxBeaconCount {
+static constexpr AttributeId Id = 0x0000001E;
+} // namespace TxBeaconCount
+
+namespace TxBeaconRequestCount {
+static constexpr AttributeId Id = 0x0000001F;
+} // namespace TxBeaconRequestCount
+
+namespace TxOtherCount {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace TxOtherCount
+
+namespace TxRetryCount {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace TxRetryCount
+
+namespace TxDirectMaxRetryExpiryCount {
+static constexpr AttributeId Id = 0x00000022;
+} // namespace TxDirectMaxRetryExpiryCount
+
+namespace TxIndirectMaxRetryExpiryCount {
+static constexpr AttributeId Id = 0x00000023;
+} // namespace TxIndirectMaxRetryExpiryCount
+
+namespace TxErrCcaCount {
+static constexpr AttributeId Id = 0x00000024;
+} // namespace TxErrCcaCount
+
+namespace TxErrAbortCount {
+static constexpr AttributeId Id = 0x00000025;
+} // namespace TxErrAbortCount
+
+namespace TxErrBusyChannelCount {
+static constexpr AttributeId Id = 0x00000026;
+} // namespace TxErrBusyChannelCount
+
+namespace RxTotalCount {
+static constexpr AttributeId Id = 0x00000027;
+} // namespace RxTotalCount
+
+namespace RxUnicastCount {
+static constexpr AttributeId Id = 0x00000028;
+} // namespace RxUnicastCount
+
+namespace RxBroadcastCount {
+static constexpr AttributeId Id = 0x00000029;
+} // namespace RxBroadcastCount
+
+namespace RxDataCount {
+static constexpr AttributeId Id = 0x0000002A;
+} // namespace RxDataCount
+
+namespace RxDataPollCount {
+static constexpr AttributeId Id = 0x0000002B;
+} // namespace RxDataPollCount
+
+namespace RxBeaconCount {
+static constexpr AttributeId Id = 0x0000002C;
+} // namespace RxBeaconCount
+
+namespace RxBeaconRequestCount {
+static constexpr AttributeId Id = 0x0000002D;
+} // namespace RxBeaconRequestCount
+
+namespace RxOtherCount {
+static constexpr AttributeId Id = 0x0000002E;
+} // namespace RxOtherCount
+
+namespace RxAddressFilteredCount {
+static constexpr AttributeId Id = 0x0000002F;
+} // namespace RxAddressFilteredCount
+
+namespace RxDestAddrFilteredCount {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace RxDestAddrFilteredCount
+
+namespace RxDuplicatedCount {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace RxDuplicatedCount
+
+namespace RxErrNoFrameCount {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace RxErrNoFrameCount
+
+namespace RxErrUnknownNeighborCount {
+static constexpr AttributeId Id = 0x00000033;
+} // namespace RxErrUnknownNeighborCount
+
+namespace RxErrInvalidSrcAddrCount {
+static constexpr AttributeId Id = 0x00000034;
+} // namespace RxErrInvalidSrcAddrCount
+
+namespace RxErrSecCount {
+static constexpr AttributeId Id = 0x00000035;
+} // namespace RxErrSecCount
+
+namespace RxErrFcsCount {
+static constexpr AttributeId Id = 0x00000036;
+} // namespace RxErrFcsCount
+
+namespace RxErrOtherCount {
+static constexpr AttributeId Id = 0x00000037;
+} // namespace RxErrOtherCount
+
+namespace ActiveTimestamp {
+static constexpr AttributeId Id = 0x00000038;
+} // namespace ActiveTimestamp
+
+namespace PendingTimestamp {
+static constexpr AttributeId Id = 0x00000039;
+} // namespace PendingTimestamp
+
+namespace Delay {
+static constexpr AttributeId Id = 0x0000003A;
+} // namespace Delay
+
+namespace SecurityPolicy {
+static constexpr AttributeId Id = 0x0000003B;
+} // namespace SecurityPolicy
+
+namespace ChannelMask {
+static constexpr AttributeId Id = 0x0000003C;
+} // namespace ChannelMask
+
+namespace OperationalDatasetComponents {
+static constexpr AttributeId Id = 0x0000003D;
+} // namespace OperationalDatasetComponents
+
+namespace ActiveNetworkFaultsList {
+static constexpr AttributeId Id = 0x0000003E;
+} // namespace ActiveNetworkFaultsList
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ThreadNetworkDiagnostics
 
 namespace WiFiNetworkDiagnostics {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Bssid                  = 0x00000000;
-static constexpr AttributeId SecurityType           = 0x00000001;
-static constexpr AttributeId WiFiVersion            = 0x00000002;
-static constexpr AttributeId ChannelNumber          = 0x00000003;
-static constexpr AttributeId Rssi                   = 0x00000004;
-static constexpr AttributeId BeaconLostCount        = 0x00000005;
-static constexpr AttributeId BeaconRxCount          = 0x00000006;
-static constexpr AttributeId PacketMulticastRxCount = 0x00000007;
-static constexpr AttributeId PacketMulticastTxCount = 0x00000008;
-static constexpr AttributeId PacketUnicastRxCount   = 0x00000009;
-static constexpr AttributeId PacketUnicastTxCount   = 0x0000000A;
-static constexpr AttributeId CurrentMaxRate         = 0x0000000B;
-static constexpr AttributeId OverrunCount           = 0x0000000C;
-} // namespace Ids
+
+namespace Bssid {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Bssid
+
+namespace SecurityType {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace SecurityType
+
+namespace WiFiVersion {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace WiFiVersion
+
+namespace ChannelNumber {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace ChannelNumber
+
+namespace Rssi {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace Rssi
+
+namespace BeaconLostCount {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace BeaconLostCount
+
+namespace BeaconRxCount {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace BeaconRxCount
+
+namespace PacketMulticastRxCount {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace PacketMulticastRxCount
+
+namespace PacketMulticastTxCount {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace PacketMulticastTxCount
+
+namespace PacketUnicastRxCount {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace PacketUnicastRxCount
+
+namespace PacketUnicastTxCount {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace PacketUnicastTxCount
+
+namespace CurrentMaxRate {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace CurrentMaxRate
+
+namespace OverrunCount {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace OverrunCount
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace WiFiNetworkDiagnostics
 
 namespace EthernetNetworkDiagnostics {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId PHYRate        = 0x00000000;
-static constexpr AttributeId FullDuplex     = 0x00000001;
-static constexpr AttributeId PacketRxCount  = 0x00000002;
-static constexpr AttributeId PacketTxCount  = 0x00000003;
-static constexpr AttributeId TxErrCount     = 0x00000004;
-static constexpr AttributeId CollisionCount = 0x00000005;
-static constexpr AttributeId OverrunCount   = 0x00000006;
-static constexpr AttributeId CarrierDetect  = 0x00000007;
-static constexpr AttributeId TimeSinceReset = 0x00000008;
-} // namespace Ids
+
+namespace PHYRate {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace PHYRate
+
+namespace FullDuplex {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace FullDuplex
+
+namespace PacketRxCount {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace PacketRxCount
+
+namespace PacketTxCount {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace PacketTxCount
+
+namespace TxErrCount {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace TxErrCount
+
+namespace CollisionCount {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace CollisionCount
+
+namespace OverrunCount {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace OverrunCount
+
+namespace CarrierDetect {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace CarrierDetect
+
+namespace TimeSinceReset {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace TimeSinceReset
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace EthernetNetworkDiagnostics
 
 namespace BridgedDeviceBasic {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId VendorName            = 0x00000001;
-static constexpr AttributeId VendorID              = 0x00000002;
-static constexpr AttributeId ProductName           = 0x00000003;
-static constexpr AttributeId UserLabel             = 0x00000005;
-static constexpr AttributeId HardwareVersion       = 0x00000007;
-static constexpr AttributeId HardwareVersionString = 0x00000008;
-static constexpr AttributeId SoftwareVersion       = 0x00000009;
-static constexpr AttributeId SoftwareVersionString = 0x0000000A;
-static constexpr AttributeId ManufacturingDate     = 0x0000000B;
-static constexpr AttributeId PartNumber            = 0x0000000C;
-static constexpr AttributeId ProductURL            = 0x0000000D;
-static constexpr AttributeId ProductLabel          = 0x0000000E;
-static constexpr AttributeId SerialNumber          = 0x0000000F;
-static constexpr AttributeId Reachable             = 0x00000011;
-} // namespace Ids
+
+namespace VendorName {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace VendorName
+
+namespace VendorID {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace VendorID
+
+namespace ProductName {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace ProductName
+
+namespace UserLabel {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace UserLabel
+
+namespace HardwareVersion {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace HardwareVersion
+
+namespace HardwareVersionString {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace HardwareVersionString
+
+namespace SoftwareVersion {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace SoftwareVersion
+
+namespace SoftwareVersionString {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace SoftwareVersionString
+
+namespace ManufacturingDate {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace ManufacturingDate
+
+namespace PartNumber {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace PartNumber
+
+namespace ProductURL {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace ProductURL
+
+namespace ProductLabel {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace ProductLabel
+
+namespace SerialNumber {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace SerialNumber
+
+namespace Reachable {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace Reachable
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BridgedDeviceBasic
 
 namespace Switch {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId NumberOfPositions = 0x00000000;
-static constexpr AttributeId CurrentPosition   = 0x00000001;
-static constexpr AttributeId MultiPressMax     = 0x00000002;
-} // namespace Ids
+
+namespace NumberOfPositions {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace NumberOfPositions
+
+namespace CurrentPosition {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentPosition
+
+namespace MultiPressMax {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MultiPressMax
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Switch
 
 namespace OperationalCredentials {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId FabricsList             = 0x00000001;
-static constexpr AttributeId SupportedFabrics        = 0x00000002;
-static constexpr AttributeId CommissionedFabrics     = 0x00000003;
-static constexpr AttributeId TrustedRootCertificates = 0x00000004;
-} // namespace Ids
+
+namespace FabricsList {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace FabricsList
+
+namespace SupportedFabrics {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace SupportedFabrics
+
+namespace CommissionedFabrics {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace CommissionedFabrics
+
+namespace TrustedRootCertificates {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace TrustedRootCertificates
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OperationalCredentials
 
 namespace FixedLabel {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId LabelList = 0x00000000;
-} // namespace Ids
+
+namespace LabelList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace LabelList
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace FixedLabel
 
 namespace ShadeConfiguration {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId PhysicalClosedLimit = 0x00000000;
-static constexpr AttributeId MotorStepSize       = 0x00000001;
-static constexpr AttributeId Status              = 0x00000002;
-static constexpr AttributeId ClosedLimit         = 0x00000010;
-static constexpr AttributeId Mode                = 0x00000011;
-} // namespace Ids
+
+namespace PhysicalClosedLimit {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace PhysicalClosedLimit
+
+namespace MotorStepSize {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MotorStepSize
+
+namespace Status {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace Status
+
+namespace ClosedLimit {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace ClosedLimit
+
+namespace Mode {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace Mode
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ShadeConfiguration
 
 namespace DoorLock {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId LockState                           = 0x00000000;
-static constexpr AttributeId LockType                            = 0x00000001;
-static constexpr AttributeId ActuatorEnabled                     = 0x00000002;
-static constexpr AttributeId DoorState                           = 0x00000003;
-static constexpr AttributeId DoorOpenEvents                      = 0x00000004;
-static constexpr AttributeId DoorClosedEvents                    = 0x00000005;
-static constexpr AttributeId OpenPeriod                          = 0x00000006;
-static constexpr AttributeId NumLockRecordsSupported             = 0x00000010;
-static constexpr AttributeId NumTotalUsersSupported              = 0x00000011;
-static constexpr AttributeId NumPinUsersSupported                = 0x00000012;
-static constexpr AttributeId NumRfidUsersSupported               = 0x00000013;
-static constexpr AttributeId NumWeekdaySchedulesSupportedPerUser = 0x00000014;
-static constexpr AttributeId NumYeardaySchedulesSupportedPerUser = 0x00000015;
-static constexpr AttributeId NumHolidaySchedulesSupportedPerUser = 0x00000016;
-static constexpr AttributeId MaxPinLength                        = 0x00000017;
-static constexpr AttributeId MinPinLength                        = 0x00000018;
-static constexpr AttributeId MaxRfidCodeLength                   = 0x00000019;
-static constexpr AttributeId MinRfidCodeLength                   = 0x0000001A;
-static constexpr AttributeId EnableLogging                       = 0x00000020;
-static constexpr AttributeId Language                            = 0x00000021;
-static constexpr AttributeId LedSettings                         = 0x00000022;
-static constexpr AttributeId AutoRelockTime                      = 0x00000023;
-static constexpr AttributeId SoundVolume                         = 0x00000024;
-static constexpr AttributeId OperatingMode                       = 0x00000025;
-static constexpr AttributeId SupportedOperatingModes             = 0x00000026;
-static constexpr AttributeId DefaultConfigurationRegister        = 0x00000027;
-static constexpr AttributeId EnableLocalProgramming              = 0x00000028;
-static constexpr AttributeId EnableOneTouchLocking               = 0x00000029;
-static constexpr AttributeId EnableInsideStatusLed               = 0x0000002A;
-static constexpr AttributeId EnablePrivacyModeButton             = 0x0000002B;
-static constexpr AttributeId WrongCodeEntryLimit                 = 0x00000030;
-static constexpr AttributeId UserCodeTemporaryDisableTime        = 0x00000031;
-static constexpr AttributeId SendPinOverTheAir                   = 0x00000032;
-static constexpr AttributeId RequirePinForRfOperation            = 0x00000033;
-static constexpr AttributeId ZigbeeSecurityLevel                 = 0x00000034;
-static constexpr AttributeId AlarmMask                           = 0x00000040;
-static constexpr AttributeId KeypadOperationEventMask            = 0x00000041;
-static constexpr AttributeId RfOperationEventMask                = 0x00000042;
-static constexpr AttributeId ManualOperationEventMask            = 0x00000043;
-static constexpr AttributeId RfidOperationEventMask              = 0x00000044;
-static constexpr AttributeId KeypadProgrammingEventMask          = 0x00000045;
-static constexpr AttributeId RfProgrammingEventMask              = 0x00000046;
-static constexpr AttributeId RfidProgrammingEventMask            = 0x00000047;
-} // namespace Ids
+
+namespace LockState {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace LockState
+
+namespace LockType {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace LockType
+
+namespace ActuatorEnabled {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ActuatorEnabled
+
+namespace DoorState {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace DoorState
+
+namespace DoorOpenEvents {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace DoorOpenEvents
+
+namespace DoorClosedEvents {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace DoorClosedEvents
+
+namespace OpenPeriod {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace OpenPeriod
+
+namespace NumLockRecordsSupported {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace NumLockRecordsSupported
+
+namespace NumTotalUsersSupported {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace NumTotalUsersSupported
+
+namespace NumPinUsersSupported {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace NumPinUsersSupported
+
+namespace NumRfidUsersSupported {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace NumRfidUsersSupported
+
+namespace NumWeekdaySchedulesSupportedPerUser {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace NumWeekdaySchedulesSupportedPerUser
+
+namespace NumYeardaySchedulesSupportedPerUser {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace NumYeardaySchedulesSupportedPerUser
+
+namespace NumHolidaySchedulesSupportedPerUser {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace NumHolidaySchedulesSupportedPerUser
+
+namespace MaxPinLength {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace MaxPinLength
+
+namespace MinPinLength {
+static constexpr AttributeId Id = 0x00000018;
+} // namespace MinPinLength
+
+namespace MaxRfidCodeLength {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace MaxRfidCodeLength
+
+namespace MinRfidCodeLength {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace MinRfidCodeLength
+
+namespace EnableLogging {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace EnableLogging
+
+namespace Language {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace Language
+
+namespace LedSettings {
+static constexpr AttributeId Id = 0x00000022;
+} // namespace LedSettings
+
+namespace AutoRelockTime {
+static constexpr AttributeId Id = 0x00000023;
+} // namespace AutoRelockTime
+
+namespace SoundVolume {
+static constexpr AttributeId Id = 0x00000024;
+} // namespace SoundVolume
+
+namespace OperatingMode {
+static constexpr AttributeId Id = 0x00000025;
+} // namespace OperatingMode
+
+namespace SupportedOperatingModes {
+static constexpr AttributeId Id = 0x00000026;
+} // namespace SupportedOperatingModes
+
+namespace DefaultConfigurationRegister {
+static constexpr AttributeId Id = 0x00000027;
+} // namespace DefaultConfigurationRegister
+
+namespace EnableLocalProgramming {
+static constexpr AttributeId Id = 0x00000028;
+} // namespace EnableLocalProgramming
+
+namespace EnableOneTouchLocking {
+static constexpr AttributeId Id = 0x00000029;
+} // namespace EnableOneTouchLocking
+
+namespace EnableInsideStatusLed {
+static constexpr AttributeId Id = 0x0000002A;
+} // namespace EnableInsideStatusLed
+
+namespace EnablePrivacyModeButton {
+static constexpr AttributeId Id = 0x0000002B;
+} // namespace EnablePrivacyModeButton
+
+namespace WrongCodeEntryLimit {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace WrongCodeEntryLimit
+
+namespace UserCodeTemporaryDisableTime {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace UserCodeTemporaryDisableTime
+
+namespace SendPinOverTheAir {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace SendPinOverTheAir
+
+namespace RequirePinForRfOperation {
+static constexpr AttributeId Id = 0x00000033;
+} // namespace RequirePinForRfOperation
+
+namespace ZigbeeSecurityLevel {
+static constexpr AttributeId Id = 0x00000034;
+} // namespace ZigbeeSecurityLevel
+
+namespace AlarmMask {
+static constexpr AttributeId Id = 0x00000040;
+} // namespace AlarmMask
+
+namespace KeypadOperationEventMask {
+static constexpr AttributeId Id = 0x00000041;
+} // namespace KeypadOperationEventMask
+
+namespace RfOperationEventMask {
+static constexpr AttributeId Id = 0x00000042;
+} // namespace RfOperationEventMask
+
+namespace ManualOperationEventMask {
+static constexpr AttributeId Id = 0x00000043;
+} // namespace ManualOperationEventMask
+
+namespace RfidOperationEventMask {
+static constexpr AttributeId Id = 0x00000044;
+} // namespace RfidOperationEventMask
+
+namespace KeypadProgrammingEventMask {
+static constexpr AttributeId Id = 0x00000045;
+} // namespace KeypadProgrammingEventMask
+
+namespace RfProgrammingEventMask {
+static constexpr AttributeId Id = 0x00000046;
+} // namespace RfProgrammingEventMask
+
+namespace RfidProgrammingEventMask {
+static constexpr AttributeId Id = 0x00000047;
+} // namespace RfidProgrammingEventMask
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace DoorLock
 
 namespace WindowCovering {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Type                             = 0x00000000;
-static constexpr AttributeId PhysicalClosedLimitLift          = 0x00000001;
-static constexpr AttributeId PhysicalClosedLimitTilt          = 0x00000002;
-static constexpr AttributeId CurrentPositionLift              = 0x00000003;
-static constexpr AttributeId CurrentPositionTilt              = 0x00000004;
-static constexpr AttributeId NumberOfActuationsLift           = 0x00000005;
-static constexpr AttributeId NumberOfActuationsTilt           = 0x00000006;
-static constexpr AttributeId ConfigStatus                     = 0x00000007;
-static constexpr AttributeId CurrentPositionLiftPercentage    = 0x00000008;
-static constexpr AttributeId CurrentPositionTiltPercentage    = 0x00000009;
-static constexpr AttributeId OperationalStatus                = 0x0000000A;
-static constexpr AttributeId TargetPositionLiftPercent100ths  = 0x0000000B;
-static constexpr AttributeId TargetPositionTiltPercent100ths  = 0x0000000C;
-static constexpr AttributeId EndProductType                   = 0x0000000D;
-static constexpr AttributeId CurrentPositionLiftPercent100ths = 0x0000000E;
-static constexpr AttributeId CurrentPositionTiltPercent100ths = 0x0000000F;
-static constexpr AttributeId InstalledOpenLimitLift           = 0x00000010;
-static constexpr AttributeId InstalledClosedLimitLift         = 0x00000011;
-static constexpr AttributeId InstalledOpenLimitTilt           = 0x00000012;
-static constexpr AttributeId InstalledClosedLimitTilt         = 0x00000013;
-static constexpr AttributeId VelocityLift                     = 0x00000014;
-static constexpr AttributeId AccelerationTimeLift             = 0x00000015;
-static constexpr AttributeId DecelerationTimeLift             = 0x00000016;
-static constexpr AttributeId Mode                             = 0x00000017;
-static constexpr AttributeId IntermediateSetpointsLift        = 0x00000018;
-static constexpr AttributeId IntermediateSetpointsTilt        = 0x00000019;
-static constexpr AttributeId SafetyStatus                     = 0x0000001A;
-} // namespace Ids
+
+namespace Type {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Type
+
+namespace PhysicalClosedLimitLift {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace PhysicalClosedLimitLift
+
+namespace PhysicalClosedLimitTilt {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace PhysicalClosedLimitTilt
+
+namespace CurrentPositionLift {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace CurrentPositionLift
+
+namespace CurrentPositionTilt {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace CurrentPositionTilt
+
+namespace NumberOfActuationsLift {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace NumberOfActuationsLift
+
+namespace NumberOfActuationsTilt {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace NumberOfActuationsTilt
+
+namespace ConfigStatus {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace ConfigStatus
+
+namespace CurrentPositionLiftPercentage {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace CurrentPositionLiftPercentage
+
+namespace CurrentPositionTiltPercentage {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace CurrentPositionTiltPercentage
+
+namespace OperationalStatus {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace OperationalStatus
+
+namespace TargetPositionLiftPercent100ths {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace TargetPositionLiftPercent100ths
+
+namespace TargetPositionTiltPercent100ths {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace TargetPositionTiltPercent100ths
+
+namespace EndProductType {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace EndProductType
+
+namespace CurrentPositionLiftPercent100ths {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace CurrentPositionLiftPercent100ths
+
+namespace CurrentPositionTiltPercent100ths {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace CurrentPositionTiltPercent100ths
+
+namespace InstalledOpenLimitLift {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace InstalledOpenLimitLift
+
+namespace InstalledClosedLimitLift {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace InstalledClosedLimitLift
+
+namespace InstalledOpenLimitTilt {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace InstalledOpenLimitTilt
+
+namespace InstalledClosedLimitTilt {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace InstalledClosedLimitTilt
+
+namespace VelocityLift {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace VelocityLift
+
+namespace AccelerationTimeLift {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace AccelerationTimeLift
+
+namespace DecelerationTimeLift {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace DecelerationTimeLift
+
+namespace Mode {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace Mode
+
+namespace IntermediateSetpointsLift {
+static constexpr AttributeId Id = 0x00000018;
+} // namespace IntermediateSetpointsLift
+
+namespace IntermediateSetpointsTilt {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace IntermediateSetpointsTilt
+
+namespace SafetyStatus {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace SafetyStatus
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace WindowCovering
 
 namespace BarrierControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId BarrierMovingState        = 0x00000001;
-static constexpr AttributeId BarrierSafetyStatus       = 0x00000002;
-static constexpr AttributeId BarrierCapabilities       = 0x00000003;
-static constexpr AttributeId BarrierOpenEvents         = 0x00000004;
-static constexpr AttributeId BarrierCloseEvents        = 0x00000005;
-static constexpr AttributeId BarrierCommandOpenEvents  = 0x00000006;
-static constexpr AttributeId BarrierCommandCloseEvents = 0x00000007;
-static constexpr AttributeId BarrierOpenPeriod         = 0x00000008;
-static constexpr AttributeId BarrierClosePeriod        = 0x00000009;
-static constexpr AttributeId BarrierPosition           = 0x0000000A;
-} // namespace Ids
+
+namespace BarrierMovingState {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace BarrierMovingState
+
+namespace BarrierSafetyStatus {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace BarrierSafetyStatus
+
+namespace BarrierCapabilities {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace BarrierCapabilities
+
+namespace BarrierOpenEvents {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace BarrierOpenEvents
+
+namespace BarrierCloseEvents {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace BarrierCloseEvents
+
+namespace BarrierCommandOpenEvents {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace BarrierCommandOpenEvents
+
+namespace BarrierCommandCloseEvents {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace BarrierCommandCloseEvents
+
+namespace BarrierOpenPeriod {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace BarrierOpenPeriod
+
+namespace BarrierClosePeriod {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace BarrierClosePeriod
+
+namespace BarrierPosition {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace BarrierPosition
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BarrierControl
 
 namespace PumpConfigurationAndControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MaxPressure            = 0x00000000;
-static constexpr AttributeId MaxSpeed               = 0x00000001;
-static constexpr AttributeId MaxFlow                = 0x00000002;
-static constexpr AttributeId MinConstPressure       = 0x00000003;
-static constexpr AttributeId MaxConstPressure       = 0x00000004;
-static constexpr AttributeId MinCompPressure        = 0x00000005;
-static constexpr AttributeId MaxCompPressure        = 0x00000006;
-static constexpr AttributeId MinConstSpeed          = 0x00000007;
-static constexpr AttributeId MaxConstSpeed          = 0x00000008;
-static constexpr AttributeId MinConstFlow           = 0x00000009;
-static constexpr AttributeId MaxConstFlow           = 0x0000000A;
-static constexpr AttributeId MinConstTemp           = 0x0000000B;
-static constexpr AttributeId MaxConstTemp           = 0x0000000C;
-static constexpr AttributeId PumpStatus             = 0x00000010;
-static constexpr AttributeId EffectiveOperationMode = 0x00000011;
-static constexpr AttributeId EffectiveControlMode   = 0x00000012;
-static constexpr AttributeId Capacity               = 0x00000013;
-static constexpr AttributeId Speed                  = 0x00000014;
-static constexpr AttributeId LifetimeRunningHours   = 0x00000015;
-static constexpr AttributeId Power                  = 0x00000016;
-static constexpr AttributeId LifetimeEnergyConsumed = 0x00000017;
-static constexpr AttributeId OperationMode          = 0x00000020;
-static constexpr AttributeId ControlMode            = 0x00000021;
-static constexpr AttributeId AlarmMask              = 0x00000022;
-} // namespace Ids
+
+namespace MaxPressure {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MaxPressure
+
+namespace MaxSpeed {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MaxSpeed
+
+namespace MaxFlow {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxFlow
+
+namespace MinConstPressure {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace MinConstPressure
+
+namespace MaxConstPressure {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace MaxConstPressure
+
+namespace MinCompPressure {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace MinCompPressure
+
+namespace MaxCompPressure {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace MaxCompPressure
+
+namespace MinConstSpeed {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace MinConstSpeed
+
+namespace MaxConstSpeed {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace MaxConstSpeed
+
+namespace MinConstFlow {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace MinConstFlow
+
+namespace MaxConstFlow {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace MaxConstFlow
+
+namespace MinConstTemp {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace MinConstTemp
+
+namespace MaxConstTemp {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace MaxConstTemp
+
+namespace PumpStatus {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace PumpStatus
+
+namespace EffectiveOperationMode {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace EffectiveOperationMode
+
+namespace EffectiveControlMode {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace EffectiveControlMode
+
+namespace Capacity {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace Capacity
+
+namespace Speed {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace Speed
+
+namespace LifetimeRunningHours {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace LifetimeRunningHours
+
+namespace Power {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace Power
+
+namespace LifetimeEnergyConsumed {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace LifetimeEnergyConsumed
+
+namespace OperationMode {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace OperationMode
+
+namespace ControlMode {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace ControlMode
+
+namespace AlarmMask {
+static constexpr AttributeId Id = 0x00000022;
+} // namespace AlarmMask
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace PumpConfigurationAndControl
 
 namespace Thermostat {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId LocalTemperature                   = 0x00000000;
-static constexpr AttributeId OutdoorTemperature                 = 0x00000001;
-static constexpr AttributeId Occupancy                          = 0x00000002;
-static constexpr AttributeId AbsMinHeatSetpointLimit            = 0x00000003;
-static constexpr AttributeId AbsMaxHeatSetpointLimit            = 0x00000004;
-static constexpr AttributeId AbsMinCoolSetpointLimit            = 0x00000005;
-static constexpr AttributeId AbsMaxCoolSetpointLimit            = 0x00000006;
-static constexpr AttributeId PiCoolingDemand                    = 0x00000007;
-static constexpr AttributeId PiHeatingDemand                    = 0x00000008;
-static constexpr AttributeId HvacSystemTypeConfiguration        = 0x00000009;
-static constexpr AttributeId LocalTemperatureCalibration        = 0x00000010;
-static constexpr AttributeId OccupiedCoolingSetpoint            = 0x00000011;
-static constexpr AttributeId OccupiedHeatingSetpoint            = 0x00000012;
-static constexpr AttributeId UnoccupiedCoolingSetpoint          = 0x00000013;
-static constexpr AttributeId UnoccupiedHeatingSetpoint          = 0x00000014;
-static constexpr AttributeId MinHeatSetpointLimit               = 0x00000015;
-static constexpr AttributeId MaxHeatSetpointLimit               = 0x00000016;
-static constexpr AttributeId MinCoolSetpointLimit               = 0x00000017;
-static constexpr AttributeId MaxCoolSetpointLimit               = 0x00000018;
-static constexpr AttributeId MinSetpointDeadBand                = 0x00000019;
-static constexpr AttributeId RemoteSensing                      = 0x0000001A;
-static constexpr AttributeId ControlSequenceOfOperation         = 0x0000001B;
-static constexpr AttributeId SystemMode                         = 0x0000001C;
-static constexpr AttributeId AlarmMask                          = 0x0000001D;
-static constexpr AttributeId ThermostatRunningMode              = 0x0000001E;
-static constexpr AttributeId StartOfWeek                        = 0x00000020;
-static constexpr AttributeId NumberOfWeeklyTransitions          = 0x00000021;
-static constexpr AttributeId NumberOfDailyTransitions           = 0x00000022;
-static constexpr AttributeId TemperatureSetpointHold            = 0x00000023;
-static constexpr AttributeId TemperatureSetpointHoldDuration    = 0x00000024;
-static constexpr AttributeId ThermostatProgrammingOperationMode = 0x00000025;
-static constexpr AttributeId HvacRelayState                     = 0x00000029;
-static constexpr AttributeId SetpointChangeSource               = 0x00000030;
-static constexpr AttributeId SetpointChangeAmount               = 0x00000031;
-static constexpr AttributeId SetpointChangeSourceTimestamp      = 0x00000032;
-static constexpr AttributeId AcType                             = 0x00000040;
-static constexpr AttributeId AcCapacity                         = 0x00000041;
-static constexpr AttributeId AcRefrigerantType                  = 0x00000042;
-static constexpr AttributeId AcCompressor                       = 0x00000043;
-static constexpr AttributeId AcErrorCode                        = 0x00000044;
-static constexpr AttributeId AcLouverPosition                   = 0x00000045;
-static constexpr AttributeId AcCoilTemperature                  = 0x00000046;
-static constexpr AttributeId AcCapacityFormat                   = 0x00000047;
-} // namespace Ids
+
+namespace LocalTemperature {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace LocalTemperature
+
+namespace OutdoorTemperature {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace OutdoorTemperature
+
+namespace Occupancy {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace Occupancy
+
+namespace AbsMinHeatSetpointLimit {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace AbsMinHeatSetpointLimit
+
+namespace AbsMaxHeatSetpointLimit {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace AbsMaxHeatSetpointLimit
+
+namespace AbsMinCoolSetpointLimit {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace AbsMinCoolSetpointLimit
+
+namespace AbsMaxCoolSetpointLimit {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace AbsMaxCoolSetpointLimit
+
+namespace PiCoolingDemand {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace PiCoolingDemand
+
+namespace PiHeatingDemand {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace PiHeatingDemand
+
+namespace HvacSystemTypeConfiguration {
+static constexpr AttributeId Id = 0x00000009;
+} // namespace HvacSystemTypeConfiguration
+
+namespace LocalTemperatureCalibration {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace LocalTemperatureCalibration
+
+namespace OccupiedCoolingSetpoint {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace OccupiedCoolingSetpoint
+
+namespace OccupiedHeatingSetpoint {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace OccupiedHeatingSetpoint
+
+namespace UnoccupiedCoolingSetpoint {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace UnoccupiedCoolingSetpoint
+
+namespace UnoccupiedHeatingSetpoint {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace UnoccupiedHeatingSetpoint
+
+namespace MinHeatSetpointLimit {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace MinHeatSetpointLimit
+
+namespace MaxHeatSetpointLimit {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace MaxHeatSetpointLimit
+
+namespace MinCoolSetpointLimit {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace MinCoolSetpointLimit
+
+namespace MaxCoolSetpointLimit {
+static constexpr AttributeId Id = 0x00000018;
+} // namespace MaxCoolSetpointLimit
+
+namespace MinSetpointDeadBand {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace MinSetpointDeadBand
+
+namespace RemoteSensing {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace RemoteSensing
+
+namespace ControlSequenceOfOperation {
+static constexpr AttributeId Id = 0x0000001B;
+} // namespace ControlSequenceOfOperation
+
+namespace SystemMode {
+static constexpr AttributeId Id = 0x0000001C;
+} // namespace SystemMode
+
+namespace AlarmMask {
+static constexpr AttributeId Id = 0x0000001D;
+} // namespace AlarmMask
+
+namespace ThermostatRunningMode {
+static constexpr AttributeId Id = 0x0000001E;
+} // namespace ThermostatRunningMode
+
+namespace StartOfWeek {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace StartOfWeek
+
+namespace NumberOfWeeklyTransitions {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace NumberOfWeeklyTransitions
+
+namespace NumberOfDailyTransitions {
+static constexpr AttributeId Id = 0x00000022;
+} // namespace NumberOfDailyTransitions
+
+namespace TemperatureSetpointHold {
+static constexpr AttributeId Id = 0x00000023;
+} // namespace TemperatureSetpointHold
+
+namespace TemperatureSetpointHoldDuration {
+static constexpr AttributeId Id = 0x00000024;
+} // namespace TemperatureSetpointHoldDuration
+
+namespace ThermostatProgrammingOperationMode {
+static constexpr AttributeId Id = 0x00000025;
+} // namespace ThermostatProgrammingOperationMode
+
+namespace HvacRelayState {
+static constexpr AttributeId Id = 0x00000029;
+} // namespace HvacRelayState
+
+namespace SetpointChangeSource {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace SetpointChangeSource
+
+namespace SetpointChangeAmount {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace SetpointChangeAmount
+
+namespace SetpointChangeSourceTimestamp {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace SetpointChangeSourceTimestamp
+
+namespace AcType {
+static constexpr AttributeId Id = 0x00000040;
+} // namespace AcType
+
+namespace AcCapacity {
+static constexpr AttributeId Id = 0x00000041;
+} // namespace AcCapacity
+
+namespace AcRefrigerantType {
+static constexpr AttributeId Id = 0x00000042;
+} // namespace AcRefrigerantType
+
+namespace AcCompressor {
+static constexpr AttributeId Id = 0x00000043;
+} // namespace AcCompressor
+
+namespace AcErrorCode {
+static constexpr AttributeId Id = 0x00000044;
+} // namespace AcErrorCode
+
+namespace AcLouverPosition {
+static constexpr AttributeId Id = 0x00000045;
+} // namespace AcLouverPosition
+
+namespace AcCoilTemperature {
+static constexpr AttributeId Id = 0x00000046;
+} // namespace AcCoilTemperature
+
+namespace AcCapacityFormat {
+static constexpr AttributeId Id = 0x00000047;
+} // namespace AcCapacityFormat
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace Thermostat
 
 namespace FanControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId FanMode         = 0x00000000;
-static constexpr AttributeId FanModeSequence = 0x00000001;
-} // namespace Ids
+
+namespace FanMode {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace FanMode
+
+namespace FanModeSequence {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace FanModeSequence
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace FanControl
 
 namespace DehumidificationControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId RelativeHumidity           = 0x00000000;
-static constexpr AttributeId DehumidificationCooling    = 0x00000001;
-static constexpr AttributeId RhDehumidificationSetpoint = 0x00000010;
-static constexpr AttributeId RelativeHumidityMode       = 0x00000011;
-static constexpr AttributeId DehumidificationLockout    = 0x00000012;
-static constexpr AttributeId DehumidificationHysteresis = 0x00000013;
-static constexpr AttributeId DehumidificationMaxCool    = 0x00000014;
-static constexpr AttributeId RelativeHumidityDisplay    = 0x00000015;
-} // namespace Ids
+
+namespace RelativeHumidity {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace RelativeHumidity
+
+namespace DehumidificationCooling {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace DehumidificationCooling
+
+namespace RhDehumidificationSetpoint {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace RhDehumidificationSetpoint
+
+namespace RelativeHumidityMode {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace RelativeHumidityMode
+
+namespace DehumidificationLockout {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace DehumidificationLockout
+
+namespace DehumidificationHysteresis {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace DehumidificationHysteresis
+
+namespace DehumidificationMaxCool {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace DehumidificationMaxCool
+
+namespace RelativeHumidityDisplay {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace RelativeHumidityDisplay
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace DehumidificationControl
 
 namespace ThermostatUserInterfaceConfiguration {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId TemperatureDisplayMode        = 0x00000000;
-static constexpr AttributeId KeypadLockout                 = 0x00000001;
-static constexpr AttributeId ScheduleProgrammingVisibility = 0x00000002;
-} // namespace Ids
+
+namespace TemperatureDisplayMode {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace TemperatureDisplayMode
+
+namespace KeypadLockout {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace KeypadLockout
+
+namespace ScheduleProgrammingVisibility {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ScheduleProgrammingVisibility
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ThermostatUserInterfaceConfiguration
 
 namespace ColorControl {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId CurrentHue                      = 0x00000000;
-static constexpr AttributeId CurrentSaturation               = 0x00000001;
-static constexpr AttributeId RemainingTime                   = 0x00000002;
-static constexpr AttributeId CurrentX                        = 0x00000003;
-static constexpr AttributeId CurrentY                        = 0x00000004;
-static constexpr AttributeId DriftCompensation               = 0x00000005;
-static constexpr AttributeId CompensationText                = 0x00000006;
-static constexpr AttributeId ColorTemperature                = 0x00000007;
-static constexpr AttributeId ColorMode                       = 0x00000008;
-static constexpr AttributeId ColorControlOptions             = 0x0000000F;
-static constexpr AttributeId NumberOfPrimaries               = 0x00000010;
-static constexpr AttributeId Primary1X                       = 0x00000011;
-static constexpr AttributeId Primary1Y                       = 0x00000012;
-static constexpr AttributeId Primary1Intensity               = 0x00000013;
-static constexpr AttributeId Primary2X                       = 0x00000015;
-static constexpr AttributeId Primary2Y                       = 0x00000016;
-static constexpr AttributeId Primary2Intensity               = 0x00000017;
-static constexpr AttributeId Primary3X                       = 0x00000019;
-static constexpr AttributeId Primary3Y                       = 0x0000001A;
-static constexpr AttributeId Primary3Intensity               = 0x0000001B;
-static constexpr AttributeId Primary4X                       = 0x00000020;
-static constexpr AttributeId Primary4Y                       = 0x00000021;
-static constexpr AttributeId Primary4Intensity               = 0x00000022;
-static constexpr AttributeId Primary5X                       = 0x00000024;
-static constexpr AttributeId Primary5Y                       = 0x00000025;
-static constexpr AttributeId Primary5Intensity               = 0x00000026;
-static constexpr AttributeId Primary6X                       = 0x00000028;
-static constexpr AttributeId Primary6Y                       = 0x00000029;
-static constexpr AttributeId Primary6Intensity               = 0x0000002A;
-static constexpr AttributeId WhitePointX                     = 0x00000030;
-static constexpr AttributeId WhitePointY                     = 0x00000031;
-static constexpr AttributeId ColorPointRX                    = 0x00000032;
-static constexpr AttributeId ColorPointRY                    = 0x00000033;
-static constexpr AttributeId ColorPointRIntensity            = 0x00000034;
-static constexpr AttributeId ColorPointGX                    = 0x00000036;
-static constexpr AttributeId ColorPointGY                    = 0x00000037;
-static constexpr AttributeId ColorPointGIntensity            = 0x00000038;
-static constexpr AttributeId ColorPointBX                    = 0x0000003A;
-static constexpr AttributeId ColorPointBY                    = 0x0000003B;
-static constexpr AttributeId ColorPointBIntensity            = 0x0000003C;
-static constexpr AttributeId EnhancedCurrentHue              = 0x00004000;
-static constexpr AttributeId EnhancedColorMode               = 0x00004001;
-static constexpr AttributeId ColorLoopActive                 = 0x00004002;
-static constexpr AttributeId ColorLoopDirection              = 0x00004003;
-static constexpr AttributeId ColorLoopTime                   = 0x00004004;
-static constexpr AttributeId ColorLoopStartEnhancedHue       = 0x00004005;
-static constexpr AttributeId ColorLoopStoredEnhancedHue      = 0x00004006;
-static constexpr AttributeId ColorCapabilities               = 0x0000400A;
-static constexpr AttributeId ColorTempPhysicalMin            = 0x0000400B;
-static constexpr AttributeId ColorTempPhysicalMax            = 0x0000400C;
-static constexpr AttributeId CoupleColorTempToLevelMinMireds = 0x0000400D;
-static constexpr AttributeId StartUpColorTemperatureMireds   = 0x00004010;
-} // namespace Ids
+
+namespace CurrentHue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace CurrentHue
+
+namespace CurrentSaturation {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentSaturation
+
+namespace RemainingTime {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace RemainingTime
+
+namespace CurrentX {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace CurrentX
+
+namespace CurrentY {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace CurrentY
+
+namespace DriftCompensation {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace DriftCompensation
+
+namespace CompensationText {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace CompensationText
+
+namespace ColorTemperature {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace ColorTemperature
+
+namespace ColorMode {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace ColorMode
+
+namespace ColorControlOptions {
+static constexpr AttributeId Id = 0x0000000F;
+} // namespace ColorControlOptions
+
+namespace NumberOfPrimaries {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace NumberOfPrimaries
+
+namespace Primary1X {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace Primary1X
+
+namespace Primary1Y {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace Primary1Y
+
+namespace Primary1Intensity {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace Primary1Intensity
+
+namespace Primary2X {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace Primary2X
+
+namespace Primary2Y {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace Primary2Y
+
+namespace Primary2Intensity {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace Primary2Intensity
+
+namespace Primary3X {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace Primary3X
+
+namespace Primary3Y {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace Primary3Y
+
+namespace Primary3Intensity {
+static constexpr AttributeId Id = 0x0000001B;
+} // namespace Primary3Intensity
+
+namespace Primary4X {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace Primary4X
+
+namespace Primary4Y {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace Primary4Y
+
+namespace Primary4Intensity {
+static constexpr AttributeId Id = 0x00000022;
+} // namespace Primary4Intensity
+
+namespace Primary5X {
+static constexpr AttributeId Id = 0x00000024;
+} // namespace Primary5X
+
+namespace Primary5Y {
+static constexpr AttributeId Id = 0x00000025;
+} // namespace Primary5Y
+
+namespace Primary5Intensity {
+static constexpr AttributeId Id = 0x00000026;
+} // namespace Primary5Intensity
+
+namespace Primary6X {
+static constexpr AttributeId Id = 0x00000028;
+} // namespace Primary6X
+
+namespace Primary6Y {
+static constexpr AttributeId Id = 0x00000029;
+} // namespace Primary6Y
+
+namespace Primary6Intensity {
+static constexpr AttributeId Id = 0x0000002A;
+} // namespace Primary6Intensity
+
+namespace WhitePointX {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace WhitePointX
+
+namespace WhitePointY {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace WhitePointY
+
+namespace ColorPointRX {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace ColorPointRX
+
+namespace ColorPointRY {
+static constexpr AttributeId Id = 0x00000033;
+} // namespace ColorPointRY
+
+namespace ColorPointRIntensity {
+static constexpr AttributeId Id = 0x00000034;
+} // namespace ColorPointRIntensity
+
+namespace ColorPointGX {
+static constexpr AttributeId Id = 0x00000036;
+} // namespace ColorPointGX
+
+namespace ColorPointGY {
+static constexpr AttributeId Id = 0x00000037;
+} // namespace ColorPointGY
+
+namespace ColorPointGIntensity {
+static constexpr AttributeId Id = 0x00000038;
+} // namespace ColorPointGIntensity
+
+namespace ColorPointBX {
+static constexpr AttributeId Id = 0x0000003A;
+} // namespace ColorPointBX
+
+namespace ColorPointBY {
+static constexpr AttributeId Id = 0x0000003B;
+} // namespace ColorPointBY
+
+namespace ColorPointBIntensity {
+static constexpr AttributeId Id = 0x0000003C;
+} // namespace ColorPointBIntensity
+
+namespace EnhancedCurrentHue {
+static constexpr AttributeId Id = 0x00004000;
+} // namespace EnhancedCurrentHue
+
+namespace EnhancedColorMode {
+static constexpr AttributeId Id = 0x00004001;
+} // namespace EnhancedColorMode
+
+namespace ColorLoopActive {
+static constexpr AttributeId Id = 0x00004002;
+} // namespace ColorLoopActive
+
+namespace ColorLoopDirection {
+static constexpr AttributeId Id = 0x00004003;
+} // namespace ColorLoopDirection
+
+namespace ColorLoopTime {
+static constexpr AttributeId Id = 0x00004004;
+} // namespace ColorLoopTime
+
+namespace ColorLoopStartEnhancedHue {
+static constexpr AttributeId Id = 0x00004005;
+} // namespace ColorLoopStartEnhancedHue
+
+namespace ColorLoopStoredEnhancedHue {
+static constexpr AttributeId Id = 0x00004006;
+} // namespace ColorLoopStoredEnhancedHue
+
+namespace ColorCapabilities {
+static constexpr AttributeId Id = 0x0000400A;
+} // namespace ColorCapabilities
+
+namespace ColorTempPhysicalMin {
+static constexpr AttributeId Id = 0x0000400B;
+} // namespace ColorTempPhysicalMin
+
+namespace ColorTempPhysicalMax {
+static constexpr AttributeId Id = 0x0000400C;
+} // namespace ColorTempPhysicalMax
+
+namespace CoupleColorTempToLevelMinMireds {
+static constexpr AttributeId Id = 0x0000400D;
+} // namespace CoupleColorTempToLevelMinMireds
+
+namespace StartUpColorTemperatureMireds {
+static constexpr AttributeId Id = 0x00004010;
+} // namespace StartUpColorTemperatureMireds
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ColorControl
 
 namespace BallastConfiguration {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId PhysicalMinLevel        = 0x00000000;
-static constexpr AttributeId PhysicalMaxLevel        = 0x00000001;
-static constexpr AttributeId BallastStatus           = 0x00000002;
-static constexpr AttributeId MinLevel                = 0x00000010;
-static constexpr AttributeId MaxLevel                = 0x00000011;
-static constexpr AttributeId PowerOnLevel            = 0x00000012;
-static constexpr AttributeId PowerOnFadeTime         = 0x00000013;
-static constexpr AttributeId IntrinsicBallastFactor  = 0x00000014;
-static constexpr AttributeId BallastFactorAdjustment = 0x00000015;
-static constexpr AttributeId LampQuality             = 0x00000020;
-static constexpr AttributeId LampType                = 0x00000030;
-static constexpr AttributeId LampManufacturer        = 0x00000031;
-static constexpr AttributeId LampRatedHours          = 0x00000032;
-static constexpr AttributeId LampBurnHours           = 0x00000033;
-static constexpr AttributeId LampAlarmMode           = 0x00000034;
-static constexpr AttributeId LampBurnHoursTripPoint  = 0x00000035;
-} // namespace Ids
+
+namespace PhysicalMinLevel {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace PhysicalMinLevel
+
+namespace PhysicalMaxLevel {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace PhysicalMaxLevel
+
+namespace BallastStatus {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace BallastStatus
+
+namespace MinLevel {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace MinLevel
+
+namespace MaxLevel {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace MaxLevel
+
+namespace PowerOnLevel {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace PowerOnLevel
+
+namespace PowerOnFadeTime {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace PowerOnFadeTime
+
+namespace IntrinsicBallastFactor {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace IntrinsicBallastFactor
+
+namespace BallastFactorAdjustment {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace BallastFactorAdjustment
+
+namespace LampQuality {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace LampQuality
+
+namespace LampType {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace LampType
+
+namespace LampManufacturer {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace LampManufacturer
+
+namespace LampRatedHours {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace LampRatedHours
+
+namespace LampBurnHours {
+static constexpr AttributeId Id = 0x00000033;
+} // namespace LampBurnHours
+
+namespace LampAlarmMode {
+static constexpr AttributeId Id = 0x00000034;
+} // namespace LampAlarmMode
+
+namespace LampBurnHoursTripPoint {
+static constexpr AttributeId Id = 0x00000035;
+} // namespace LampBurnHoursTripPoint
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BallastConfiguration
 
 namespace IlluminanceMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-static constexpr AttributeId LightSensorType  = 0x00000004;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace LightSensorType {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace LightSensorType
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace IlluminanceMeasurement
 
 namespace IlluminanceLevelSensing {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId LevelStatus            = 0x00000000;
-static constexpr AttributeId LightSensorType        = 0x00000001;
-static constexpr AttributeId IlluminanceLevelTarget = 0x00000010;
-} // namespace Ids
+
+namespace LevelStatus {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace LevelStatus
+
+namespace LightSensorType {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace LightSensorType
+
+namespace IlluminanceLevelTarget {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace IlluminanceLevelTarget
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace IlluminanceLevelSensing
 
 namespace TemperatureMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TemperatureMeasurement
 
 namespace PressureMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-static constexpr AttributeId ScaledValue      = 0x00000010;
-static constexpr AttributeId MinScaledValue   = 0x00000011;
-static constexpr AttributeId MaxScaledValue   = 0x00000012;
-static constexpr AttributeId ScaledTolerance  = 0x00000013;
-static constexpr AttributeId Scale            = 0x00000014;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace ScaledValue {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace ScaledValue
+
+namespace MinScaledValue {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace MinScaledValue
+
+namespace MaxScaledValue {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace MaxScaledValue
+
+namespace ScaledTolerance {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace ScaledTolerance
+
+namespace Scale {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace Scale
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace PressureMeasurement
 
 namespace FlowMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace FlowMeasurement
 
 namespace RelativeHumidityMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace RelativeHumidityMeasurement
 
 namespace OccupancySensing {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Occupancy                                    = 0x00000000;
-static constexpr AttributeId OccupancySensorType                          = 0x00000001;
-static constexpr AttributeId OccupancySensorTypeBitmap                    = 0x00000002;
-static constexpr AttributeId PirOccupiedToUnoccupiedDelay                 = 0x00000010;
-static constexpr AttributeId PirUnoccupiedToOccupiedDelay                 = 0x00000011;
-static constexpr AttributeId PirUnoccupiedToOccupiedThreshold             = 0x00000012;
-static constexpr AttributeId UltrasonicOccupiedToUnoccupiedDelay          = 0x00000020;
-static constexpr AttributeId UltrasonicUnoccupiedToOccupiedDelay          = 0x00000021;
-static constexpr AttributeId UltrasonicUnoccupiedToOccupiedThreshold      = 0x00000022;
-static constexpr AttributeId PhysicalContactOccupiedToUnoccupiedDelay     = 0x00000030;
-static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedDelay     = 0x00000031;
-static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedThreshold = 0x00000032;
-} // namespace Ids
+
+namespace Occupancy {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Occupancy
+
+namespace OccupancySensorType {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace OccupancySensorType
+
+namespace OccupancySensorTypeBitmap {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace OccupancySensorTypeBitmap
+
+namespace PirOccupiedToUnoccupiedDelay {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace PirOccupiedToUnoccupiedDelay
+
+namespace PirUnoccupiedToOccupiedDelay {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace PirUnoccupiedToOccupiedDelay
+
+namespace PirUnoccupiedToOccupiedThreshold {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace PirUnoccupiedToOccupiedThreshold
+
+namespace UltrasonicOccupiedToUnoccupiedDelay {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace UltrasonicOccupiedToUnoccupiedDelay
+
+namespace UltrasonicUnoccupiedToOccupiedDelay {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace UltrasonicUnoccupiedToOccupiedDelay
+
+namespace UltrasonicUnoccupiedToOccupiedThreshold {
+static constexpr AttributeId Id = 0x00000022;
+} // namespace UltrasonicUnoccupiedToOccupiedThreshold
+
+namespace PhysicalContactOccupiedToUnoccupiedDelay {
+static constexpr AttributeId Id = 0x00000030;
+} // namespace PhysicalContactOccupiedToUnoccupiedDelay
+
+namespace PhysicalContactUnoccupiedToOccupiedDelay {
+static constexpr AttributeId Id = 0x00000031;
+} // namespace PhysicalContactUnoccupiedToOccupiedDelay
+
+namespace PhysicalContactUnoccupiedToOccupiedThreshold {
+static constexpr AttributeId Id = 0x00000032;
+} // namespace PhysicalContactUnoccupiedToOccupiedThreshold
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OccupancySensing
 
 namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace CarbonMonoxideConcentrationMeasurement
 
 namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace CarbonDioxideConcentrationMeasurement
 
 namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace EthyleneConcentrationMeasurement
 
 namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace EthyleneOxideConcentrationMeasurement
 
 namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace HydrogenConcentrationMeasurement
 
 namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace HydrogenSulphideConcentrationMeasurement
 
 namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace NitricOxideConcentrationMeasurement
 
 namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace NitrogenDioxideConcentrationMeasurement
 
 namespace OxygenConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OxygenConcentrationMeasurement
 
 namespace OzoneConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace OzoneConcentrationMeasurement
 
 namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace SulfurDioxideConcentrationMeasurement
 
 namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace DissolvedOxygenConcentrationMeasurement
 
 namespace BromateConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BromateConcentrationMeasurement
 
 namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ChloraminesConcentrationMeasurement
 
 namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ChlorineConcentrationMeasurement
 
 namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace FecalColiformAndEColiConcentrationMeasurement
 
 namespace FluorideConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace FluorideConcentrationMeasurement
 
 namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace HaloaceticAcidsConcentrationMeasurement
 
 namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TotalTrihalomethanesConcentrationMeasurement
 
 namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TotalColiformBacteriaConcentrationMeasurement
 
 namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TurbidityConcentrationMeasurement
 
 namespace CopperConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace CopperConcentrationMeasurement
 
 namespace LeadConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace LeadConcentrationMeasurement
 
 namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ManganeseConcentrationMeasurement
 
 namespace SulfateConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace SulfateConcentrationMeasurement
 
 namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BromodichloromethaneConcentrationMeasurement
 
 namespace BromoformConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace BromoformConcentrationMeasurement
 
 namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ChlorodibromomethaneConcentrationMeasurement
 
 namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ChloroformConcentrationMeasurement
 
 namespace SodiumConcentrationMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x00000000;
-static constexpr AttributeId MinMeasuredValue = 0x00000001;
-static constexpr AttributeId MaxMeasuredValue = 0x00000002;
-static constexpr AttributeId Tolerance        = 0x00000003;
-} // namespace Ids
+
+namespace MeasuredValue {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Tolerance
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace SodiumConcentrationMeasurement
 
 namespace IasZone {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId ZoneState                              = 0x00000000;
-static constexpr AttributeId ZoneType                               = 0x00000001;
-static constexpr AttributeId ZoneStatus                             = 0x00000002;
-static constexpr AttributeId IasCieAddress                          = 0x00000010;
-static constexpr AttributeId ZoneId                                 = 0x00000011;
-static constexpr AttributeId NumberOfZoneSensitivityLevelsSupported = 0x00000012;
-static constexpr AttributeId CurrentZoneSensitivityLevel            = 0x00000013;
-} // namespace Ids
+
+namespace ZoneState {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace ZoneState
+
+namespace ZoneType {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace ZoneType
+
+namespace ZoneStatus {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ZoneStatus
+
+namespace IasCieAddress {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace IasCieAddress
+
+namespace ZoneId {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace ZoneId
+
+namespace NumberOfZoneSensitivityLevelsSupported {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace NumberOfZoneSensitivityLevelsSupported
+
+namespace CurrentZoneSensitivityLevel {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace CurrentZoneSensitivityLevel
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace IasZone
 
 namespace IasWd {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MaxDuration = 0x00000000;
-} // namespace Ids
+
+namespace MaxDuration {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MaxDuration
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace IasWd
 
 namespace WakeOnLan {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId WakeOnLanMacAddress = 0x00000000;
-} // namespace Ids
+
+namespace WakeOnLanMacAddress {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace WakeOnLanMacAddress
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace WakeOnLan
 
 namespace TvChannel {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId TvChannelList    = 0x00000000;
-static constexpr AttributeId TvChannelLineup  = 0x00000001;
-static constexpr AttributeId CurrentTvChannel = 0x00000002;
-} // namespace Ids
+
+namespace TvChannelList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace TvChannelList
+
+namespace TvChannelLineup {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace TvChannelLineup
+
+namespace CurrentTvChannel {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace CurrentTvChannel
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TvChannel
 
 namespace TargetNavigator {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId TargetNavigatorList    = 0x00000000;
-static constexpr AttributeId CurrentNavigatorTarget = 0x00000001;
-} // namespace Ids
+
+namespace TargetNavigatorList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace TargetNavigatorList
+
+namespace CurrentNavigatorTarget {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentNavigatorTarget
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TargetNavigator
 
 namespace MediaPlayback {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId PlaybackState     = 0x00000000;
-static constexpr AttributeId StartTime         = 0x00000001;
-static constexpr AttributeId Duration          = 0x00000002;
-static constexpr AttributeId PositionUpdatedAt = 0x00000003;
-static constexpr AttributeId Position          = 0x00000004;
-static constexpr AttributeId PlaybackSpeed     = 0x00000005;
-static constexpr AttributeId SeekRangeEnd      = 0x00000006;
-static constexpr AttributeId SeekRangeStart    = 0x00000007;
-} // namespace Ids
+
+namespace PlaybackState {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace PlaybackState
+
+namespace StartTime {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace StartTime
+
+namespace Duration {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace Duration
+
+namespace PositionUpdatedAt {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace PositionUpdatedAt
+
+namespace Position {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace Position
+
+namespace PlaybackSpeed {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace PlaybackSpeed
+
+namespace SeekRangeEnd {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace SeekRangeEnd
+
+namespace SeekRangeStart {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace SeekRangeStart
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace MediaPlayback
 
 namespace MediaInput {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MediaInputList    = 0x00000000;
-static constexpr AttributeId CurrentMediaInput = 0x00000001;
-} // namespace Ids
+
+namespace MediaInputList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MediaInputList
+
+namespace CurrentMediaInput {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentMediaInput
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace MediaInput
 
 namespace ContentLauncher {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId AcceptsHeaderList       = 0x00000000;
-static constexpr AttributeId SupportedStreamingTypes = 0x00000001;
-} // namespace Ids
+
+namespace AcceptsHeaderList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace AcceptsHeaderList
+
+namespace SupportedStreamingTypes {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace SupportedStreamingTypes
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ContentLauncher
 
 namespace AudioOutput {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId AudioOutputList    = 0x00000000;
-static constexpr AttributeId CurrentAudioOutput = 0x00000001;
-} // namespace Ids
+
+namespace AudioOutputList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace AudioOutputList
+
+namespace CurrentAudioOutput {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CurrentAudioOutput
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace AudioOutput
 
 namespace ApplicationLauncher {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId ApplicationLauncherList = 0x00000000;
-static constexpr AttributeId CatalogVendorId         = 0x00000001;
-static constexpr AttributeId ApplicationId           = 0x00000002;
-} // namespace Ids
+
+namespace ApplicationLauncherList {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace ApplicationLauncherList
+
+namespace CatalogVendorId {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace CatalogVendorId
+
+namespace ApplicationId {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ApplicationId
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ApplicationLauncher
 
 namespace ApplicationBasic {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId VendorName        = 0x00000000;
-static constexpr AttributeId VendorId          = 0x00000001;
-static constexpr AttributeId ApplicationName   = 0x00000002;
-static constexpr AttributeId ProductId         = 0x00000003;
-static constexpr AttributeId ApplicationId     = 0x00000005;
-static constexpr AttributeId CatalogVendorId   = 0x00000006;
-static constexpr AttributeId ApplicationStatus = 0x00000007;
-} // namespace Ids
+
+namespace VendorName {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace VendorName
+
+namespace VendorId {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace VendorId
+
+namespace ApplicationName {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace ApplicationName
+
+namespace ProductId {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace ProductId
+
+namespace ApplicationId {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace ApplicationId
+
+namespace CatalogVendorId {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace CatalogVendorId
+
+namespace ApplicationStatus {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace ApplicationStatus
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ApplicationBasic
 
 namespace TestCluster {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Boolean               = 0x00000000;
-static constexpr AttributeId Bitmap8               = 0x00000001;
-static constexpr AttributeId Bitmap16              = 0x00000002;
-static constexpr AttributeId Bitmap32              = 0x00000003;
-static constexpr AttributeId Bitmap64              = 0x00000004;
-static constexpr AttributeId Int8u                 = 0x00000005;
-static constexpr AttributeId Int16u                = 0x00000006;
-static constexpr AttributeId Int32u                = 0x00000008;
-static constexpr AttributeId Int64u                = 0x0000000C;
-static constexpr AttributeId Int8s                 = 0x0000000D;
-static constexpr AttributeId Int16s                = 0x0000000E;
-static constexpr AttributeId Int32s                = 0x00000010;
-static constexpr AttributeId Int64s                = 0x00000014;
-static constexpr AttributeId Enum8                 = 0x00000015;
-static constexpr AttributeId Enum16                = 0x00000016;
-static constexpr AttributeId OctetString           = 0x00000019;
-static constexpr AttributeId ListInt8u             = 0x0000001A;
-static constexpr AttributeId ListOctetString       = 0x0000001B;
-static constexpr AttributeId ListStructOctetString = 0x0000001C;
-static constexpr AttributeId LongOctetString       = 0x0000001D;
-static constexpr AttributeId CharString            = 0x0000001E;
-static constexpr AttributeId LongCharString        = 0x0000001F;
-static constexpr AttributeId EpochUs               = 0x00000020;
-static constexpr AttributeId EpochS                = 0x00000021;
-static constexpr AttributeId Unsupported           = 0x000000FF;
-} // namespace Ids
+
+namespace Boolean {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Boolean
+
+namespace Bitmap8 {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace Bitmap8
+
+namespace Bitmap16 {
+static constexpr AttributeId Id = 0x00000002;
+} // namespace Bitmap16
+
+namespace Bitmap32 {
+static constexpr AttributeId Id = 0x00000003;
+} // namespace Bitmap32
+
+namespace Bitmap64 {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace Bitmap64
+
+namespace Int8u {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace Int8u
+
+namespace Int16u {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace Int16u
+
+namespace Int32u {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace Int32u
+
+namespace Int64u {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace Int64u
+
+namespace Int8s {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace Int8s
+
+namespace Int16s {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace Int16s
+
+namespace Int32s {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace Int32s
+
+namespace Int64s {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace Int64s
+
+namespace Enum8 {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace Enum8
+
+namespace Enum16 {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace Enum16
+
+namespace OctetString {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace OctetString
+
+namespace ListInt8u {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace ListInt8u
+
+namespace ListOctetString {
+static constexpr AttributeId Id = 0x0000001B;
+} // namespace ListOctetString
+
+namespace ListStructOctetString {
+static constexpr AttributeId Id = 0x0000001C;
+} // namespace ListStructOctetString
+
+namespace LongOctetString {
+static constexpr AttributeId Id = 0x0000001D;
+} // namespace LongOctetString
+
+namespace CharString {
+static constexpr AttributeId Id = 0x0000001E;
+} // namespace CharString
+
+namespace LongCharString {
+static constexpr AttributeId Id = 0x0000001F;
+} // namespace LongCharString
+
+namespace EpochUs {
+static constexpr AttributeId Id = 0x00000020;
+} // namespace EpochUs
+
+namespace EpochS {
+static constexpr AttributeId Id = 0x00000021;
+} // namespace EpochS
+
+namespace Unsupported {
+static constexpr AttributeId Id = 0x000000FF;
+} // namespace Unsupported
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace TestCluster
 
 namespace ApplianceIdentification {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId BasicIdentification       = 0x00000000;
-static constexpr AttributeId CompanyName               = 0x00000010;
-static constexpr AttributeId CompanyId                 = 0x00000011;
-static constexpr AttributeId BrandName                 = 0x00000012;
-static constexpr AttributeId BrandId                   = 0x00000013;
-static constexpr AttributeId Model                     = 0x00000014;
-static constexpr AttributeId PartNumber                = 0x00000015;
-static constexpr AttributeId ProductRevision           = 0x00000016;
-static constexpr AttributeId SoftwareRevision          = 0x00000017;
-static constexpr AttributeId ProductTypeName           = 0x00000018;
-static constexpr AttributeId ProductTypeId             = 0x00000019;
-static constexpr AttributeId CecedSpecificationVersion = 0x0000001A;
-} // namespace Ids
+
+namespace BasicIdentification {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace BasicIdentification
+
+namespace CompanyName {
+static constexpr AttributeId Id = 0x00000010;
+} // namespace CompanyName
+
+namespace CompanyId {
+static constexpr AttributeId Id = 0x00000011;
+} // namespace CompanyId
+
+namespace BrandName {
+static constexpr AttributeId Id = 0x00000012;
+} // namespace BrandName
+
+namespace BrandId {
+static constexpr AttributeId Id = 0x00000013;
+} // namespace BrandId
+
+namespace Model {
+static constexpr AttributeId Id = 0x00000014;
+} // namespace Model
+
+namespace PartNumber {
+static constexpr AttributeId Id = 0x00000015;
+} // namespace PartNumber
+
+namespace ProductRevision {
+static constexpr AttributeId Id = 0x00000016;
+} // namespace ProductRevision
+
+namespace SoftwareRevision {
+static constexpr AttributeId Id = 0x00000017;
+} // namespace SoftwareRevision
+
+namespace ProductTypeName {
+static constexpr AttributeId Id = 0x00000018;
+} // namespace ProductTypeName
+
+namespace ProductTypeId {
+static constexpr AttributeId Id = 0x00000019;
+} // namespace ProductTypeId
+
+namespace CecedSpecificationVersion {
+static constexpr AttributeId Id = 0x0000001A;
+} // namespace CecedSpecificationVersion
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ApplianceIdentification
 
 namespace MeterIdentification {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId CompanyName      = 0x00000000;
-static constexpr AttributeId MeterTypeId      = 0x00000001;
-static constexpr AttributeId DataQualityId    = 0x00000004;
-static constexpr AttributeId CustomerName     = 0x00000005;
-static constexpr AttributeId Model            = 0x00000006;
-static constexpr AttributeId PartNumber       = 0x00000007;
-static constexpr AttributeId ProductRevision  = 0x00000008;
-static constexpr AttributeId SoftwareRevision = 0x0000000A;
-static constexpr AttributeId UtilityName      = 0x0000000B;
-static constexpr AttributeId Pod              = 0x0000000C;
-static constexpr AttributeId AvailablePower   = 0x0000000D;
-static constexpr AttributeId PowerThreshold   = 0x0000000E;
-} // namespace Ids
+
+namespace CompanyName {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace CompanyName
+
+namespace MeterTypeId {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace MeterTypeId
+
+namespace DataQualityId {
+static constexpr AttributeId Id = 0x00000004;
+} // namespace DataQualityId
+
+namespace CustomerName {
+static constexpr AttributeId Id = 0x00000005;
+} // namespace CustomerName
+
+namespace Model {
+static constexpr AttributeId Id = 0x00000006;
+} // namespace Model
+
+namespace PartNumber {
+static constexpr AttributeId Id = 0x00000007;
+} // namespace PartNumber
+
+namespace ProductRevision {
+static constexpr AttributeId Id = 0x00000008;
+} // namespace ProductRevision
+
+namespace SoftwareRevision {
+static constexpr AttributeId Id = 0x0000000A;
+} // namespace SoftwareRevision
+
+namespace UtilityName {
+static constexpr AttributeId Id = 0x0000000B;
+} // namespace UtilityName
+
+namespace Pod {
+static constexpr AttributeId Id = 0x0000000C;
+} // namespace Pod
+
+namespace AvailablePower {
+static constexpr AttributeId Id = 0x0000000D;
+} // namespace AvailablePower
+
+namespace PowerThreshold {
+static constexpr AttributeId Id = 0x0000000E;
+} // namespace PowerThreshold
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace MeterIdentification
 
 namespace ApplianceStatistics {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId LogMaxSize      = 0x00000000;
-static constexpr AttributeId LogQueueMaxSize = 0x00000001;
-} // namespace Ids
+
+namespace LogMaxSize {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace LogMaxSize
+
+namespace LogQueueMaxSize {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace LogQueueMaxSize
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ApplianceStatistics
 
 namespace ElectricalMeasurement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId MeasurementType                          = 0x00000000;
-static constexpr AttributeId DcVoltage                                = 0x00000100;
-static constexpr AttributeId DcVoltageMin                             = 0x00000101;
-static constexpr AttributeId DcVoltageMax                             = 0x00000102;
-static constexpr AttributeId DcCurrent                                = 0x00000103;
-static constexpr AttributeId DcCurrentMin                             = 0x00000104;
-static constexpr AttributeId DcCurrentMax                             = 0x00000105;
-static constexpr AttributeId DcPower                                  = 0x00000106;
-static constexpr AttributeId DcPowerMin                               = 0x00000107;
-static constexpr AttributeId DcPowerMax                               = 0x00000108;
-static constexpr AttributeId DcVoltageMultiplier                      = 0x00000200;
-static constexpr AttributeId DcVoltageDivisor                         = 0x00000201;
-static constexpr AttributeId DcCurrentMultiplier                      = 0x00000202;
-static constexpr AttributeId DcCurrentDivisor                         = 0x00000203;
-static constexpr AttributeId DcPowerMultiplier                        = 0x00000204;
-static constexpr AttributeId DcPowerDivisor                           = 0x00000205;
-static constexpr AttributeId AcFrequency                              = 0x00000300;
-static constexpr AttributeId AcFrequencyMin                           = 0x00000301;
-static constexpr AttributeId AcFrequencyMax                           = 0x00000302;
-static constexpr AttributeId NeutralCurrent                           = 0x00000303;
-static constexpr AttributeId TotalActivePower                         = 0x00000304;
-static constexpr AttributeId TotalReactivePower                       = 0x00000305;
-static constexpr AttributeId TotalApparentPower                       = 0x00000306;
-static constexpr AttributeId Measured1stHarmonicCurrent               = 0x00000307;
-static constexpr AttributeId Measured3rdHarmonicCurrent               = 0x00000308;
-static constexpr AttributeId Measured5thHarmonicCurrent               = 0x00000309;
-static constexpr AttributeId Measured7thHarmonicCurrent               = 0x0000030A;
-static constexpr AttributeId Measured9thHarmonicCurrent               = 0x0000030B;
-static constexpr AttributeId Measured11thHarmonicCurrent              = 0x0000030C;
-static constexpr AttributeId MeasuredPhase1stHarmonicCurrent          = 0x0000030D;
-static constexpr AttributeId MeasuredPhase3rdHarmonicCurrent          = 0x0000030E;
-static constexpr AttributeId MeasuredPhase5thHarmonicCurrent          = 0x0000030F;
-static constexpr AttributeId MeasuredPhase7thHarmonicCurrent          = 0x00000310;
-static constexpr AttributeId MeasuredPhase9thHarmonicCurrent          = 0x00000311;
-static constexpr AttributeId MeasuredPhase11thHarmonicCurrent         = 0x00000312;
-static constexpr AttributeId AcFrequencyMultiplier                    = 0x00000400;
-static constexpr AttributeId AcFrequencyDivisor                       = 0x00000401;
-static constexpr AttributeId PowerMultiplier                          = 0x00000402;
-static constexpr AttributeId PowerDivisor                             = 0x00000403;
-static constexpr AttributeId HarmonicCurrentMultiplier                = 0x00000404;
-static constexpr AttributeId PhaseHarmonicCurrentMultiplier           = 0x00000405;
-static constexpr AttributeId InstantaneousVoltage                     = 0x00000500;
-static constexpr AttributeId InstantaneousLineCurrent                 = 0x00000501;
-static constexpr AttributeId InstantaneousActiveCurrent               = 0x00000502;
-static constexpr AttributeId InstantaneousReactiveCurrent             = 0x00000503;
-static constexpr AttributeId InstantaneousPower                       = 0x00000504;
-static constexpr AttributeId RmsVoltage                               = 0x00000505;
-static constexpr AttributeId RmsVoltageMin                            = 0x00000506;
-static constexpr AttributeId RmsVoltageMax                            = 0x00000507;
-static constexpr AttributeId RmsCurrent                               = 0x00000508;
-static constexpr AttributeId RmsCurrentMin                            = 0x00000509;
-static constexpr AttributeId RmsCurrentMax                            = 0x0000050A;
-static constexpr AttributeId ActivePower                              = 0x0000050B;
-static constexpr AttributeId ActivePowerMin                           = 0x0000050C;
-static constexpr AttributeId ActivePowerMax                           = 0x0000050D;
-static constexpr AttributeId ReactivePower                            = 0x0000050E;
-static constexpr AttributeId ApparentPower                            = 0x0000050F;
-static constexpr AttributeId PowerFactor                              = 0x00000510;
-static constexpr AttributeId AverageRmsVoltageMeasurementPeriod       = 0x00000511;
-static constexpr AttributeId AverageRmsUnderVoltageCounter            = 0x00000513;
-static constexpr AttributeId RmsExtremeOverVoltagePeriod              = 0x00000514;
-static constexpr AttributeId RmsExtremeUnderVoltagePeriod             = 0x00000515;
-static constexpr AttributeId RmsVoltageSagPeriod                      = 0x00000516;
-static constexpr AttributeId RmsVoltageSwellPeriod                    = 0x00000517;
-static constexpr AttributeId AcVoltageMultiplier                      = 0x00000600;
-static constexpr AttributeId AcVoltageDivisor                         = 0x00000601;
-static constexpr AttributeId AcCurrentMultiplier                      = 0x00000602;
-static constexpr AttributeId AcCurrentDivisor                         = 0x00000603;
-static constexpr AttributeId AcPowerMultiplier                        = 0x00000604;
-static constexpr AttributeId AcPowerDivisor                           = 0x00000605;
-static constexpr AttributeId OverloadAlarmsMask                       = 0x00000700;
-static constexpr AttributeId VoltageOverload                          = 0x00000701;
-static constexpr AttributeId CurrentOverload                          = 0x00000702;
-static constexpr AttributeId AcOverloadAlarmsMask                     = 0x00000800;
-static constexpr AttributeId AcVoltageOverload                        = 0x00000801;
-static constexpr AttributeId AcCurrentOverload                        = 0x00000802;
-static constexpr AttributeId AcActivePowerOverload                    = 0x00000803;
-static constexpr AttributeId AcReactivePowerOverload                  = 0x00000804;
-static constexpr AttributeId AverageRmsOverVoltage                    = 0x00000805;
-static constexpr AttributeId AverageRmsUnderVoltage                   = 0x00000806;
-static constexpr AttributeId RmsExtremeOverVoltage                    = 0x00000807;
-static constexpr AttributeId RmsExtremeUnderVoltage                   = 0x00000808;
-static constexpr AttributeId RmsVoltageSag                            = 0x00000809;
-static constexpr AttributeId RmsVoltageSwell                          = 0x0000080A;
-static constexpr AttributeId LineCurrentPhaseB                        = 0x00000901;
-static constexpr AttributeId ActiveCurrentPhaseB                      = 0x00000902;
-static constexpr AttributeId ReactiveCurrentPhaseB                    = 0x00000903;
-static constexpr AttributeId RmsVoltagePhaseB                         = 0x00000905;
-static constexpr AttributeId RmsVoltageMinPhaseB                      = 0x00000906;
-static constexpr AttributeId RmsVoltageMaxPhaseB                      = 0x00000907;
-static constexpr AttributeId RmsCurrentPhaseB                         = 0x00000908;
-static constexpr AttributeId RmsCurrentMinPhaseB                      = 0x00000909;
-static constexpr AttributeId RmsCurrentMaxPhaseB                      = 0x0000090A;
-static constexpr AttributeId ActivePowerPhaseB                        = 0x0000090B;
-static constexpr AttributeId ActivePowerMinPhaseB                     = 0x0000090C;
-static constexpr AttributeId ActivePowerMaxPhaseB                     = 0x0000090D;
-static constexpr AttributeId ReactivePowerPhaseB                      = 0x0000090E;
-static constexpr AttributeId ApparentPowerPhaseB                      = 0x0000090F;
-static constexpr AttributeId PowerFactorPhaseB                        = 0x00000910;
-static constexpr AttributeId AverageRmsVoltageMeasurementPeriodPhaseB = 0x00000911;
-static constexpr AttributeId AverageRmsOverVoltageCounterPhaseB       = 0x00000912;
-static constexpr AttributeId AverageRmsUnderVoltageCounterPhaseB      = 0x00000913;
-static constexpr AttributeId RmsExtremeOverVoltagePeriodPhaseB        = 0x00000914;
-static constexpr AttributeId RmsExtremeUnderVoltagePeriodPhaseB       = 0x00000915;
-static constexpr AttributeId RmsVoltageSagPeriodPhaseB                = 0x00000916;
-static constexpr AttributeId RmsVoltageSwellPeriodPhaseB              = 0x00000917;
-static constexpr AttributeId LineCurrentPhaseC                        = 0x00000A01;
-static constexpr AttributeId ActiveCurrentPhaseC                      = 0x00000A02;
-static constexpr AttributeId ReactiveCurrentPhaseC                    = 0x00000A03;
-static constexpr AttributeId RmsVoltagePhaseC                         = 0x00000A05;
-static constexpr AttributeId RmsVoltageMinPhaseC                      = 0x00000A06;
-static constexpr AttributeId RmsVoltageMaxPhaseC                      = 0x00000A07;
-static constexpr AttributeId RmsCurrentPhaseC                         = 0x00000A08;
-static constexpr AttributeId RmsCurrentMinPhaseC                      = 0x00000A09;
-static constexpr AttributeId RmsCurrentMaxPhaseC                      = 0x00000A0A;
-static constexpr AttributeId ActivePowerPhaseC                        = 0x00000A0B;
-static constexpr AttributeId ActivePowerMinPhaseC                     = 0x00000A0C;
-static constexpr AttributeId ActivePowerMaxPhaseC                     = 0x00000A0D;
-static constexpr AttributeId ReactivePowerPhaseC                      = 0x00000A0E;
-static constexpr AttributeId ApparentPowerPhaseC                      = 0x00000A0F;
-static constexpr AttributeId PowerFactorPhaseC                        = 0x00000A10;
-static constexpr AttributeId AverageRmsVoltageMeasurementPeriodPhaseC = 0x00000A11;
-static constexpr AttributeId AverageRmsOverVoltageCounterPhaseC       = 0x00000A12;
-static constexpr AttributeId AverageRmsUnderVoltageCounterPhaseC      = 0x00000A13;
-static constexpr AttributeId RmsExtremeOverVoltagePeriodPhaseC        = 0x00000A14;
-static constexpr AttributeId RmsExtremeUnderVoltagePeriodPhaseC       = 0x00000A15;
-static constexpr AttributeId RmsVoltageSagPeriodPhaseC                = 0x00000A16;
-static constexpr AttributeId RmsVoltageSwellPeriodPhaseC              = 0x00000A17;
-} // namespace Ids
+
+namespace MeasurementType {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace MeasurementType
+
+namespace DcVoltage {
+static constexpr AttributeId Id = 0x00000100;
+} // namespace DcVoltage
+
+namespace DcVoltageMin {
+static constexpr AttributeId Id = 0x00000101;
+} // namespace DcVoltageMin
+
+namespace DcVoltageMax {
+static constexpr AttributeId Id = 0x00000102;
+} // namespace DcVoltageMax
+
+namespace DcCurrent {
+static constexpr AttributeId Id = 0x00000103;
+} // namespace DcCurrent
+
+namespace DcCurrentMin {
+static constexpr AttributeId Id = 0x00000104;
+} // namespace DcCurrentMin
+
+namespace DcCurrentMax {
+static constexpr AttributeId Id = 0x00000105;
+} // namespace DcCurrentMax
+
+namespace DcPower {
+static constexpr AttributeId Id = 0x00000106;
+} // namespace DcPower
+
+namespace DcPowerMin {
+static constexpr AttributeId Id = 0x00000107;
+} // namespace DcPowerMin
+
+namespace DcPowerMax {
+static constexpr AttributeId Id = 0x00000108;
+} // namespace DcPowerMax
+
+namespace DcVoltageMultiplier {
+static constexpr AttributeId Id = 0x00000200;
+} // namespace DcVoltageMultiplier
+
+namespace DcVoltageDivisor {
+static constexpr AttributeId Id = 0x00000201;
+} // namespace DcVoltageDivisor
+
+namespace DcCurrentMultiplier {
+static constexpr AttributeId Id = 0x00000202;
+} // namespace DcCurrentMultiplier
+
+namespace DcCurrentDivisor {
+static constexpr AttributeId Id = 0x00000203;
+} // namespace DcCurrentDivisor
+
+namespace DcPowerMultiplier {
+static constexpr AttributeId Id = 0x00000204;
+} // namespace DcPowerMultiplier
+
+namespace DcPowerDivisor {
+static constexpr AttributeId Id = 0x00000205;
+} // namespace DcPowerDivisor
+
+namespace AcFrequency {
+static constexpr AttributeId Id = 0x00000300;
+} // namespace AcFrequency
+
+namespace AcFrequencyMin {
+static constexpr AttributeId Id = 0x00000301;
+} // namespace AcFrequencyMin
+
+namespace AcFrequencyMax {
+static constexpr AttributeId Id = 0x00000302;
+} // namespace AcFrequencyMax
+
+namespace NeutralCurrent {
+static constexpr AttributeId Id = 0x00000303;
+} // namespace NeutralCurrent
+
+namespace TotalActivePower {
+static constexpr AttributeId Id = 0x00000304;
+} // namespace TotalActivePower
+
+namespace TotalReactivePower {
+static constexpr AttributeId Id = 0x00000305;
+} // namespace TotalReactivePower
+
+namespace TotalApparentPower {
+static constexpr AttributeId Id = 0x00000306;
+} // namespace TotalApparentPower
+
+namespace Measured1stHarmonicCurrent {
+static constexpr AttributeId Id = 0x00000307;
+} // namespace Measured1stHarmonicCurrent
+
+namespace Measured3rdHarmonicCurrent {
+static constexpr AttributeId Id = 0x00000308;
+} // namespace Measured3rdHarmonicCurrent
+
+namespace Measured5thHarmonicCurrent {
+static constexpr AttributeId Id = 0x00000309;
+} // namespace Measured5thHarmonicCurrent
+
+namespace Measured7thHarmonicCurrent {
+static constexpr AttributeId Id = 0x0000030A;
+} // namespace Measured7thHarmonicCurrent
+
+namespace Measured9thHarmonicCurrent {
+static constexpr AttributeId Id = 0x0000030B;
+} // namespace Measured9thHarmonicCurrent
+
+namespace Measured11thHarmonicCurrent {
+static constexpr AttributeId Id = 0x0000030C;
+} // namespace Measured11thHarmonicCurrent
+
+namespace MeasuredPhase1stHarmonicCurrent {
+static constexpr AttributeId Id = 0x0000030D;
+} // namespace MeasuredPhase1stHarmonicCurrent
+
+namespace MeasuredPhase3rdHarmonicCurrent {
+static constexpr AttributeId Id = 0x0000030E;
+} // namespace MeasuredPhase3rdHarmonicCurrent
+
+namespace MeasuredPhase5thHarmonicCurrent {
+static constexpr AttributeId Id = 0x0000030F;
+} // namespace MeasuredPhase5thHarmonicCurrent
+
+namespace MeasuredPhase7thHarmonicCurrent {
+static constexpr AttributeId Id = 0x00000310;
+} // namespace MeasuredPhase7thHarmonicCurrent
+
+namespace MeasuredPhase9thHarmonicCurrent {
+static constexpr AttributeId Id = 0x00000311;
+} // namespace MeasuredPhase9thHarmonicCurrent
+
+namespace MeasuredPhase11thHarmonicCurrent {
+static constexpr AttributeId Id = 0x00000312;
+} // namespace MeasuredPhase11thHarmonicCurrent
+
+namespace AcFrequencyMultiplier {
+static constexpr AttributeId Id = 0x00000400;
+} // namespace AcFrequencyMultiplier
+
+namespace AcFrequencyDivisor {
+static constexpr AttributeId Id = 0x00000401;
+} // namespace AcFrequencyDivisor
+
+namespace PowerMultiplier {
+static constexpr AttributeId Id = 0x00000402;
+} // namespace PowerMultiplier
+
+namespace PowerDivisor {
+static constexpr AttributeId Id = 0x00000403;
+} // namespace PowerDivisor
+
+namespace HarmonicCurrentMultiplier {
+static constexpr AttributeId Id = 0x00000404;
+} // namespace HarmonicCurrentMultiplier
+
+namespace PhaseHarmonicCurrentMultiplier {
+static constexpr AttributeId Id = 0x00000405;
+} // namespace PhaseHarmonicCurrentMultiplier
+
+namespace InstantaneousVoltage {
+static constexpr AttributeId Id = 0x00000500;
+} // namespace InstantaneousVoltage
+
+namespace InstantaneousLineCurrent {
+static constexpr AttributeId Id = 0x00000501;
+} // namespace InstantaneousLineCurrent
+
+namespace InstantaneousActiveCurrent {
+static constexpr AttributeId Id = 0x00000502;
+} // namespace InstantaneousActiveCurrent
+
+namespace InstantaneousReactiveCurrent {
+static constexpr AttributeId Id = 0x00000503;
+} // namespace InstantaneousReactiveCurrent
+
+namespace InstantaneousPower {
+static constexpr AttributeId Id = 0x00000504;
+} // namespace InstantaneousPower
+
+namespace RmsVoltage {
+static constexpr AttributeId Id = 0x00000505;
+} // namespace RmsVoltage
+
+namespace RmsVoltageMin {
+static constexpr AttributeId Id = 0x00000506;
+} // namespace RmsVoltageMin
+
+namespace RmsVoltageMax {
+static constexpr AttributeId Id = 0x00000507;
+} // namespace RmsVoltageMax
+
+namespace RmsCurrent {
+static constexpr AttributeId Id = 0x00000508;
+} // namespace RmsCurrent
+
+namespace RmsCurrentMin {
+static constexpr AttributeId Id = 0x00000509;
+} // namespace RmsCurrentMin
+
+namespace RmsCurrentMax {
+static constexpr AttributeId Id = 0x0000050A;
+} // namespace RmsCurrentMax
+
+namespace ActivePower {
+static constexpr AttributeId Id = 0x0000050B;
+} // namespace ActivePower
+
+namespace ActivePowerMin {
+static constexpr AttributeId Id = 0x0000050C;
+} // namespace ActivePowerMin
+
+namespace ActivePowerMax {
+static constexpr AttributeId Id = 0x0000050D;
+} // namespace ActivePowerMax
+
+namespace ReactivePower {
+static constexpr AttributeId Id = 0x0000050E;
+} // namespace ReactivePower
+
+namespace ApparentPower {
+static constexpr AttributeId Id = 0x0000050F;
+} // namespace ApparentPower
+
+namespace PowerFactor {
+static constexpr AttributeId Id = 0x00000510;
+} // namespace PowerFactor
+
+namespace AverageRmsVoltageMeasurementPeriod {
+static constexpr AttributeId Id = 0x00000511;
+} // namespace AverageRmsVoltageMeasurementPeriod
+
+namespace AverageRmsUnderVoltageCounter {
+static constexpr AttributeId Id = 0x00000513;
+} // namespace AverageRmsUnderVoltageCounter
+
+namespace RmsExtremeOverVoltagePeriod {
+static constexpr AttributeId Id = 0x00000514;
+} // namespace RmsExtremeOverVoltagePeriod
+
+namespace RmsExtremeUnderVoltagePeriod {
+static constexpr AttributeId Id = 0x00000515;
+} // namespace RmsExtremeUnderVoltagePeriod
+
+namespace RmsVoltageSagPeriod {
+static constexpr AttributeId Id = 0x00000516;
+} // namespace RmsVoltageSagPeriod
+
+namespace RmsVoltageSwellPeriod {
+static constexpr AttributeId Id = 0x00000517;
+} // namespace RmsVoltageSwellPeriod
+
+namespace AcVoltageMultiplier {
+static constexpr AttributeId Id = 0x00000600;
+} // namespace AcVoltageMultiplier
+
+namespace AcVoltageDivisor {
+static constexpr AttributeId Id = 0x00000601;
+} // namespace AcVoltageDivisor
+
+namespace AcCurrentMultiplier {
+static constexpr AttributeId Id = 0x00000602;
+} // namespace AcCurrentMultiplier
+
+namespace AcCurrentDivisor {
+static constexpr AttributeId Id = 0x00000603;
+} // namespace AcCurrentDivisor
+
+namespace AcPowerMultiplier {
+static constexpr AttributeId Id = 0x00000604;
+} // namespace AcPowerMultiplier
+
+namespace AcPowerDivisor {
+static constexpr AttributeId Id = 0x00000605;
+} // namespace AcPowerDivisor
+
+namespace OverloadAlarmsMask {
+static constexpr AttributeId Id = 0x00000700;
+} // namespace OverloadAlarmsMask
+
+namespace VoltageOverload {
+static constexpr AttributeId Id = 0x00000701;
+} // namespace VoltageOverload
+
+namespace CurrentOverload {
+static constexpr AttributeId Id = 0x00000702;
+} // namespace CurrentOverload
+
+namespace AcOverloadAlarmsMask {
+static constexpr AttributeId Id = 0x00000800;
+} // namespace AcOverloadAlarmsMask
+
+namespace AcVoltageOverload {
+static constexpr AttributeId Id = 0x00000801;
+} // namespace AcVoltageOverload
+
+namespace AcCurrentOverload {
+static constexpr AttributeId Id = 0x00000802;
+} // namespace AcCurrentOverload
+
+namespace AcActivePowerOverload {
+static constexpr AttributeId Id = 0x00000803;
+} // namespace AcActivePowerOverload
+
+namespace AcReactivePowerOverload {
+static constexpr AttributeId Id = 0x00000804;
+} // namespace AcReactivePowerOverload
+
+namespace AverageRmsOverVoltage {
+static constexpr AttributeId Id = 0x00000805;
+} // namespace AverageRmsOverVoltage
+
+namespace AverageRmsUnderVoltage {
+static constexpr AttributeId Id = 0x00000806;
+} // namespace AverageRmsUnderVoltage
+
+namespace RmsExtremeOverVoltage {
+static constexpr AttributeId Id = 0x00000807;
+} // namespace RmsExtremeOverVoltage
+
+namespace RmsExtremeUnderVoltage {
+static constexpr AttributeId Id = 0x00000808;
+} // namespace RmsExtremeUnderVoltage
+
+namespace RmsVoltageSag {
+static constexpr AttributeId Id = 0x00000809;
+} // namespace RmsVoltageSag
+
+namespace RmsVoltageSwell {
+static constexpr AttributeId Id = 0x0000080A;
+} // namespace RmsVoltageSwell
+
+namespace LineCurrentPhaseB {
+static constexpr AttributeId Id = 0x00000901;
+} // namespace LineCurrentPhaseB
+
+namespace ActiveCurrentPhaseB {
+static constexpr AttributeId Id = 0x00000902;
+} // namespace ActiveCurrentPhaseB
+
+namespace ReactiveCurrentPhaseB {
+static constexpr AttributeId Id = 0x00000903;
+} // namespace ReactiveCurrentPhaseB
+
+namespace RmsVoltagePhaseB {
+static constexpr AttributeId Id = 0x00000905;
+} // namespace RmsVoltagePhaseB
+
+namespace RmsVoltageMinPhaseB {
+static constexpr AttributeId Id = 0x00000906;
+} // namespace RmsVoltageMinPhaseB
+
+namespace RmsVoltageMaxPhaseB {
+static constexpr AttributeId Id = 0x00000907;
+} // namespace RmsVoltageMaxPhaseB
+
+namespace RmsCurrentPhaseB {
+static constexpr AttributeId Id = 0x00000908;
+} // namespace RmsCurrentPhaseB
+
+namespace RmsCurrentMinPhaseB {
+static constexpr AttributeId Id = 0x00000909;
+} // namespace RmsCurrentMinPhaseB
+
+namespace RmsCurrentMaxPhaseB {
+static constexpr AttributeId Id = 0x0000090A;
+} // namespace RmsCurrentMaxPhaseB
+
+namespace ActivePowerPhaseB {
+static constexpr AttributeId Id = 0x0000090B;
+} // namespace ActivePowerPhaseB
+
+namespace ActivePowerMinPhaseB {
+static constexpr AttributeId Id = 0x0000090C;
+} // namespace ActivePowerMinPhaseB
+
+namespace ActivePowerMaxPhaseB {
+static constexpr AttributeId Id = 0x0000090D;
+} // namespace ActivePowerMaxPhaseB
+
+namespace ReactivePowerPhaseB {
+static constexpr AttributeId Id = 0x0000090E;
+} // namespace ReactivePowerPhaseB
+
+namespace ApparentPowerPhaseB {
+static constexpr AttributeId Id = 0x0000090F;
+} // namespace ApparentPowerPhaseB
+
+namespace PowerFactorPhaseB {
+static constexpr AttributeId Id = 0x00000910;
+} // namespace PowerFactorPhaseB
+
+namespace AverageRmsVoltageMeasurementPeriodPhaseB {
+static constexpr AttributeId Id = 0x00000911;
+} // namespace AverageRmsVoltageMeasurementPeriodPhaseB
+
+namespace AverageRmsOverVoltageCounterPhaseB {
+static constexpr AttributeId Id = 0x00000912;
+} // namespace AverageRmsOverVoltageCounterPhaseB
+
+namespace AverageRmsUnderVoltageCounterPhaseB {
+static constexpr AttributeId Id = 0x00000913;
+} // namespace AverageRmsUnderVoltageCounterPhaseB
+
+namespace RmsExtremeOverVoltagePeriodPhaseB {
+static constexpr AttributeId Id = 0x00000914;
+} // namespace RmsExtremeOverVoltagePeriodPhaseB
+
+namespace RmsExtremeUnderVoltagePeriodPhaseB {
+static constexpr AttributeId Id = 0x00000915;
+} // namespace RmsExtremeUnderVoltagePeriodPhaseB
+
+namespace RmsVoltageSagPeriodPhaseB {
+static constexpr AttributeId Id = 0x00000916;
+} // namespace RmsVoltageSagPeriodPhaseB
+
+namespace RmsVoltageSwellPeriodPhaseB {
+static constexpr AttributeId Id = 0x00000917;
+} // namespace RmsVoltageSwellPeriodPhaseB
+
+namespace LineCurrentPhaseC {
+static constexpr AttributeId Id = 0x00000A01;
+} // namespace LineCurrentPhaseC
+
+namespace ActiveCurrentPhaseC {
+static constexpr AttributeId Id = 0x00000A02;
+} // namespace ActiveCurrentPhaseC
+
+namespace ReactiveCurrentPhaseC {
+static constexpr AttributeId Id = 0x00000A03;
+} // namespace ReactiveCurrentPhaseC
+
+namespace RmsVoltagePhaseC {
+static constexpr AttributeId Id = 0x00000A05;
+} // namespace RmsVoltagePhaseC
+
+namespace RmsVoltageMinPhaseC {
+static constexpr AttributeId Id = 0x00000A06;
+} // namespace RmsVoltageMinPhaseC
+
+namespace RmsVoltageMaxPhaseC {
+static constexpr AttributeId Id = 0x00000A07;
+} // namespace RmsVoltageMaxPhaseC
+
+namespace RmsCurrentPhaseC {
+static constexpr AttributeId Id = 0x00000A08;
+} // namespace RmsCurrentPhaseC
+
+namespace RmsCurrentMinPhaseC {
+static constexpr AttributeId Id = 0x00000A09;
+} // namespace RmsCurrentMinPhaseC
+
+namespace RmsCurrentMaxPhaseC {
+static constexpr AttributeId Id = 0x00000A0A;
+} // namespace RmsCurrentMaxPhaseC
+
+namespace ActivePowerPhaseC {
+static constexpr AttributeId Id = 0x00000A0B;
+} // namespace ActivePowerPhaseC
+
+namespace ActivePowerMinPhaseC {
+static constexpr AttributeId Id = 0x00000A0C;
+} // namespace ActivePowerMinPhaseC
+
+namespace ActivePowerMaxPhaseC {
+static constexpr AttributeId Id = 0x00000A0D;
+} // namespace ActivePowerMaxPhaseC
+
+namespace ReactivePowerPhaseC {
+static constexpr AttributeId Id = 0x00000A0E;
+} // namespace ReactivePowerPhaseC
+
+namespace ApparentPowerPhaseC {
+static constexpr AttributeId Id = 0x00000A0F;
+} // namespace ApparentPowerPhaseC
+
+namespace PowerFactorPhaseC {
+static constexpr AttributeId Id = 0x00000A10;
+} // namespace PowerFactorPhaseC
+
+namespace AverageRmsVoltageMeasurementPeriodPhaseC {
+static constexpr AttributeId Id = 0x00000A11;
+} // namespace AverageRmsVoltageMeasurementPeriodPhaseC
+
+namespace AverageRmsOverVoltageCounterPhaseC {
+static constexpr AttributeId Id = 0x00000A12;
+} // namespace AverageRmsOverVoltageCounterPhaseC
+
+namespace AverageRmsUnderVoltageCounterPhaseC {
+static constexpr AttributeId Id = 0x00000A13;
+} // namespace AverageRmsUnderVoltageCounterPhaseC
+
+namespace RmsExtremeOverVoltagePeriodPhaseC {
+static constexpr AttributeId Id = 0x00000A14;
+} // namespace RmsExtremeOverVoltagePeriodPhaseC
+
+namespace RmsExtremeUnderVoltagePeriodPhaseC {
+static constexpr AttributeId Id = 0x00000A15;
+} // namespace RmsExtremeUnderVoltagePeriodPhaseC
+
+namespace RmsVoltageSagPeriodPhaseC {
+static constexpr AttributeId Id = 0x00000A16;
+} // namespace RmsVoltageSagPeriodPhaseC
+
+namespace RmsVoltageSwellPeriodPhaseC {
+static constexpr AttributeId Id = 0x00000A17;
+} // namespace RmsVoltageSwellPeriodPhaseC
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace ElectricalMeasurement
 
 namespace GroupKeyManagement {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId Groups    = 0x00000000;
-static constexpr AttributeId GroupKeys = 0x00000001;
-} // namespace Ids
+
+namespace Groups {
+static constexpr AttributeId Id = 0x00000000;
+} // namespace Groups
+
+namespace GroupKeys {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace GroupKeys
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace GroupKeyManagement
 
 namespace SampleMfgSpecificCluster {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId EmberSampleAttribute  = 0x10020000;
-static constexpr AttributeId EmberSampleAttribute2 = 0x10020001;
-} // namespace Ids
+
+namespace EmberSampleAttribute {
+static constexpr AttributeId Id = 0x10020000;
+} // namespace EmberSampleAttribute
+
+namespace EmberSampleAttribute2 {
+static constexpr AttributeId Id = 0x10020001;
+} // namespace EmberSampleAttribute2
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster
 
 namespace SampleMfgSpecificCluster2 {
 namespace Attributes {
-namespace Ids {
-static constexpr AttributeId EmberSampleAttribute3 = 0x10490000;
-static constexpr AttributeId EmberSampleAttribute4 = 0x10490001;
-} // namespace Ids
+
+namespace EmberSampleAttribute3 {
+static constexpr AttributeId Id = 0x10490000;
+} // namespace EmberSampleAttribute3
+
+namespace EmberSampleAttribute4 {
+static constexpr AttributeId Id = 0x10490001;
+} // namespace EmberSampleAttribute4
+
+namespace FeatureMap = Globals::Attributes::FeatureMap;
+
+namespace ClusterRevision = Globals::Attributes::ClusterRevision;
+
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster2
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -1171,14 +1171,14 @@ CHIP_ERROR BinaryInputBasicCluster::SubscribeAttributePresentValue(Callback::Can
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BinaryInputBasic::Attributes::Ids::PresentValue;
+    attributePath.mFieldId    = BinaryInputBasic::Attributes::PresentValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BinaryInputBasicCluster::ReportAttributePresentValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(BinaryInputBasic::Attributes::Ids::PresentValue, onReportCallback,
+    return RequestAttributeReporting(BinaryInputBasic::Attributes::PresentValue::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
@@ -1201,14 +1201,14 @@ CHIP_ERROR BinaryInputBasicCluster::SubscribeAttributeStatusFlags(Callback::Canc
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BinaryInputBasic::Attributes::Ids::StatusFlags;
+    attributePath.mFieldId    = BinaryInputBasic::Attributes::StatusFlags::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BinaryInputBasicCluster::ReportAttributeStatusFlags(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(BinaryInputBasic::Attributes::Ids::StatusFlags, onReportCallback,
+    return RequestAttributeReporting(BinaryInputBasic::Attributes::StatusFlags::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -2496,14 +2496,14 @@ CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentHue(Callback::Cancelabl
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentHue;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentHue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentHue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(ColorControl::Attributes::Ids::CurrentHue, onReportCallback,
+    return RequestAttributeReporting(ColorControl::Attributes::CurrentHue::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -2526,14 +2526,14 @@ CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentSaturation(Callback::Ca
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentSaturation;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentSaturation::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentSaturation(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(ColorControl::Attributes::Ids::CurrentSaturation, onReportCallback,
+    return RequestAttributeReporting(ColorControl::Attributes::CurrentSaturation::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -2568,14 +2568,14 @@ CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentX(Callback::Cancelable 
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentX;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentX::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentX(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(ColorControl::Attributes::Ids::CurrentX, onReportCallback,
+    return RequestAttributeReporting(ColorControl::Attributes::CurrentX::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -2598,14 +2598,14 @@ CHIP_ERROR ColorControlCluster::SubscribeAttributeCurrentY(Callback::Cancelable 
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentY;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentY::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentY(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(ColorControl::Attributes::Ids::CurrentY, onReportCallback,
+    return RequestAttributeReporting(ColorControl::Attributes::CurrentY::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -2652,14 +2652,14 @@ CHIP_ERROR ColorControlCluster::SubscribeAttributeColorTemperature(Callback::Can
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorTemperature;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorTemperature::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeColorTemperature(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(ColorControl::Attributes::Ids::ColorTemperature, onReportCallback,
+    return RequestAttributeReporting(ColorControl::Attributes::ColorTemperature::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -4669,14 +4669,14 @@ CHIP_ERROR DoorLockCluster::SubscribeAttributeLockState(Callback::Cancelable * o
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = DoorLock::Attributes::Ids::LockState;
+    attributePath.mFieldId    = DoorLock::Attributes::LockState::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR DoorLockCluster::ReportAttributeLockState(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(DoorLock::Attributes::Ids::LockState, onReportCallback,
+    return RequestAttributeReporting(DoorLock::Attributes::LockState::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -6184,14 +6184,14 @@ CHIP_ERROR LevelControlCluster::SubscribeAttributeCurrentLevel(Callback::Cancela
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = LevelControl::Attributes::Ids::CurrentLevel;
+    attributePath.mFieldId    = LevelControl::Attributes::CurrentLevel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR LevelControlCluster::ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(LevelControl::Attributes::Ids::CurrentLevel, onReportCallback,
+    return RequestAttributeReporting(LevelControl::Attributes::CurrentLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -7734,14 +7734,14 @@ CHIP_ERROR OccupancySensingCluster::SubscribeAttributeOccupancy(Callback::Cancel
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OccupancySensing::Attributes::Ids::Occupancy;
+    attributePath.mFieldId    = OccupancySensing::Attributes::Occupancy::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OccupancySensingCluster::ReportAttributeOccupancy(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(OccupancySensing::Attributes::Ids::Occupancy, onReportCallback,
+    return RequestAttributeReporting(OccupancySensing::Attributes::Occupancy::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -8040,14 +8040,14 @@ CHIP_ERROR OnOffCluster::SubscribeAttributeOnOff(Callback::Cancelable * onSucces
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OnOff::Attributes::Ids::OnOff;
+    attributePath.mFieldId    = OnOff::Attributes::OnOff::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(OnOff::Attributes::Ids::OnOff, onReportCallback,
+    return RequestAttributeReporting(OnOff::Attributes::OnOff::Id, onReportCallback,
                                      BasicAttributeFilter<BooleanAttributeCallback>);
 }
 
@@ -8823,14 +8823,14 @@ CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback:
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PressureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = PressureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR PressureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(PressureMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(PressureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -8951,14 +8951,14 @@ CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeCapacity(Callba
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::Capacity;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Capacity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeCapacity(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::Ids::Capacity, onReportCallback,
+    return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::Capacity::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -9024,14 +9024,14 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::SubscribeAttributeMeasuredValue(C
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR RelativeHumidityMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(RelativeHumidityMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(RelativeHumidityMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -9578,14 +9578,14 @@ CHIP_ERROR SwitchCluster::SubscribeAttributeCurrentPosition(Callback::Cancelable
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Switch::Attributes::Ids::CurrentPosition;
+    attributePath.mFieldId    = Switch::Attributes::CurrentPosition::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR SwitchCluster::ReportAttributeCurrentPosition(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(Switch::Attributes::Ids::CurrentPosition, onReportCallback,
+    return RequestAttributeReporting(Switch::Attributes::CurrentPosition::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -9867,14 +9867,14 @@ CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMeasuredValue(Callba
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TemperatureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = TemperatureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(TemperatureMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(TemperatureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -11030,14 +11030,14 @@ CHIP_ERROR ThermostatCluster::SubscribeAttributeLocalTemperature(Callback::Cance
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::LocalTemperature;
+    attributePath.mFieldId    = Thermostat::Attributes::LocalTemperature::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatCluster::ReportAttributeLocalTemperature(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(Thermostat::Attributes::Ids::LocalTemperature, onReportCallback,
+    return RequestAttributeReporting(Thermostat::Attributes::LocalTemperature::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -12884,14 +12884,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionLiftPercentag
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionLiftPercentage;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionLiftPercentage::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::CurrentPositionLiftPercentage, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionLiftPercentage::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -12914,14 +12914,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionTiltPercentag
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionTiltPercentage;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionTiltPercentage::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::CurrentPositionTiltPercentage, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionTiltPercentage::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -12944,14 +12944,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeOperationalStatus(Callback::
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::OperationalStatus;
+    attributePath.mFieldId    = WindowCovering::Attributes::OperationalStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeOperationalStatus(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::OperationalStatus, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::OperationalStatus::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -12974,14 +12974,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeTargetPositionLiftPercent100
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::TargetPositionLiftPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::TargetPositionLiftPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::TargetPositionLiftPercent100ths, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::TargetPositionLiftPercent100ths::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -13004,14 +13004,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeTargetPositionTiltPercent100
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::TargetPositionTiltPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::TargetPositionTiltPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::TargetPositionTiltPercent100ths, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::TargetPositionTiltPercent100ths::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -13046,14 +13046,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionLiftPercent10
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionLiftPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::CurrentPositionLiftPercent100ths, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -13076,14 +13076,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeCurrentPositionTiltPercent10
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionTiltPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionTiltPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::CurrentPositionTiltPercent100ths, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::CurrentPositionTiltPercent100ths::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
@@ -13183,14 +13183,14 @@ CHIP_ERROR WindowCoveringCluster::SubscribeAttributeSafetyStatus(Callback::Cance
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::SafetyStatus;
+    attributePath.mFieldId    = WindowCovering::Attributes::SafetyStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReportAttributeSafetyStatus(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(WindowCovering::Attributes::Ids::SafetyStatus, onReportCallback,
+    return RequestAttributeReporting(WindowCovering::Attributes::SafetyStatus::Id, onReportCallback,
                                      BasicAttributeFilter<Int16uAttributeCallback>);
 }
 

--- a/zzz_generated/controller-clusters/zap-generated/tests/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/tests/CHIPClusters.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR AccountLoginClusterTest::WriteAttributeClusterRevision(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -59,7 +59,7 @@ CHIP_ERROR AdministratorCommissioningClusterTest::WriteAttributeClusterRevision(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -77,7 +77,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeVendorName(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::VendorName;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::VendorName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -94,7 +94,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeVendorId(Callback::Cancela
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::VendorId;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::VendorId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -112,7 +112,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeApplicationName(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::ApplicationName;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::ApplicationName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -129,7 +129,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeProductId(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::ProductId;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::ProductId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -147,7 +147,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeApplicationId(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::ApplicationId;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::ApplicationId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -165,7 +165,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeCatalogVendorId(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::CatalogVendorId;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::CatalogVendorId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -183,7 +183,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeApplicationStatus(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationBasic::Attributes::Ids::ApplicationStatus;
+    attributePath.mFieldId    = ApplicationBasic::Attributes::ApplicationStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -201,7 +201,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeClusterRevision(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -219,7 +219,7 @@ CHIP_ERROR ApplicationLauncherClusterTest::WriteAttributeCatalogVendorId(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationLauncher::Attributes::Ids::CatalogVendorId;
+    attributePath.mFieldId    = ApplicationLauncher::Attributes::CatalogVendorId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -237,7 +237,7 @@ CHIP_ERROR ApplicationLauncherClusterTest::WriteAttributeApplicationId(Callback:
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ApplicationLauncher::Attributes::Ids::ApplicationId;
+    attributePath.mFieldId    = ApplicationLauncher::Attributes::ApplicationId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -255,7 +255,7 @@ CHIP_ERROR ApplicationLauncherClusterTest::WriteAttributeClusterRevision(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -273,7 +273,7 @@ CHIP_ERROR AudioOutputClusterTest::WriteAttributeCurrentAudioOutput(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = AudioOutput::Attributes::Ids::CurrentAudioOutput;
+    attributePath.mFieldId    = AudioOutput::Attributes::CurrentAudioOutput::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -290,7 +290,7 @@ CHIP_ERROR AudioOutputClusterTest::WriteAttributeClusterRevision(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -308,7 +308,7 @@ CHIP_ERROR BarrierControlClusterTest::WriteAttributeBarrierMovingState(Callback:
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BarrierControl::Attributes::Ids::BarrierMovingState;
+    attributePath.mFieldId    = BarrierControl::Attributes::BarrierMovingState::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -326,7 +326,7 @@ CHIP_ERROR BarrierControlClusterTest::WriteAttributeBarrierSafetyStatus(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BarrierControl::Attributes::Ids::BarrierSafetyStatus;
+    attributePath.mFieldId    = BarrierControl::Attributes::BarrierSafetyStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -344,7 +344,7 @@ CHIP_ERROR BarrierControlClusterTest::WriteAttributeBarrierCapabilities(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BarrierControl::Attributes::Ids::BarrierCapabilities;
+    attributePath.mFieldId    = BarrierControl::Attributes::BarrierCapabilities::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -362,7 +362,7 @@ CHIP_ERROR BarrierControlClusterTest::WriteAttributeBarrierPosition(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BarrierControl::Attributes::Ids::BarrierPosition;
+    attributePath.mFieldId    = BarrierControl::Attributes::BarrierPosition::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -380,7 +380,7 @@ CHIP_ERROR BarrierControlClusterTest::WriteAttributeClusterRevision(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -398,7 +398,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeInteractionModelVersion(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::InteractionModelVersion;
+    attributePath.mFieldId    = Basic::Attributes::InteractionModelVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -415,7 +415,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeVendorName(Callback::Cancelable * onS
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::VendorName;
+    attributePath.mFieldId    = Basic::Attributes::VendorName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -432,7 +432,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeVendorID(Callback::Cancelable * onSuc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::VendorID;
+    attributePath.mFieldId    = Basic::Attributes::VendorID::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -449,7 +449,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeProductName(Callback::Cancelable * on
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::ProductName;
+    attributePath.mFieldId    = Basic::Attributes::ProductName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -466,7 +466,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeProductID(Callback::Cancelable * onSu
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::ProductID;
+    attributePath.mFieldId    = Basic::Attributes::ProductID::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -483,7 +483,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeHardwareVersion(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::HardwareVersion;
+    attributePath.mFieldId    = Basic::Attributes::HardwareVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -501,7 +501,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeHardwareVersionString(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::HardwareVersionString;
+    attributePath.mFieldId    = Basic::Attributes::HardwareVersionString::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -518,7 +518,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeSoftwareVersion(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::SoftwareVersion;
+    attributePath.mFieldId    = Basic::Attributes::SoftwareVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -536,7 +536,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeSoftwareVersionString(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::SoftwareVersionString;
+    attributePath.mFieldId    = Basic::Attributes::SoftwareVersionString::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -554,7 +554,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeManufacturingDate(Callback::Cancelabl
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::ManufacturingDate;
+    attributePath.mFieldId    = Basic::Attributes::ManufacturingDate::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -571,7 +571,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributePartNumber(Callback::Cancelable * onS
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::PartNumber;
+    attributePath.mFieldId    = Basic::Attributes::PartNumber::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -588,7 +588,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeProductURL(Callback::Cancelable * onS
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::ProductURL;
+    attributePath.mFieldId    = Basic::Attributes::ProductURL::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -605,7 +605,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeProductLabel(Callback::Cancelable * o
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::ProductLabel;
+    attributePath.mFieldId    = Basic::Attributes::ProductLabel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -622,7 +622,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeSerialNumber(Callback::Cancelable * o
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::SerialNumber;
+    attributePath.mFieldId    = Basic::Attributes::SerialNumber::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -639,7 +639,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeReachable(Callback::Cancelable * onSu
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Basic::Attributes::Ids::Reachable;
+    attributePath.mFieldId    = Basic::Attributes::Reachable::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -656,7 +656,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeClusterRevision(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -673,7 +673,7 @@ CHIP_ERROR BinaryInputBasicClusterTest::WriteAttributeStatusFlags(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BinaryInputBasic::Attributes::Ids::StatusFlags;
+    attributePath.mFieldId    = BinaryInputBasic::Attributes::StatusFlags::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -691,7 +691,7 @@ CHIP_ERROR BinaryInputBasicClusterTest::WriteAttributeClusterRevision(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -708,7 +708,7 @@ CHIP_ERROR BindingClusterTest::WriteAttributeClusterRevision(Callback::Cancelabl
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -726,7 +726,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeVendorName(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::VendorName;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::VendorName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -743,7 +743,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeVendorID(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::VendorID;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::VendorID::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -761,7 +761,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductName(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::ProductName;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::ProductName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -779,7 +779,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeHardwareVersion(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::HardwareVersion;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::HardwareVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -797,7 +797,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeHardwareVersionString(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::HardwareVersionString;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::HardwareVersionString::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -815,7 +815,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSoftwareVersion(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::SoftwareVersion;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::SoftwareVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -833,7 +833,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSoftwareVersionString(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::SoftwareVersionString;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::SoftwareVersionString::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -851,7 +851,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeManufacturingDate(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::ManufacturingDate;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::ManufacturingDate::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -869,7 +869,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributePartNumber(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::PartNumber;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::PartNumber::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -887,7 +887,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductURL(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::ProductURL;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::ProductURL::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -905,7 +905,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductLabel(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::ProductLabel;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::ProductLabel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -923,7 +923,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSerialNumber(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::SerialNumber;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::SerialNumber::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -940,7 +940,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeReachable(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Ids::Reachable;
+    attributePath.mFieldId    = BridgedDeviceBasic::Attributes::Reachable::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -958,7 +958,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeClusterRevision(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -975,7 +975,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeCurrentHue(Callback::Cancelabl
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentHue;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentHue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -993,7 +993,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeCurrentSaturation(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentSaturation;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentSaturation::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1010,7 +1010,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeRemainingTime(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::RemainingTime;
+    attributePath.mFieldId    = ColorControl::Attributes::RemainingTime::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1027,7 +1027,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeCurrentX(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentX;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentX::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1044,7 +1044,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeCurrentY(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CurrentY;
+    attributePath.mFieldId    = ColorControl::Attributes::CurrentY::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1062,7 +1062,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeDriftCompensation(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::DriftCompensation;
+    attributePath.mFieldId    = ColorControl::Attributes::DriftCompensation::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1080,7 +1080,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeCompensationText(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CompensationText;
+    attributePath.mFieldId    = ColorControl::Attributes::CompensationText::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1098,7 +1098,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorTemperature(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorTemperature;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorTemperature::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1115,7 +1115,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorMode(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorMode;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorMode::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1133,7 +1133,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeNumberOfPrimaries(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::NumberOfPrimaries;
+    attributePath.mFieldId    = ColorControl::Attributes::NumberOfPrimaries::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1150,7 +1150,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary1X(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary1X;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary1X::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1167,7 +1167,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary1Y(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary1Y;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary1Y::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1185,7 +1185,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary1Intensity(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary1Intensity;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary1Intensity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1202,7 +1202,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary2X(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary2X;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary2X::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1219,7 +1219,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary2Y(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary2Y;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary2Y::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1237,7 +1237,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary2Intensity(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary2Intensity;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary2Intensity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1254,7 +1254,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary3X(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary3X;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary3X::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1271,7 +1271,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary3Y(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary3Y;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary3Y::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1289,7 +1289,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary3Intensity(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary3Intensity;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary3Intensity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1306,7 +1306,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary4X(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary4X;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary4X::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1323,7 +1323,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary4Y(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary4Y;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary4Y::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1341,7 +1341,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary4Intensity(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary4Intensity;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary4Intensity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1358,7 +1358,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary5X(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary5X;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary5X::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1375,7 +1375,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary5Y(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary5Y;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary5Y::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1393,7 +1393,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary5Intensity(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary5Intensity;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary5Intensity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1410,7 +1410,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary6X(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary6X;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary6X::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1427,7 +1427,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary6Y(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary6Y;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary6Y::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1445,7 +1445,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributePrimary6Intensity(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::Primary6Intensity;
+    attributePath.mFieldId    = ColorControl::Attributes::Primary6Intensity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1463,7 +1463,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeEnhancedCurrentHue(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::EnhancedCurrentHue;
+    attributePath.mFieldId    = ColorControl::Attributes::EnhancedCurrentHue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1481,7 +1481,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeEnhancedColorMode(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::EnhancedColorMode;
+    attributePath.mFieldId    = ColorControl::Attributes::EnhancedColorMode::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1498,7 +1498,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorLoopActive(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorLoopActive;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorLoopActive::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1516,7 +1516,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorLoopDirection(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorLoopDirection;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorLoopDirection::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1533,7 +1533,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorLoopTime(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorLoopTime;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorLoopTime::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1551,7 +1551,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorLoopStartEnhancedHue(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorLoopStartEnhancedHue;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorLoopStartEnhancedHue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1569,7 +1569,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorLoopStoredEnhancedHue(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorLoopStoredEnhancedHue;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorLoopStoredEnhancedHue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1587,7 +1587,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorCapabilities(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorCapabilities;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorCapabilities::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1605,7 +1605,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorTempPhysicalMin(Callback:
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorTempPhysicalMin;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorTempPhysicalMin::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1623,7 +1623,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeColorTempPhysicalMax(Callback:
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::ColorTempPhysicalMax;
+    attributePath.mFieldId    = ColorControl::Attributes::ColorTempPhysicalMax::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1641,7 +1641,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeCoupleColorTempToLevelMinMired
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ColorControl::Attributes::Ids::CoupleColorTempToLevelMinMireds;
+    attributePath.mFieldId    = ColorControl::Attributes::CoupleColorTempToLevelMinMireds::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1659,7 +1659,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeClusterRevision(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1677,7 +1677,7 @@ CHIP_ERROR ContentLauncherClusterTest::WriteAttributeClusterRevision(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1694,7 +1694,7 @@ CHIP_ERROR DescriptorClusterTest::WriteAttributeClusterRevision(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1711,7 +1711,7 @@ CHIP_ERROR DoorLockClusterTest::WriteAttributeLockState(Callback::Cancelable * o
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = DoorLock::Attributes::Ids::LockState;
+    attributePath.mFieldId    = DoorLock::Attributes::LockState::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1728,7 +1728,7 @@ CHIP_ERROR DoorLockClusterTest::WriteAttributeLockType(Callback::Cancelable * on
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = DoorLock::Attributes::Ids::LockType;
+    attributePath.mFieldId    = DoorLock::Attributes::LockType::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1745,7 +1745,7 @@ CHIP_ERROR DoorLockClusterTest::WriteAttributeActuatorEnabled(Callback::Cancelab
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = DoorLock::Attributes::Ids::ActuatorEnabled;
+    attributePath.mFieldId    = DoorLock::Attributes::ActuatorEnabled::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1762,7 +1762,7 @@ CHIP_ERROR DoorLockClusterTest::WriteAttributeClusterRevision(Callback::Cancelab
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1780,7 +1780,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeMeasurementType(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::MeasurementType;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::MeasurementType::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1798,7 +1798,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeTotalActivePower(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::TotalActivePower;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::TotalActivePower::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1815,7 +1815,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeRmsVoltage(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::RmsVoltage;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::RmsVoltage::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1833,7 +1833,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeRmsVoltageMin(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::RmsVoltageMin;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::RmsVoltageMin::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1851,7 +1851,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeRmsVoltageMax(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::RmsVoltageMax;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::RmsVoltageMax::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1868,7 +1868,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeRmsCurrent(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::RmsCurrent;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::RmsCurrent::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1886,7 +1886,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeRmsCurrentMin(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::RmsCurrentMin;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::RmsCurrentMin::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1904,7 +1904,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeRmsCurrentMax(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::RmsCurrentMax;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::RmsCurrentMax::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1922,7 +1922,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeActivePower(Callback:
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::ActivePower;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::ActivePower::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1940,7 +1940,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeActivePowerMin(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::ActivePowerMin;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::ActivePowerMin::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1958,7 +1958,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeActivePowerMax(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ElectricalMeasurement::Attributes::Ids::ActivePowerMax;
+    attributePath.mFieldId    = ElectricalMeasurement::Attributes::ActivePowerMax::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1976,7 +1976,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeClusterRevision(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -1994,7 +1994,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributePacketRxCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::Ids::PacketRxCount;
+    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2012,7 +2012,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributePacketTxCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::Ids::PacketTxCount;
+    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::PacketTxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2030,7 +2030,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributeTxErrCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::Ids::TxErrCount;
+    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::TxErrCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2048,7 +2048,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributeCollisionCount(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::Ids::CollisionCount;
+    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::CollisionCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2066,7 +2066,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributeOverrunCount(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::Ids::OverrunCount;
+    attributePath.mFieldId    = EthernetNetworkDiagnostics::Attributes::OverrunCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2084,7 +2084,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributeClusterRevision(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2101,7 +2101,7 @@ CHIP_ERROR FixedLabelClusterTest::WriteAttributeClusterRevision(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2118,7 +2118,7 @@ CHIP_ERROR FlowMeasurementClusterTest::WriteAttributeMeasuredValue(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = FlowMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = FlowMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2136,7 +2136,7 @@ CHIP_ERROR FlowMeasurementClusterTest::WriteAttributeMinMeasuredValue(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = FlowMeasurement::Attributes::Ids::MinMeasuredValue;
+    attributePath.mFieldId    = FlowMeasurement::Attributes::MinMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2154,7 +2154,7 @@ CHIP_ERROR FlowMeasurementClusterTest::WriteAttributeMaxMeasuredValue(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = FlowMeasurement::Attributes::Ids::MaxMeasuredValue;
+    attributePath.mFieldId    = FlowMeasurement::Attributes::MaxMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2172,7 +2172,7 @@ CHIP_ERROR FlowMeasurementClusterTest::WriteAttributeClusterRevision(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2190,7 +2190,7 @@ CHIP_ERROR GeneralCommissioningClusterTest::WriteAttributeClusterRevision(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2207,7 +2207,7 @@ CHIP_ERROR GeneralDiagnosticsClusterTest::WriteAttributeRebootCount(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = GeneralDiagnostics::Attributes::Ids::RebootCount;
+    attributePath.mFieldId    = GeneralDiagnostics::Attributes::RebootCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2224,7 +2224,7 @@ CHIP_ERROR GeneralDiagnosticsClusterTest::WriteAttributeUpTime(Callback::Cancela
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = GeneralDiagnostics::Attributes::Ids::UpTime;
+    attributePath.mFieldId    = GeneralDiagnostics::Attributes::UpTime::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2242,7 +2242,7 @@ CHIP_ERROR GeneralDiagnosticsClusterTest::WriteAttributeTotalOperationalHours(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = GeneralDiagnostics::Attributes::Ids::TotalOperationalHours;
+    attributePath.mFieldId    = GeneralDiagnostics::Attributes::TotalOperationalHours::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2259,7 +2259,7 @@ CHIP_ERROR GeneralDiagnosticsClusterTest::WriteAttributeBootReasons(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = GeneralDiagnostics::Attributes::Ids::BootReasons;
+    attributePath.mFieldId    = GeneralDiagnostics::Attributes::BootReasons::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2277,7 +2277,7 @@ CHIP_ERROR GeneralDiagnosticsClusterTest::WriteAttributeClusterRevision(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2295,7 +2295,7 @@ CHIP_ERROR GroupKeyManagementClusterTest::WriteAttributeClusterRevision(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2312,7 +2312,7 @@ CHIP_ERROR GroupsClusterTest::WriteAttributeNameSupport(Callback::Cancelable * o
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Groups::Attributes::Ids::NameSupport;
+    attributePath.mFieldId    = Groups::Attributes::NameSupport::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2329,7 +2329,7 @@ CHIP_ERROR GroupsClusterTest::WriteAttributeClusterRevision(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2346,7 +2346,7 @@ CHIP_ERROR IdentifyClusterTest::WriteAttributeClusterRevision(Callback::Cancelab
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2363,7 +2363,7 @@ CHIP_ERROR KeypadInputClusterTest::WriteAttributeClusterRevision(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2380,7 +2380,7 @@ CHIP_ERROR LevelControlClusterTest::WriteAttributeCurrentLevel(Callback::Cancela
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = LevelControl::Attributes::Ids::CurrentLevel;
+    attributePath.mFieldId    = LevelControl::Attributes::CurrentLevel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2398,7 +2398,7 @@ CHIP_ERROR LevelControlClusterTest::WriteAttributeClusterRevision(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2415,7 +2415,7 @@ CHIP_ERROR LowPowerClusterTest::WriteAttributeClusterRevision(Callback::Cancelab
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2433,7 +2433,7 @@ CHIP_ERROR MediaInputClusterTest::WriteAttributeCurrentMediaInput(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaInput::Attributes::Ids::CurrentMediaInput;
+    attributePath.mFieldId    = MediaInput::Attributes::CurrentMediaInput::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2450,7 +2450,7 @@ CHIP_ERROR MediaInputClusterTest::WriteAttributeClusterRevision(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2467,7 +2467,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributePlaybackState(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::PlaybackState;
+    attributePath.mFieldId    = MediaPlayback::Attributes::PlaybackState::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2484,7 +2484,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributeStartTime(Callback::Cancelabl
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::StartTime;
+    attributePath.mFieldId    = MediaPlayback::Attributes::StartTime::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2501,7 +2501,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributeDuration(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::Duration;
+    attributePath.mFieldId    = MediaPlayback::Attributes::Duration::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2519,7 +2519,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributePositionUpdatedAt(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::PositionUpdatedAt;
+    attributePath.mFieldId    = MediaPlayback::Attributes::PositionUpdatedAt::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2536,7 +2536,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributePosition(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::Position;
+    attributePath.mFieldId    = MediaPlayback::Attributes::Position::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2553,7 +2553,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributePlaybackSpeed(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::PlaybackSpeed;
+    attributePath.mFieldId    = MediaPlayback::Attributes::PlaybackSpeed::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2570,7 +2570,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributeSeekRangeEnd(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::SeekRangeEnd;
+    attributePath.mFieldId    = MediaPlayback::Attributes::SeekRangeEnd::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2587,7 +2587,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributeSeekRangeStart(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = MediaPlayback::Attributes::Ids::SeekRangeStart;
+    attributePath.mFieldId    = MediaPlayback::Attributes::SeekRangeStart::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2605,7 +2605,7 @@ CHIP_ERROR MediaPlaybackClusterTest::WriteAttributeClusterRevision(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2622,7 +2622,7 @@ CHIP_ERROR NetworkCommissioningClusterTest::WriteAttributeFeatureMap(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::FeatureMap;
+    attributePath.mFieldId    = Globals::Attributes::FeatureMap::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2640,7 +2640,7 @@ CHIP_ERROR NetworkCommissioningClusterTest::WriteAttributeClusterRevision(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2658,7 +2658,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderClusterTest::WriteAttributeClusterRevision(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2676,7 +2676,7 @@ CHIP_ERROR OtaSoftwareUpdateRequestorClusterTest::WriteAttributeUpdatePossible(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OtaSoftwareUpdateRequestor::Attributes::Ids::UpdatePossible;
+    attributePath.mFieldId    = OtaSoftwareUpdateRequestor::Attributes::UpdatePossible::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2694,7 +2694,7 @@ CHIP_ERROR OtaSoftwareUpdateRequestorClusterTest::WriteAttributeClusterRevision(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2711,7 +2711,7 @@ CHIP_ERROR OccupancySensingClusterTest::WriteAttributeOccupancy(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OccupancySensing::Attributes::Ids::Occupancy;
+    attributePath.mFieldId    = OccupancySensing::Attributes::Occupancy::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2729,7 +2729,7 @@ CHIP_ERROR OccupancySensingClusterTest::WriteAttributeOccupancySensorType(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OccupancySensing::Attributes::Ids::OccupancySensorType;
+    attributePath.mFieldId    = OccupancySensing::Attributes::OccupancySensorType::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2747,7 +2747,7 @@ CHIP_ERROR OccupancySensingClusterTest::WriteAttributeOccupancySensorTypeBitmap(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OccupancySensing::Attributes::Ids::OccupancySensorTypeBitmap;
+    attributePath.mFieldId    = OccupancySensing::Attributes::OccupancySensorTypeBitmap::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2765,7 +2765,7 @@ CHIP_ERROR OccupancySensingClusterTest::WriteAttributeClusterRevision(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2782,7 +2782,7 @@ CHIP_ERROR OnOffClusterTest::WriteAttributeOnOff(Callback::Cancelable * onSucces
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OnOff::Attributes::Ids::OnOff;
+    attributePath.mFieldId    = OnOff::Attributes::OnOff::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2799,7 +2799,7 @@ CHIP_ERROR OnOffClusterTest::WriteAttributeGlobalSceneControl(Callback::Cancelab
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OnOff::Attributes::Ids::GlobalSceneControl;
+    attributePath.mFieldId    = OnOff::Attributes::GlobalSceneControl::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2816,7 +2816,7 @@ CHIP_ERROR OnOffClusterTest::WriteAttributeFeatureMap(Callback::Cancelable * onS
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::FeatureMap;
+    attributePath.mFieldId    = Globals::Attributes::FeatureMap::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2833,7 +2833,7 @@ CHIP_ERROR OnOffClusterTest::WriteAttributeClusterRevision(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2851,7 +2851,7 @@ CHIP_ERROR OnOffSwitchConfigurationClusterTest::WriteAttributeSwitchType(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OnOffSwitchConfiguration::Attributes::Ids::SwitchType;
+    attributePath.mFieldId    = OnOffSwitchConfiguration::Attributes::SwitchType::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2869,7 +2869,7 @@ CHIP_ERROR OnOffSwitchConfigurationClusterTest::WriteAttributeClusterRevision(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2887,7 +2887,7 @@ CHIP_ERROR OperationalCredentialsClusterTest::WriteAttributeSupportedFabrics(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OperationalCredentials::Attributes::Ids::SupportedFabrics;
+    attributePath.mFieldId    = OperationalCredentials::Attributes::SupportedFabrics::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2905,7 +2905,7 @@ CHIP_ERROR OperationalCredentialsClusterTest::WriteAttributeCommissionedFabrics(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = OperationalCredentials::Attributes::Ids::CommissionedFabrics;
+    attributePath.mFieldId    = OperationalCredentials::Attributes::CommissionedFabrics::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2923,7 +2923,7 @@ CHIP_ERROR OperationalCredentialsClusterTest::WriteAttributeClusterRevision(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2940,7 +2940,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeStatus(Callback::Cancelable * o
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::Status;
+    attributePath.mFieldId    = PowerSource::Attributes::Status::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2957,7 +2957,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeOrder(Callback::Cancelable * on
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::Order;
+    attributePath.mFieldId    = PowerSource::Attributes::Order::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2974,7 +2974,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeDescription(Callback::Cancelabl
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::Description;
+    attributePath.mFieldId    = PowerSource::Attributes::Description::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -2991,7 +2991,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeBatteryVoltage(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::BatteryVoltage;
+    attributePath.mFieldId    = PowerSource::Attributes::BatteryVoltage::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3009,7 +3009,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeBatteryPercentRemaining(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::BatteryPercentRemaining;
+    attributePath.mFieldId    = PowerSource::Attributes::BatteryPercentRemaining::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3027,7 +3027,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeBatteryTimeRemaining(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::BatteryTimeRemaining;
+    attributePath.mFieldId    = PowerSource::Attributes::BatteryTimeRemaining::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3045,7 +3045,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeBatteryChargeLevel(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::BatteryChargeLevel;
+    attributePath.mFieldId    = PowerSource::Attributes::BatteryChargeLevel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3063,7 +3063,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeBatteryChargeState(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PowerSource::Attributes::Ids::BatteryChargeState;
+    attributePath.mFieldId    = PowerSource::Attributes::BatteryChargeState::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3080,7 +3080,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeFeatureMap(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::FeatureMap;
+    attributePath.mFieldId    = Globals::Attributes::FeatureMap::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3097,7 +3097,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeClusterRevision(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3115,7 +3115,7 @@ CHIP_ERROR PressureMeasurementClusterTest::WriteAttributeMeasuredValue(Callback:
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PressureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = PressureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3133,7 +3133,7 @@ CHIP_ERROR PressureMeasurementClusterTest::WriteAttributeMinMeasuredValue(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PressureMeasurement::Attributes::Ids::MinMeasuredValue;
+    attributePath.mFieldId    = PressureMeasurement::Attributes::MinMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3151,7 +3151,7 @@ CHIP_ERROR PressureMeasurementClusterTest::WriteAttributeMaxMeasuredValue(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PressureMeasurement::Attributes::Ids::MaxMeasuredValue;
+    attributePath.mFieldId    = PressureMeasurement::Attributes::MaxMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3169,7 +3169,7 @@ CHIP_ERROR PressureMeasurementClusterTest::WriteAttributeClusterRevision(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3187,7 +3187,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeMaxPressure(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::MaxPressure;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::MaxPressure::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3205,7 +3205,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeMaxSpeed(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::MaxSpeed;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::MaxSpeed::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3222,7 +3222,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeMaxFlow(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::MaxFlow;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::MaxFlow::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3240,7 +3240,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeEffectiveOperat
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::EffectiveOperationMode;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::EffectiveOperationMode::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3258,7 +3258,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeEffectiveContro
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::EffectiveControlMode;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::EffectiveControlMode::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3276,7 +3276,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeCapacity(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::Capacity;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Capacity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3294,7 +3294,7 @@ CHIP_ERROR PumpConfigurationAndControlClusterTest::WriteAttributeClusterRevision
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3312,7 +3312,7 @@ CHIP_ERROR RelativeHumidityMeasurementClusterTest::WriteAttributeMeasuredValue(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3330,7 +3330,7 @@ CHIP_ERROR RelativeHumidityMeasurementClusterTest::WriteAttributeMinMeasuredValu
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::Ids::MinMeasuredValue;
+    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3348,7 +3348,7 @@ CHIP_ERROR RelativeHumidityMeasurementClusterTest::WriteAttributeMaxMeasuredValu
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::Ids::MaxMeasuredValue;
+    attributePath.mFieldId    = RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3366,7 +3366,7 @@ CHIP_ERROR RelativeHumidityMeasurementClusterTest::WriteAttributeClusterRevision
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3383,7 +3383,7 @@ CHIP_ERROR ScenesClusterTest::WriteAttributeSceneCount(Callback::Cancelable * on
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Scenes::Attributes::Ids::SceneCount;
+    attributePath.mFieldId    = Scenes::Attributes::SceneCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3400,7 +3400,7 @@ CHIP_ERROR ScenesClusterTest::WriteAttributeCurrentScene(Callback::Cancelable * 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Scenes::Attributes::Ids::CurrentScene;
+    attributePath.mFieldId    = Scenes::Attributes::CurrentScene::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3417,7 +3417,7 @@ CHIP_ERROR ScenesClusterTest::WriteAttributeCurrentGroup(Callback::Cancelable * 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Scenes::Attributes::Ids::CurrentGroup;
+    attributePath.mFieldId    = Scenes::Attributes::CurrentGroup::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3434,7 +3434,7 @@ CHIP_ERROR ScenesClusterTest::WriteAttributeSceneValid(Callback::Cancelable * on
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Scenes::Attributes::Ids::SceneValid;
+    attributePath.mFieldId    = Scenes::Attributes::SceneValid::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3451,7 +3451,7 @@ CHIP_ERROR ScenesClusterTest::WriteAttributeNameSupport(Callback::Cancelable * o
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Scenes::Attributes::Ids::NameSupport;
+    attributePath.mFieldId    = Scenes::Attributes::NameSupport::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3468,7 +3468,7 @@ CHIP_ERROR ScenesClusterTest::WriteAttributeClusterRevision(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3486,7 +3486,7 @@ CHIP_ERROR SoftwareDiagnosticsClusterTest::WriteAttributeCurrentHeapFree(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = SoftwareDiagnostics::Attributes::Ids::CurrentHeapFree;
+    attributePath.mFieldId    = SoftwareDiagnostics::Attributes::CurrentHeapFree::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3504,7 +3504,7 @@ CHIP_ERROR SoftwareDiagnosticsClusterTest::WriteAttributeCurrentHeapUsed(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = SoftwareDiagnostics::Attributes::Ids::CurrentHeapUsed;
+    attributePath.mFieldId    = SoftwareDiagnostics::Attributes::CurrentHeapUsed::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3522,7 +3522,7 @@ CHIP_ERROR SoftwareDiagnosticsClusterTest::WriteAttributeCurrentHeapHighWatermar
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = SoftwareDiagnostics::Attributes::Ids::CurrentHeapHighWatermark;
+    attributePath.mFieldId    = SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3540,7 +3540,7 @@ CHIP_ERROR SoftwareDiagnosticsClusterTest::WriteAttributeClusterRevision(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3557,7 +3557,7 @@ CHIP_ERROR SwitchClusterTest::WriteAttributeNumberOfPositions(Callback::Cancelab
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Switch::Attributes::Ids::NumberOfPositions;
+    attributePath.mFieldId    = Switch::Attributes::NumberOfPositions::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3574,7 +3574,7 @@ CHIP_ERROR SwitchClusterTest::WriteAttributeCurrentPosition(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Switch::Attributes::Ids::CurrentPosition;
+    attributePath.mFieldId    = Switch::Attributes::CurrentPosition::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3591,7 +3591,7 @@ CHIP_ERROR SwitchClusterTest::WriteAttributeClusterRevision(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3609,7 +3609,7 @@ CHIP_ERROR TvChannelClusterTest::WriteAttributeTvChannelLineup(Callback::Cancela
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TvChannel::Attributes::Ids::TvChannelLineup;
+    attributePath.mFieldId    = TvChannel::Attributes::TvChannelLineup::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3627,7 +3627,7 @@ CHIP_ERROR TvChannelClusterTest::WriteAttributeCurrentTvChannel(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TvChannel::Attributes::Ids::CurrentTvChannel;
+    attributePath.mFieldId    = TvChannel::Attributes::CurrentTvChannel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3644,7 +3644,7 @@ CHIP_ERROR TvChannelClusterTest::WriteAttributeClusterRevision(Callback::Cancela
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3662,7 +3662,7 @@ CHIP_ERROR TargetNavigatorClusterTest::WriteAttributeClusterRevision(Callback::C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3680,7 +3680,7 @@ CHIP_ERROR TemperatureMeasurementClusterTest::WriteAttributeMeasuredValue(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TemperatureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = TemperatureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3698,7 +3698,7 @@ CHIP_ERROR TemperatureMeasurementClusterTest::WriteAttributeMinMeasuredValue(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TemperatureMeasurement::Attributes::Ids::MinMeasuredValue;
+    attributePath.mFieldId    = TemperatureMeasurement::Attributes::MinMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3716,7 +3716,7 @@ CHIP_ERROR TemperatureMeasurementClusterTest::WriteAttributeMaxMeasuredValue(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TemperatureMeasurement::Attributes::Ids::MaxMeasuredValue;
+    attributePath.mFieldId    = TemperatureMeasurement::Attributes::MaxMeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3734,7 +3734,7 @@ CHIP_ERROR TemperatureMeasurementClusterTest::WriteAttributeClusterRevision(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3751,7 +3751,7 @@ CHIP_ERROR TestClusterClusterTest::WriteAttributeClusterRevision(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3768,7 +3768,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeLocalTemperature(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::LocalTemperature;
+    attributePath.mFieldId    = Thermostat::Attributes::LocalTemperature::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3786,7 +3786,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeAbsMinHeatSetpointLimit(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::AbsMinHeatSetpointLimit;
+    attributePath.mFieldId    = Thermostat::Attributes::AbsMinHeatSetpointLimit::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3804,7 +3804,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeAbsMaxHeatSetpointLimit(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::AbsMaxHeatSetpointLimit;
+    attributePath.mFieldId    = Thermostat::Attributes::AbsMaxHeatSetpointLimit::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3822,7 +3822,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeAbsMinCoolSetpointLimit(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::AbsMinCoolSetpointLimit;
+    attributePath.mFieldId    = Thermostat::Attributes::AbsMinCoolSetpointLimit::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3840,7 +3840,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeAbsMaxCoolSetpointLimit(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::AbsMaxCoolSetpointLimit;
+    attributePath.mFieldId    = Thermostat::Attributes::AbsMaxCoolSetpointLimit::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3857,7 +3857,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeStartOfWeek(Callback::Cancelable
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::StartOfWeek;
+    attributePath.mFieldId    = Thermostat::Attributes::StartOfWeek::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3875,7 +3875,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeNumberOfWeeklyTransitions(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::NumberOfWeeklyTransitions;
+    attributePath.mFieldId    = Thermostat::Attributes::NumberOfWeeklyTransitions::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3893,7 +3893,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeNumberOfDailyTransitions(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Thermostat::Attributes::Ids::NumberOfDailyTransitions;
+    attributePath.mFieldId    = Thermostat::Attributes::NumberOfDailyTransitions::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3910,7 +3910,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeFeatureMap(Callback::Cancelable 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::FeatureMap;
+    attributePath.mFieldId    = Globals::Attributes::FeatureMap::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3927,7 +3927,7 @@ CHIP_ERROR ThermostatClusterTest::WriteAttributeClusterRevision(Callback::Cancel
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3945,7 +3945,7 @@ CHIP_ERROR ThermostatUserInterfaceConfigurationClusterTest::WriteAttributeCluste
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3962,7 +3962,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeChannel(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::Channel;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Channel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3980,7 +3980,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRoutingRole(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RoutingRole;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RoutingRole::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -3998,7 +3998,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeNetworkName(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::NetworkName;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::NetworkName::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4015,7 +4015,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributePanId(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::PanId;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::PanId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4033,7 +4033,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeExtendedPanId(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::ExtendedPanId;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::ExtendedPanId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4051,7 +4051,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeMeshLocalPrefix(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::MeshLocalPrefix;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4069,7 +4069,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeOverrunCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::OverrunCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::OverrunCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4087,7 +4087,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributePartitionId(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::PartitionId;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::PartitionId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4104,7 +4104,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeWeighting(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::Weighting;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Weighting::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4122,7 +4122,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeDataVersion(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::DataVersion;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::DataVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4140,7 +4140,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeStableDataVersion(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::StableDataVersion;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::StableDataVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4158,7 +4158,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeLeaderRouterId(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::LeaderRouterId;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::LeaderRouterId::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4176,7 +4176,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeDetachedRoleCount(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::DetachedRoleCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4194,7 +4194,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeChildRoleCount(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::ChildRoleCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::ChildRoleCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4212,7 +4212,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRouterRoleCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RouterRoleCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RouterRoleCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4230,7 +4230,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeLeaderRoleCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::LeaderRoleCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4248,7 +4248,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeAttachAttemptCount
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::AttachAttemptCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4266,7 +4266,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributePartitionIdChangeC
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::PartitionIdChangeCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4283,7 +4283,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeBetterPartitionAtt
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::BetterPartitionAttachAttemptCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4301,7 +4301,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeParentChangeCount(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::ParentChangeCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::ParentChangeCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4319,7 +4319,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxTotalCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxTotalCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxTotalCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4337,7 +4337,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxUnicastCount(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxUnicastCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxUnicastCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4355,7 +4355,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxBroadcastCount(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxBroadcastCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4373,7 +4373,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxAckRequestedCoun
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxAckRequestedCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4391,7 +4391,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxAckedCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxAckedCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxAckedCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4409,7 +4409,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxNoAckRequestedCo
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxNoAckRequestedCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4427,7 +4427,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxDataCount(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxDataCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxDataCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4445,7 +4445,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxDataPollCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxDataPollCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxDataPollCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4463,7 +4463,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxBeaconCount(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxBeaconCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxBeaconCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4481,7 +4481,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxBeaconRequestCou
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxBeaconRequestCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4499,7 +4499,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxOtherCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxOtherCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxOtherCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4517,7 +4517,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxRetryCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxRetryCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxRetryCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4535,7 +4535,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxDirectMaxRetryEx
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxDirectMaxRetryExpiryCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4552,7 +4552,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxIndirectMaxRetry
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxIndirectMaxRetryExpiryCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4570,7 +4570,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxErrCcaCount(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxErrCcaCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4588,7 +4588,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxErrAbortCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxErrAbortCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4606,7 +4606,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeTxErrBusyChannelCo
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::TxErrBusyChannelCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4624,7 +4624,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxTotalCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxTotalCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxTotalCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4642,7 +4642,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxUnicastCount(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxUnicastCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxUnicastCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4660,7 +4660,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxBroadcastCount(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxBroadcastCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4678,7 +4678,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxDataCount(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxDataCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxDataCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4696,7 +4696,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxDataPollCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxDataPollCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxDataPollCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4714,7 +4714,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxBeaconCount(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxBeaconCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxBeaconCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4732,7 +4732,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxBeaconRequestCou
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxBeaconRequestCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4750,7 +4750,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxOtherCount(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxOtherCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxOtherCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4768,7 +4768,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxAddressFilteredC
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxAddressFilteredCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4786,7 +4786,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxDestAddrFiltered
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxDestAddrFilteredCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4804,7 +4804,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxDuplicatedCount(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxDuplicatedCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4822,7 +4822,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxErrNoFrameCount(
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxErrNoFrameCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4840,7 +4840,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxErrUnknownNeighb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxErrUnknownNeighborCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4858,7 +4858,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxErrInvalidSrcAdd
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxErrInvalidSrcAddrCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4876,7 +4876,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxErrSecCount(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxErrSecCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxErrSecCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4894,7 +4894,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxErrFcsCount(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxErrFcsCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4912,7 +4912,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeRxErrOtherCount(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::RxErrOtherCount;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4930,7 +4930,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeActiveTimestamp(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::ActiveTimestamp;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4948,7 +4948,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributePendingTimestamp(C
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::PendingTimestamp;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::PendingTimestamp::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4965,7 +4965,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeDelay(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::Delay;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Delay::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -4983,7 +4983,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeChannelMask(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::Ids::ChannelMask;
+    attributePath.mFieldId    = ThreadNetworkDiagnostics::Attributes::ChannelMask::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5001,7 +5001,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeClusterRevision(Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5019,7 +5019,7 @@ CHIP_ERROR WakeOnLanClusterTest::WriteAttributeWakeOnLanMacAddress(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WakeOnLan::Attributes::Ids::WakeOnLanMacAddress;
+    attributePath.mFieldId    = WakeOnLan::Attributes::WakeOnLanMacAddress::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5036,7 +5036,7 @@ CHIP_ERROR WakeOnLanClusterTest::WriteAttributeClusterRevision(Callback::Cancela
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5053,7 +5053,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeBssid(Callback::Canc
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::Bssid;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Bssid::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5071,7 +5071,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeSecurityType(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::SecurityType;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::SecurityType::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5089,7 +5089,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeWiFiVersion(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::WiFiVersion;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::WiFiVersion::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5107,7 +5107,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeChannelNumber(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::ChannelNumber;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::ChannelNumber::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5124,7 +5124,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeRssi(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::Rssi;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Rssi::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5142,7 +5142,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeBeaconLostCount(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::BeaconLostCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::BeaconLostCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5160,7 +5160,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeBeaconRxCount(Callba
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::BeaconRxCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::BeaconRxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5178,7 +5178,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributePacketMulticastRxCou
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::PacketMulticastRxCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::PacketMulticastRxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5196,7 +5196,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributePacketMulticastTxCou
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::PacketMulticastTxCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::PacketMulticastTxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5214,7 +5214,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributePacketUnicastRxCount
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::PacketUnicastRxCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::PacketUnicastRxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5232,7 +5232,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributePacketUnicastTxCount
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::PacketUnicastTxCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::PacketUnicastTxCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5250,7 +5250,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeCurrentMaxRate(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::CurrentMaxRate;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::CurrentMaxRate::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5268,7 +5268,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeOverrunCount(Callbac
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::Ids::OverrunCount;
+    attributePath.mFieldId    = WiFiNetworkDiagnostics::Attributes::OverrunCount::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5286,7 +5286,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsClusterTest::WriteAttributeClusterRevision(Call
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5303,7 +5303,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeType(Callback::Cancelable * 
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::Type;
+    attributePath.mFieldId    = WindowCovering::Attributes::Type::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5321,7 +5321,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeCurrentPositionLift(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionLift;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionLift::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5339,7 +5339,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeCurrentPositionTilt(Callback
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionTilt;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionTilt::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5356,7 +5356,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeConfigStatus(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::ConfigStatus;
+    attributePath.mFieldId    = WindowCovering::Attributes::ConfigStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5374,7 +5374,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeCurrentPositionLiftPercentag
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionLiftPercentage;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionLiftPercentage::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5392,7 +5392,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeCurrentPositionTiltPercentag
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionTiltPercentage;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionTiltPercentage::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5410,7 +5410,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeOperationalStatus(Callback::
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::OperationalStatus;
+    attributePath.mFieldId    = WindowCovering::Attributes::OperationalStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5428,7 +5428,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeTargetPositionLiftPercent100
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::TargetPositionLiftPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::TargetPositionLiftPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5446,7 +5446,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeTargetPositionTiltPercent100
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::TargetPositionTiltPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::TargetPositionTiltPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5463,7 +5463,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeEndProductType(Callback::Can
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::EndProductType;
+    attributePath.mFieldId    = WindowCovering::Attributes::EndProductType::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5481,7 +5481,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeCurrentPositionLiftPercent10
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionLiftPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5499,7 +5499,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeCurrentPositionTiltPercent10
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::CurrentPositionTiltPercent100ths;
+    attributePath.mFieldId    = WindowCovering::Attributes::CurrentPositionTiltPercent100ths::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5517,7 +5517,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeInstalledOpenLimitLift(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::InstalledOpenLimitLift;
+    attributePath.mFieldId    = WindowCovering::Attributes::InstalledOpenLimitLift::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5535,7 +5535,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeInstalledClosedLimitLift(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::InstalledClosedLimitLift;
+    attributePath.mFieldId    = WindowCovering::Attributes::InstalledClosedLimitLift::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5553,7 +5553,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeInstalledOpenLimitTilt(Callb
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::InstalledOpenLimitTilt;
+    attributePath.mFieldId    = WindowCovering::Attributes::InstalledOpenLimitTilt::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5571,7 +5571,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeInstalledClosedLimitTilt(Cal
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::InstalledClosedLimitTilt;
+    attributePath.mFieldId    = WindowCovering::Attributes::InstalledClosedLimitTilt::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5588,7 +5588,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeSafetyStatus(Callback::Cance
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = WindowCovering::Attributes::Ids::SafetyStatus;
+    attributePath.mFieldId    = WindowCovering::Attributes::SafetyStatus::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
@@ -5606,7 +5606,7 @@ CHIP_ERROR WindowCoveringClusterTest::WriteAttributeClusterRevision(Callback::Ca
     attributePath.mNodeId     = mDevice->GetDeviceId();
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = Globals::Attributes::Ids::ClusterRevision;
+    attributePath.mFieldId    = Globals::Attributes::ClusterRevision::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));

--- a/zzz_generated/pump-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-app/zap-generated/CHIPClusters.cpp
@@ -65,14 +65,14 @@ CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Can
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = FlowMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = FlowMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR FlowMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(FlowMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(FlowMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -133,14 +133,14 @@ CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback:
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PressureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = PressureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR PressureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(PressureMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(PressureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -201,14 +201,14 @@ CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMeasuredValue(Callba
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TemperatureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = TemperatureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(TemperatureMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(TemperatureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
@@ -65,14 +65,14 @@ CHIP_ERROR FlowMeasurementCluster::SubscribeAttributeMeasuredValue(Callback::Can
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = FlowMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = FlowMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR FlowMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(FlowMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(FlowMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -490,14 +490,14 @@ CHIP_ERROR LevelControlCluster::SubscribeAttributeCurrentLevel(Callback::Cancela
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = LevelControl::Attributes::Ids::CurrentLevel;
+    attributePath.mFieldId    = LevelControl::Attributes::CurrentLevel::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR LevelControlCluster::ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(LevelControl::Attributes::Ids::CurrentLevel, onReportCallback,
+    return RequestAttributeReporting(LevelControl::Attributes::CurrentLevel::Id, onReportCallback,
                                      BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
@@ -673,14 +673,14 @@ CHIP_ERROR PressureMeasurementCluster::SubscribeAttributeMeasuredValue(Callback:
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PressureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = PressureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR PressureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(PressureMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(PressureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -801,14 +801,14 @@ CHIP_ERROR PumpConfigurationAndControlCluster::SubscribeAttributeCapacity(Callba
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Ids::Capacity;
+    attributePath.mFieldId    = PumpConfigurationAndControl::Attributes::Capacity::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::ReportAttributeCapacity(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::Ids::Capacity, onReportCallback,
+    return RequestAttributeReporting(PumpConfigurationAndControl::Attributes::Capacity::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 
@@ -874,14 +874,14 @@ CHIP_ERROR TemperatureMeasurementCluster::SubscribeAttributeMeasuredValue(Callba
     chip::app::AttributePathParams attributePath;
     attributePath.mEndpointId = mEndpoint;
     attributePath.mClusterId  = mClusterId;
-    attributePath.mFieldId    = TemperatureMeasurement::Attributes::Ids::MeasuredValue;
+    attributePath.mFieldId    = TemperatureMeasurement::Attributes::MeasuredValue::Id;
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendSubscribeAttributeRequest(attributePath, minInterval, maxInterval, onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
 {
-    return RequestAttributeReporting(TemperatureMeasurement::Attributes::Ids::MeasuredValue, onReportCallback,
+    return RequestAttributeReporting(TemperatureMeasurement::Attributes::MeasuredValue::Id, onReportCallback,
                                      BasicAttributeFilter<Int16sAttributeCallback>);
 }
 


### PR DESCRIPTION
#### Problem
Right now our namespacing looks like `ClusterName::Ids::AttributeName`.  We want to have metadata about attributes other than the id, so are planning to introduce a `ClusterName::AttributeName` namespace anyway.  And in that case we should have the ids be `ClusterName::AttributeName::Id`.

#### Change overview
Do the above renaming.

#### Testing
No functionality changes.  Tree compiles.