### PR TITLE
Switch from Commands::Ids::CommandName to Commands::CommandName::Id.

### DIFF
--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -179,7 +179,7 @@ exit:
 
 bool emberAfTestClusterClusterTestSpecificCallback(EndpointId endpoint, app::CommandHandler * apCommandObj)
 {
-    return sendNumericResponse(endpoint, apCommandObj, Commands::Ids::TestSpecificResponse, 7);
+    return sendNumericResponse(endpoint, apCommandObj, Commands::TestSpecificResponse::Id, 7);
 }
 
 bool emberAfTestClusterClusterTestNotHandledCallback(EndpointId endpoint, app::CommandHandler *)
@@ -195,5 +195,5 @@ bool emberAfTestClusterClusterTestAddArgumentsCallback(EndpointId endpoint, app:
         return emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
     }
 
-    return sendNumericResponse(endpoint, apCommandObj, Commands::Ids::TestAddArgumentsResponse, static_cast<uint8_t>(arg1 + arg2));
+    return sendNumericResponse(endpoint, apCommandObj, Commands::TestAddArgumentsResponse::Id, static_cast<uint8_t>(arg1 + arg2));
 }

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -46,7 +46,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, {{asUpperCamelCase parent.name}}::Commands::Ids::{{asUpperCamelCase name}},
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));

