### PR TITLE
move qemu CI back to latest - we should not require every PR to merge…

### DIFF
--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.5.7
+            image: connectedhomeip/chip-build-esp32-qemu:latest
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 


### PR DESCRIPTION
… with master to pass

#### Problem
Fixing CI to 0.5.7 would require all PRs to be rebased (not ideal) and masks the error in CI only , but vscode would still be broken

#### Change overview
use latest again, which I moved to 0.5.7 for esp, espqemu and vscode