### PR TITLE
Implement the ResetEthNetworkDiagnosticsCounts method in ConnectivityManager

### DIFF
--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -102,7 +102,12 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (Connectivit
 
 bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
-    EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Set(endpoint, 0);
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+
+    VerifyOrExit(DeviceLayer::ConnectivityMgr().ResetEthNetworkDiagnosticsCounts() == CHIP_NO_ERROR,
+                 status = EMBER_ZCL_STATUS_FAILURE);
+
+    status = EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketRxCount attribute"));
 
     status = EthernetNetworkDiagnostics::Attributes::PacketTxCount::Set(endpoint, 0);

--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -107,7 +107,7 @@ bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(EndpointId endp
     VerifyOrExit(DeviceLayer::ConnectivityMgr().ResetEthNetworkDiagnosticsCounts() == CHIP_NO_ERROR,
                  status = EMBER_ZCL_STATUS_FAILURE);
 
-    status = EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Set(endpoint, 0);
+    status = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketRxCount attribute"));
 
     status = EthernetNetworkDiagnostics::Attributes::PacketTxCount::Set(endpoint, 0);

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -173,6 +173,7 @@ public:
     CHIP_ERROR GetEthTxErrCount(uint64_t & txErrCount);
     CHIP_ERROR GetEthCollisionCount(uint64_t & collisionCount);
     CHIP_ERROR GetEthOverrunCount(uint64_t & overrunCount);
+    CHIP_ERROR ResetEthNetworkDiagnosticsCounts();
 
     // WiFi network diagnostics methods
     CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType);
@@ -408,6 +409,11 @@ inline CHIP_ERROR ConnectivityManager::GetEthCollisionCount(uint64_t & collision
 inline CHIP_ERROR ConnectivityManager::GetEthOverrunCount(uint64_t & overrunCount)
 {
     return static_cast<ImplClass *>(this)->_GetEthOverrunCount(overrunCount);
+}
+
+inline CHIP_ERROR ConnectivityManager::ResetEthNetworkDiagnosticsCounts()
+{
+    return static_cast<ImplClass *>(this)->_ResetEthNetworkDiagnosticsCounts();
 }
 
 inline CHIP_ERROR ConnectivityManager::GetWiFiSecurityType(uint8_t & securityType)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl.h
@@ -52,6 +52,7 @@ public:
     CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
     CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
     CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
+    CHIP_ERROR _ResetEthNetworkDiagnosticsCounts();
 
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -103,6 +104,12 @@ inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthCollisionCou
 
 template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthOverrunCount(uint64_t & overrunCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_ResetEthNetworkDiagnosticsCounts()
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1035,6 +1035,13 @@ CHIP_ERROR ConnectivityManagerImpl::_GetEthOverrunCount(uint64_t & overrunCount)
     return GetEthernetStatsCount(EthernetStatsCountType::kEthOverrunCount, overrunCount);
 }
 
+CHIP_ERROR ConnectivityManagerImpl::_ResetEthNetworkDiagnosticsCounts()
+{
+    // On Linux simulation, the packet statistic informations are shared by all running programs,
+    // the current running program does not have permission to reset those counts.
+    return CHIP_NO_ERROR;
+}
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 CHIP_ERROR ConnectivityManagerImpl::_GetWiFiChannelNumber(uint16_t & channelNumber)
 {

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -155,6 +155,7 @@ private:
     CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
     CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
     CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
+    CHIP_ERROR _ResetEthNetworkDiagnosticsCounts();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR _GetWiFiChannelNumber(uint16_t & channelNumber);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -172,6 +172,8 @@ private:
 
     // ==================== ConnectivityManager Private Methods ====================
 
+    CHIP_ERROR ResetEthernetStatsCount();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     void DriveAPState();
     CHIP_ERROR ConfigureWiFiAP();
@@ -187,6 +189,12 @@ private:
     static ConnectivityManagerImpl sInstance;
 
     // ===== Private members reserved for use by this class only.
+
+    uint64_t mEthPacketRxCount  = 0;
+    uint64_t mEthPacketTxCount  = 0;
+    uint64_t mEthTxErrCount     = 0;
+    uint64_t mEthCollisionCount = 0;
+    uint64_t mEthOverrunCount   = 0;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     ConnectivityManager::WiFiStationMode mWiFiStationMode;

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -257,14 +257,17 @@ ConnectionType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname
         return ConnectionType::kConnectionWiFi;
 
     // Test ethtool for CONNECTION_ETHERNET
-    struct ethtool_cmd ecmd = {};
-    ecmd.cmd                = ETHTOOL_GSET;
-    struct ifreq ifr        = {};
-    ifr.ifr_data            = reinterpret_cast<char *>(&ecmd);
-    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+    if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
+    {
+        struct ethtool_cmd ecmd = {};
+        ecmd.cmd                = ETHTOOL_GSET;
+        struct ifreq ifr        = {};
+        ifr.ifr_data            = reinterpret_cast<char *>(&ecmd);
+        strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
 
-    if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
-        return ConnectionType::kConnectionEthernet;
+        if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
+            return ConnectionType::kConnectionEthernet;
+    }
 
     return ConnectionType::kConnectionUnknown;
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Ethernet diagnostic attributes are hooked to SDK-internal logic to produce attribute values, if the platform does not want to provide one we fall back to asking the attribute store.

* emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback method currently only reset the counts within attribute store, we also need to calls the reset counters api on the platform side to reset the count if the attribute values are produced by the platform. 

#### Change overview
Implement the ResetEthNetworkDiagnosticsCounts method for the zcl com…

#### Testing
How was this tested? (at least one bullet point required)
* On Linux simulation, the Ethernet stats are shared by all running programs, the current running program with matter stack does not have the permission to reset those counts, so just non-op within this callback