### PR TITLE
Generate github comments from size reports (small scale)

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -41,3 +41,16 @@ jobs:
                   scripts/helpers/bloat_check.py                        \
                        --github-repository project-chip/connectedhomeip \
                        --github-api-token "${{ secrets.GITHUB_TOKEN }}"
+
+            - name: Report2
+              run: |
+                  scripts/tools/memory/gh_report.py \
+                    --verbose \
+                    --report-increases 1 \
+                    --report-pr \
+                    --github-comment \
+                    --github-limit-artifact-pages 5 \
+                    --github-limit-artifacts 50 \
+                    --github-limit-comments 2 \
+                    --github-repository project-chip/connectedhomeip \
+                    --github-api-token "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### Problem

The current bloat report requires preserving large binaries, and has
trouble matching tree parents for comparison.

In a24a6c308a4 (PR #9331), many workflows started uploading small json
artifacts contains size information for their builds, but these have not
yet been used to generate reports.

#### Change overview

This change adds a run of `scripts/tools/memory/gh_report.py` to the
periodic bloat check workflow, with tight rate limiting in case there
are unexpected problems.

#### Testing

Manually run offline with various data sets, and minimally on the live
repository.