--- a/src/app/zap-templates/templates/app/ids/Commands.zapt
+++ b/src/app/zap-templates/templates/app/ids/Commands.zapt
@@ -8,15 +8,7 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-namespace Globals {
-namespace Commands {
-namespace Ids {
-{{#zcl_global_commands}}
-static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
-{{/zcl_global_commands}}
-} // namespace Ids
-} // namespace Commands
-} // namespace Globals
+// Matter does not have global commands
 
 {{#zcl_clusters}}
 
@@ -24,11 +16,13 @@ static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode
 {{#first}}
 namespace {{asUpperCamelCase parent.label}} {
 namespace Commands {
-namespace Ids {
+
 {{/first}}
-static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
+namespace {{asUpperCamelCase label}} {
+static constexpr CommandId Id = {{asMEI manufacturerCode code}};
+} // namespace {{asUpperCamelCase label}}
+
 {{#last}}
-} // namespace Ids
 } // namespace Commands
 } // namespace {{asUpperCamelCase parent.label}}
 {{/last}}

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -57,7 +57,7 @@ void Dispatch{{asUpperCamelCase side}}Command({{#if (isServer side)}}CommandHand
         switch (aCommandId)
         {
     {{/first}}
-        case Clusters::{{asUpperCamelCase parent.name}}::Commands::Ids::{{asUpperCamelCase name}}: {
+        case Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Id: {
         {{> im_command_handler_cluster_commands}}
             break;
         }

--- a/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::BarrierControl::Commands::Ids::BarrierControlGoToPercent: {
+        case Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Id: {
             expectArgumentCount = 1;
             uint8_t percentOpen;
             bool argExists[1];
@@ -315,7 +315,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::BarrierControl::Commands::Ids::BarrierControlStop: {
+        case Clusters::BarrierControl::Commands::BarrierControlStop::Id: {
 
             wasHandled = emberAfBarrierControlClusterBarrierControlStopCallback(aEndpointId, apCommandObj);
             break;
@@ -374,7 +374,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Binding::Commands::Ids::Bind: {
+        case Clusters::Binding::Commands::Bind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -444,7 +444,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Binding::Commands::Ids::Unbind: {
+        case Clusters::Binding::Commands::Unbind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -559,7 +559,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ColorControl::Commands::Ids::ColorLoopSet: {
+        case Clusters::ColorControl::Commands::ColorLoopSet::Id: {
             expectArgumentCount = 7;
             uint8_t updateFlags;
             uint8_t action;
@@ -642,7 +642,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedMoveHue: {
+        case Clusters::ColorControl::Commands::EnhancedMoveHue::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint16_t rate;
@@ -713,7 +713,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedMoveToHue: {
+        case Clusters::ColorControl::Commands::EnhancedMoveToHue::Id: {
             expectArgumentCount = 5;
             uint16_t enhancedHue;
             uint8_t direction;
@@ -788,7 +788,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedMoveToHueAndSaturation: {
+        case Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Id: {
             expectArgumentCount = 5;
             uint16_t enhancedHue;
             uint8_t saturation;
@@ -863,7 +863,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedStepHue: {
+        case Clusters::ColorControl::Commands::EnhancedStepHue::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint16_t stepSize;
@@ -938,7 +938,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveColor: {
+        case Clusters::ColorControl::Commands::MoveColor::Id: {
             expectArgumentCount = 4;
             int16_t rateX;
             int16_t rateY;
@@ -1009,7 +1009,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveColorTemperature::Id: {
             expectArgumentCount = 6;
             uint8_t moveMode;
             uint16_t rate;
@@ -1089,7 +1089,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveHue: {
+        case Clusters::ColorControl::Commands::MoveHue::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -1160,7 +1160,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveSaturation: {
+        case Clusters::ColorControl::Commands::MoveSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -1231,7 +1231,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColor: {
+        case Clusters::ColorControl::Commands::MoveToColor::Id: {
             expectArgumentCount = 5;
             uint16_t colorX;
             uint16_t colorY;
@@ -1306,7 +1306,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveToColorTemperature::Id: {
             expectArgumentCount = 4;
             uint16_t colorTemperature;
             uint16_t transitionTime;
@@ -1377,7 +1377,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHue: {
+        case Clusters::ColorControl::Commands::MoveToHue::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t direction;
@@ -1452,7 +1452,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHueAndSaturation: {
+        case Clusters::ColorControl::Commands::MoveToHueAndSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t saturation;
@@ -1527,7 +1527,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToSaturation: {
+        case Clusters::ColorControl::Commands::MoveToSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t saturation;
             uint16_t transitionTime;
@@ -1598,7 +1598,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColor: {
+        case Clusters::ColorControl::Commands::StepColor::Id: {
             expectArgumentCount = 5;
             int16_t stepX;
             int16_t stepY;
@@ -1673,7 +1673,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColorTemperature: {
+        case Clusters::ColorControl::Commands::StepColorTemperature::Id: {
             expectArgumentCount = 7;
             uint8_t stepMode;
             uint16_t stepSize;
@@ -1757,7 +1757,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepHue: {
+        case Clusters::ColorControl::Commands::StepHue::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1832,7 +1832,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepSaturation: {
+        case Clusters::ColorControl::Commands::StepSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1907,7 +1907,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StopMoveStep: {
+        case Clusters::ColorControl::Commands::StopMoveStep::Id: {
             expectArgumentCount = 2;
             uint8_t optionsMask;
             uint8_t optionsOverride;
@@ -2015,7 +2015,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -2127,17 +2127,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DoorLock::Commands::Ids::ClearAllPins: {
+        case Clusters::DoorLock::Commands::ClearAllPins::Id: {
 
             wasHandled = emberAfDoorLockClusterClearAllPinsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearAllRfids: {
+        case Clusters::DoorLock::Commands::ClearAllRfids::Id: {
 
             wasHandled = emberAfDoorLockClusterClearAllRfidsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearHolidaySchedule: {
+        case Clusters::DoorLock::Commands::ClearHolidaySchedule::Id: {
             expectArgumentCount = 1;
             uint8_t scheduleId;
             bool argExists[1];
@@ -2195,7 +2195,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearPin: {
+        case Clusters::DoorLock::Commands::ClearPin::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2253,7 +2253,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearRfid: {
+        case Clusters::DoorLock::Commands::ClearRfid::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2311,7 +2311,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::ClearWeekdaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2373,7 +2373,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearYeardaySchedule: {
+        case Clusters::DoorLock::Commands::ClearYeardaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2435,7 +2435,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetHolidaySchedule: {
+        case Clusters::DoorLock::Commands::GetHolidaySchedule::Id: {
             expectArgumentCount = 1;
             uint8_t scheduleId;
             bool argExists[1];
@@ -2493,7 +2493,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetLogRecord: {
+        case Clusters::DoorLock::Commands::GetLogRecord::Id: {
             expectArgumentCount = 1;
             uint16_t logIndex;
             bool argExists[1];
@@ -2551,7 +2551,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetPin: {
+        case Clusters::DoorLock::Commands::GetPin::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2609,7 +2609,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetRfid: {
+        case Clusters::DoorLock::Commands::GetRfid::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2667,7 +2667,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetUserType: {
+        case Clusters::DoorLock::Commands::GetUserType::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2725,7 +2725,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::GetWeekdaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2787,7 +2787,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetYeardaySchedule: {
+        case Clusters::DoorLock::Commands::GetYeardaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2849,7 +2849,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::LockDoor: {
+        case Clusters::DoorLock::Commands::LockDoor::Id: {
             expectArgumentCount = 1;
             const uint8_t * PIN;
             bool argExists[1];
@@ -2908,7 +2908,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetHolidaySchedule: {
+        case Clusters::DoorLock::Commands::SetHolidaySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t scheduleId;
             uint32_t localStartTime;
@@ -2979,7 +2979,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetPin: {
+        case Clusters::DoorLock::Commands::SetPin::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -3051,7 +3051,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetRfid: {
+        case Clusters::DoorLock::Commands::SetRfid::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -3123,7 +3123,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetUserType: {
+        case Clusters::DoorLock::Commands::SetUserType::Id: {
             expectArgumentCount = 2;
             uint16_t userId;
             uint8_t userType;
@@ -3185,7 +3185,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::SetWeekdaySchedule::Id: {
             expectArgumentCount = 7;
             uint8_t scheduleId;
             uint16_t userId;
@@ -3268,7 +3268,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetYeardaySchedule: {
+        case Clusters::DoorLock::Commands::SetYeardaySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t scheduleId;
             uint16_t userId;
@@ -3339,7 +3339,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockDoor: {
+        case Clusters::DoorLock::Commands::UnlockDoor::Id: {
             expectArgumentCount = 1;
             const uint8_t * PIN;
             bool argExists[1];
@@ -3398,7 +3398,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockWithTimeout: {
+        case Clusters::DoorLock::Commands::UnlockWithTimeout::Id: {
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
             const uint8_t * pin;
@@ -3507,7 +3507,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::EthernetNetworkDiagnostics::Commands::Ids::ResetCounts: {
+        case Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Id: {
 
             wasHandled = emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(aEndpointId, apCommandObj);
             break;
@@ -3558,7 +3558,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -3625,12 +3625,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -3748,7 +3748,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Groups::Commands::Ids::AddGroup: {
+        case Clusters::Groups::Commands::AddGroup::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             const uint8_t * groupName;
@@ -3812,7 +3812,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::AddGroupIfIdentifying: {
+        case Clusters::Groups::Commands::AddGroupIfIdentifying::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             const uint8_t * groupName;
@@ -3876,7 +3876,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::GetGroupMembership: {
+        case Clusters::Groups::Commands::GetGroupMembership::Id: {
             expectArgumentCount = 2;
             uint8_t groupCount;
             /* TYPE WARNING: array array defaults to */ uint8_t * groupList;
@@ -3939,12 +3939,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveAllGroups: {
+        case Clusters::Groups::Commands::RemoveAllGroups::Id: {
 
             wasHandled = emberAfGroupsClusterRemoveAllGroupsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveGroup: {
+        case Clusters::Groups::Commands::RemoveGroup::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -4002,7 +4002,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::ViewGroup: {
+        case Clusters::Groups::Commands::ViewGroup::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -4105,7 +4105,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::IasZone::Commands::Ids::ZoneEnrollResponse: {
+        case Clusters::IasZone::Commands::ZoneEnrollResponse::Id: {
             expectArgumentCount = 2;
             uint8_t enrollResponseCode;
             uint8_t zoneId;
@@ -4212,7 +4212,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Identify::Commands::Ids::Identify: {
+        case Clusters::Identify::Commands::Identify::Id: {
             expectArgumentCount = 1;
             uint16_t identifyTime;
             bool argExists[1];
@@ -4270,7 +4270,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Identify::Commands::Ids::IdentifyQuery: {
+        case Clusters::Identify::Commands::IdentifyQuery::Id: {
 
             wasHandled = emberAfIdentifyClusterIdentifyQueryCallback(aEndpointId, apCommandObj);
             break;
@@ -4320,7 +4320,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -4391,7 +4391,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -4462,7 +4462,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -4525,7 +4525,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -4587,7 +4587,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -4662,7 +4662,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -4729,7 +4729,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -4791,7 +4791,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -4841,7 +4841,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LowPower::Commands::Ids::Sleep: {
+        case Clusters::LowPower::Commands::Sleep::Id: {
 
             wasHandled = emberAfLowPowerClusterSleepCallback(aEndpointId, apCommandObj);
             break;
@@ -4891,7 +4891,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -4958,7 +4958,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -5029,7 +5029,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -5096,7 +5096,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -5163,7 +5163,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -5222,7 +5222,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -5289,7 +5289,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -5356,7 +5356,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -5423,7 +5423,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -5540,7 +5540,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t newVersion;
@@ -5603,7 +5603,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t softwareVersion;
@@ -5666,7 +5666,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImage: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Id: {
             expectArgumentCount = 8;
             uint16_t vendorId;
             uint16_t productId;
@@ -5801,17 +5801,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -5861,7 +5861,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -5936,7 +5936,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -5995,7 +5995,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -6054,7 +6054,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -6113,7 +6113,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -6171,7 +6171,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -6229,7 +6229,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -6288,7 +6288,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -6348,7 +6348,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -6456,7 +6456,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Scenes::Commands::Ids::AddScene: {
+        case Clusters::Scenes::Commands::AddScene::Id: {
             expectArgumentCount = 5;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6533,7 +6533,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::GetSceneMembership: {
+        case Clusters::Scenes::Commands::GetSceneMembership::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -6591,7 +6591,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RecallScene: {
+        case Clusters::Scenes::Commands::RecallScene::Id: {
             expectArgumentCount = 3;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6657,7 +6657,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveAllScenes: {
+        case Clusters::Scenes::Commands::RemoveAllScenes::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -6715,7 +6715,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveScene: {
+        case Clusters::Scenes::Commands::RemoveScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6777,7 +6777,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::StoreScene: {
+        case Clusters::Scenes::Commands::StoreScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6839,7 +6839,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::ViewScene: {
+        case Clusters::Scenes::Commands::ViewScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6946,7 +6946,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::SoftwareDiagnostics::Commands::Ids::ResetWatermarks: {
+        case Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Id: {
 
             wasHandled = emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(aEndpointId, apCommandObj);
             break;
@@ -6997,12 +6997,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::TestCluster::Commands::Ids::Test: {
+        case Clusters::TestCluster::Commands::Test::Id: {
 
             wasHandled = emberAfTestClusterClusterTestCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestAddArguments: {
+        case Clusters::TestCluster::Commands::TestAddArguments::Id: {
             expectArgumentCount = 2;
             uint8_t arg1;
             uint8_t arg2;
@@ -7064,12 +7064,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestNotHandled: {
+        case Clusters::TestCluster::Commands::TestNotHandled::Id: {
 
             wasHandled = emberAfTestClusterClusterTestNotHandledCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestSpecific: {
+        case Clusters::TestCluster::Commands::TestSpecific::Id: {
 
             wasHandled = emberAfTestClusterClusterTestSpecificCallback(aEndpointId, apCommandObj);
             break;
@@ -7119,7 +7119,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ThreadNetworkDiagnostics::Commands::Ids::ResetCounts: {
+        case Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Id: {
 
             wasHandled = emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(aEndpointId, apCommandObj);
             break;
@@ -7170,7 +7170,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::WiFiNetworkDiagnostics::Commands::Ids::ResetCounts: {
+        case Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Id: {
 
             wasHandled = emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(aEndpointId, apCommandObj);
             break;
@@ -7221,17 +7221,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::WindowCovering::Commands::Ids::DownOrClose: {
+        case Clusters::WindowCovering::Commands::DownOrClose::Id: {
 
             wasHandled = emberAfWindowCoveringClusterDownOrCloseCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::StopMotion: {
+        case Clusters::WindowCovering::Commands::StopMotion::Id: {
 
             wasHandled = emberAfWindowCoveringClusterStopMotionCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::UpOrOpen: {
+        case Clusters::WindowCovering::Commands::UpOrOpen::Id: {
 
             wasHandled = emberAfWindowCoveringClusterUpOrOpenCallback(aEndpointId, apCommandObj);
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
@@ -25,723 +25,1687 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-namespace Globals {
-namespace Commands {
-namespace Ids {
-static constexpr CommandId ReadAttributes                     = 0x00000000;
-static constexpr CommandId ReadAttributesResponse             = 0x00000001;
-static constexpr CommandId WriteAttributes                    = 0x00000002;
-static constexpr CommandId WriteAttributesUndivided           = 0x00000003;
-static constexpr CommandId WriteAttributesResponse            = 0x00000004;
-static constexpr CommandId WriteAttributesNoResponse          = 0x00000005;
-static constexpr CommandId ConfigureReporting                 = 0x00000006;
-static constexpr CommandId ConfigureReportingResponse         = 0x00000007;
-static constexpr CommandId ReadReportingConfiguration         = 0x00000008;
-static constexpr CommandId ReadReportingConfigurationResponse = 0x00000009;
-static constexpr CommandId ReportAttributes                   = 0x0000000A;
-static constexpr CommandId DefaultResponse                    = 0x0000000B;
-static constexpr CommandId DiscoverAttributes                 = 0x0000000C;
-static constexpr CommandId DiscoverAttributesResponse         = 0x0000000D;
-static constexpr CommandId ReadAttributesStructured           = 0x0000000E;
-static constexpr CommandId WriteAttributesStructured          = 0x0000000F;
-static constexpr CommandId WriteAttributesStructuredResponse  = 0x00000010;
-static constexpr CommandId DiscoverCommandsReceived           = 0x00000011;
-static constexpr CommandId DiscoverCommandsReceivedResponse   = 0x00000012;
-static constexpr CommandId DiscoverCommandsGenerated          = 0x00000013;
-static constexpr CommandId DiscoverCommandsGeneratedResponse  = 0x00000014;
-static constexpr CommandId DiscoverAttributesExtended         = 0x00000015;
-static constexpr CommandId DiscoverAttributesExtendedResponse = 0x00000016;
-} // namespace Ids
-} // namespace Commands
-} // namespace Globals
+// Matter does not have global commands
 
 namespace Identify {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId Identify              = 0x00000000;
-static constexpr CommandId IdentifyQueryResponse = 0x00000000;
-static constexpr CommandId IdentifyQuery         = 0x00000001;
-static constexpr CommandId TriggerEffect         = 0x00000040;
-} // namespace Ids
+
+namespace Identify {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Identify
+
+namespace IdentifyQueryResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace IdentifyQueryResponse
+
+namespace IdentifyQuery {
+static constexpr CommandId Id = 0x00000001;
+} // namespace IdentifyQuery
+
+namespace TriggerEffect {
+static constexpr CommandId Id = 0x00000040;
+} // namespace TriggerEffect
+
 } // namespace Commands
 } // namespace Identify
 
 namespace Groups {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId AddGroup                   = 0x00000000;
-static constexpr CommandId AddGroupResponse           = 0x00000000;
-static constexpr CommandId ViewGroup                  = 0x00000001;
-static constexpr CommandId ViewGroupResponse          = 0x00000001;
-static constexpr CommandId GetGroupMembership         = 0x00000002;
-static constexpr CommandId GetGroupMembershipResponse = 0x00000002;
-static constexpr CommandId RemoveGroup                = 0x00000003;
-static constexpr CommandId RemoveGroupResponse        = 0x00000003;
-static constexpr CommandId RemoveAllGroups            = 0x00000004;
-static constexpr CommandId AddGroupIfIdentifying      = 0x00000005;
-} // namespace Ids
+
+namespace AddGroup {
+static constexpr CommandId Id = 0x00000000;
+} // namespace AddGroup
+
+namespace AddGroupResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace AddGroupResponse
+
+namespace ViewGroup {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ViewGroup
+
+namespace ViewGroupResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ViewGroupResponse
+
+namespace GetGroupMembership {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetGroupMembership
+
+namespace GetGroupMembershipResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetGroupMembershipResponse
+
+namespace RemoveGroup {
+static constexpr CommandId Id = 0x00000003;
+} // namespace RemoveGroup
+
+namespace RemoveGroupResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace RemoveGroupResponse
+
+namespace RemoveAllGroups {
+static constexpr CommandId Id = 0x00000004;
+} // namespace RemoveAllGroups
+
+namespace AddGroupIfIdentifying {
+static constexpr CommandId Id = 0x00000005;
+} // namespace AddGroupIfIdentifying
+
 } // namespace Commands
 } // namespace Groups
 
 namespace Scenes {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId AddScene                   = 0x00000000;
-static constexpr CommandId AddSceneResponse           = 0x00000000;
-static constexpr CommandId ViewScene                  = 0x00000001;
-static constexpr CommandId ViewSceneResponse          = 0x00000001;
-static constexpr CommandId RemoveScene                = 0x00000002;
-static constexpr CommandId RemoveSceneResponse        = 0x00000002;
-static constexpr CommandId RemoveAllScenes            = 0x00000003;
-static constexpr CommandId RemoveAllScenesResponse    = 0x00000003;
-static constexpr CommandId StoreScene                 = 0x00000004;
-static constexpr CommandId StoreSceneResponse         = 0x00000004;
-static constexpr CommandId RecallScene                = 0x00000005;
-static constexpr CommandId GetSceneMembership         = 0x00000006;
-static constexpr CommandId GetSceneMembershipResponse = 0x00000006;
-static constexpr CommandId EnhancedAddScene           = 0x00000040;
-static constexpr CommandId EnhancedAddSceneResponse   = 0x00000040;
-static constexpr CommandId EnhancedViewScene          = 0x00000041;
-static constexpr CommandId EnhancedViewSceneResponse  = 0x00000041;
-static constexpr CommandId CopyScene                  = 0x00000042;
-static constexpr CommandId CopySceneResponse          = 0x00000042;
-} // namespace Ids
+
+namespace AddScene {
+static constexpr CommandId Id = 0x00000000;
+} // namespace AddScene
+
+namespace AddSceneResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace AddSceneResponse
+
+namespace ViewScene {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ViewScene
+
+namespace ViewSceneResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ViewSceneResponse
+
+namespace RemoveScene {
+static constexpr CommandId Id = 0x00000002;
+} // namespace RemoveScene
+
+namespace RemoveSceneResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace RemoveSceneResponse
+
+namespace RemoveAllScenes {
+static constexpr CommandId Id = 0x00000003;
+} // namespace RemoveAllScenes
+
+namespace RemoveAllScenesResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace RemoveAllScenesResponse
+
+namespace StoreScene {
+static constexpr CommandId Id = 0x00000004;
+} // namespace StoreScene
+
+namespace StoreSceneResponse {
+static constexpr CommandId Id = 0x00000004;
+} // namespace StoreSceneResponse
+
+namespace RecallScene {
+static constexpr CommandId Id = 0x00000005;
+} // namespace RecallScene
+
+namespace GetSceneMembership {
+static constexpr CommandId Id = 0x00000006;
+} // namespace GetSceneMembership
+
+namespace GetSceneMembershipResponse {
+static constexpr CommandId Id = 0x00000006;
+} // namespace GetSceneMembershipResponse
+
+namespace EnhancedAddScene {
+static constexpr CommandId Id = 0x00000040;
+} // namespace EnhancedAddScene
+
+namespace EnhancedAddSceneResponse {
+static constexpr CommandId Id = 0x00000040;
+} // namespace EnhancedAddSceneResponse
+
+namespace EnhancedViewScene {
+static constexpr CommandId Id = 0x00000041;
+} // namespace EnhancedViewScene
+
+namespace EnhancedViewSceneResponse {
+static constexpr CommandId Id = 0x00000041;
+} // namespace EnhancedViewSceneResponse
+
+namespace CopyScene {
+static constexpr CommandId Id = 0x00000042;
+} // namespace CopyScene
+
+namespace CopySceneResponse {
+static constexpr CommandId Id = 0x00000042;
+} // namespace CopySceneResponse
+
 } // namespace Commands
 } // namespace Scenes
 
 namespace OnOff {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId Off                                    = 0x00000000;
-static constexpr CommandId SampleMfgSpecificOffWithTransition     = 0x10020000;
-static constexpr CommandId On                                     = 0x00000001;
-static constexpr CommandId SampleMfgSpecificOnWithTransition      = 0x10020001;
-static constexpr CommandId SampleMfgSpecificOnWithTransition2     = 0x10490001;
-static constexpr CommandId Toggle                                 = 0x00000002;
-static constexpr CommandId SampleMfgSpecificToggleWithTransition  = 0x10020002;
-static constexpr CommandId SampleMfgSpecificToggleWithTransition2 = 0x10490002;
-static constexpr CommandId OffWithEffect                          = 0x00000040;
-static constexpr CommandId OnWithRecallGlobalScene                = 0x00000041;
-static constexpr CommandId OnWithTimedOff                         = 0x00000042;
-} // namespace Ids
+
+namespace Off {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Off
+
+namespace SampleMfgSpecificOffWithTransition {
+static constexpr CommandId Id = 0x10020000;
+} // namespace SampleMfgSpecificOffWithTransition
+
+namespace On {
+static constexpr CommandId Id = 0x00000001;
+} // namespace On
+
+namespace SampleMfgSpecificOnWithTransition {
+static constexpr CommandId Id = 0x10020001;
+} // namespace SampleMfgSpecificOnWithTransition
+
+namespace SampleMfgSpecificOnWithTransition2 {
+static constexpr CommandId Id = 0x10490001;
+} // namespace SampleMfgSpecificOnWithTransition2
+
+namespace Toggle {
+static constexpr CommandId Id = 0x00000002;
+} // namespace Toggle
+
+namespace SampleMfgSpecificToggleWithTransition {
+static constexpr CommandId Id = 0x10020002;
+} // namespace SampleMfgSpecificToggleWithTransition
+
+namespace SampleMfgSpecificToggleWithTransition2 {
+static constexpr CommandId Id = 0x10490002;
+} // namespace SampleMfgSpecificToggleWithTransition2
+
+namespace OffWithEffect {
+static constexpr CommandId Id = 0x00000040;
+} // namespace OffWithEffect
+
+namespace OnWithRecallGlobalScene {
+static constexpr CommandId Id = 0x00000041;
+} // namespace OnWithRecallGlobalScene
+
+namespace OnWithTimedOff {
+static constexpr CommandId Id = 0x00000042;
+} // namespace OnWithTimedOff
+
 } // namespace Commands
 } // namespace OnOff
 
 namespace LevelControl {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId MoveToLevel          = 0x00000000;
-static constexpr CommandId Move                 = 0x00000001;
-static constexpr CommandId Step                 = 0x00000002;
-static constexpr CommandId Stop                 = 0x00000003;
-static constexpr CommandId MoveToLevelWithOnOff = 0x00000004;
-static constexpr CommandId MoveWithOnOff        = 0x00000005;
-static constexpr CommandId StepWithOnOff        = 0x00000006;
-static constexpr CommandId StopWithOnOff        = 0x00000007;
-} // namespace Ids
+
+namespace MoveToLevel {
+static constexpr CommandId Id = 0x00000000;
+} // namespace MoveToLevel
+
+namespace Move {
+static constexpr CommandId Id = 0x00000001;
+} // namespace Move
+
+namespace Step {
+static constexpr CommandId Id = 0x00000002;
+} // namespace Step
+
+namespace Stop {
+static constexpr CommandId Id = 0x00000003;
+} // namespace Stop
+
+namespace MoveToLevelWithOnOff {
+static constexpr CommandId Id = 0x00000004;
+} // namespace MoveToLevelWithOnOff
+
+namespace MoveWithOnOff {
+static constexpr CommandId Id = 0x00000005;
+} // namespace MoveWithOnOff
+
+namespace StepWithOnOff {
+static constexpr CommandId Id = 0x00000006;
+} // namespace StepWithOnOff
+
+namespace StopWithOnOff {
+static constexpr CommandId Id = 0x00000007;
+} // namespace StopWithOnOff
+
 } // namespace Commands
 } // namespace LevelControl
 
 namespace Alarms {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ResetAlarm       = 0x00000000;
-static constexpr CommandId Alarm            = 0x00000000;
-static constexpr CommandId ResetAllAlarms   = 0x00000001;
-static constexpr CommandId GetAlarmResponse = 0x00000001;
-static constexpr CommandId GetAlarm         = 0x00000002;
-static constexpr CommandId ResetAlarmLog    = 0x00000003;
-} // namespace Ids
+
+namespace ResetAlarm {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ResetAlarm
+
+namespace Alarm {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Alarm
+
+namespace ResetAllAlarms {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ResetAllAlarms
+
+namespace GetAlarmResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace GetAlarmResponse
+
+namespace GetAlarm {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetAlarm
+
+namespace ResetAlarmLog {
+static constexpr CommandId Id = 0x00000003;
+} // namespace ResetAlarmLog
+
 } // namespace Commands
 } // namespace Alarms
 
 namespace PowerProfile {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId PowerProfileRequest                         = 0x00000000;
-static constexpr CommandId PowerProfileNotification                    = 0x00000000;
-static constexpr CommandId PowerProfileStateRequest                    = 0x00000001;
-static constexpr CommandId PowerProfileResponse                        = 0x00000001;
-static constexpr CommandId GetPowerProfilePriceResponse                = 0x00000002;
-static constexpr CommandId PowerProfileStateResponse                   = 0x00000002;
-static constexpr CommandId GetOverallSchedulePriceResponse             = 0x00000003;
-static constexpr CommandId GetPowerProfilePrice                        = 0x00000003;
-static constexpr CommandId EnergyPhasesScheduleNotification            = 0x00000004;
-static constexpr CommandId PowerProfilesStateNotification              = 0x00000004;
-static constexpr CommandId EnergyPhasesScheduleResponse                = 0x00000005;
-static constexpr CommandId GetOverallSchedulePrice                     = 0x00000005;
-static constexpr CommandId PowerProfileScheduleConstraintsRequest      = 0x00000006;
-static constexpr CommandId EnergyPhasesScheduleRequest                 = 0x00000006;
-static constexpr CommandId EnergyPhasesScheduleStateRequest            = 0x00000007;
-static constexpr CommandId EnergyPhasesScheduleStateResponse           = 0x00000007;
-static constexpr CommandId GetPowerProfilePriceExtendedResponse        = 0x00000008;
-static constexpr CommandId EnergyPhasesScheduleStateNotification       = 0x00000008;
-static constexpr CommandId PowerProfileScheduleConstraintsNotification = 0x00000009;
-static constexpr CommandId PowerProfileScheduleConstraintsResponse     = 0x0000000A;
-static constexpr CommandId GetPowerProfilePriceExtended                = 0x0000000B;
-} // namespace Ids
+
+namespace PowerProfileRequest {
+static constexpr CommandId Id = 0x00000000;
+} // namespace PowerProfileRequest
+
+namespace PowerProfileNotification {
+static constexpr CommandId Id = 0x00000000;
+} // namespace PowerProfileNotification
+
+namespace PowerProfileStateRequest {
+static constexpr CommandId Id = 0x00000001;
+} // namespace PowerProfileStateRequest
+
+namespace PowerProfileResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace PowerProfileResponse
+
+namespace GetPowerProfilePriceResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetPowerProfilePriceResponse
+
+namespace PowerProfileStateResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace PowerProfileStateResponse
+
+namespace GetOverallSchedulePriceResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace GetOverallSchedulePriceResponse
+
+namespace GetPowerProfilePrice {
+static constexpr CommandId Id = 0x00000003;
+} // namespace GetPowerProfilePrice
+
+namespace EnergyPhasesScheduleNotification {
+static constexpr CommandId Id = 0x00000004;
+} // namespace EnergyPhasesScheduleNotification
+
+namespace PowerProfilesStateNotification {
+static constexpr CommandId Id = 0x00000004;
+} // namespace PowerProfilesStateNotification
+
+namespace EnergyPhasesScheduleResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace EnergyPhasesScheduleResponse
+
+namespace GetOverallSchedulePrice {
+static constexpr CommandId Id = 0x00000005;
+} // namespace GetOverallSchedulePrice
+
+namespace PowerProfileScheduleConstraintsRequest {
+static constexpr CommandId Id = 0x00000006;
+} // namespace PowerProfileScheduleConstraintsRequest
+
+namespace EnergyPhasesScheduleRequest {
+static constexpr CommandId Id = 0x00000006;
+} // namespace EnergyPhasesScheduleRequest
+
+namespace EnergyPhasesScheduleStateRequest {
+static constexpr CommandId Id = 0x00000007;
+} // namespace EnergyPhasesScheduleStateRequest
+
+namespace EnergyPhasesScheduleStateResponse {
+static constexpr CommandId Id = 0x00000007;
+} // namespace EnergyPhasesScheduleStateResponse
+
+namespace GetPowerProfilePriceExtendedResponse {
+static constexpr CommandId Id = 0x00000008;
+} // namespace GetPowerProfilePriceExtendedResponse
+
+namespace EnergyPhasesScheduleStateNotification {
+static constexpr CommandId Id = 0x00000008;
+} // namespace EnergyPhasesScheduleStateNotification
+
+namespace PowerProfileScheduleConstraintsNotification {
+static constexpr CommandId Id = 0x00000009;
+} // namespace PowerProfileScheduleConstraintsNotification
+
+namespace PowerProfileScheduleConstraintsResponse {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace PowerProfileScheduleConstraintsResponse
+
+namespace GetPowerProfilePriceExtended {
+static constexpr CommandId Id = 0x0000000B;
+} // namespace GetPowerProfilePriceExtended
+
 } // namespace Commands
 } // namespace PowerProfile
 
 namespace ApplianceControl {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ExecutionOfACommand     = 0x00000000;
-static constexpr CommandId SignalStateResponse     = 0x00000000;
-static constexpr CommandId SignalState             = 0x00000001;
-static constexpr CommandId SignalStateNotification = 0x00000001;
-static constexpr CommandId WriteFunctions          = 0x00000002;
-static constexpr CommandId OverloadPauseResume     = 0x00000003;
-static constexpr CommandId OverloadPause           = 0x00000004;
-static constexpr CommandId OverloadWarning         = 0x00000005;
-} // namespace Ids
+
+namespace ExecutionOfACommand {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ExecutionOfACommand
+
+namespace SignalStateResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace SignalStateResponse
+
+namespace SignalState {
+static constexpr CommandId Id = 0x00000001;
+} // namespace SignalState
+
+namespace SignalStateNotification {
+static constexpr CommandId Id = 0x00000001;
+} // namespace SignalStateNotification
+
+namespace WriteFunctions {
+static constexpr CommandId Id = 0x00000002;
+} // namespace WriteFunctions
+
+namespace OverloadPauseResume {
+static constexpr CommandId Id = 0x00000003;
+} // namespace OverloadPauseResume
+
+namespace OverloadPause {
+static constexpr CommandId Id = 0x00000004;
+} // namespace OverloadPause
+
+namespace OverloadWarning {
+static constexpr CommandId Id = 0x00000005;
+} // namespace OverloadWarning
+
 } // namespace Commands
 } // namespace ApplianceControl
 
 namespace PollControl {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId CheckIn              = 0x00000000;
-static constexpr CommandId CheckInResponse      = 0x00000000;
-static constexpr CommandId FastPollStop         = 0x00000001;
-static constexpr CommandId SetLongPollInterval  = 0x00000002;
-static constexpr CommandId SetShortPollInterval = 0x00000003;
-} // namespace Ids
+
+namespace CheckIn {
+static constexpr CommandId Id = 0x00000000;
+} // namespace CheckIn
+
+namespace CheckInResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace CheckInResponse
+
+namespace FastPollStop {
+static constexpr CommandId Id = 0x00000001;
+} // namespace FastPollStop
+
+namespace SetLongPollInterval {
+static constexpr CommandId Id = 0x00000002;
+} // namespace SetLongPollInterval
+
+namespace SetShortPollInterval {
+static constexpr CommandId Id = 0x00000003;
+} // namespace SetShortPollInterval
+
 } // namespace Commands
 } // namespace PollControl
 
 namespace Basic {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId StartUp         = 0x00000000;
-static constexpr CommandId MfgSpecificPing = 0x10020000;
-static constexpr CommandId ShutDown        = 0x00000001;
-static constexpr CommandId Leave           = 0x00000002;
-} // namespace Ids
+
+namespace StartUp {
+static constexpr CommandId Id = 0x00000000;
+} // namespace StartUp
+
+namespace MfgSpecificPing {
+static constexpr CommandId Id = 0x10020000;
+} // namespace MfgSpecificPing
+
+namespace ShutDown {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ShutDown
+
+namespace Leave {
+static constexpr CommandId Id = 0x00000002;
+} // namespace Leave
+
 } // namespace Commands
 } // namespace Basic
 
 namespace OtaSoftwareUpdateProvider {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId QueryImage                 = 0x00000000;
-static constexpr CommandId ApplyUpdateRequest         = 0x00000001;
-static constexpr CommandId NotifyUpdateApplied        = 0x00000002;
-static constexpr CommandId QueryImageResponse         = 0x00000003;
-static constexpr CommandId ApplyUpdateRequestResponse = 0x00000004;
-} // namespace Ids
+
+namespace QueryImage {
+static constexpr CommandId Id = 0x00000000;
+} // namespace QueryImage
+
+namespace ApplyUpdateRequest {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ApplyUpdateRequest
+
+namespace NotifyUpdateApplied {
+static constexpr CommandId Id = 0x00000002;
+} // namespace NotifyUpdateApplied
+
+namespace QueryImageResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace QueryImageResponse
+
+namespace ApplyUpdateRequestResponse {
+static constexpr CommandId Id = 0x00000004;
+} // namespace ApplyUpdateRequestResponse
+
 } // namespace Commands
 } // namespace OtaSoftwareUpdateProvider
 
 namespace OtaSoftwareUpdateRequestor {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId AnnounceOtaProvider = 0x00000000;
-} // namespace Ids
+
+namespace AnnounceOtaProvider {
+static constexpr CommandId Id = 0x00000000;
+} // namespace AnnounceOtaProvider
+
 } // namespace Commands
 } // namespace OtaSoftwareUpdateRequestor
 
 namespace GeneralCommissioning {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ArmFailSafe                   = 0x00000000;
-static constexpr CommandId ArmFailSafeResponse           = 0x00000001;
-static constexpr CommandId SetRegulatoryConfig           = 0x00000002;
-static constexpr CommandId SetRegulatoryConfigResponse   = 0x00000003;
-static constexpr CommandId CommissioningComplete         = 0x00000004;
-static constexpr CommandId CommissioningCompleteResponse = 0x00000005;
-} // namespace Ids
+
+namespace ArmFailSafe {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ArmFailSafe
+
+namespace ArmFailSafeResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ArmFailSafeResponse
+
+namespace SetRegulatoryConfig {
+static constexpr CommandId Id = 0x00000002;
+} // namespace SetRegulatoryConfig
+
+namespace SetRegulatoryConfigResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace SetRegulatoryConfigResponse
+
+namespace CommissioningComplete {
+static constexpr CommandId Id = 0x00000004;
+} // namespace CommissioningComplete
+
+namespace CommissioningCompleteResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace CommissioningCompleteResponse
+
 } // namespace Commands
 } // namespace GeneralCommissioning
 
 namespace NetworkCommissioning {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ScanNetworks                      = 0x00000000;
-static constexpr CommandId ScanNetworksResponse              = 0x00000001;
-static constexpr CommandId AddWiFiNetwork                    = 0x00000002;
-static constexpr CommandId AddWiFiNetworkResponse            = 0x00000003;
-static constexpr CommandId UpdateWiFiNetwork                 = 0x00000004;
-static constexpr CommandId UpdateWiFiNetworkResponse         = 0x00000005;
-static constexpr CommandId AddThreadNetwork                  = 0x00000006;
-static constexpr CommandId AddThreadNetworkResponse          = 0x00000007;
-static constexpr CommandId UpdateThreadNetwork               = 0x00000008;
-static constexpr CommandId UpdateThreadNetworkResponse       = 0x00000009;
-static constexpr CommandId RemoveNetwork                     = 0x0000000A;
-static constexpr CommandId RemoveNetworkResponse             = 0x0000000B;
-static constexpr CommandId EnableNetwork                     = 0x0000000C;
-static constexpr CommandId EnableNetworkResponse             = 0x0000000D;
-static constexpr CommandId DisableNetwork                    = 0x0000000E;
-static constexpr CommandId DisableNetworkResponse            = 0x0000000F;
-static constexpr CommandId GetLastNetworkCommissioningResult = 0x00000010;
-} // namespace Ids
+
+namespace ScanNetworks {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ScanNetworks
+
+namespace ScanNetworksResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ScanNetworksResponse
+
+namespace AddWiFiNetwork {
+static constexpr CommandId Id = 0x00000002;
+} // namespace AddWiFiNetwork
+
+namespace AddWiFiNetworkResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace AddWiFiNetworkResponse
+
+namespace UpdateWiFiNetwork {
+static constexpr CommandId Id = 0x00000004;
+} // namespace UpdateWiFiNetwork
+
+namespace UpdateWiFiNetworkResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace UpdateWiFiNetworkResponse
+
+namespace AddThreadNetwork {
+static constexpr CommandId Id = 0x00000006;
+} // namespace AddThreadNetwork
+
+namespace AddThreadNetworkResponse {
+static constexpr CommandId Id = 0x00000007;
+} // namespace AddThreadNetworkResponse
+
+namespace UpdateThreadNetwork {
+static constexpr CommandId Id = 0x00000008;
+} // namespace UpdateThreadNetwork
+
+namespace UpdateThreadNetworkResponse {
+static constexpr CommandId Id = 0x00000009;
+} // namespace UpdateThreadNetworkResponse
+
+namespace RemoveNetwork {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace RemoveNetwork
+
+namespace RemoveNetworkResponse {
+static constexpr CommandId Id = 0x0000000B;
+} // namespace RemoveNetworkResponse
+
+namespace EnableNetwork {
+static constexpr CommandId Id = 0x0000000C;
+} // namespace EnableNetwork
+
+namespace EnableNetworkResponse {
+static constexpr CommandId Id = 0x0000000D;
+} // namespace EnableNetworkResponse
+
+namespace DisableNetwork {
+static constexpr CommandId Id = 0x0000000E;
+} // namespace DisableNetwork
+
+namespace DisableNetworkResponse {
+static constexpr CommandId Id = 0x0000000F;
+} // namespace DisableNetworkResponse
+
+namespace GetLastNetworkCommissioningResult {
+static constexpr CommandId Id = 0x00000010;
+} // namespace GetLastNetworkCommissioningResult
+
 } // namespace Commands
 } // namespace NetworkCommissioning
 
 namespace DiagnosticLogs {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId RetrieveLogsRequest  = 0x00000000;
-static constexpr CommandId RetrieveLogsResponse = 0x00000001;
-} // namespace Ids
+
+namespace RetrieveLogsRequest {
+static constexpr CommandId Id = 0x00000000;
+} // namespace RetrieveLogsRequest
+
+namespace RetrieveLogsResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace RetrieveLogsResponse
+
 } // namespace Commands
 } // namespace DiagnosticLogs
 
 namespace SoftwareDiagnostics {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ResetWatermarks = 0x00000000;
-} // namespace Ids
+
+namespace ResetWatermarks {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ResetWatermarks
+
 } // namespace Commands
 } // namespace SoftwareDiagnostics
 
 namespace ThreadNetworkDiagnostics {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ResetCounts = 0x00000000;
-} // namespace Ids
+
+namespace ResetCounts {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ResetCounts
+
 } // namespace Commands
 } // namespace ThreadNetworkDiagnostics
 
 namespace WiFiNetworkDiagnostics {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ResetCounts = 0x00000000;
-} // namespace Ids
+
+namespace ResetCounts {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ResetCounts
+
 } // namespace Commands
 } // namespace WiFiNetworkDiagnostics
 
 namespace EthernetNetworkDiagnostics {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ResetCounts = 0x00000000;
-} // namespace Ids
+
+namespace ResetCounts {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ResetCounts
+
 } // namespace Commands
 } // namespace EthernetNetworkDiagnostics
 
 namespace BridgedDeviceBasic {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId StartUp          = 0x00000000;
-static constexpr CommandId ShutDown         = 0x00000001;
-static constexpr CommandId Leave            = 0x00000002;
-static constexpr CommandId ReachableChanged = 0x00000003;
-} // namespace Ids
+
+namespace StartUp {
+static constexpr CommandId Id = 0x00000000;
+} // namespace StartUp
+
+namespace ShutDown {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ShutDown
+
+namespace Leave {
+static constexpr CommandId Id = 0x00000002;
+} // namespace Leave
+
+namespace ReachableChanged {
+static constexpr CommandId Id = 0x00000003;
+} // namespace ReachableChanged
+
 } // namespace Commands
 } // namespace BridgedDeviceBasic
 
 namespace AdministratorCommissioning {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId OpenCommissioningWindow      = 0x00000000;
-static constexpr CommandId OpenBasicCommissioningWindow = 0x00000001;
-static constexpr CommandId RevokeCommissioning          = 0x00000002;
-} // namespace Ids
+
+namespace OpenCommissioningWindow {
+static constexpr CommandId Id = 0x00000000;
+} // namespace OpenCommissioningWindow
+
+namespace OpenBasicCommissioningWindow {
+static constexpr CommandId Id = 0x00000001;
+} // namespace OpenBasicCommissioningWindow
+
+namespace RevokeCommissioning {
+static constexpr CommandId Id = 0x00000002;
+} // namespace RevokeCommissioning
+
 } // namespace Commands
 } // namespace AdministratorCommissioning
 
 namespace OperationalCredentials {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId AttestationRequest           = 0x00000000;
-static constexpr CommandId AttestationResponse          = 0x00000001;
-static constexpr CommandId CertificateChainRequest      = 0x00000002;
-static constexpr CommandId CertificateChainResponse     = 0x00000003;
-static constexpr CommandId OpCSRRequest                 = 0x00000004;
-static constexpr CommandId OpCSRResponse                = 0x00000005;
-static constexpr CommandId AddNOC                       = 0x00000006;
-static constexpr CommandId UpdateNOC                    = 0x00000007;
-static constexpr CommandId NOCResponse                  = 0x00000008;
-static constexpr CommandId UpdateFabricLabel            = 0x00000009;
-static constexpr CommandId RemoveFabric                 = 0x0000000A;
-static constexpr CommandId AddTrustedRootCertificate    = 0x0000000B;
-static constexpr CommandId RemoveTrustedRootCertificate = 0x0000000C;
-} // namespace Ids
+
+namespace AttestationRequest {
+static constexpr CommandId Id = 0x00000000;
+} // namespace AttestationRequest
+
+namespace AttestationResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace AttestationResponse
+
+namespace CertificateChainRequest {
+static constexpr CommandId Id = 0x00000002;
+} // namespace CertificateChainRequest
+
+namespace CertificateChainResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace CertificateChainResponse
+
+namespace OpCSRRequest {
+static constexpr CommandId Id = 0x00000004;
+} // namespace OpCSRRequest
+
+namespace OpCSRResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace OpCSRResponse
+
+namespace AddNOC {
+static constexpr CommandId Id = 0x00000006;
+} // namespace AddNOC
+
+namespace UpdateNOC {
+static constexpr CommandId Id = 0x00000007;
+} // namespace UpdateNOC
+
+namespace NOCResponse {
+static constexpr CommandId Id = 0x00000008;
+} // namespace NOCResponse
+
+namespace UpdateFabricLabel {
+static constexpr CommandId Id = 0x00000009;
+} // namespace UpdateFabricLabel
+
+namespace RemoveFabric {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace RemoveFabric
+
+namespace AddTrustedRootCertificate {
+static constexpr CommandId Id = 0x0000000B;
+} // namespace AddTrustedRootCertificate
+
+namespace RemoveTrustedRootCertificate {
+static constexpr CommandId Id = 0x0000000C;
+} // namespace RemoveTrustedRootCertificate
+
 } // namespace Commands
 } // namespace OperationalCredentials
 
 namespace DoorLock {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId LockDoor                     = 0x00000000;
-static constexpr CommandId LockDoorResponse             = 0x00000000;
-static constexpr CommandId UnlockDoor                   = 0x00000001;
-static constexpr CommandId UnlockDoorResponse           = 0x00000001;
-static constexpr CommandId Toggle                       = 0x00000002;
-static constexpr CommandId ToggleResponse               = 0x00000002;
-static constexpr CommandId UnlockWithTimeout            = 0x00000003;
-static constexpr CommandId UnlockWithTimeoutResponse    = 0x00000003;
-static constexpr CommandId GetLogRecord                 = 0x00000004;
-static constexpr CommandId GetLogRecordResponse         = 0x00000004;
-static constexpr CommandId SetPin                       = 0x00000005;
-static constexpr CommandId SetPinResponse               = 0x00000005;
-static constexpr CommandId GetPin                       = 0x00000006;
-static constexpr CommandId GetPinResponse               = 0x00000006;
-static constexpr CommandId ClearPin                     = 0x00000007;
-static constexpr CommandId ClearPinResponse             = 0x00000007;
-static constexpr CommandId ClearAllPins                 = 0x00000008;
-static constexpr CommandId ClearAllPinsResponse         = 0x00000008;
-static constexpr CommandId SetUserStatus                = 0x00000009;
-static constexpr CommandId SetUserStatusResponse        = 0x00000009;
-static constexpr CommandId GetUserStatus                = 0x0000000A;
-static constexpr CommandId GetUserStatusResponse        = 0x0000000A;
-static constexpr CommandId SetWeekdaySchedule           = 0x0000000B;
-static constexpr CommandId SetWeekdayScheduleResponse   = 0x0000000B;
-static constexpr CommandId GetWeekdaySchedule           = 0x0000000C;
-static constexpr CommandId GetWeekdayScheduleResponse   = 0x0000000C;
-static constexpr CommandId ClearWeekdaySchedule         = 0x0000000D;
-static constexpr CommandId ClearWeekdayScheduleResponse = 0x0000000D;
-static constexpr CommandId SetYeardaySchedule           = 0x0000000E;
-static constexpr CommandId SetYeardayScheduleResponse   = 0x0000000E;
-static constexpr CommandId GetYeardaySchedule           = 0x0000000F;
-static constexpr CommandId GetYeardayScheduleResponse   = 0x0000000F;
-static constexpr CommandId ClearYeardaySchedule         = 0x00000010;
-static constexpr CommandId ClearYeardayScheduleResponse = 0x00000010;
-static constexpr CommandId SetHolidaySchedule           = 0x00000011;
-static constexpr CommandId SetHolidayScheduleResponse   = 0x00000011;
-static constexpr CommandId GetHolidaySchedule           = 0x00000012;
-static constexpr CommandId GetHolidayScheduleResponse   = 0x00000012;
-static constexpr CommandId ClearHolidaySchedule         = 0x00000013;
-static constexpr CommandId ClearHolidayScheduleResponse = 0x00000013;
-static constexpr CommandId SetUserType                  = 0x00000014;
-static constexpr CommandId SetUserTypeResponse          = 0x00000014;
-static constexpr CommandId GetUserType                  = 0x00000015;
-static constexpr CommandId GetUserTypeResponse          = 0x00000015;
-static constexpr CommandId SetRfid                      = 0x00000016;
-static constexpr CommandId SetRfidResponse              = 0x00000016;
-static constexpr CommandId GetRfid                      = 0x00000017;
-static constexpr CommandId GetRfidResponse              = 0x00000017;
-static constexpr CommandId ClearRfid                    = 0x00000018;
-static constexpr CommandId ClearRfidResponse            = 0x00000018;
-static constexpr CommandId ClearAllRfids                = 0x00000019;
-static constexpr CommandId ClearAllRfidsResponse        = 0x00000019;
-static constexpr CommandId OperationEventNotification   = 0x00000020;
-static constexpr CommandId ProgrammingEventNotification = 0x00000021;
-} // namespace Ids
+
+namespace LockDoor {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LockDoor
+
+namespace LockDoorResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LockDoorResponse
+
+namespace UnlockDoor {
+static constexpr CommandId Id = 0x00000001;
+} // namespace UnlockDoor
+
+namespace UnlockDoorResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace UnlockDoorResponse
+
+namespace Toggle {
+static constexpr CommandId Id = 0x00000002;
+} // namespace Toggle
+
+namespace ToggleResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace ToggleResponse
+
+namespace UnlockWithTimeout {
+static constexpr CommandId Id = 0x00000003;
+} // namespace UnlockWithTimeout
+
+namespace UnlockWithTimeoutResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace UnlockWithTimeoutResponse
+
+namespace GetLogRecord {
+static constexpr CommandId Id = 0x00000004;
+} // namespace GetLogRecord
+
+namespace GetLogRecordResponse {
+static constexpr CommandId Id = 0x00000004;
+} // namespace GetLogRecordResponse
+
+namespace SetPin {
+static constexpr CommandId Id = 0x00000005;
+} // namespace SetPin
+
+namespace SetPinResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace SetPinResponse
+
+namespace GetPin {
+static constexpr CommandId Id = 0x00000006;
+} // namespace GetPin
+
+namespace GetPinResponse {
+static constexpr CommandId Id = 0x00000006;
+} // namespace GetPinResponse
+
+namespace ClearPin {
+static constexpr CommandId Id = 0x00000007;
+} // namespace ClearPin
+
+namespace ClearPinResponse {
+static constexpr CommandId Id = 0x00000007;
+} // namespace ClearPinResponse
+
+namespace ClearAllPins {
+static constexpr CommandId Id = 0x00000008;
+} // namespace ClearAllPins
+
+namespace ClearAllPinsResponse {
+static constexpr CommandId Id = 0x00000008;
+} // namespace ClearAllPinsResponse
+
+namespace SetUserStatus {
+static constexpr CommandId Id = 0x00000009;
+} // namespace SetUserStatus
+
+namespace SetUserStatusResponse {
+static constexpr CommandId Id = 0x00000009;
+} // namespace SetUserStatusResponse
+
+namespace GetUserStatus {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace GetUserStatus
+
+namespace GetUserStatusResponse {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace GetUserStatusResponse
+
+namespace SetWeekdaySchedule {
+static constexpr CommandId Id = 0x0000000B;
+} // namespace SetWeekdaySchedule
+
+namespace SetWeekdayScheduleResponse {
+static constexpr CommandId Id = 0x0000000B;
+} // namespace SetWeekdayScheduleResponse
+
+namespace GetWeekdaySchedule {
+static constexpr CommandId Id = 0x0000000C;
+} // namespace GetWeekdaySchedule
+
+namespace GetWeekdayScheduleResponse {
+static constexpr CommandId Id = 0x0000000C;
+} // namespace GetWeekdayScheduleResponse
+
+namespace ClearWeekdaySchedule {
+static constexpr CommandId Id = 0x0000000D;
+} // namespace ClearWeekdaySchedule
+
+namespace ClearWeekdayScheduleResponse {
+static constexpr CommandId Id = 0x0000000D;
+} // namespace ClearWeekdayScheduleResponse
+
+namespace SetYeardaySchedule {
+static constexpr CommandId Id = 0x0000000E;
+} // namespace SetYeardaySchedule
+
+namespace SetYeardayScheduleResponse {
+static constexpr CommandId Id = 0x0000000E;
+} // namespace SetYeardayScheduleResponse
+
+namespace GetYeardaySchedule {
+static constexpr CommandId Id = 0x0000000F;
+} // namespace GetYeardaySchedule
+
+namespace GetYeardayScheduleResponse {
+static constexpr CommandId Id = 0x0000000F;
+} // namespace GetYeardayScheduleResponse
+
+namespace ClearYeardaySchedule {
+static constexpr CommandId Id = 0x00000010;
+} // namespace ClearYeardaySchedule
+
+namespace ClearYeardayScheduleResponse {
+static constexpr CommandId Id = 0x00000010;
+} // namespace ClearYeardayScheduleResponse
+
+namespace SetHolidaySchedule {
+static constexpr CommandId Id = 0x00000011;
+} // namespace SetHolidaySchedule
+
+namespace SetHolidayScheduleResponse {
+static constexpr CommandId Id = 0x00000011;
+} // namespace SetHolidayScheduleResponse
+
+namespace GetHolidaySchedule {
+static constexpr CommandId Id = 0x00000012;
+} // namespace GetHolidaySchedule
+
+namespace GetHolidayScheduleResponse {
+static constexpr CommandId Id = 0x00000012;
+} // namespace GetHolidayScheduleResponse
+
+namespace ClearHolidaySchedule {
+static constexpr CommandId Id = 0x00000013;
+} // namespace ClearHolidaySchedule
+
+namespace ClearHolidayScheduleResponse {
+static constexpr CommandId Id = 0x00000013;
+} // namespace ClearHolidayScheduleResponse
+
+namespace SetUserType {
+static constexpr CommandId Id = 0x00000014;
+} // namespace SetUserType
+
+namespace SetUserTypeResponse {
+static constexpr CommandId Id = 0x00000014;
+} // namespace SetUserTypeResponse
+
+namespace GetUserType {
+static constexpr CommandId Id = 0x00000015;
+} // namespace GetUserType
+
+namespace GetUserTypeResponse {
+static constexpr CommandId Id = 0x00000015;
+} // namespace GetUserTypeResponse
+
+namespace SetRfid {
+static constexpr CommandId Id = 0x00000016;
+} // namespace SetRfid
+
+namespace SetRfidResponse {
+static constexpr CommandId Id = 0x00000016;
+} // namespace SetRfidResponse
+
+namespace GetRfid {
+static constexpr CommandId Id = 0x00000017;
+} // namespace GetRfid
+
+namespace GetRfidResponse {
+static constexpr CommandId Id = 0x00000017;
+} // namespace GetRfidResponse
+
+namespace ClearRfid {
+static constexpr CommandId Id = 0x00000018;
+} // namespace ClearRfid
+
+namespace ClearRfidResponse {
+static constexpr CommandId Id = 0x00000018;
+} // namespace ClearRfidResponse
+
+namespace ClearAllRfids {
+static constexpr CommandId Id = 0x00000019;
+} // namespace ClearAllRfids
+
+namespace ClearAllRfidsResponse {
+static constexpr CommandId Id = 0x00000019;
+} // namespace ClearAllRfidsResponse
+
+namespace OperationEventNotification {
+static constexpr CommandId Id = 0x00000020;
+} // namespace OperationEventNotification
+
+namespace ProgrammingEventNotification {
+static constexpr CommandId Id = 0x00000021;
+} // namespace ProgrammingEventNotification
+
 } // namespace Commands
 } // namespace DoorLock
 
 namespace WindowCovering {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId UpOrOpen           = 0x00000000;
-static constexpr CommandId DownOrClose        = 0x00000001;
-static constexpr CommandId StopMotion         = 0x00000002;
-static constexpr CommandId GoToLiftValue      = 0x00000004;
-static constexpr CommandId GoToLiftPercentage = 0x00000005;
-static constexpr CommandId GoToTiltValue      = 0x00000007;
-static constexpr CommandId GoToTiltPercentage = 0x00000008;
-} // namespace Ids
+
+namespace UpOrOpen {
+static constexpr CommandId Id = 0x00000000;
+} // namespace UpOrOpen
+
+namespace DownOrClose {
+static constexpr CommandId Id = 0x00000001;
+} // namespace DownOrClose
+
+namespace StopMotion {
+static constexpr CommandId Id = 0x00000002;
+} // namespace StopMotion
+
+namespace GoToLiftValue {
+static constexpr CommandId Id = 0x00000004;
+} // namespace GoToLiftValue
+
+namespace GoToLiftPercentage {
+static constexpr CommandId Id = 0x00000005;
+} // namespace GoToLiftPercentage
+
+namespace GoToTiltValue {
+static constexpr CommandId Id = 0x00000007;
+} // namespace GoToTiltValue
+
+namespace GoToTiltPercentage {
+static constexpr CommandId Id = 0x00000008;
+} // namespace GoToTiltPercentage
+
 } // namespace Commands
 } // namespace WindowCovering
 
 namespace BarrierControl {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId BarrierControlGoToPercent = 0x00000000;
-static constexpr CommandId BarrierControlStop        = 0x00000001;
-} // namespace Ids
+
+namespace BarrierControlGoToPercent {
+static constexpr CommandId Id = 0x00000000;
+} // namespace BarrierControlGoToPercent
+
+namespace BarrierControlStop {
+static constexpr CommandId Id = 0x00000001;
+} // namespace BarrierControlStop
+
 } // namespace Commands
 } // namespace BarrierControl
 
 namespace Thermostat {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId SetpointRaiseLower    = 0x00000000;
-static constexpr CommandId CurrentWeeklySchedule = 0x00000000;
-static constexpr CommandId SetWeeklySchedule     = 0x00000001;
-static constexpr CommandId RelayStatusLog        = 0x00000001;
-static constexpr CommandId GetWeeklySchedule     = 0x00000002;
-static constexpr CommandId ClearWeeklySchedule   = 0x00000003;
-static constexpr CommandId GetRelayStatusLog     = 0x00000004;
-} // namespace Ids
+
+namespace SetpointRaiseLower {
+static constexpr CommandId Id = 0x00000000;
+} // namespace SetpointRaiseLower
+
+namespace CurrentWeeklySchedule {
+static constexpr CommandId Id = 0x00000000;
+} // namespace CurrentWeeklySchedule
+
+namespace SetWeeklySchedule {
+static constexpr CommandId Id = 0x00000001;
+} // namespace SetWeeklySchedule
+
+namespace RelayStatusLog {
+static constexpr CommandId Id = 0x00000001;
+} // namespace RelayStatusLog
+
+namespace GetWeeklySchedule {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetWeeklySchedule
+
+namespace ClearWeeklySchedule {
+static constexpr CommandId Id = 0x00000003;
+} // namespace ClearWeeklySchedule
+
+namespace GetRelayStatusLog {
+static constexpr CommandId Id = 0x00000004;
+} // namespace GetRelayStatusLog
+
 } // namespace Commands
 } // namespace Thermostat
 
 namespace ColorControl {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId MoveToHue                      = 0x00000000;
-static constexpr CommandId MoveHue                        = 0x00000001;
-static constexpr CommandId StepHue                        = 0x00000002;
-static constexpr CommandId MoveToSaturation               = 0x00000003;
-static constexpr CommandId MoveSaturation                 = 0x00000004;
-static constexpr CommandId StepSaturation                 = 0x00000005;
-static constexpr CommandId MoveToHueAndSaturation         = 0x00000006;
-static constexpr CommandId MoveToColor                    = 0x00000007;
-static constexpr CommandId MoveColor                      = 0x00000008;
-static constexpr CommandId StepColor                      = 0x00000009;
-static constexpr CommandId MoveToColorTemperature         = 0x0000000A;
-static constexpr CommandId EnhancedMoveToHue              = 0x00000040;
-static constexpr CommandId EnhancedMoveHue                = 0x00000041;
-static constexpr CommandId EnhancedStepHue                = 0x00000042;
-static constexpr CommandId EnhancedMoveToHueAndSaturation = 0x00000043;
-static constexpr CommandId ColorLoopSet                   = 0x00000044;
-static constexpr CommandId StopMoveStep                   = 0x00000047;
-static constexpr CommandId MoveColorTemperature           = 0x0000004B;
-static constexpr CommandId StepColorTemperature           = 0x0000004C;
-} // namespace Ids
+
+namespace MoveToHue {
+static constexpr CommandId Id = 0x00000000;
+} // namespace MoveToHue
+
+namespace MoveHue {
+static constexpr CommandId Id = 0x00000001;
+} // namespace MoveHue
+
+namespace StepHue {
+static constexpr CommandId Id = 0x00000002;
+} // namespace StepHue
+
+namespace MoveToSaturation {
+static constexpr CommandId Id = 0x00000003;
+} // namespace MoveToSaturation
+
+namespace MoveSaturation {
+static constexpr CommandId Id = 0x00000004;
+} // namespace MoveSaturation
+
+namespace StepSaturation {
+static constexpr CommandId Id = 0x00000005;
+} // namespace StepSaturation
+
+namespace MoveToHueAndSaturation {
+static constexpr CommandId Id = 0x00000006;
+} // namespace MoveToHueAndSaturation
+
+namespace MoveToColor {
+static constexpr CommandId Id = 0x00000007;
+} // namespace MoveToColor
+
+namespace MoveColor {
+static constexpr CommandId Id = 0x00000008;
+} // namespace MoveColor
+
+namespace StepColor {
+static constexpr CommandId Id = 0x00000009;
+} // namespace StepColor
+
+namespace MoveToColorTemperature {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace MoveToColorTemperature
+
+namespace EnhancedMoveToHue {
+static constexpr CommandId Id = 0x00000040;
+} // namespace EnhancedMoveToHue
+
+namespace EnhancedMoveHue {
+static constexpr CommandId Id = 0x00000041;
+} // namespace EnhancedMoveHue
+
+namespace EnhancedStepHue {
+static constexpr CommandId Id = 0x00000042;
+} // namespace EnhancedStepHue
+
+namespace EnhancedMoveToHueAndSaturation {
+static constexpr CommandId Id = 0x00000043;
+} // namespace EnhancedMoveToHueAndSaturation
+
+namespace ColorLoopSet {
+static constexpr CommandId Id = 0x00000044;
+} // namespace ColorLoopSet
+
+namespace StopMoveStep {
+static constexpr CommandId Id = 0x00000047;
+} // namespace StopMoveStep
+
+namespace MoveColorTemperature {
+static constexpr CommandId Id = 0x0000004B;
+} // namespace MoveColorTemperature
+
+namespace StepColorTemperature {
+static constexpr CommandId Id = 0x0000004C;
+} // namespace StepColorTemperature
+
 } // namespace Commands
 } // namespace ColorControl
 
 namespace IasZone {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ZoneEnrollResponse                  = 0x00000000;
-static constexpr CommandId ZoneStatusChangeNotification        = 0x00000000;
-static constexpr CommandId InitiateNormalOperationMode         = 0x00000001;
-static constexpr CommandId ZoneEnrollRequest                   = 0x00000001;
-static constexpr CommandId InitiateTestMode                    = 0x00000002;
-static constexpr CommandId InitiateNormalOperationModeResponse = 0x00000002;
-static constexpr CommandId InitiateTestModeResponse            = 0x00000003;
-} // namespace Ids
+
+namespace ZoneEnrollResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ZoneEnrollResponse
+
+namespace ZoneStatusChangeNotification {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ZoneStatusChangeNotification
+
+namespace InitiateNormalOperationMode {
+static constexpr CommandId Id = 0x00000001;
+} // namespace InitiateNormalOperationMode
+
+namespace ZoneEnrollRequest {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ZoneEnrollRequest
+
+namespace InitiateTestMode {
+static constexpr CommandId Id = 0x00000002;
+} // namespace InitiateTestMode
+
+namespace InitiateNormalOperationModeResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace InitiateNormalOperationModeResponse
+
+namespace InitiateTestModeResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace InitiateTestModeResponse
+
 } // namespace Commands
 } // namespace IasZone
 
 namespace IasAce {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId Arm                        = 0x00000000;
-static constexpr CommandId ArmResponse                = 0x00000000;
-static constexpr CommandId Bypass                     = 0x00000001;
-static constexpr CommandId GetZoneIdMapResponse       = 0x00000001;
-static constexpr CommandId Emergency                  = 0x00000002;
-static constexpr CommandId GetZoneInformationResponse = 0x00000002;
-static constexpr CommandId Fire                       = 0x00000003;
-static constexpr CommandId ZoneStatusChanged          = 0x00000003;
-static constexpr CommandId Panic                      = 0x00000004;
-static constexpr CommandId PanelStatusChanged         = 0x00000004;
-static constexpr CommandId GetZoneIdMap               = 0x00000005;
-static constexpr CommandId GetPanelStatusResponse     = 0x00000005;
-static constexpr CommandId GetZoneInformation         = 0x00000006;
-static constexpr CommandId SetBypassedZoneList        = 0x00000006;
-static constexpr CommandId GetPanelStatus             = 0x00000007;
-static constexpr CommandId BypassResponse             = 0x00000007;
-static constexpr CommandId GetBypassedZoneList        = 0x00000008;
-static constexpr CommandId GetZoneStatusResponse      = 0x00000008;
-static constexpr CommandId GetZoneStatus              = 0x00000009;
-} // namespace Ids
+
+namespace Arm {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Arm
+
+namespace ArmResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ArmResponse
+
+namespace Bypass {
+static constexpr CommandId Id = 0x00000001;
+} // namespace Bypass
+
+namespace GetZoneIdMapResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace GetZoneIdMapResponse
+
+namespace Emergency {
+static constexpr CommandId Id = 0x00000002;
+} // namespace Emergency
+
+namespace GetZoneInformationResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetZoneInformationResponse
+
+namespace Fire {
+static constexpr CommandId Id = 0x00000003;
+} // namespace Fire
+
+namespace ZoneStatusChanged {
+static constexpr CommandId Id = 0x00000003;
+} // namespace ZoneStatusChanged
+
+namespace Panic {
+static constexpr CommandId Id = 0x00000004;
+} // namespace Panic
+
+namespace PanelStatusChanged {
+static constexpr CommandId Id = 0x00000004;
+} // namespace PanelStatusChanged
+
+namespace GetZoneIdMap {
+static constexpr CommandId Id = 0x00000005;
+} // namespace GetZoneIdMap
+
+namespace GetPanelStatusResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace GetPanelStatusResponse
+
+namespace GetZoneInformation {
+static constexpr CommandId Id = 0x00000006;
+} // namespace GetZoneInformation
+
+namespace SetBypassedZoneList {
+static constexpr CommandId Id = 0x00000006;
+} // namespace SetBypassedZoneList
+
+namespace GetPanelStatus {
+static constexpr CommandId Id = 0x00000007;
+} // namespace GetPanelStatus
+
+namespace BypassResponse {
+static constexpr CommandId Id = 0x00000007;
+} // namespace BypassResponse
+
+namespace GetBypassedZoneList {
+static constexpr CommandId Id = 0x00000008;
+} // namespace GetBypassedZoneList
+
+namespace GetZoneStatusResponse {
+static constexpr CommandId Id = 0x00000008;
+} // namespace GetZoneStatusResponse
+
+namespace GetZoneStatus {
+static constexpr CommandId Id = 0x00000009;
+} // namespace GetZoneStatus
+
 } // namespace Commands
 } // namespace IasAce
 
 namespace IasWd {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId StartWarning = 0x00000000;
-static constexpr CommandId Squawk       = 0x00000001;
-} // namespace Ids
+
+namespace StartWarning {
+static constexpr CommandId Id = 0x00000000;
+} // namespace StartWarning
+
+namespace Squawk {
+static constexpr CommandId Id = 0x00000001;
+} // namespace Squawk
+
 } // namespace Commands
 } // namespace IasWd
 
 namespace TvChannel {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ChangeChannel         = 0x00000000;
-static constexpr CommandId ChangeChannelResponse = 0x00000000;
-static constexpr CommandId ChangeChannelByNumber = 0x00000001;
-static constexpr CommandId SkipChannel           = 0x00000002;
-} // namespace Ids
+
+namespace ChangeChannel {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ChangeChannel
+
+namespace ChangeChannelResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ChangeChannelResponse
+
+namespace ChangeChannelByNumber {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ChangeChannelByNumber
+
+namespace SkipChannel {
+static constexpr CommandId Id = 0x00000002;
+} // namespace SkipChannel
+
 } // namespace Commands
 } // namespace TvChannel
 
 namespace TargetNavigator {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId NavigateTarget         = 0x00000000;
-static constexpr CommandId NavigateTargetResponse = 0x00000000;
-} // namespace Ids
+
+namespace NavigateTarget {
+static constexpr CommandId Id = 0x00000000;
+} // namespace NavigateTarget
+
+namespace NavigateTargetResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace NavigateTargetResponse
+
 } // namespace Commands
 } // namespace TargetNavigator
 
 namespace MediaPlayback {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId MediaPlay                 = 0x00000000;
-static constexpr CommandId MediaPlayResponse         = 0x00000000;
-static constexpr CommandId MediaPause                = 0x00000001;
-static constexpr CommandId MediaPauseResponse        = 0x00000001;
-static constexpr CommandId MediaStop                 = 0x00000002;
-static constexpr CommandId MediaStopResponse         = 0x00000002;
-static constexpr CommandId MediaStartOver            = 0x00000003;
-static constexpr CommandId MediaStartOverResponse    = 0x00000003;
-static constexpr CommandId MediaPrevious             = 0x00000004;
-static constexpr CommandId MediaPreviousResponse     = 0x00000004;
-static constexpr CommandId MediaNext                 = 0x00000005;
-static constexpr CommandId MediaNextResponse         = 0x00000005;
-static constexpr CommandId MediaRewind               = 0x00000006;
-static constexpr CommandId MediaRewindResponse       = 0x00000006;
-static constexpr CommandId MediaFastForward          = 0x00000007;
-static constexpr CommandId MediaFastForwardResponse  = 0x00000007;
-static constexpr CommandId MediaSkipForward          = 0x00000008;
-static constexpr CommandId MediaSkipForwardResponse  = 0x00000008;
-static constexpr CommandId MediaSkipBackward         = 0x00000009;
-static constexpr CommandId MediaSkipBackwardResponse = 0x00000009;
-static constexpr CommandId MediaSeek                 = 0x0000000A;
-static constexpr CommandId MediaSeekResponse         = 0x0000000B;
-} // namespace Ids
+
+namespace MediaPlay {
+static constexpr CommandId Id = 0x00000000;
+} // namespace MediaPlay
+
+namespace MediaPlayResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace MediaPlayResponse
+
+namespace MediaPause {
+static constexpr CommandId Id = 0x00000001;
+} // namespace MediaPause
+
+namespace MediaPauseResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace MediaPauseResponse
+
+namespace MediaStop {
+static constexpr CommandId Id = 0x00000002;
+} // namespace MediaStop
+
+namespace MediaStopResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace MediaStopResponse
+
+namespace MediaStartOver {
+static constexpr CommandId Id = 0x00000003;
+} // namespace MediaStartOver
+
+namespace MediaStartOverResponse {
+static constexpr CommandId Id = 0x00000003;
+} // namespace MediaStartOverResponse
+
+namespace MediaPrevious {
+static constexpr CommandId Id = 0x00000004;
+} // namespace MediaPrevious
+
+namespace MediaPreviousResponse {
+static constexpr CommandId Id = 0x00000004;
+} // namespace MediaPreviousResponse
+
+namespace MediaNext {
+static constexpr CommandId Id = 0x00000005;
+} // namespace MediaNext
+
+namespace MediaNextResponse {
+static constexpr CommandId Id = 0x00000005;
+} // namespace MediaNextResponse
+
+namespace MediaRewind {
+static constexpr CommandId Id = 0x00000006;
+} // namespace MediaRewind
+
+namespace MediaRewindResponse {
+static constexpr CommandId Id = 0x00000006;
+} // namespace MediaRewindResponse
+
+namespace MediaFastForward {
+static constexpr CommandId Id = 0x00000007;
+} // namespace MediaFastForward
+
+namespace MediaFastForwardResponse {
+static constexpr CommandId Id = 0x00000007;
+} // namespace MediaFastForwardResponse
+
+namespace MediaSkipForward {
+static constexpr CommandId Id = 0x00000008;
+} // namespace MediaSkipForward
+
+namespace MediaSkipForwardResponse {
+static constexpr CommandId Id = 0x00000008;
+} // namespace MediaSkipForwardResponse
+
+namespace MediaSkipBackward {
+static constexpr CommandId Id = 0x00000009;
+} // namespace MediaSkipBackward
+
+namespace MediaSkipBackwardResponse {
+static constexpr CommandId Id = 0x00000009;
+} // namespace MediaSkipBackwardResponse
+
+namespace MediaSeek {
+static constexpr CommandId Id = 0x0000000A;
+} // namespace MediaSeek
+
+namespace MediaSeekResponse {
+static constexpr CommandId Id = 0x0000000B;
+} // namespace MediaSeekResponse
+
 } // namespace Commands
 } // namespace MediaPlayback
 
 namespace MediaInput {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId SelectInput     = 0x00000000;
-static constexpr CommandId ShowInputStatus = 0x00000001;
-static constexpr CommandId HideInputStatus = 0x00000002;
-static constexpr CommandId RenameInput     = 0x00000003;
-} // namespace Ids
+
+namespace SelectInput {
+static constexpr CommandId Id = 0x00000000;
+} // namespace SelectInput
+
+namespace ShowInputStatus {
+static constexpr CommandId Id = 0x00000001;
+} // namespace ShowInputStatus
+
+namespace HideInputStatus {
+static constexpr CommandId Id = 0x00000002;
+} // namespace HideInputStatus
+
+namespace RenameInput {
+static constexpr CommandId Id = 0x00000003;
+} // namespace RenameInput
+
 } // namespace Commands
 } // namespace MediaInput
 
 namespace LowPower {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId Sleep = 0x00000000;
-} // namespace Ids
+
+namespace Sleep {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Sleep
+
 } // namespace Commands
 } // namespace LowPower
 
 namespace KeypadInput {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId SendKey         = 0x00000000;
-static constexpr CommandId SendKeyResponse = 0x00000000;
-} // namespace Ids
+
+namespace SendKey {
+static constexpr CommandId Id = 0x00000000;
+} // namespace SendKey
+
+namespace SendKeyResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace SendKeyResponse
+
 } // namespace Commands
 } // namespace KeypadInput
 
 namespace ContentLauncher {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId LaunchContent         = 0x00000000;
-static constexpr CommandId LaunchContentResponse = 0x00000000;
-static constexpr CommandId LaunchURL             = 0x00000001;
-static constexpr CommandId LaunchURLResponse     = 0x00000001;
-} // namespace Ids
+
+namespace LaunchContent {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LaunchContent
+
+namespace LaunchContentResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LaunchContentResponse
+
+namespace LaunchURL {
+static constexpr CommandId Id = 0x00000001;
+} // namespace LaunchURL
+
+namespace LaunchURLResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace LaunchURLResponse
+
 } // namespace Commands
 } // namespace ContentLauncher
 
 namespace AudioOutput {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId SelectOutput = 0x00000000;
-static constexpr CommandId RenameOutput = 0x00000001;
-} // namespace Ids
+
+namespace SelectOutput {
+static constexpr CommandId Id = 0x00000000;
+} // namespace SelectOutput
+
+namespace RenameOutput {
+static constexpr CommandId Id = 0x00000001;
+} // namespace RenameOutput
+
 } // namespace Commands
 } // namespace AudioOutput
 
 namespace ApplicationLauncher {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId LaunchApp         = 0x00000000;
-static constexpr CommandId LaunchAppResponse = 0x00000000;
-} // namespace Ids
+
+namespace LaunchApp {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LaunchApp
+
+namespace LaunchAppResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LaunchAppResponse
+
 } // namespace Commands
 } // namespace ApplicationLauncher
 
 namespace ApplicationBasic {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId ChangeStatus = 0x00000000;
-} // namespace Ids
+
+namespace ChangeStatus {
+static constexpr CommandId Id = 0x00000000;
+} // namespace ChangeStatus
+
 } // namespace Commands
 } // namespace ApplicationBasic
 
 namespace AccountLogin {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId GetSetupPIN         = 0x00000000;
-static constexpr CommandId GetSetupPINResponse = 0x00000000;
-static constexpr CommandId Login               = 0x00000001;
-} // namespace Ids
+
+namespace GetSetupPIN {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetSetupPIN
+
+namespace GetSetupPINResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetSetupPINResponse
+
+namespace Login {
+static constexpr CommandId Id = 0x00000001;
+} // namespace Login
+
 } // namespace Commands
 } // namespace AccountLogin
 
 namespace TestCluster {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId Test                     = 0x00000000;
-static constexpr CommandId TestSpecificResponse     = 0x00000000;
-static constexpr CommandId TestNotHandled           = 0x00000001;
-static constexpr CommandId TestAddArgumentsResponse = 0x00000001;
-static constexpr CommandId TestSpecific             = 0x00000002;
-static constexpr CommandId TestUnknownCommand       = 0x00000003;
-static constexpr CommandId TestAddArguments         = 0x00000004;
-} // namespace Ids
+
+namespace Test {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Test
+
+namespace TestSpecificResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace TestSpecificResponse
+
+namespace TestNotHandled {
+static constexpr CommandId Id = 0x00000001;
+} // namespace TestNotHandled
+
+namespace TestAddArgumentsResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace TestAddArgumentsResponse
+
+namespace TestSpecific {
+static constexpr CommandId Id = 0x00000002;
+} // namespace TestSpecific
+
+namespace TestUnknownCommand {
+static constexpr CommandId Id = 0x00000003;
+} // namespace TestUnknownCommand
+
+namespace TestAddArguments {
+static constexpr CommandId Id = 0x00000004;
+} // namespace TestAddArguments
+
 } // namespace Commands
 } // namespace TestCluster
 
 namespace Messaging {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId DisplayMessage          = 0x00000000;
-static constexpr CommandId GetLastMessage          = 0x00000000;
-static constexpr CommandId CancelMessage           = 0x00000001;
-static constexpr CommandId MessageConfirmation     = 0x00000001;
-static constexpr CommandId DisplayProtectedMessage = 0x00000002;
-static constexpr CommandId GetMessageCancellation  = 0x00000002;
-static constexpr CommandId CancelAllMessages       = 0x00000003;
-} // namespace Ids
+
+namespace DisplayMessage {
+static constexpr CommandId Id = 0x00000000;
+} // namespace DisplayMessage
+
+namespace GetLastMessage {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetLastMessage
+
+namespace CancelMessage {
+static constexpr CommandId Id = 0x00000001;
+} // namespace CancelMessage
+
+namespace MessageConfirmation {
+static constexpr CommandId Id = 0x00000001;
+} // namespace MessageConfirmation
+
+namespace DisplayProtectedMessage {
+static constexpr CommandId Id = 0x00000002;
+} // namespace DisplayProtectedMessage
+
+namespace GetMessageCancellation {
+static constexpr CommandId Id = 0x00000002;
+} // namespace GetMessageCancellation
+
+namespace CancelAllMessages {
+static constexpr CommandId Id = 0x00000003;
+} // namespace CancelAllMessages
+
 } // namespace Commands
 } // namespace Messaging
 
 namespace ApplianceEventsAndAlert {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId GetAlerts          = 0x00000000;
-static constexpr CommandId GetAlertsResponse  = 0x00000000;
-static constexpr CommandId AlertsNotification = 0x00000001;
-static constexpr CommandId EventsNotification = 0x00000002;
-} // namespace Ids
+
+namespace GetAlerts {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetAlerts
+
+namespace GetAlertsResponse {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetAlertsResponse
+
+namespace AlertsNotification {
+static constexpr CommandId Id = 0x00000001;
+} // namespace AlertsNotification
+
+namespace EventsNotification {
+static constexpr CommandId Id = 0x00000002;
+} // namespace EventsNotification
+
 } // namespace Commands
 } // namespace ApplianceEventsAndAlert
 
 namespace ApplianceStatistics {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId LogNotification     = 0x00000000;
-static constexpr CommandId LogRequest          = 0x00000000;
-static constexpr CommandId LogResponse         = 0x00000001;
-static constexpr CommandId LogQueueRequest     = 0x00000001;
-static constexpr CommandId LogQueueResponse    = 0x00000002;
-static constexpr CommandId StatisticsAvailable = 0x00000003;
-} // namespace Ids
+
+namespace LogNotification {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LogNotification
+
+namespace LogRequest {
+static constexpr CommandId Id = 0x00000000;
+} // namespace LogRequest
+
+namespace LogResponse {
+static constexpr CommandId Id = 0x00000001;
+} // namespace LogResponse
+
+namespace LogQueueRequest {
+static constexpr CommandId Id = 0x00000001;
+} // namespace LogQueueRequest
+
+namespace LogQueueResponse {
+static constexpr CommandId Id = 0x00000002;
+} // namespace LogQueueResponse
+
+namespace StatisticsAvailable {
+static constexpr CommandId Id = 0x00000003;
+} // namespace StatisticsAvailable
+
 } // namespace Commands
 } // namespace ApplianceStatistics
 
 namespace ElectricalMeasurement {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId GetProfileInfoResponseCommand        = 0x00000000;
-static constexpr CommandId GetProfileInfoCommand                = 0x00000000;
-static constexpr CommandId GetMeasurementProfileResponseCommand = 0x00000001;
-static constexpr CommandId GetMeasurementProfileCommand         = 0x00000001;
-} // namespace Ids
+
+namespace GetProfileInfoResponseCommand {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetProfileInfoResponseCommand
+
+namespace GetProfileInfoCommand {
+static constexpr CommandId Id = 0x00000000;
+} // namespace GetProfileInfoCommand
+
+namespace GetMeasurementProfileResponseCommand {
+static constexpr CommandId Id = 0x00000001;
+} // namespace GetMeasurementProfileResponseCommand
+
+namespace GetMeasurementProfileCommand {
+static constexpr CommandId Id = 0x00000001;
+} // namespace GetMeasurementProfileCommand
+
 } // namespace Commands
 } // namespace ElectricalMeasurement
 
 namespace Binding {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId Bind   = 0x00000000;
-static constexpr CommandId Unbind = 0x00000001;
-} // namespace Ids
+
+namespace Bind {
+static constexpr CommandId Id = 0x00000000;
+} // namespace Bind
+
+namespace Unbind {
+static constexpr CommandId Id = 0x00000001;
+} // namespace Unbind
+
 } // namespace Commands
 } // namespace Binding
 
 namespace SampleMfgSpecificCluster {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId CommandOne = 0x10020000;
-} // namespace Ids
+
+namespace CommandOne {
+static constexpr CommandId Id = 0x10020000;
+} // namespace CommandOne
+
 } // namespace Commands
 } // namespace SampleMfgSpecificCluster
 
 namespace SampleMfgSpecificCluster2 {
 namespace Commands {
-namespace Ids {
-static constexpr CommandId CommandTwo = 0x10490000;
-} // namespace Ids
+
+namespace CommandTwo {
+static constexpr CommandId Id = 0x10490000;
+} // namespace CommandTwo
+
 } // namespace Commands
 } // namespace SampleMfgSpecificCluster2
 

--- a/zzz_generated/bridge-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/bridge-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -369,7 +369,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -436,12 +436,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -559,7 +559,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -630,7 +630,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -701,7 +701,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -764,7 +764,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -826,7 +826,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -901,7 +901,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -968,7 +968,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -1030,7 +1030,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -1080,7 +1080,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -1147,7 +1147,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1218,7 +1218,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -1285,7 +1285,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -1352,7 +1352,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -1411,7 +1411,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -1478,7 +1478,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -1545,7 +1545,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -1612,7 +1612,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1729,17 +1729,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -1789,7 +1789,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1864,7 +1864,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -1923,7 +1923,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -1982,7 +1982,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -2041,7 +2041,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -2099,7 +2099,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -2157,7 +2157,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -2216,7 +2216,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -2276,7 +2276,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR AccountLoginCluster::GetSetupPIN(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AccountLogin::Commands::Ids::GetSetupPIN,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AccountLogin::Commands::GetSetupPIN::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -100,7 +100,7 @@ CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, 
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AccountLogin::Commands::Ids::Login,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AccountLogin::Commands::Login::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -159,7 +159,7 @@ CHIP_ERROR AdministratorCommissioningCluster::OpenBasicCommissioningWindow(Callb
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow,
+                                         AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -204,7 +204,7 @@ CHIP_ERROR AdministratorCommissioningCluster::OpenCommissioningWindow(Callback::
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow,
+                                         AdministratorCommissioning::Commands::OpenCommissioningWindow::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -256,7 +256,7 @@ CHIP_ERROR AdministratorCommissioningCluster::RevokeCommissioning(Callback::Canc
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         AdministratorCommissioning::Commands::Ids::RevokeCommissioning,
+                                         AdministratorCommissioning::Commands::RevokeCommissioning::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -309,7 +309,7 @@ CHIP_ERROR ApplicationBasicCluster::ChangeStatus(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ApplicationBasic::Commands::Ids::ChangeStatus,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ApplicationBasic::Commands::ChangeStatus::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -448,7 +448,7 @@ CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ApplicationLauncher::Commands::Ids::LaunchApp,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ApplicationLauncher::Commands::LaunchApp::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -543,7 +543,7 @@ CHIP_ERROR AudioOutputCluster::RenameOutput(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AudioOutput::Commands::Ids::RenameOutput,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AudioOutput::Commands::RenameOutput::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -586,7 +586,7 @@ CHIP_ERROR AudioOutputCluster::SelectOutput(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AudioOutput::Commands::Ids::SelectOutput,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, AudioOutput::Commands::SelectOutput::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -666,7 +666,7 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         BarrierControl::Commands::Ids::BarrierControlGoToPercent,
+                                         BarrierControl::Commands::BarrierControlGoToPercent::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -707,7 +707,7 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, BarrierControl::Commands::Ids::BarrierControlStop,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, BarrierControl::Commands::BarrierControlStop::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -807,7 +807,7 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Basic::Commands::Ids::MfgSpecificPing,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Basic::Commands::MfgSpecificPing::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1239,7 +1239,7 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Binding::Commands::Ids::Bind,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Binding::Commands::Bind::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1287,7 +1287,7 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Binding::Commands::Ids::Unbind,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Binding::Commands::Unbind::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1548,7 +1548,7 @@ CHIP_ERROR ColorControlCluster::ColorLoopSet(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::ColorLoopSet,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::ColorLoopSet::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1601,7 +1601,7 @@ CHIP_ERROR ColorControlCluster::EnhancedMoveHue(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::EnhancedMoveHue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::EnhancedMoveHue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1649,7 +1649,7 @@ CHIP_ERROR ColorControlCluster::EnhancedMoveToHue(Callback::Cancelable * onSucce
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::EnhancedMoveToHue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::EnhancedMoveToHue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1701,7 +1701,7 @@ CHIP_ERROR ColorControlCluster::EnhancedMoveToHueAndSaturation(Callback::Cancela
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         ColorControl::Commands::Ids::EnhancedMoveToHueAndSaturation,
+                                         ColorControl::Commands::EnhancedMoveToHueAndSaturation::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1751,7 +1751,7 @@ CHIP_ERROR ColorControlCluster::EnhancedStepHue(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::EnhancedStepHue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::EnhancedStepHue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1800,7 +1800,7 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveColor,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveColor::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1849,7 +1849,7 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveColorTemperature,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveColorTemperature::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1900,7 +1900,7 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveHue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveHue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1947,7 +1947,7 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveSaturation,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveSaturation::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -1995,7 +1995,7 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveToColor,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveToColor::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2046,7 +2046,7 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         ColorControl::Commands::Ids::MoveToColorTemperature,
+                                         ColorControl::Commands::MoveToColorTemperature::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2094,7 +2094,7 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveToHue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveToHue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2145,7 +2145,7 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         ColorControl::Commands::Ids::MoveToHueAndSaturation,
+                                         ColorControl::Commands::MoveToHueAndSaturation::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2195,7 +2195,7 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::MoveToSaturation,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::MoveToSaturation::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2243,7 +2243,7 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::StepColor,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::StepColor::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2294,7 +2294,7 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::StepColorTemperature,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::StepColorTemperature::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2348,7 +2348,7 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::StepHue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::StepHue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2398,7 +2398,7 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::StepSaturation,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::StepSaturation::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -2447,7 +2447,7 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::Ids::StopMoveStep,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ColorControl::Commands::StopMoveStep::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3440,7 +3440,7 @@ CHIP_ERROR ContentLauncherCluster::LaunchContent(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ContentLauncher::Commands::Ids::LaunchContent,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ContentLauncher::Commands::LaunchContent::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3483,7 +3483,7 @@ CHIP_ERROR ContentLauncherCluster::LaunchURL(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ContentLauncher::Commands::Ids::LaunchURL,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, ContentLauncher::Commands::LaunchURL::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3627,8 +3627,7 @@ CHIP_ERROR DiagnosticLogsCluster::RetrieveLogsRequest(Callback::Cancelable * onS
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         DiagnosticLogs::Commands::Ids::RetrieveLogsRequest,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DiagnosticLogs::Commands::RetrieveLogsRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3675,7 +3674,7 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearAllPins,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearAllPins::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3713,7 +3712,7 @@ CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearAllRfids,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearAllRfids::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3752,7 +3751,7 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearHolidaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearHolidaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3793,7 +3792,7 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearPin,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearPin::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3834,7 +3833,7 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearRfid,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearRfid::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3875,7 +3874,7 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearWeekdaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearWeekdaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3918,7 +3917,7 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::ClearYeardaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::ClearYeardaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -3961,7 +3960,7 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetHolidaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetHolidaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4002,7 +4001,7 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetLogRecord,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetLogRecord::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4043,7 +4042,7 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetPin,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetPin::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4084,7 +4083,7 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetRfid,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetRfid::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4125,7 +4124,7 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetUserType,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetUserType::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4166,7 +4165,7 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetWeekdaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetWeekdaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4209,7 +4208,7 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::GetYeardaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::GetYeardaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4252,7 +4251,7 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::LockDoor,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::LockDoor::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4294,7 +4293,7 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::SetHolidaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::SetHolidaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4341,7 +4340,7 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::SetPin,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::SetPin::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4388,7 +4387,7 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::SetRfid,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::SetRfid::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4435,7 +4434,7 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::SetUserType,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::SetUserType::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4479,7 +4478,7 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::SetWeekdaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::SetWeekdaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4532,7 +4531,7 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::SetYeardaySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::SetYeardaySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4579,7 +4578,7 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::UnlockDoor,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::UnlockDoor::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4620,7 +4619,7 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::Ids::UnlockWithTimeout,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, DoorLock::Commands::UnlockWithTimeout::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -4878,7 +4877,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsCluster::ResetCounts(Callback::Cancelable *
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         EthernetNetworkDiagnostics::Commands::Ids::ResetCounts,
+                                         EthernetNetworkDiagnostics::Commands::ResetCounts::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5068,7 +5067,7 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, GeneralCommissioning::Commands::Ids::ArmFailSafe,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, GeneralCommissioning::Commands::ArmFailSafe::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5114,7 +5113,7 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         GeneralCommissioning::Commands::Ids::CommissioningComplete,
+                                         GeneralCommissioning::Commands::CommissioningComplete::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5155,7 +5154,7 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         GeneralCommissioning::Commands::Ids::SetRegulatoryConfig,
+                                         GeneralCommissioning::Commands::SetRegulatoryConfig::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5369,7 +5368,7 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::Ids::AddGroup,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::AddGroup::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5412,7 +5411,7 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::Ids::AddGroupIfIdentifying,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::AddGroupIfIdentifying::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5455,7 +5454,7 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::Ids::GetGroupMembership,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::GetGroupMembership::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5497,7 +5496,7 @@ CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::Ids::RemoveAllGroups,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::RemoveAllGroups::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5536,7 +5535,7 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::Ids::RemoveGroup,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::RemoveGroup::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5577,7 +5576,7 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::Ids::ViewGroup,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Groups::Commands::ViewGroup::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5644,7 +5643,7 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Identify::Commands::Ids::Identify,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Identify::Commands::Identify::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5684,7 +5683,7 @@ CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Identify::Commands::Ids::IdentifyQuery,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Identify::Commands::IdentifyQuery::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5766,7 +5765,7 @@ CHIP_ERROR KeypadInputCluster::SendKey(Callback::Cancelable * onSuccessCallback,
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, KeypadInput::Commands::Ids::SendKey,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, KeypadInput::Commands::SendKey::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5821,7 +5820,7 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::Move,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Move::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5868,7 +5867,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::MoveToLevel,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::MoveToLevel::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5916,7 +5915,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::MoveToLevelWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::MoveToLevelWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -5959,7 +5958,7 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::MoveWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::MoveWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6003,7 +6002,7 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::Step,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Step::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6052,7 +6051,7 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::StepWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::StepWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6097,7 +6096,7 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::Stop,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Stop::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6139,7 +6138,7 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::StopWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::StopWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6221,7 +6220,7 @@ CHIP_ERROR LowPowerCluster::Sleep(Callback::Cancelable * onSuccessCallback, Call
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LowPower::Commands::Ids::Sleep,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LowPower::Commands::Sleep::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6273,7 +6272,7 @@ CHIP_ERROR MediaInputCluster::HideInputStatus(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::Ids::HideInputStatus,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::HideInputStatus::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6312,7 +6311,7 @@ CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::Ids::RenameInput,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::RenameInput::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6355,7 +6354,7 @@ CHIP_ERROR MediaInputCluster::SelectInput(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::Ids::SelectInput,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::SelectInput::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6395,7 +6394,7 @@ CHIP_ERROR MediaInputCluster::ShowInputStatus(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::Ids::ShowInputStatus,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaInput::Commands::ShowInputStatus::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6472,7 +6471,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaFastForward(Callback::Cancelable * onSucce
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaFastForward,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaFastForward::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6510,7 +6509,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaNext(Callback::Cancelable * onSuccessCallb
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaNext,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaNext::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6548,7 +6547,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaPause(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaPause,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaPause::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6586,7 +6585,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaPlay(Callback::Cancelable * onSuccessCallb
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaPlay,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaPlay::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6624,7 +6623,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaPrevious(Callback::Cancelable * onSuccessC
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaPrevious,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaPrevious::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6662,7 +6661,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaRewind(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaRewind,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaRewind::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6701,7 +6700,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaSeek(Callback::Cancelable * onSuccessCallb
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaSeek,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaSeek::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6742,7 +6741,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipBackward(Callback::Cancelable * onSucc
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaSkipBackward,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaSkipBackward::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6783,7 +6782,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipForward(Callback::Cancelable * onSucce
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaSkipForward,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaSkipForward::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6823,7 +6822,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaStartOver(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaStartOver,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaStartOver::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -6861,7 +6860,7 @@ CHIP_ERROR MediaPlaybackCluster::MediaStop(Callback::Cancelable * onSuccessCallb
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::Ids::MediaStop,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, MediaPlayback::Commands::MediaStop::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7012,7 +7011,7 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::AddThreadNetwork,
+                                         NetworkCommissioning::Commands::AddThreadNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7059,7 +7058,7 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::AddWiFiNetwork,
+                                         NetworkCommissioning::Commands::AddWiFiNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7108,7 +7107,7 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::DisableNetwork,
+                                         NetworkCommissioning::Commands::DisableNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7154,8 +7153,7 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::EnableNetwork,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::EnableNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7202,7 +7200,7 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult,
+                                         NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7244,8 +7242,7 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::RemoveNetwork,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::RemoveNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7291,7 +7288,7 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::Ids::ScanNetworks,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::ScanNetworks::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7339,7 +7336,7 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::UpdateThreadNetwork,
+                                         NetworkCommissioning::Commands::UpdateThreadNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7386,7 +7383,7 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork,
+                                         NetworkCommissioning::Commands::UpdateWiFiNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7461,7 +7458,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::ApplyUpdateRequest(Callback::Cancel
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest,
+                                         OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7506,7 +7503,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::NotifyUpdateApplied(Callback::Cance
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied,
+                                         OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7553,7 +7550,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateProvider::Commands::Ids::QueryImage,
+                                         OtaSoftwareUpdateProvider::Commands::QueryImage::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7625,7 +7622,7 @@ CHIP_ERROR OtaSoftwareUpdateRequestorCluster::AnnounceOtaProvider(Callback::Canc
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateRequestor::Commands::Ids::AnnounceOtaProvider,
+                                         OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7795,7 +7792,7 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::Off,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Off::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7834,7 +7831,7 @@ CHIP_ERROR OnOffCluster::OffWithEffect(Callback::Cancelable * onSuccessCallback,
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::OffWithEffect,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::OffWithEffect::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7876,7 +7873,7 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::On,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::On::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7914,7 +7911,7 @@ CHIP_ERROR OnOffCluster::OnWithRecallGlobalScene(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::OnWithRecallGlobalScene,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::OnWithRecallGlobalScene::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7953,7 +7950,7 @@ CHIP_ERROR OnOffCluster::OnWithTimedOff(Callback::Cancelable * onSuccessCallback
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::OnWithTimedOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::OnWithTimedOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -7997,7 +7994,7 @@ CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::Toggle,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Toggle::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8243,7 +8240,7 @@ CHIP_ERROR OperationalCredentialsCluster::AddNOC(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OperationalCredentials::Commands::Ids::AddNOC,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OperationalCredentials::Commands::AddNOC::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8294,7 +8291,7 @@ CHIP_ERROR OperationalCredentialsCluster::AddTrustedRootCertificate(Callback::Ca
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::AddTrustedRootCertificate,
+                                         OperationalCredentials::Commands::AddTrustedRootCertificate::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8337,7 +8334,7 @@ CHIP_ERROR OperationalCredentialsCluster::AttestationRequest(Callback::Cancelabl
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::AttestationRequest,
+                                         OperationalCredentials::Commands::AttestationRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8379,7 +8376,7 @@ CHIP_ERROR OperationalCredentialsCluster::CertificateChainRequest(Callback::Canc
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::CertificateChainRequest,
+                                         OperationalCredentials::Commands::CertificateChainRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8421,7 +8418,7 @@ CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::OpCSRRequest,
+                                         OperationalCredentials::Commands::OpCSRRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8463,7 +8460,7 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::RemoveFabric,
+                                         OperationalCredentials::Commands::RemoveFabric::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8506,7 +8503,7 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveTrustedRootCertificate(Callback:
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate,
+                                         OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8548,7 +8545,7 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::UpdateFabricLabel,
+                                         OperationalCredentials::Commands::UpdateFabricLabel::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -8590,7 +8587,7 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateNOC(Callback::Cancelable * onSuc
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OperationalCredentials::Commands::Ids::UpdateNOC,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OperationalCredentials::Commands::UpdateNOC::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9087,7 +9084,7 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::AddScene,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::AddScene::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9140,7 +9137,7 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::GetSceneMembership,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::GetSceneMembership::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9181,7 +9178,7 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::RecallScene,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::RecallScene::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9226,7 +9223,7 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::RemoveAllScenes,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::RemoveAllScenes::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9267,7 +9264,7 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::RemoveScene,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::RemoveScene::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9310,7 +9307,7 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::StoreScene,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::StoreScene::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9353,7 +9350,7 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::Ids::ViewScene,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Scenes::Commands::ViewScene::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9471,7 +9468,7 @@ CHIP_ERROR SoftwareDiagnosticsCluster::ResetWatermarks(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         SoftwareDiagnostics::Commands::Ids::ResetWatermarks,
+                                         SoftwareDiagnostics::Commands::ResetWatermarks::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9616,7 +9613,7 @@ CHIP_ERROR TvChannelCluster::ChangeChannel(Callback::Cancelable * onSuccessCallb
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TvChannel::Commands::Ids::ChangeChannel,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TvChannel::Commands::ChangeChannel::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9658,7 +9655,7 @@ CHIP_ERROR TvChannelCluster::ChangeChannelByNumber(Callback::Cancelable * onSucc
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TvChannel::Commands::Ids::ChangeChannelByNumber,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TvChannel::Commands::ChangeChannelByNumber::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9701,7 +9698,7 @@ CHIP_ERROR TvChannelCluster::SkipChannel(Callback::Cancelable * onSuccessCallbac
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TvChannel::Commands::Ids::SkipChannel,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TvChannel::Commands::SkipChannel::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9792,7 +9789,7 @@ CHIP_ERROR TargetNavigatorCluster::NavigateTarget(Callback::Cancelable * onSucce
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TargetNavigator::Commands::Ids::NavigateTarget,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TargetNavigator::Commands::NavigateTarget::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9928,7 +9925,7 @@ CHIP_ERROR TestClusterCluster::Test(Callback::Cancelable * onSuccessCallback, Ca
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::Ids::Test,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::Test::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -9967,7 +9964,7 @@ CHIP_ERROR TestClusterCluster::TestAddArguments(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::Ids::TestAddArguments,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::TestAddArguments::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10009,7 +10006,7 @@ CHIP_ERROR TestClusterCluster::TestNotHandled(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::Ids::TestNotHandled,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::TestNotHandled::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10047,7 +10044,7 @@ CHIP_ERROR TestClusterCluster::TestSpecific(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::Ids::TestSpecific,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::TestSpecific::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10086,7 +10083,7 @@ CHIP_ERROR TestClusterCluster::TestUnknownCommand(Callback::Cancelable * onSucce
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::Ids::TestUnknownCommand,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, TestCluster::Commands::TestUnknownCommand::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10813,7 +10810,7 @@ CHIP_ERROR ThermostatCluster::ClearWeeklySchedule(Callback::Cancelable * onSucce
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::Ids::ClearWeeklySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::ClearWeeklySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10851,7 +10848,7 @@ CHIP_ERROR ThermostatCluster::GetRelayStatusLog(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::Ids::GetRelayStatusLog,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::GetRelayStatusLog::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10890,7 +10887,7 @@ CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::Ids::GetWeeklySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::GetWeeklySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10934,7 +10931,7 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::Ids::SetWeeklySchedule,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::SetWeeklySchedule::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -10981,7 +10978,7 @@ CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::Ids::SetpointRaiseLower,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, Thermostat::Commands::SetpointRaiseLower::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -11501,7 +11498,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsCluster::ResetCounts(Callback::Cancelable * o
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         ThreadNetworkDiagnostics::Commands::Ids::ResetCounts,
+                                         ThreadNetworkDiagnostics::Commands::ResetCounts::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12336,8 +12333,7 @@ CHIP_ERROR WiFiNetworkDiagnosticsCluster::ResetCounts(Callback::Cancelable * onS
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         WiFiNetworkDiagnostics::Commands::Ids::ResetCounts,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WiFiNetworkDiagnostics::Commands::ResetCounts::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12545,7 +12541,7 @@ CHIP_ERROR WindowCoveringCluster::DownOrClose(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::DownOrClose,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::DownOrClose::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12585,7 +12581,7 @@ CHIP_ERROR WindowCoveringCluster::GoToLiftPercentage(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::GoToLiftPercentage,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::GoToLiftPercentage::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12628,7 +12624,7 @@ CHIP_ERROR WindowCoveringCluster::GoToLiftValue(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::GoToLiftValue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::GoToLiftValue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12670,7 +12666,7 @@ CHIP_ERROR WindowCoveringCluster::GoToTiltPercentage(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::GoToTiltPercentage,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::GoToTiltPercentage::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12713,7 +12709,7 @@ CHIP_ERROR WindowCoveringCluster::GoToTiltValue(Callback::Cancelable * onSuccess
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::GoToTiltValue,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::GoToTiltValue::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12753,7 +12749,7 @@ CHIP_ERROR WindowCoveringCluster::StopMotion(Callback::Cancelable * onSuccessCal
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::StopMotion,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::StopMotion::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -12791,7 +12787,7 @@ CHIP_ERROR WindowCoveringCluster::UpOrOpen(Callback::Cancelable * onSuccessCallb
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::Ids::UpOrOpen,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, WindowCovering::Commands::UpOrOpen::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));

--- a/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::AccountLogin::Commands::Ids::GetSetupPINResponse: {
+        case Clusters::AccountLogin::Commands::GetSetupPINResponse::Id: {
             expectArgumentCount = 1;
             const uint8_t * setupPIN;
             bool argExists[1];
@@ -173,7 +173,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::ApplicationLauncher::Commands::Ids::LaunchAppResponse: {
+        case Clusters::ApplicationLauncher::Commands::LaunchAppResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
             const uint8_t * data;
@@ -283,7 +283,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::ContentLauncher::Commands::Ids::LaunchContentResponse: {
+        case Clusters::ContentLauncher::Commands::LaunchContentResponse::Id: {
             expectArgumentCount = 2;
             const uint8_t * data;
             uint8_t contentLaunchStatus;
@@ -347,7 +347,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::ContentLauncher::Commands::Ids::LaunchURLResponse: {
+        case Clusters::ContentLauncher::Commands::LaunchURLResponse::Id: {
             expectArgumentCount = 2;
             const uint8_t * data;
             uint8_t contentLaunchStatus;
@@ -456,7 +456,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::DoorLock::Commands::Ids::ClearAllPinsResponse: {
+        case Clusters::DoorLock::Commands::ClearAllPinsResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -514,7 +514,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearAllRfidsResponse: {
+        case Clusters::DoorLock::Commands::ClearAllRfidsResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -572,7 +572,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearHolidayScheduleResponse: {
+        case Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -630,7 +630,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearPinResponse: {
+        case Clusters::DoorLock::Commands::ClearPinResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -688,7 +688,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearRfidResponse: {
+        case Clusters::DoorLock::Commands::ClearRfidResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -746,7 +746,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearWeekdayScheduleResponse: {
+        case Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -804,7 +804,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearYeardayScheduleResponse: {
+        case Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -862,7 +862,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetHolidayScheduleResponse: {
+        case Clusters::DoorLock::Commands::GetHolidayScheduleResponse::Id: {
             expectArgumentCount = 5;
             uint8_t scheduleId;
             uint8_t status;
@@ -937,7 +937,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetLogRecordResponse: {
+        case Clusters::DoorLock::Commands::GetLogRecordResponse::Id: {
             expectArgumentCount = 7;
             uint16_t logEntryId;
             uint32_t timestamp;
@@ -1022,7 +1022,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetPinResponse: {
+        case Clusters::DoorLock::Commands::GetPinResponse::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -1094,7 +1094,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetRfidResponse: {
+        case Clusters::DoorLock::Commands::GetRfidResponse::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -1166,7 +1166,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetUserTypeResponse: {
+        case Clusters::DoorLock::Commands::GetUserTypeResponse::Id: {
             expectArgumentCount = 2;
             uint16_t userId;
             uint8_t userType;
@@ -1228,7 +1228,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetWeekdayScheduleResponse: {
+        case Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::Id: {
             expectArgumentCount = 8;
             uint8_t scheduleId;
             uint16_t userId;
@@ -1315,7 +1315,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetYeardayScheduleResponse: {
+        case Clusters::DoorLock::Commands::GetYeardayScheduleResponse::Id: {
             expectArgumentCount = 5;
             uint8_t scheduleId;
             uint16_t userId;
@@ -1390,7 +1390,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::LockDoorResponse: {
+        case Clusters::DoorLock::Commands::LockDoorResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1448,7 +1448,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetHolidayScheduleResponse: {
+        case Clusters::DoorLock::Commands::SetHolidayScheduleResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1506,7 +1506,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetPinResponse: {
+        case Clusters::DoorLock::Commands::SetPinResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1564,7 +1564,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetRfidResponse: {
+        case Clusters::DoorLock::Commands::SetRfidResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1622,7 +1622,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetUserTypeResponse: {
+        case Clusters::DoorLock::Commands::SetUserTypeResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1680,7 +1680,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetWeekdayScheduleResponse: {
+        case Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1738,7 +1738,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetYeardayScheduleResponse: {
+        case Clusters::DoorLock::Commands::SetYeardayScheduleResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1796,7 +1796,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockDoorResponse: {
+        case Clusters::DoorLock::Commands::UnlockDoorResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1854,7 +1854,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockWithTimeoutResponse: {
+        case Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -1957,7 +1957,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafeResponse: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -2021,7 +2021,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningCompleteResponse: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -2085,7 +2085,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfigResponse: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -2195,7 +2195,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::Groups::Commands::Ids::AddGroupResponse: {
+        case Clusters::Groups::Commands::AddGroupResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
             uint16_t groupId;
@@ -2257,7 +2257,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::GetGroupMembershipResponse: {
+        case Clusters::Groups::Commands::GetGroupMembershipResponse::Id: {
             expectArgumentCount = 3;
             uint8_t capacity;
             uint8_t groupCount;
@@ -2325,7 +2325,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveGroupResponse: {
+        case Clusters::Groups::Commands::RemoveGroupResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
             uint16_t groupId;
@@ -2387,7 +2387,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::ViewGroupResponse: {
+        case Clusters::Groups::Commands::ViewGroupResponse::Id: {
             expectArgumentCount = 3;
             uint8_t status;
             uint16_t groupId;
@@ -2500,7 +2500,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::Identify::Commands::Ids::IdentifyQueryResponse: {
+        case Clusters::Identify::Commands::IdentifyQueryResponse::Id: {
             expectArgumentCount = 1;
             uint16_t timeout;
             bool argExists[1];
@@ -2603,7 +2603,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::KeypadInput::Commands::Ids::SendKeyResponse: {
+        case Clusters::KeypadInput::Commands::SendKeyResponse::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -2706,7 +2706,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::MediaPlayback::Commands::Ids::MediaFastForwardResponse: {
+        case Clusters::MediaPlayback::Commands::MediaFastForwardResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -2765,7 +2765,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaNextResponse: {
+        case Clusters::MediaPlayback::Commands::MediaNextResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -2823,7 +2823,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaPauseResponse: {
+        case Clusters::MediaPlayback::Commands::MediaPauseResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -2881,7 +2881,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaPlayResponse: {
+        case Clusters::MediaPlayback::Commands::MediaPlayResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -2939,7 +2939,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaPreviousResponse: {
+        case Clusters::MediaPlayback::Commands::MediaPreviousResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -2998,7 +2998,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaRewindResponse: {
+        case Clusters::MediaPlayback::Commands::MediaRewindResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -3056,7 +3056,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaSeekResponse: {
+        case Clusters::MediaPlayback::Commands::MediaSeekResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -3114,7 +3114,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaSkipBackwardResponse: {
+        case Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -3173,7 +3173,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaSkipForwardResponse: {
+        case Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -3232,7 +3232,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaStartOverResponse: {
+        case Clusters::MediaPlayback::Commands::MediaStartOverResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -3291,7 +3291,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaStopResponse: {
+        case Clusters::MediaPlayback::Commands::MediaStopResponse::Id: {
             expectArgumentCount = 1;
             uint8_t mediaPlaybackStatus;
             bool argExists[1];
@@ -3394,7 +3394,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3458,7 +3458,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3522,7 +3522,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3586,7 +3586,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3650,7 +3650,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3714,7 +3714,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworksResponse: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::Id: {
             expectArgumentCount = 4;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3788,7 +3788,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3852,7 +3852,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3962,7 +3962,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequestResponse: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequestResponse::Id: {
             expectArgumentCount = 2;
             uint8_t action;
             uint32_t delayedActionTime;
@@ -4025,7 +4025,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImageResponse: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::Id: {
             expectArgumentCount = 8;
             uint8_t status;
             uint32_t delayedActionTime;
@@ -4161,7 +4161,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationResponse: {
+        case Clusters::OperationalCredentials::Commands::AttestationResponse::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan AttestationElements;
             chip::ByteSpan Signature;
@@ -4224,7 +4224,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainResponse: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainResponse::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan Certificate;
             bool argExists[1];
@@ -4283,7 +4283,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::NOCResponse: {
+        case Clusters::OperationalCredentials::Commands::NOCResponse::Id: {
             expectArgumentCount = 3;
             uint8_t StatusCode;
             uint8_t FabricIndex;
@@ -4350,7 +4350,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRResponse: {
+        case Clusters::OperationalCredentials::Commands::OpCSRResponse::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCSRElements;
             chip::ByteSpan AttestationSignature;
@@ -4459,7 +4459,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::Scenes::Commands::Ids::AddSceneResponse: {
+        case Clusters::Scenes::Commands::AddSceneResponse::Id: {
             expectArgumentCount = 3;
             uint8_t status;
             uint16_t groupId;
@@ -4525,7 +4525,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::GetSceneMembershipResponse: {
+        case Clusters::Scenes::Commands::GetSceneMembershipResponse::Id: {
             expectArgumentCount = 5;
             uint8_t status;
             uint8_t capacity;
@@ -4601,7 +4601,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveAllScenesResponse: {
+        case Clusters::Scenes::Commands::RemoveAllScenesResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
             uint16_t groupId;
@@ -4663,7 +4663,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveSceneResponse: {
+        case Clusters::Scenes::Commands::RemoveSceneResponse::Id: {
             expectArgumentCount = 3;
             uint8_t status;
             uint16_t groupId;
@@ -4729,7 +4729,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::StoreSceneResponse: {
+        case Clusters::Scenes::Commands::StoreSceneResponse::Id: {
             expectArgumentCount = 3;
             uint8_t status;
             uint16_t groupId;
@@ -4795,7 +4795,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::ViewSceneResponse: {
+        case Clusters::Scenes::Commands::ViewSceneResponse::Id: {
             expectArgumentCount = 6;
             uint8_t status;
             uint16_t groupId;
@@ -4922,7 +4922,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::TvChannel::Commands::Ids::ChangeChannelResponse: {
+        case Clusters::TvChannel::Commands::ChangeChannelResponse::Id: {
             expectArgumentCount = 2;
             /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch;
             uint8_t ErrorType;
@@ -5031,7 +5031,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::TargetNavigator::Commands::Ids::NavigateTargetResponse: {
+        case Clusters::TargetNavigator::Commands::NavigateTargetResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
             const uint8_t * data;
@@ -5140,7 +5140,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::TestCluster::Commands::Ids::TestAddArgumentsResponse: {
+        case Clusters::TestCluster::Commands::TestAddArgumentsResponse::Id: {
             expectArgumentCount = 1;
             uint8_t returnValue;
             bool argExists[1];
@@ -5198,7 +5198,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestSpecificResponse: {
+        case Clusters::TestCluster::Commands::TestSpecificResponse::Id: {
             expectArgumentCount = 1;
             uint8_t returnValue;
             bool argExists[1];

--- a/zzz_generated/lighting-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/lighting-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ColorControl::Commands::Ids::ColorLoopSet: {
+        case Clusters::ColorControl::Commands::ColorLoopSet::Id: {
             expectArgumentCount = 7;
             uint8_t updateFlags;
             uint8_t action;
@@ -340,7 +340,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedMoveHue: {
+        case Clusters::ColorControl::Commands::EnhancedMoveHue::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint16_t rate;
@@ -411,7 +411,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedMoveToHue: {
+        case Clusters::ColorControl::Commands::EnhancedMoveToHue::Id: {
             expectArgumentCount = 5;
             uint16_t enhancedHue;
             uint8_t direction;
@@ -486,7 +486,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedMoveToHueAndSaturation: {
+        case Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Id: {
             expectArgumentCount = 5;
             uint16_t enhancedHue;
             uint8_t saturation;
@@ -561,7 +561,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::EnhancedStepHue: {
+        case Clusters::ColorControl::Commands::EnhancedStepHue::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint16_t stepSize;
@@ -636,7 +636,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveColor: {
+        case Clusters::ColorControl::Commands::MoveColor::Id: {
             expectArgumentCount = 4;
             int16_t rateX;
             int16_t rateY;
@@ -707,7 +707,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveColorTemperature::Id: {
             expectArgumentCount = 6;
             uint8_t moveMode;
             uint16_t rate;
@@ -787,7 +787,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveHue: {
+        case Clusters::ColorControl::Commands::MoveHue::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -858,7 +858,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveSaturation: {
+        case Clusters::ColorControl::Commands::MoveSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -929,7 +929,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColor: {
+        case Clusters::ColorControl::Commands::MoveToColor::Id: {
             expectArgumentCount = 5;
             uint16_t colorX;
             uint16_t colorY;
@@ -1004,7 +1004,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveToColorTemperature::Id: {
             expectArgumentCount = 4;
             uint16_t colorTemperature;
             uint16_t transitionTime;
@@ -1075,7 +1075,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHue: {
+        case Clusters::ColorControl::Commands::MoveToHue::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t direction;
@@ -1150,7 +1150,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHueAndSaturation: {
+        case Clusters::ColorControl::Commands::MoveToHueAndSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t saturation;
@@ -1225,7 +1225,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToSaturation: {
+        case Clusters::ColorControl::Commands::MoveToSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t saturation;
             uint16_t transitionTime;
@@ -1296,7 +1296,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColor: {
+        case Clusters::ColorControl::Commands::StepColor::Id: {
             expectArgumentCount = 5;
             int16_t stepX;
             int16_t stepY;
@@ -1371,7 +1371,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColorTemperature: {
+        case Clusters::ColorControl::Commands::StepColorTemperature::Id: {
             expectArgumentCount = 7;
             uint8_t stepMode;
             uint16_t stepSize;
@@ -1455,7 +1455,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepHue: {
+        case Clusters::ColorControl::Commands::StepHue::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1530,7 +1530,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepSaturation: {
+        case Clusters::ColorControl::Commands::StepSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1605,7 +1605,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StopMoveStep: {
+        case Clusters::ColorControl::Commands::StopMoveStep::Id: {
             expectArgumentCount = 2;
             uint8_t optionsMask;
             uint8_t optionsOverride;
@@ -1713,7 +1713,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -1825,7 +1825,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::EthernetNetworkDiagnostics::Commands::Ids::ResetCounts: {
+        case Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Id: {
 
             wasHandled = emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(aEndpointId, apCommandObj);
             break;
@@ -1876,7 +1876,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -1943,12 +1943,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -2066,7 +2066,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -2137,7 +2137,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -2208,7 +2208,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -2271,7 +2271,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -2333,7 +2333,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -2408,7 +2408,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -2475,7 +2475,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -2537,7 +2537,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -2587,7 +2587,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -2654,7 +2654,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -2725,7 +2725,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -2792,7 +2792,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -2859,7 +2859,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -2918,7 +2918,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -2985,7 +2985,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -3052,7 +3052,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -3119,7 +3119,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -3236,17 +3236,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -3296,7 +3296,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -3371,7 +3371,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -3430,7 +3430,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -3489,7 +3489,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -3548,7 +3548,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -3606,7 +3606,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -3664,7 +3664,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -3723,7 +3723,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -3783,7 +3783,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -3891,7 +3891,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::SoftwareDiagnostics::Commands::Ids::ResetWatermarks: {
+        case Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Id: {
 
             wasHandled = emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(aEndpointId, apCommandObj);
             break;
@@ -3942,7 +3942,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ThreadNetworkDiagnostics::Commands::Ids::ResetCounts: {
+        case Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Id: {
 
             wasHandled = emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(aEndpointId, apCommandObj);
             break;
@@ -3993,7 +3993,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::WiFiNetworkDiagnostics::Commands::Ids::ResetCounts: {
+        case Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Id: {
 
             wasHandled = emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(aEndpointId, apCommandObj);
             break;

--- a/zzz_generated/lock-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/lock-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -369,7 +369,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -436,12 +436,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -559,7 +559,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -626,7 +626,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -697,7 +697,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -764,7 +764,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -831,7 +831,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -890,7 +890,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -957,7 +957,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -1024,7 +1024,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -1091,7 +1091,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1208,17 +1208,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -1268,7 +1268,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1343,7 +1343,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -1402,7 +1402,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -1461,7 +1461,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -1520,7 +1520,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -1578,7 +1578,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -1636,7 +1636,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -1695,7 +1695,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -1755,7 +1755,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;

--- a/zzz_generated/ota-provider-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/ota-provider-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t newVersion;
@@ -131,7 +131,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t softwareVersion;
@@ -194,7 +194,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImage: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Id: {
             expectArgumentCount = 8;
             uint16_t vendorId;
             uint16_t productId;
@@ -329,7 +329,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -404,7 +404,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -463,7 +463,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -522,7 +522,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -581,7 +581,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -639,7 +639,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -697,7 +697,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
@@ -61,7 +61,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::ApplyUpdateRequest(Callback::Cancel
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest,
+                                         OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -106,7 +106,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::NotifyUpdateApplied(Callback::Cance
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied,
+                                         OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -153,7 +153,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OtaSoftwareUpdateProvider::Commands::Ids::QueryImage,
+                                         OtaSoftwareUpdateProvider::Commands::QueryImage::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));

--- a/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequestResponse: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequestResponse::Id: {
             expectArgumentCount = 2;
             uint8_t action;
             uint32_t delayedActionTime;
@@ -131,7 +131,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImageResponse: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::Id: {
             expectArgumentCount = 8;
             uint8_t status;
             uint32_t delayedActionTime;

--- a/zzz_generated/pump-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/pump-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -266,7 +266,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -378,7 +378,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -445,12 +445,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -568,7 +568,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -639,7 +639,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -710,7 +710,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -773,7 +773,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -835,7 +835,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -910,7 +910,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -977,7 +977,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -1039,7 +1039,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -1089,7 +1089,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -1156,7 +1156,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1227,7 +1227,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -1294,7 +1294,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -1361,7 +1361,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -1428,7 +1428,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -1495,7 +1495,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -1562,7 +1562,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1679,17 +1679,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -1739,7 +1739,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1814,7 +1814,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -1873,7 +1873,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -1932,7 +1932,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -1991,7 +1991,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -2049,7 +2049,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -2107,7 +2107,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -2166,7 +2166,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -2226,7 +2226,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::Move,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Move::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -174,7 +174,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::MoveToLevel,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::MoveToLevel::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -222,7 +222,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::MoveToLevelWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::MoveToLevelWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -265,7 +265,7 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::MoveWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::MoveWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -309,7 +309,7 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::Step,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Step::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -358,7 +358,7 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::StepWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::StepWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -403,7 +403,7 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::Stop,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Stop::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -445,7 +445,7 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::Ids::StopWithOnOff,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, LevelControl::Commands::StopWithOnOff::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -527,7 +527,7 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::Off,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Off::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -565,7 +565,7 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::On,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::On::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -603,7 +603,7 @@ CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callba
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Ids::Toggle,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OnOff::Commands::Toggle::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));

--- a/zzz_generated/pump-controller-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -266,7 +266,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -378,7 +378,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -445,12 +445,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -568,7 +568,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -635,7 +635,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -706,7 +706,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -773,7 +773,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -840,7 +840,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -899,7 +899,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -966,7 +966,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -1033,7 +1033,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -1100,7 +1100,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1217,7 +1217,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1292,7 +1292,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -1351,7 +1351,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -1410,7 +1410,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -1469,7 +1469,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -1527,7 +1527,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -1585,7 +1585,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -1644,7 +1644,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -1704,7 +1704,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;

--- a/zzz_generated/temperature-measurement-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/temperature-measurement-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -369,7 +369,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -436,12 +436,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -559,7 +559,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -630,7 +630,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -697,7 +697,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -764,7 +764,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -823,7 +823,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -890,7 +890,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -957,7 +957,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1074,7 +1074,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1149,7 +1149,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -1208,7 +1208,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -1267,7 +1267,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -1326,7 +1326,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -1384,7 +1384,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -1442,7 +1442,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -1501,7 +1501,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -1561,7 +1561,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;

--- a/zzz_generated/thermostat/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/thermostat/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::BarrierControl::Commands::Ids::BarrierControlGoToPercent: {
+        case Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Id: {
             expectArgumentCount = 1;
             uint8_t percentOpen;
             bool argExists[1];
@@ -315,7 +315,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::BarrierControl::Commands::Ids::BarrierControlStop: {
+        case Clusters::BarrierControl::Commands::BarrierControlStop::Id: {
 
             wasHandled = emberAfBarrierControlClusterBarrierControlStopCallback(aEndpointId, apCommandObj);
             break;
@@ -374,7 +374,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Binding::Commands::Ids::Bind: {
+        case Clusters::Binding::Commands::Bind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -444,7 +444,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Binding::Commands::Ids::Unbind: {
+        case Clusters::Binding::Commands::Unbind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -559,7 +559,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ColorControl::Commands::Ids::MoveColor: {
+        case Clusters::ColorControl::Commands::MoveColor::Id: {
             expectArgumentCount = 4;
             int16_t rateX;
             int16_t rateY;
@@ -630,7 +630,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveColorTemperature::Id: {
             expectArgumentCount = 6;
             uint8_t moveMode;
             uint16_t rate;
@@ -710,7 +710,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveHue: {
+        case Clusters::ColorControl::Commands::MoveHue::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -781,7 +781,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveSaturation: {
+        case Clusters::ColorControl::Commands::MoveSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -852,7 +852,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColor: {
+        case Clusters::ColorControl::Commands::MoveToColor::Id: {
             expectArgumentCount = 5;
             uint16_t colorX;
             uint16_t colorY;
@@ -927,7 +927,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveToColorTemperature::Id: {
             expectArgumentCount = 4;
             uint16_t colorTemperature;
             uint16_t transitionTime;
@@ -998,7 +998,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHue: {
+        case Clusters::ColorControl::Commands::MoveToHue::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t direction;
@@ -1073,7 +1073,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHueAndSaturation: {
+        case Clusters::ColorControl::Commands::MoveToHueAndSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t saturation;
@@ -1148,7 +1148,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToSaturation: {
+        case Clusters::ColorControl::Commands::MoveToSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t saturation;
             uint16_t transitionTime;
@@ -1219,7 +1219,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColor: {
+        case Clusters::ColorControl::Commands::StepColor::Id: {
             expectArgumentCount = 5;
             int16_t stepX;
             int16_t stepY;
@@ -1294,7 +1294,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColorTemperature: {
+        case Clusters::ColorControl::Commands::StepColorTemperature::Id: {
             expectArgumentCount = 7;
             uint8_t stepMode;
             uint16_t stepSize;
@@ -1378,7 +1378,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepHue: {
+        case Clusters::ColorControl::Commands::StepHue::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1453,7 +1453,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepSaturation: {
+        case Clusters::ColorControl::Commands::StepSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1528,7 +1528,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StopMoveStep: {
+        case Clusters::ColorControl::Commands::StopMoveStep::Id: {
             expectArgumentCount = 2;
             uint8_t optionsMask;
             uint8_t optionsOverride;
@@ -1636,7 +1636,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -1748,17 +1748,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DoorLock::Commands::Ids::ClearAllPins: {
+        case Clusters::DoorLock::Commands::ClearAllPins::Id: {
 
             wasHandled = emberAfDoorLockClusterClearAllPinsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearAllRfids: {
+        case Clusters::DoorLock::Commands::ClearAllRfids::Id: {
 
             wasHandled = emberAfDoorLockClusterClearAllRfidsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearHolidaySchedule: {
+        case Clusters::DoorLock::Commands::ClearHolidaySchedule::Id: {
             expectArgumentCount = 1;
             uint8_t scheduleId;
             bool argExists[1];
@@ -1816,7 +1816,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearPin: {
+        case Clusters::DoorLock::Commands::ClearPin::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -1874,7 +1874,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearRfid: {
+        case Clusters::DoorLock::Commands::ClearRfid::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -1932,7 +1932,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::ClearWeekdaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -1994,7 +1994,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearYeardaySchedule: {
+        case Clusters::DoorLock::Commands::ClearYeardaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2056,7 +2056,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetHolidaySchedule: {
+        case Clusters::DoorLock::Commands::GetHolidaySchedule::Id: {
             expectArgumentCount = 1;
             uint8_t scheduleId;
             bool argExists[1];
@@ -2114,7 +2114,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetLogRecord: {
+        case Clusters::DoorLock::Commands::GetLogRecord::Id: {
             expectArgumentCount = 1;
             uint16_t logIndex;
             bool argExists[1];
@@ -2172,7 +2172,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetPin: {
+        case Clusters::DoorLock::Commands::GetPin::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2230,7 +2230,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetRfid: {
+        case Clusters::DoorLock::Commands::GetRfid::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2288,7 +2288,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetUserType: {
+        case Clusters::DoorLock::Commands::GetUserType::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2346,7 +2346,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::GetWeekdaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2408,7 +2408,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetYeardaySchedule: {
+        case Clusters::DoorLock::Commands::GetYeardaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2470,7 +2470,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::LockDoor: {
+        case Clusters::DoorLock::Commands::LockDoor::Id: {
             expectArgumentCount = 1;
             const uint8_t * PIN;
             bool argExists[1];
@@ -2529,7 +2529,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetHolidaySchedule: {
+        case Clusters::DoorLock::Commands::SetHolidaySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t scheduleId;
             uint32_t localStartTime;
@@ -2600,7 +2600,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetPin: {
+        case Clusters::DoorLock::Commands::SetPin::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -2672,7 +2672,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetRfid: {
+        case Clusters::DoorLock::Commands::SetRfid::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -2744,7 +2744,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetUserType: {
+        case Clusters::DoorLock::Commands::SetUserType::Id: {
             expectArgumentCount = 2;
             uint16_t userId;
             uint8_t userType;
@@ -2806,7 +2806,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::SetWeekdaySchedule::Id: {
             expectArgumentCount = 7;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2889,7 +2889,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetYeardaySchedule: {
+        case Clusters::DoorLock::Commands::SetYeardaySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2960,7 +2960,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockDoor: {
+        case Clusters::DoorLock::Commands::UnlockDoor::Id: {
             expectArgumentCount = 1;
             const uint8_t * PIN;
             bool argExists[1];
@@ -3019,7 +3019,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockWithTimeout: {
+        case Clusters::DoorLock::Commands::UnlockWithTimeout::Id: {
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
             const uint8_t * pin;
@@ -3128,7 +3128,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -3195,12 +3195,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -3318,7 +3318,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Groups::Commands::Ids::AddGroup: {
+        case Clusters::Groups::Commands::AddGroup::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             const uint8_t * groupName;
@@ -3382,7 +3382,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::AddGroupIfIdentifying: {
+        case Clusters::Groups::Commands::AddGroupIfIdentifying::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             const uint8_t * groupName;
@@ -3446,7 +3446,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::GetGroupMembership: {
+        case Clusters::Groups::Commands::GetGroupMembership::Id: {
             expectArgumentCount = 2;
             uint8_t groupCount;
             /* TYPE WARNING: array array defaults to */ uint8_t * groupList;
@@ -3509,12 +3509,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveAllGroups: {
+        case Clusters::Groups::Commands::RemoveAllGroups::Id: {
 
             wasHandled = emberAfGroupsClusterRemoveAllGroupsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveGroup: {
+        case Clusters::Groups::Commands::RemoveGroup::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -3572,7 +3572,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::ViewGroup: {
+        case Clusters::Groups::Commands::ViewGroup::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -3675,7 +3675,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::IasZone::Commands::Ids::ZoneEnrollResponse: {
+        case Clusters::IasZone::Commands::ZoneEnrollResponse::Id: {
             expectArgumentCount = 2;
             uint8_t enrollResponseCode;
             uint8_t zoneId;
@@ -3782,7 +3782,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Identify::Commands::Ids::Identify: {
+        case Clusters::Identify::Commands::Identify::Id: {
             expectArgumentCount = 1;
             uint16_t identifyTime;
             bool argExists[1];
@@ -3840,7 +3840,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Identify::Commands::Ids::IdentifyQuery: {
+        case Clusters::Identify::Commands::IdentifyQuery::Id: {
 
             wasHandled = emberAfIdentifyClusterIdentifyQueryCallback(aEndpointId, apCommandObj);
             break;
@@ -3890,7 +3890,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -3961,7 +3961,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -4032,7 +4032,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -4095,7 +4095,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -4157,7 +4157,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -4232,7 +4232,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -4299,7 +4299,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -4361,7 +4361,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -4411,7 +4411,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LowPower::Commands::Ids::Sleep: {
+        case Clusters::LowPower::Commands::Sleep::Id: {
 
             wasHandled = emberAfLowPowerClusterSleepCallback(aEndpointId, apCommandObj);
             break;
@@ -4461,7 +4461,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -4528,7 +4528,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -4599,7 +4599,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -4666,7 +4666,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -4733,7 +4733,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -4792,7 +4792,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -4859,7 +4859,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -4926,7 +4926,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -4993,7 +4993,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -5110,7 +5110,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t newVersion;
@@ -5173,7 +5173,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t softwareVersion;
@@ -5236,7 +5236,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImage: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Id: {
             expectArgumentCount = 8;
             uint16_t vendorId;
             uint16_t productId;
@@ -5371,17 +5371,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -5431,7 +5431,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -5506,7 +5506,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -5565,7 +5565,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -5624,7 +5624,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -5683,7 +5683,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -5741,7 +5741,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -5799,7 +5799,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -5858,7 +5858,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -5918,7 +5918,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -6026,7 +6026,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Scenes::Commands::Ids::AddScene: {
+        case Clusters::Scenes::Commands::AddScene::Id: {
             expectArgumentCount = 5;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6103,7 +6103,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::GetSceneMembership: {
+        case Clusters::Scenes::Commands::GetSceneMembership::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -6161,7 +6161,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RecallScene: {
+        case Clusters::Scenes::Commands::RecallScene::Id: {
             expectArgumentCount = 3;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6227,7 +6227,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveAllScenes: {
+        case Clusters::Scenes::Commands::RemoveAllScenes::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -6285,7 +6285,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveScene: {
+        case Clusters::Scenes::Commands::RemoveScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6347,7 +6347,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::StoreScene: {
+        case Clusters::Scenes::Commands::StoreScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6409,7 +6409,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::ViewScene: {
+        case Clusters::Scenes::Commands::ViewScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6516,17 +6516,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::TestCluster::Commands::Ids::Test: {
+        case Clusters::TestCluster::Commands::Test::Id: {
 
             wasHandled = emberAfTestClusterClusterTestCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestNotHandled: {
+        case Clusters::TestCluster::Commands::TestNotHandled::Id: {
 
             wasHandled = emberAfTestClusterClusterTestNotHandledCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestSpecific: {
+        case Clusters::TestCluster::Commands::TestSpecific::Id: {
 
             wasHandled = emberAfTestClusterClusterTestSpecificCallback(aEndpointId, apCommandObj);
             break;
@@ -6576,12 +6576,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Thermostat::Commands::Ids::ClearWeeklySchedule: {
+        case Clusters::Thermostat::Commands::ClearWeeklySchedule::Id: {
 
             wasHandled = emberAfThermostatClusterClearWeeklyScheduleCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::Thermostat::Commands::Ids::GetWeeklySchedule: {
+        case Clusters::Thermostat::Commands::GetWeeklySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t daysToReturn;
             uint8_t modeToReturn;
@@ -6644,7 +6644,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Thermostat::Commands::Ids::SetWeeklySchedule: {
+        case Clusters::Thermostat::Commands::SetWeeklySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t numberOfTransitionsForSequence;
             uint8_t dayOfWeekForSequence;
@@ -6716,7 +6716,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Thermostat::Commands::Ids::SetpointRaiseLower: {
+        case Clusters::Thermostat::Commands::SetpointRaiseLower::Id: {
             expectArgumentCount = 2;
             uint8_t mode;
             int8_t amount;

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, GeneralCommissioning::Commands::Ids::ArmFailSafe,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, GeneralCommissioning::Commands::ArmFailSafe::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -106,7 +106,7 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         GeneralCommissioning::Commands::Ids::CommissioningComplete,
+                                         GeneralCommissioning::Commands::CommissioningComplete::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -147,7 +147,7 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         GeneralCommissioning::Commands::Ids::SetRegulatoryConfig,
+                                         GeneralCommissioning::Commands::SetRegulatoryConfig::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -251,7 +251,7 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::DisableNetwork,
+                                         NetworkCommissioning::Commands::DisableNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -297,8 +297,7 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::EnableNetwork,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::EnableNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -345,7 +344,7 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult,
+                                         NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -387,8 +386,7 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         NetworkCommissioning::Commands::Ids::RemoveNetwork,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::RemoveNetwork::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -434,7 +432,7 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::Ids::ScanNetworks,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, NetworkCommissioning::Commands::ScanNetworks::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -494,7 +492,7 @@ CHIP_ERROR OperationalCredentialsCluster::AddNOC(Callback::Cancelable * onSucces
 
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OperationalCredentials::Commands::Ids::AddNOC,
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, OperationalCredentials::Commands::AddNOC::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -545,7 +543,7 @@ CHIP_ERROR OperationalCredentialsCluster::AddTrustedRootCertificate(Callback::Ca
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::AddTrustedRootCertificate,
+                                         OperationalCredentials::Commands::AddTrustedRootCertificate::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -588,7 +586,7 @@ CHIP_ERROR OperationalCredentialsCluster::AttestationRequest(Callback::Cancelabl
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::AttestationRequest,
+                                         OperationalCredentials::Commands::AttestationRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -630,7 +628,7 @@ CHIP_ERROR OperationalCredentialsCluster::CertificateChainRequest(Callback::Canc
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::CertificateChainRequest,
+                                         OperationalCredentials::Commands::CertificateChainRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -672,7 +670,7 @@ CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::OpCSRRequest,
+                                         OperationalCredentials::Commands::OpCSRRequest::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -714,7 +712,7 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::RemoveFabric,
+                                         OperationalCredentials::Commands::RemoveFabric::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
@@ -756,7 +754,7 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
-                                         OperationalCredentials::Commands::Ids::UpdateFabricLabel,
+                                         OperationalCredentials::Commands::UpdateFabricLabel::Id,
                                          (app::CommandPathFlags::kEndpointIdValid) };
 
     SuccessOrExit(err = app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));

--- a/zzz_generated/tv-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/tv-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AccountLogin::Commands::Ids::GetSetupPIN: {
+        case Clusters::AccountLogin::Commands::GetSetupPIN::Id: {
             expectArgumentCount = 1;
             const uint8_t * tempAccountIdentifier;
             bool argExists[1];
@@ -128,7 +128,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AccountLogin::Commands::Ids::Login: {
+        case Clusters::AccountLogin::Commands::Login::Id: {
             expectArgumentCount = 2;
             const uint8_t * tempAccountIdentifier;
             const uint8_t * setupPIN;
@@ -238,7 +238,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -297,7 +297,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -376,7 +376,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -427,7 +427,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ApplicationBasic::Commands::Ids::ChangeStatus: {
+        case Clusters::ApplicationBasic::Commands::ChangeStatus::Id: {
             expectArgumentCount = 1;
             uint8_t status;
             bool argExists[1];
@@ -530,7 +530,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ApplicationLauncher::Commands::Ids::LaunchApp: {
+        case Clusters::ApplicationLauncher::Commands::LaunchApp::Id: {
             expectArgumentCount = 3;
             const uint8_t * data;
             uint16_t catalogVendorId;
@@ -645,7 +645,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AudioOutput::Commands::Ids::RenameOutput: {
+        case Clusters::AudioOutput::Commands::RenameOutput::Id: {
             expectArgumentCount = 2;
             uint8_t index;
             const uint8_t * name;
@@ -709,7 +709,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AudioOutput::Commands::Ids::SelectOutput: {
+        case Clusters::AudioOutput::Commands::SelectOutput::Id: {
             expectArgumentCount = 1;
             uint8_t index;
             bool argExists[1];
@@ -821,7 +821,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Binding::Commands::Ids::Bind: {
+        case Clusters::Binding::Commands::Bind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -891,7 +891,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Binding::Commands::Ids::Unbind: {
+        case Clusters::Binding::Commands::Unbind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -1006,7 +1006,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ContentLauncher::Commands::Ids::LaunchContent: {
+        case Clusters::ContentLauncher::Commands::LaunchContent::Id: {
             expectArgumentCount = 2;
             bool autoPlay;
             const uint8_t * data;
@@ -1070,7 +1070,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ContentLauncher::Commands::Ids::LaunchURL: {
+        case Clusters::ContentLauncher::Commands::LaunchURL::Id: {
             expectArgumentCount = 2;
             const uint8_t * contentURL;
             const uint8_t * displayString;
@@ -1180,7 +1180,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -1292,7 +1292,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafeResponse: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -1356,7 +1356,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningCompleteResponse: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -1420,7 +1420,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfigResponse: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -1530,7 +1530,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -1597,12 +1597,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -1720,7 +1720,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::KeypadInput::Commands::Ids::SendKey: {
+        case Clusters::KeypadInput::Commands::SendKey::Id: {
             expectArgumentCount = 1;
             uint8_t keyCode;
             bool argExists[1];
@@ -1823,7 +1823,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -1894,7 +1894,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -1965,7 +1965,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -2028,7 +2028,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -2090,7 +2090,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -2165,7 +2165,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -2232,7 +2232,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -2294,7 +2294,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -2344,7 +2344,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LowPower::Commands::Ids::Sleep: {
+        case Clusters::LowPower::Commands::Sleep::Id: {
 
             wasHandled = emberAfLowPowerClusterSleepCallback(aEndpointId, apCommandObj);
             break;
@@ -2394,12 +2394,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::MediaInput::Commands::Ids::HideInputStatus: {
+        case Clusters::MediaInput::Commands::HideInputStatus::Id: {
 
             wasHandled = emberAfMediaInputClusterHideInputStatusCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaInput::Commands::Ids::RenameInput: {
+        case Clusters::MediaInput::Commands::RenameInput::Id: {
             expectArgumentCount = 2;
             uint8_t index;
             const uint8_t * name;
@@ -2463,7 +2463,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::MediaInput::Commands::Ids::SelectInput: {
+        case Clusters::MediaInput::Commands::SelectInput::Id: {
             expectArgumentCount = 1;
             uint8_t index;
             bool argExists[1];
@@ -2521,7 +2521,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::MediaInput::Commands::Ids::ShowInputStatus: {
+        case Clusters::MediaInput::Commands::ShowInputStatus::Id: {
 
             wasHandled = emberAfMediaInputClusterShowInputStatusCallback(aEndpointId, apCommandObj);
             break;
@@ -2571,37 +2571,37 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::MediaPlayback::Commands::Ids::MediaFastForward: {
+        case Clusters::MediaPlayback::Commands::MediaFastForward::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaFastForwardCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaNext: {
+        case Clusters::MediaPlayback::Commands::MediaNext::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaNextCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaPause: {
+        case Clusters::MediaPlayback::Commands::MediaPause::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaPauseCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaPlay: {
+        case Clusters::MediaPlayback::Commands::MediaPlay::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaPlayCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaPrevious: {
+        case Clusters::MediaPlayback::Commands::MediaPrevious::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaPreviousCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaRewind: {
+        case Clusters::MediaPlayback::Commands::MediaRewind::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaRewindCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaSeek: {
+        case Clusters::MediaPlayback::Commands::MediaSeek::Id: {
             expectArgumentCount = 1;
             uint64_t position;
             bool argExists[1];
@@ -2659,7 +2659,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaSkipBackward: {
+        case Clusters::MediaPlayback::Commands::MediaSkipBackward::Id: {
             expectArgumentCount = 1;
             uint64_t deltaPositionMilliseconds;
             bool argExists[1];
@@ -2718,7 +2718,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaSkipForward: {
+        case Clusters::MediaPlayback::Commands::MediaSkipForward::Id: {
             expectArgumentCount = 1;
             uint64_t deltaPositionMilliseconds;
             bool argExists[1];
@@ -2777,12 +2777,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaStartOver: {
+        case Clusters::MediaPlayback::Commands::MediaStartOver::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaStartOverCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::MediaPlayback::Commands::Ids::MediaStop: {
+        case Clusters::MediaPlayback::Commands::MediaStop::Id: {
 
             wasHandled = emberAfMediaPlaybackClusterMediaStopCallback(aEndpointId, apCommandObj);
             break;
@@ -2832,7 +2832,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -2896,7 +2896,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -2960,7 +2960,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3024,7 +3024,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3088,7 +3088,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3152,7 +3152,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworksResponse: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::Id: {
             expectArgumentCount = 4;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3226,7 +3226,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3290,7 +3290,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetworkResponse: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
             const uint8_t * debugText;
@@ -3400,7 +3400,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -3467,7 +3467,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -3538,7 +3538,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -3605,7 +3605,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -3672,7 +3672,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -3731,7 +3731,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -3798,7 +3798,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -3865,7 +3865,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -3932,7 +3932,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -4049,7 +4049,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t newVersion;
@@ -4112,7 +4112,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t softwareVersion;
@@ -4175,7 +4175,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImage: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Id: {
             expectArgumentCount = 8;
             uint16_t vendorId;
             uint16_t productId;
@@ -4310,17 +4310,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -4370,7 +4370,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationResponse: {
+        case Clusters::OperationalCredentials::Commands::AttestationResponse::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan AttestationElements;
             chip::ByteSpan Signature;
@@ -4433,7 +4433,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainResponse: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainResponse::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan Certificate;
             bool argExists[1];
@@ -4492,7 +4492,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::NOCResponse: {
+        case Clusters::OperationalCredentials::Commands::NOCResponse::Id: {
             expectArgumentCount = 3;
             uint8_t StatusCode;
             uint8_t FabricIndex;
@@ -4559,7 +4559,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRResponse: {
+        case Clusters::OperationalCredentials::Commands::OpCSRResponse::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCSRElements;
             chip::ByteSpan AttestationSignature;
@@ -4668,7 +4668,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -4743,7 +4743,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -4802,7 +4802,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -4861,7 +4861,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -4920,7 +4920,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -4978,7 +4978,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -5036,7 +5036,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -5095,7 +5095,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -5155,7 +5155,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -5263,7 +5263,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::TvChannel::Commands::Ids::ChangeChannel: {
+        case Clusters::TvChannel::Commands::ChangeChannel::Id: {
             expectArgumentCount = 1;
             const uint8_t * match;
             bool argExists[1];
@@ -5322,7 +5322,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::TvChannel::Commands::Ids::ChangeChannelByNumber: {
+        case Clusters::TvChannel::Commands::ChangeChannelByNumber::Id: {
             expectArgumentCount = 2;
             uint16_t majorNumber;
             uint16_t minorNumber;
@@ -5385,7 +5385,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::TvChannel::Commands::Ids::SkipChannel: {
+        case Clusters::TvChannel::Commands::SkipChannel::Id: {
             expectArgumentCount = 1;
             uint16_t Count;
             bool argExists[1];
@@ -5488,7 +5488,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::TargetNavigator::Commands::Ids::NavigateTarget: {
+        case Clusters::TargetNavigator::Commands::NavigateTarget::Id: {
             expectArgumentCount = 2;
             uint8_t target;
             const uint8_t * data;

--- a/zzz_generated/tv-casting-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/tv-casting-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::BarrierControl::Commands::Ids::BarrierControlGoToPercent: {
+        case Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Id: {
             expectArgumentCount = 1;
             uint8_t percentOpen;
             bool argExists[1];
@@ -315,7 +315,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::BarrierControl::Commands::Ids::BarrierControlStop: {
+        case Clusters::BarrierControl::Commands::BarrierControlStop::Id: {
 
             wasHandled = emberAfBarrierControlClusterBarrierControlStopCallback(aEndpointId, apCommandObj);
             break;
@@ -374,7 +374,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Binding::Commands::Ids::Bind: {
+        case Clusters::Binding::Commands::Bind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -444,7 +444,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Binding::Commands::Ids::Unbind: {
+        case Clusters::Binding::Commands::Unbind::Id: {
             expectArgumentCount = 4;
             chip::NodeId nodeId;
             chip::GroupId groupId;
@@ -559,7 +559,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::ColorControl::Commands::Ids::MoveColor: {
+        case Clusters::ColorControl::Commands::MoveColor::Id: {
             expectArgumentCount = 4;
             int16_t rateX;
             int16_t rateY;
@@ -630,7 +630,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveColorTemperature::Id: {
             expectArgumentCount = 6;
             uint8_t moveMode;
             uint16_t rate;
@@ -710,7 +710,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveHue: {
+        case Clusters::ColorControl::Commands::MoveHue::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -781,7 +781,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveSaturation: {
+        case Clusters::ColorControl::Commands::MoveSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -852,7 +852,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColor: {
+        case Clusters::ColorControl::Commands::MoveToColor::Id: {
             expectArgumentCount = 5;
             uint16_t colorX;
             uint16_t colorY;
@@ -927,7 +927,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToColorTemperature: {
+        case Clusters::ColorControl::Commands::MoveToColorTemperature::Id: {
             expectArgumentCount = 4;
             uint16_t colorTemperature;
             uint16_t transitionTime;
@@ -998,7 +998,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHue: {
+        case Clusters::ColorControl::Commands::MoveToHue::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t direction;
@@ -1073,7 +1073,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToHueAndSaturation: {
+        case Clusters::ColorControl::Commands::MoveToHueAndSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t hue;
             uint8_t saturation;
@@ -1148,7 +1148,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::MoveToSaturation: {
+        case Clusters::ColorControl::Commands::MoveToSaturation::Id: {
             expectArgumentCount = 4;
             uint8_t saturation;
             uint16_t transitionTime;
@@ -1219,7 +1219,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColor: {
+        case Clusters::ColorControl::Commands::StepColor::Id: {
             expectArgumentCount = 5;
             int16_t stepX;
             int16_t stepY;
@@ -1294,7 +1294,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepColorTemperature: {
+        case Clusters::ColorControl::Commands::StepColorTemperature::Id: {
             expectArgumentCount = 7;
             uint8_t stepMode;
             uint16_t stepSize;
@@ -1378,7 +1378,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepHue: {
+        case Clusters::ColorControl::Commands::StepHue::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1453,7 +1453,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StepSaturation: {
+        case Clusters::ColorControl::Commands::StepSaturation::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -1528,7 +1528,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::ColorControl::Commands::Ids::StopMoveStep: {
+        case Clusters::ColorControl::Commands::StopMoveStep::Id: {
             expectArgumentCount = 2;
             uint8_t optionsMask;
             uint8_t optionsOverride;
@@ -1636,7 +1636,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DiagnosticLogs::Commands::Ids::RetrieveLogsRequest: {
+        case Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Id: {
             expectArgumentCount = 3;
             uint8_t intent;
             uint8_t requestedProtocol;
@@ -1748,17 +1748,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::DoorLock::Commands::Ids::ClearAllPins: {
+        case Clusters::DoorLock::Commands::ClearAllPins::Id: {
 
             wasHandled = emberAfDoorLockClusterClearAllPinsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearAllRfids: {
+        case Clusters::DoorLock::Commands::ClearAllRfids::Id: {
 
             wasHandled = emberAfDoorLockClusterClearAllRfidsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearHolidaySchedule: {
+        case Clusters::DoorLock::Commands::ClearHolidaySchedule::Id: {
             expectArgumentCount = 1;
             uint8_t scheduleId;
             bool argExists[1];
@@ -1816,7 +1816,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearPin: {
+        case Clusters::DoorLock::Commands::ClearPin::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -1874,7 +1874,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearRfid: {
+        case Clusters::DoorLock::Commands::ClearRfid::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -1932,7 +1932,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::ClearWeekdaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -1994,7 +1994,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::ClearYeardaySchedule: {
+        case Clusters::DoorLock::Commands::ClearYeardaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2056,7 +2056,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetHolidaySchedule: {
+        case Clusters::DoorLock::Commands::GetHolidaySchedule::Id: {
             expectArgumentCount = 1;
             uint8_t scheduleId;
             bool argExists[1];
@@ -2114,7 +2114,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetLogRecord: {
+        case Clusters::DoorLock::Commands::GetLogRecord::Id: {
             expectArgumentCount = 1;
             uint16_t logIndex;
             bool argExists[1];
@@ -2172,7 +2172,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetPin: {
+        case Clusters::DoorLock::Commands::GetPin::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2230,7 +2230,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetRfid: {
+        case Clusters::DoorLock::Commands::GetRfid::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2288,7 +2288,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetUserType: {
+        case Clusters::DoorLock::Commands::GetUserType::Id: {
             expectArgumentCount = 1;
             uint16_t userId;
             bool argExists[1];
@@ -2346,7 +2346,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::GetWeekdaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2408,7 +2408,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::GetYeardaySchedule: {
+        case Clusters::DoorLock::Commands::GetYeardaySchedule::Id: {
             expectArgumentCount = 2;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2470,7 +2470,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::LockDoor: {
+        case Clusters::DoorLock::Commands::LockDoor::Id: {
             expectArgumentCount = 1;
             const uint8_t * PIN;
             bool argExists[1];
@@ -2529,7 +2529,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetHolidaySchedule: {
+        case Clusters::DoorLock::Commands::SetHolidaySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t scheduleId;
             uint32_t localStartTime;
@@ -2600,7 +2600,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetPin: {
+        case Clusters::DoorLock::Commands::SetPin::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -2672,7 +2672,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetRfid: {
+        case Clusters::DoorLock::Commands::SetRfid::Id: {
             expectArgumentCount = 4;
             uint16_t userId;
             uint8_t userStatus;
@@ -2744,7 +2744,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetUserType: {
+        case Clusters::DoorLock::Commands::SetUserType::Id: {
             expectArgumentCount = 2;
             uint16_t userId;
             uint8_t userType;
@@ -2806,7 +2806,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetWeekdaySchedule: {
+        case Clusters::DoorLock::Commands::SetWeekdaySchedule::Id: {
             expectArgumentCount = 7;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2889,7 +2889,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::SetYeardaySchedule: {
+        case Clusters::DoorLock::Commands::SetYeardaySchedule::Id: {
             expectArgumentCount = 4;
             uint8_t scheduleId;
             uint16_t userId;
@@ -2960,7 +2960,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockDoor: {
+        case Clusters::DoorLock::Commands::UnlockDoor::Id: {
             expectArgumentCount = 1;
             const uint8_t * PIN;
             bool argExists[1];
@@ -3019,7 +3019,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::DoorLock::Commands::Ids::UnlockWithTimeout: {
+        case Clusters::DoorLock::Commands::UnlockWithTimeout::Id: {
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
             const uint8_t * pin;
@@ -3128,7 +3128,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -3195,12 +3195,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -3318,7 +3318,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Groups::Commands::Ids::AddGroup: {
+        case Clusters::Groups::Commands::AddGroup::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             const uint8_t * groupName;
@@ -3382,7 +3382,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::AddGroupIfIdentifying: {
+        case Clusters::Groups::Commands::AddGroupIfIdentifying::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             const uint8_t * groupName;
@@ -3446,7 +3446,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::GetGroupMembership: {
+        case Clusters::Groups::Commands::GetGroupMembership::Id: {
             expectArgumentCount = 2;
             uint8_t groupCount;
             /* TYPE WARNING: array array defaults to */ uint8_t * groupList;
@@ -3509,12 +3509,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveAllGroups: {
+        case Clusters::Groups::Commands::RemoveAllGroups::Id: {
 
             wasHandled = emberAfGroupsClusterRemoveAllGroupsCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::Groups::Commands::Ids::RemoveGroup: {
+        case Clusters::Groups::Commands::RemoveGroup::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -3572,7 +3572,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Groups::Commands::Ids::ViewGroup: {
+        case Clusters::Groups::Commands::ViewGroup::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -3675,7 +3675,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::IasZone::Commands::Ids::ZoneEnrollResponse: {
+        case Clusters::IasZone::Commands::ZoneEnrollResponse::Id: {
             expectArgumentCount = 2;
             uint8_t enrollResponseCode;
             uint8_t zoneId;
@@ -3782,7 +3782,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Identify::Commands::Ids::Identify: {
+        case Clusters::Identify::Commands::Identify::Id: {
             expectArgumentCount = 1;
             uint16_t identifyTime;
             bool argExists[1];
@@ -3840,7 +3840,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Identify::Commands::Ids::IdentifyQuery: {
+        case Clusters::Identify::Commands::IdentifyQuery::Id: {
 
             wasHandled = emberAfIdentifyClusterIdentifyQueryCallback(aEndpointId, apCommandObj);
             break;
@@ -3890,7 +3890,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::LevelControl::Commands::Ids::Move: {
+        case Clusters::LevelControl::Commands::Move::Id: {
             expectArgumentCount = 4;
             uint8_t moveMode;
             uint8_t rate;
@@ -3961,7 +3961,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevel: {
+        case Clusters::LevelControl::Commands::MoveToLevel::Id: {
             expectArgumentCount = 4;
             uint8_t level;
             uint16_t transitionTime;
@@ -4032,7 +4032,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveToLevelWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t level;
             uint16_t transitionTime;
@@ -4095,7 +4095,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::MoveWithOnOff: {
+        case Clusters::LevelControl::Commands::MoveWithOnOff::Id: {
             expectArgumentCount = 2;
             uint8_t moveMode;
             uint8_t rate;
@@ -4157,7 +4157,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Step: {
+        case Clusters::LevelControl::Commands::Step::Id: {
             expectArgumentCount = 5;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -4232,7 +4232,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StepWithOnOff: {
+        case Clusters::LevelControl::Commands::StepWithOnOff::Id: {
             expectArgumentCount = 3;
             uint8_t stepMode;
             uint8_t stepSize;
@@ -4299,7 +4299,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::Stop: {
+        case Clusters::LevelControl::Commands::Stop::Id: {
             expectArgumentCount = 2;
             uint8_t optionMask;
             uint8_t optionOverride;
@@ -4361,7 +4361,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::LevelControl::Commands::Ids::StopWithOnOff: {
+        case Clusters::LevelControl::Commands::StopWithOnOff::Id: {
 
             wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(aEndpointId, apCommandObj);
             break;
@@ -4411,7 +4411,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -4478,7 +4478,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -4549,7 +4549,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -4616,7 +4616,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -4683,7 +4683,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -4742,7 +4742,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -4809,7 +4809,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -4876,7 +4876,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -4943,7 +4943,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -5060,7 +5060,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::ApplyUpdateRequest: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t newVersion;
@@ -5123,7 +5123,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::NotifyUpdateApplied: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan updateToken;
             uint32_t softwareVersion;
@@ -5186,7 +5186,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OtaSoftwareUpdateProvider::Commands::Ids::QueryImage: {
+        case Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Id: {
             expectArgumentCount = 8;
             uint16_t vendorId;
             uint16_t productId;
@@ -5321,17 +5321,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OnOff::Commands::Ids::Off: {
+        case Clusters::OnOff::Commands::Off::Id: {
 
             wasHandled = emberAfOnOffClusterOffCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::On: {
+        case Clusters::OnOff::Commands::On::Id: {
 
             wasHandled = emberAfOnOffClusterOnCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::OnOff::Commands::Ids::Toggle: {
+        case Clusters::OnOff::Commands::Toggle::Id: {
 
             wasHandled = emberAfOnOffClusterToggleCallback(aEndpointId, apCommandObj);
             break;
@@ -5381,7 +5381,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -5456,7 +5456,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -5515,7 +5515,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -5574,7 +5574,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -5633,7 +5633,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -5691,7 +5691,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -5749,7 +5749,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -5808,7 +5808,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -5868,7 +5868,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -5976,7 +5976,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::Scenes::Commands::Ids::AddScene: {
+        case Clusters::Scenes::Commands::AddScene::Id: {
             expectArgumentCount = 5;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6053,7 +6053,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::GetSceneMembership: {
+        case Clusters::Scenes::Commands::GetSceneMembership::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -6111,7 +6111,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RecallScene: {
+        case Clusters::Scenes::Commands::RecallScene::Id: {
             expectArgumentCount = 3;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6177,7 +6177,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveAllScenes: {
+        case Clusters::Scenes::Commands::RemoveAllScenes::Id: {
             expectArgumentCount = 1;
             uint16_t groupId;
             bool argExists[1];
@@ -6235,7 +6235,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::RemoveScene: {
+        case Clusters::Scenes::Commands::RemoveScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6297,7 +6297,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::StoreScene: {
+        case Clusters::Scenes::Commands::StoreScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6359,7 +6359,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::Scenes::Commands::Ids::ViewScene: {
+        case Clusters::Scenes::Commands::ViewScene::Id: {
             expectArgumentCount = 2;
             uint16_t groupId;
             uint8_t sceneId;
@@ -6466,17 +6466,17 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::TestCluster::Commands::Ids::Test: {
+        case Clusters::TestCluster::Commands::Test::Id: {
 
             wasHandled = emberAfTestClusterClusterTestCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestNotHandled: {
+        case Clusters::TestCluster::Commands::TestNotHandled::Id: {
 
             wasHandled = emberAfTestClusterClusterTestNotHandledCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::TestCluster::Commands::Ids::TestSpecific: {
+        case Clusters::TestCluster::Commands::TestSpecific::Id: {
 
             wasHandled = emberAfTestClusterClusterTestSpecificCallback(aEndpointId, apCommandObj);
             break;

--- a/zzz_generated/window-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/window-app/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenBasicCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id: {
             expectArgumentCount = 1;
             uint16_t CommissioningTimeout;
             bool argExists[1];
@@ -127,7 +127,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::OpenCommissioningWindow: {
+        case Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Id: {
             expectArgumentCount = 6;
             uint16_t CommissioningTimeout;
             chip::ByteSpan PAKEVerifier;
@@ -206,7 +206,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::AdministratorCommissioning::Commands::Ids::RevokeCommissioning: {
+        case Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Id: {
 
             wasHandled = emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(aEndpointId, apCommandObj);
             break;
@@ -257,7 +257,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafe: {
+        case Clusters::GeneralCommissioning::Commands::ArmFailSafe::Id: {
             expectArgumentCount = 3;
             uint16_t expiryLengthSeconds;
             uint64_t breadcrumb;
@@ -324,12 +324,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::CommissioningComplete: {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id: {
 
             wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
+        case Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Id: {
             expectArgumentCount = 4;
             uint8_t location;
             const uint8_t * countryCode;
@@ -447,7 +447,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -514,7 +514,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -585,7 +585,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::DisableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::DisableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -652,7 +652,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
+        case Clusters::NetworkCommissioning::Commands::EnableNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;
             uint64_t breadcrumb;
@@ -719,7 +719,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::GetLastNetworkCommissioningResult: {
+        case Clusters::NetworkCommissioning::Commands::GetLastNetworkCommissioningResult::Id: {
             expectArgumentCount = 1;
             uint32_t timeoutMs;
             bool argExists[1];
@@ -778,7 +778,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetwork: {
+        case Clusters::NetworkCommissioning::Commands::RemoveNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan NetworkID;
             uint64_t Breadcrumb;
@@ -845,7 +845,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworks: {
+        case Clusters::NetworkCommissioning::Commands::ScanNetworks::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan ssid;
             uint64_t breadcrumb;
@@ -912,7 +912,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Id: {
             expectArgumentCount = 3;
             chip::ByteSpan operationalDataset;
             uint64_t breadcrumb;
@@ -979,7 +979,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetwork: {
+        case Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Id: {
             expectArgumentCount = 4;
             chip::ByteSpan ssid;
             chip::ByteSpan credentials;
@@ -1096,7 +1096,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::OperationalCredentials::Commands::Ids::AddNOC: {
+        case Clusters::OperationalCredentials::Commands::AddNOC::Id: {
             expectArgumentCount = 5;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1171,7 +1171,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AddTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan RootCertificate;
             bool argExists[1];
@@ -1230,7 +1230,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::AttestationRequest: {
+        case Clusters::OperationalCredentials::Commands::AttestationRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan AttestationNonce;
             bool argExists[1];
@@ -1289,7 +1289,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::CertificateChainRequest: {
+        case Clusters::OperationalCredentials::Commands::CertificateChainRequest::Id: {
             expectArgumentCount = 1;
             uint8_t CertificateType;
             bool argExists[1];
@@ -1348,7 +1348,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::OpCSRRequest: {
+        case Clusters::OperationalCredentials::Commands::OpCSRRequest::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan CSRNonce;
             bool argExists[1];
@@ -1406,7 +1406,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveFabric: {
+        case Clusters::OperationalCredentials::Commands::RemoveFabric::Id: {
             expectArgumentCount = 1;
             uint8_t FabricIndex;
             bool argExists[1];
@@ -1464,7 +1464,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::RemoveTrustedRootCertificate: {
+        case Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Id: {
             expectArgumentCount = 1;
             chip::ByteSpan TrustedRootIdentifier;
             bool argExists[1];
@@ -1523,7 +1523,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id: {
             expectArgumentCount = 1;
             const uint8_t * Label;
             bool argExists[1];
@@ -1583,7 +1583,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::OperationalCredentials::Commands::Ids::UpdateNOC: {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id: {
             expectArgumentCount = 2;
             chip::ByteSpan NOCValue;
             chip::ByteSpan ICACValue;
@@ -1691,12 +1691,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
     {
         switch (aCommandId)
         {
-        case Clusters::WindowCovering::Commands::Ids::DownOrClose: {
+        case Clusters::WindowCovering::Commands::DownOrClose::Id: {
 
             wasHandled = emberAfWindowCoveringClusterDownOrCloseCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::GoToLiftPercentage: {
+        case Clusters::WindowCovering::Commands::GoToLiftPercentage::Id: {
             expectArgumentCount = 2;
             uint8_t liftPercentageValue;
             uint16_t liftPercent100thsValue;
@@ -1759,7 +1759,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::GoToLiftValue: {
+        case Clusters::WindowCovering::Commands::GoToLiftValue::Id: {
             expectArgumentCount = 1;
             uint16_t liftValue;
             bool argExists[1];
@@ -1817,7 +1817,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::GoToTiltPercentage: {
+        case Clusters::WindowCovering::Commands::GoToTiltPercentage::Id: {
             expectArgumentCount = 2;
             uint8_t tiltPercentageValue;
             uint16_t tiltPercent100thsValue;
@@ -1880,7 +1880,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::GoToTiltValue: {
+        case Clusters::WindowCovering::Commands::GoToTiltValue::Id: {
             expectArgumentCount = 1;
             uint16_t tiltValue;
             bool argExists[1];
@@ -1938,12 +1938,12 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             }
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::StopMotion: {
+        case Clusters::WindowCovering::Commands::StopMotion::Id: {
 
             wasHandled = emberAfWindowCoveringClusterStopMotionCallback(aEndpointId, apCommandObj);
             break;
         }
-        case Clusters::WindowCovering::Commands::Ids::UpOrOpen: {
+        case Clusters::WindowCovering::Commands::UpOrOpen::Id: {
 
             wasHandled = emberAfWindowCoveringClusterUpOrOpenCallback(aEndpointId, apCommandObj);
             break;


### PR DESCRIPTION
#### Problem
We will want to have per-command metadata, so it makes sense to have a namespace per command.  At that point the command id should just be in that namespace.

#### Change overview
See above.

#### Testing
No behavior changes.  Tree compiles.