### PR TITLE
Remove unnecessary dependencies on FabricTable objects

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -129,7 +129,6 @@ private:
 } gPingArguments;
 
 Protocols::Echo::EchoClient gEchoClient;
-Transport::FabricTable gFabrics;
 
 CHIP_ERROR SendEchoRequest(streamer_t * stream);
 void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState);
@@ -306,7 +305,7 @@ void StartPinging(streamer_t * stream, char * destination)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gPingArguments.IsUsingTCP())
     {
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gFabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);
@@ -315,7 +314,7 @@ void StartPinging(streamer_t * stream, char * destination)
     else
 #endif
     {
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gFabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -201,7 +201,6 @@ void ProcessCommand(streamer_t * stream, char * destination)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    Transport::FabricTable fabrics;
     Transport::PeerAddress peerAddress;
 
     if (!chip::Inet::IPAddress::FromString(destination, gDestAddr))
@@ -227,7 +226,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     {
         peerAddress = Transport::PeerAddress::TCP(gDestAddr, gSendArguments.GetPort());
 
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -235,7 +234,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     {
         peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
 
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -44,7 +44,7 @@ namespace {
 bool HaveOperationalCredentials()
 {
     // Look for any fabric info that has a useful operational identity.
-    for (const Transport::FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
+    for (const FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
     {
         if (fabricInfo.IsInitialized())
         {
@@ -247,7 +247,7 @@ CHIP_ERROR MdnsServer::GetCommissionableInstanceName(char * buffer, size_t buffe
 /// Set MDNS operational advertisement
 CHIP_ERROR MdnsServer::AdvertiseOperational()
 {
-    for (const Transport::FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
+    for (const FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
     {
         if (fabricInfo.IsInitialized())
         {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -41,14 +41,13 @@
 #include <sys/param.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
-#include <transport/FabricTable.h>
 #include <transport/SessionManager.h>
 
+using chip::kMinValidFabricIndex;
 using chip::RendezvousInformationFlag;
 using chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr;
 using chip::Inet::IPAddressType;
 using chip::Transport::BleListenParameters;
-using chip::Transport::kMinValidFabricIndex;
 using chip::Transport::PeerAddress;
 using chip::Transport::UdpListenParameters;
 
@@ -117,7 +116,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 #endif
     SuccessOrExit(err);
 
-    err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mFabrics, &mMessageCounterManager);
+    err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mMessageCounterManager);
     SuccessOrExit(err);
 
     err = mExchangeMgr.Init(&mSessions);

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -61,7 +61,7 @@ public:
 
     CHIP_ERROR AddTestCommissioning();
 
-    Transport::FabricTable & GetFabricTable() { return mFabrics; }
+    FabricTable & GetFabricTable() { return mFabrics; }
 
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeMgr; }
 
@@ -125,7 +125,7 @@ private:
     SessionManager mSessions;
     CASEServer mCASEServer;
     Messaging::ExchangeManager mExchangeMgr;
-    Transport::FabricTable mFabrics;
+    FabricTable mFabrics;
     SessionIDAllocator mSessionIDAllocator;
     secure_channel::MessageCounterManager mMessageCounterManager;
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -418,14 +418,13 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::FabricTable fabrics;
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     chip::gSystemLayer.Init();
 
-    err = chip::gSessionManager.Init(&chip::gSystemLayer, &chip::gTransportManager, &fabrics, &chip::gMessageCounterManager);
+    err = chip::gSessionManager.Init(&chip::gSystemLayer, &chip::gTransportManager, &chip::gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = chip::gExchangeManager.Init(&chip::gSessionManager);

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -71,14 +71,13 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::FabricTable fabrics;
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     gSystemLayer.Init();
 
-    err = gSessionManager.Init(&gSystemLayer, &gTransportManager, &fabrics, &gMessageCounterManager);
+    err = gSessionManager.Init(&gSystemLayer, &gTransportManager, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -135,14 +135,13 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::FabricTable fabrics;
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     gSystemLayer.Init();
 
-    err = gSessionManager.Init(&gSystemLayer, &gTransportManager, &fabrics, &gMessageCounterManager);
+    err = gSessionManager.Init(&gSystemLayer, &gTransportManager, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -158,14 +158,13 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::FabricTable fabrics;
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     chip::gSystemLayer.Init();
 
-    err = chip::gSessionManager.Init(&chip::gSystemLayer, &chip::gTransportManager, &fabrics, &chip::gMessageCounterManager);
+    err = chip::gSessionManager.Init(&chip::gSystemLayer, &chip::gTransportManager, &chip::gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = chip::gExchangeManager.Init(&chip::gSessionManager);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -679,7 +679,6 @@ int main(int argc, char * argv[])
     std::mutex mutex;
     std::unique_lock<std::mutex> lock(mutex);
     MockInteractionModelApp mockDelegate;
-    chip::Transport::FabricTable fabrics;
 
     if (argc <= 1)
     {
@@ -702,7 +701,7 @@ int main(int argc, char * argv[])
                                      .SetListenPort(IM_CLIENT_PORT));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &fabrics, &gMessageCounterManager);
+    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager);
     SuccessOrExit(err);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -203,7 +203,6 @@ int main(int argc, char * argv[])
     MockInteractionModelApp mockDelegate;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     const chip::FabricIndex gFabricIndex = 0;
-    chip::Transport::FabricTable fabrics;
 
     InitializeChip();
 
@@ -211,7 +210,7 @@ int main(int argc, char * argv[])
         chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &fabrics, &gMessageCounterManager);
+    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager);
     SuccessOrExit(err);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -49,4 +49,6 @@ typedef uint32_t TransactionId;
 typedef uint32_t StatusCode;
 typedef uint8_t Percent;
 typedef uint16_t Percent100ths;
+
+static constexpr FabricIndex kUndefinedFabricIndex = 0;
 } // namespace chip

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -274,7 +274,7 @@ void ChannelContext::EnterCasePairingState()
     ExchangeContext * ctxt = mExchangeManager->NewContext(session.Value(), prepare.mCasePairingSession);
     VerifyOrReturn(ctxt != nullptr);
 
-    Transport::FabricInfo * fabric = mFabricsTable->FindFabricWithIndex(mFabricIndex);
+    FabricInfo * fabric = mFabricsTable->FindFabricWithIndex(mFabricIndex);
     VerifyOrReturn(fabric != nullptr);
     CHIP_ERROR err = prepare.mCasePairingSession->EstablishSession(addr, fabric, prepare.mBuilder.GetPeerNodeId(),
                                                                    mExchangeManager->GetNextKeyId(), ctxt, this);

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -80,7 +80,7 @@ class ChannelContext : public ReferenceCounted<ChannelContext, ChannelContextDel
 public:
     ChannelContext(ExchangeManager * exchangeManager, ChannelManager * channelManager) :
         mState(ChannelState::kNone), mExchangeManager(exchangeManager), mChannelManager(channelManager), mFabricsTable(nullptr),
-        mFabricIndex(Transport::kUndefinedFabricIndex)
+        mFabricIndex(kUndefinedFabricIndex)
     {}
 
     void Start(const ChannelBuilder & builder);
@@ -123,7 +123,7 @@ private:
     ChannelState mState;
     ExchangeManager * mExchangeManager;
     ChannelManager * mChannelManager;
-    Transport::FabricTable * mFabricsTable;
+    FabricTable * mFabricsTable;
     FabricIndex mFabricIndex;
 
     enum class PrepareState

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -510,7 +510,7 @@ CHIP_ERROR Device::WarmupCASESession()
     mLocalMessageCounter = 0;
     mPeerMessageCounter  = 0;
 
-    Transport::FabricInfo * fabric = mFabricsTable->FindFabricWithIndex(mFabricIndex);
+    FabricInfo * fabric = mFabricsTable->FindFabricWithIndex(mFabricIndex);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     ReturnErrorOnFailure(mCASESession.EstablishSession(mDeviceAddress, fabric, mDeviceId, keyID, exchange, this));

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -88,7 +88,7 @@ struct ControllerDeviceInitParams
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * bleLayer = nullptr;
 #endif
-    Transport::FabricTable * fabricsTable                 = nullptr;
+    FabricTable * fabricsTable                            = nullptr;
     DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
 };
 
@@ -517,9 +517,9 @@ private:
     static void OnOpenPairingWindowSuccessResponse(void * context);
     static void OnOpenPairingWindowFailureResponse(void * context, uint8_t status);
 
-    FabricIndex mFabricIndex = Transport::kUndefinedFabricIndex;
+    FabricIndex mFabricIndex = kUndefinedFabricIndex;
 
-    Transport::FabricTable * mFabricsTable = nullptr;
+    FabricTable * mFabricsTable = nullptr;
 
     bool mDeviceOperationalCertProvisioned = false;
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -155,7 +155,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 
 CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParams & params)
 {
-    Transport::FabricInfo newFabric;
+    FabricInfo newFabric;
 
     ReturnErrorCodeIf(params.ephemeralKeypair == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     newFabric.SetEphemeralKey(params.ephemeralKeypair);
@@ -187,7 +187,7 @@ CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParam
     ReturnErrorOnFailure(newFabric.SetNOCCert(chipCertSpan));
     newFabric.SetVendorId(params.controllerVendorId);
 
-    Transport::FabricInfo * fabric = params.systemState->Fabrics()->FindFabricWithIndex(mFabricIndex);
+    FabricInfo * fabric = params.systemState->Fabrics()->FindFabricWithIndex(mFabricIndex);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     ReturnErrorOnFailure(fabric->SetFabricInfo(newFabric));
@@ -683,7 +683,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
 
     uint16_t keyID = 0;
 
-    Transport::FabricInfo * fabric = mSystemState->Fabrics()->FindFabricWithIndex(mFabricIndex);
+    FabricInfo * fabric = mSystemState->Fabrics()->FindFabricWithIndex(mFabricIndex);
 
     VerifyOrExit(IsOperationalNodeId(remoteDeviceId), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -306,7 +306,7 @@ protected:
 
     void PersistNextKeyId();
 
-    FabricIndex mFabricIndex = Transport::kMinValidFabricIndex;
+    FabricIndex mFabricIndex = kMinValidFabricIndex;
 
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -129,14 +129,14 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         params.imDelegate = chip::Platform::New<DeviceControllerInteractionModelDelegate>();
     }
 
-    stateParams.fabricTable           = chip::Platform::New<Transport::FabricTable>();
+    stateParams.fabricTable           = chip::Platform::New<FabricTable>();
     stateParams.sessionMgr            = chip::Platform::New<SessionManager>();
     stateParams.exchangeMgr           = chip::Platform::New<Messaging::ExchangeManager>();
     stateParams.messageCounterManager = chip::Platform::New<secure_channel::MessageCounterManager>();
 
     ReturnErrorOnFailure(stateParams.fabricTable->Init(mStorageDelegate));
-    ReturnErrorOnFailure(stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr, stateParams.fabricTable,
-                                                      stateParams.messageCounterManager));
+    ReturnErrorOnFailure(
+        stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr, stateParams.messageCounterManager));
     ReturnErrorOnFailure(stateParams.exchangeMgr->Init(stateParams.sessionMgr));
     ReturnErrorOnFailure(stateParams.messageCounterManager->Init(stateParams.exchangeMgr));
 

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -55,7 +55,7 @@ struct DeviceControllerSystemStateParams
     SessionManager * sessionMgr                                   = nullptr;
     Messaging::ExchangeManager * exchangeMgr                      = nullptr;
     secure_channel::MessageCounterManager * messageCounterManager = nullptr;
-    Transport::FabricTable * fabricTable                          = nullptr;
+    FabricTable * fabricTable                                     = nullptr;
     DeviceControllerInteractionModelDelegate * imDelegate         = nullptr;
 };
 
@@ -116,7 +116,7 @@ public:
     SessionManager * SessionMgr() { return mSessionMgr; };
     Messaging::ExchangeManager * ExchangeMgr() { return mExchangeMgr; }
     secure_channel::MessageCounterManager * MessageCounterManager() { return mMessageCounterManager; };
-    Transport::FabricTable * Fabrics() { return mFabrics; };
+    FabricTable * Fabrics() { return mFabrics; };
     DeviceControllerInteractionModelDelegate * IMDelegate() { return mIMDelegate; }
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * BleLayer() { return mBleLayer; };
@@ -134,7 +134,7 @@ private:
     SessionManager * mSessionMgr                                   = nullptr;
     Messaging::ExchangeManager * mExchangeMgr                      = nullptr;
     secure_channel::MessageCounterManager * mMessageCounterManager = nullptr;
-    Transport::FabricTable * mFabrics                              = nullptr;
+    FabricTable * mFabrics                                         = nullptr;
     DeviceControllerInteractionModelDelegate * mIMDelegate         = nullptr;
 
     std::atomic<uint32_t> mRefCount{ 1 };

--- a/src/controller/tests/TestDevice.cpp
+++ b/src/controller/tests/TestDevice.cpp
@@ -72,7 +72,7 @@ void TestDevice_EstablishSessionDirectly(nlTestSuite * inSuite, void * inContext
         BleListenParameters(&blelayer)
 #endif
     );
-    sessionManager.Init(&systemLayer, &transportMgr, fabrics, &messageCounterManager);
+    sessionManager.Init(&systemLayer, &transportMgr, &messageCounterManager);
     exchangeMgr.Init(&sessionManager);
     messageCounterManager.Init(&exchangeMgr);
 

--- a/src/messaging/ExchangeACL.h
+++ b/src/messaging/ExchangeACL.h
@@ -102,7 +102,7 @@ private:
 class DLL_EXPORT CASEExchangeACL : public ExchangeACL
 {
 public:
-    CASEExchangeACL(Transport::FabricInfo * info) : mFabricInfo(info) {}
+    CASEExchangeACL(FabricInfo * info) : mFabricInfo(info) {}
     virtual ~CASEExchangeACL() {}
 
     PermissionLevel GetPermissionLevel(const ACLSubject & subject, const ACLTarget & target) override
@@ -116,7 +116,7 @@ public:
     }
 
 private:
-    Transport::FabricInfo * mFabricInfo;
+    FabricInfo * mFabricInfo;
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -150,11 +150,11 @@ public:
 
     ExchangeMessageDispatch * GetMessageDispatch() { return mDispatch; }
 
-    ExchangeACL * GetExchangeACL(Transport::FabricTable & table)
+    ExchangeACL * GetExchangeACL(FabricTable & table)
     {
         if (mExchangeACL == nullptr)
         {
-            Transport::FabricInfo * fabric = table.FindFabricWithIndex(mSecureSession.Value().GetFabricIndex());
+            FabricInfo * fabric = table.FindFabricWithIndex(mSecureSession.Value().GetFabricIndex());
             if (fabric != nullptr)
             {
                 mExchangeACL = chip::Platform::New<CASEExchangeACL>(fabric);

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -30,9 +30,7 @@ CHIP_ERROR MessagingContext::Init(nlTestSuite * suite, TransportMgrBase * transp
 
     mIOContext = ioContext;
 
-    mFabrics.Reset();
-
-    ReturnErrorOnFailure(mSessionManager.Init(&GetSystemLayer(), transport, &mFabrics, &mMessageCounterManager));
+    ReturnErrorOnFailure(mSessionManager.Init(&GetSystemLayer(), transport, &mMessageCounterManager));
 
     ReturnErrorOnFailure(mExchangeManager.Init(&mSessionManager));
     ReturnErrorOnFailure(mMessageCounterManager.Init(&mExchangeManager));

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -20,7 +20,6 @@
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
-#include <transport/FabricTable.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/tests/NetworkTestHelpers.h>
@@ -103,7 +102,6 @@ private:
     Transport::PeerAddress mBobAddress;
     SecurePairingUsingTestSecret mPairingAliceToBob;
     SecurePairingUsingTestSecret mPairingBobToAlice;
-    Transport::FabricTable mFabrics;
     FabricIndex mSrcFabricIndex  = 0;
     FabricIndex mDestFabricIndex = 0;
 };

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -200,8 +200,6 @@ int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Transport::FabricTable fabrics;
-
     if (argc <= 1)
     {
         printf("Missing Echo Server IP address\n");
@@ -234,7 +232,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -244,7 +242,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -61,8 +61,6 @@ int main(int argc, char * argv[])
     bool useTCP      = false;
     bool disableEcho = false;
 
-    chip::Transport::FabricTable fabrics;
-
     const chip::FabricIndex gFabricIndex = 0;
 
     if (argc > 2)
@@ -89,7 +87,7 @@ int main(int argc, char * argv[])
             chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -98,7 +96,7 @@ int main(int argc, char * argv[])
             chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -31,7 +31,7 @@ namespace chip {
 
 CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
                                                      Ble::BleLayer * bleLayer, SessionManager * sessionManager,
-                                                     Transport::FabricTable * fabrics, SessionIDAllocator * idAllocator)
+                                                     FabricTable * fabrics, SessionIDAllocator * idAllocator)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -38,8 +38,8 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                             Ble::BleLayer * bleLayer, SessionManager * sessionManager,
-                                             Transport::FabricTable * fabrics, SessionIDAllocator * idAllocator);
+                                             Ble::BleLayer * bleLayer, SessionManager * sessionManager, FabricTable * fabrics,
+                                             SessionIDAllocator * idAllocator);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -65,7 +65,7 @@ private:
     SessionManager * mSessionManager = nullptr;
     Ble::BleLayer * mBleLayer        = nullptr;
 
-    Transport::FabricTable * mFabrics = nullptr;
+    FabricTable * mFabrics = nullptr;
 
     CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -234,8 +234,7 @@ CHIP_ERROR CASESession::Init(uint16_t localSessionId, SessionEstablishmentDelega
 }
 
 CHIP_ERROR
-CASESession::ListenForSessionEstablishment(uint16_t localSessionId, Transport::FabricTable * fabrics,
-                                           SessionEstablishmentDelegate * delegate)
+CASESession::ListenForSessionEstablishment(uint16_t localSessionId, FabricTable * fabrics, SessionEstablishmentDelegate * delegate)
 {
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(Init(localSessionId, delegate));
@@ -249,8 +248,8 @@ CASESession::ListenForSessionEstablishment(uint16_t localSessionId, Transport::F
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::EstablishSession(const Transport::PeerAddress peerAddress, Transport::FabricInfo * fabric,
-                                         NodeId peerNodeId, uint16_t localSessionId, ExchangeContext * exchangeCtxt,
+CHIP_ERROR CASESession::EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId,
+                                         uint16_t localSessionId, ExchangeContext * exchangeCtxt,
                                          SessionEstablishmentDelegate * delegate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -431,7 +430,7 @@ CHIP_ERROR CASESession::HandleSigma1(System::PacketBufferHandle && msg)
     ByteSpan initiatorPubKey;
 
     const ByteSpan * ipkListSpan = GetIPKList();
-    FabricIndex fabricIndex      = Transport::kUndefinedFabricIndex;
+    FabricIndex fabricIndex      = kUndefinedFabricIndex;
 
     SuccessOrExit(err = mCommissioningHash.AddData(ByteSpan{ msg->Start(), msg->DataLength() }));
 
@@ -463,7 +462,7 @@ CHIP_ERROR CASESession::HandleSigma1(System::PacketBufferHandle && msg)
     VerifyOrExit(mFabricsTable != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     fabricIndex =
         mFabricsTable->FindDestinationIDCandidate(destinationIdentifier, initiatorRandom, ipkListSpan, GetIPKListEntries());
-    VerifyOrExit(fabricIndex != Transport::kUndefinedFabricIndex, err = CHIP_ERROR_KEY_NOT_FOUND);
+    VerifyOrExit(fabricIndex != kUndefinedFabricIndex, err = CHIP_ERROR_KEY_NOT_FOUND);
 
     mFabricInfo = mFabricsTable->FindFabricWithIndex(fabricIndex);
     VerifyOrExit(mFabricInfo != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -97,8 +97,7 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR ListenForSessionEstablishment(uint16_t mySessionId, Transport::FabricTable * fabrics,
-                                             SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR ListenForSessionEstablishment(uint16_t mySessionId, FabricTable * fabrics, SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -113,7 +112,7 @@ public:
      *
      * @return CHIP_ERROR      The result of initialization
      */
-    CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, Transport::FabricInfo * fabric, NodeId peerNodeId,
+    CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, FabricInfo * fabric, NodeId peerNodeId,
                                 uint16_t mySessionId, Messaging::ExchangeContext * exchangeCtxt,
                                 SessionEstablishmentDelegate * delegate);
 
@@ -188,10 +187,7 @@ public:
         return &mMessageDispatch;
     }
 
-    FabricIndex GetFabricIndex() const
-    {
-        return mFabricInfo != nullptr ? mFabricInfo->GetFabricIndex() : Transport::kUndefinedFabricIndex;
-    }
+    FabricIndex GetFabricIndex() const { return mFabricInfo != nullptr ? mFabricInfo->GetFabricIndex() : kUndefinedFabricIndex; }
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     /** @brief This function zeroes out and resets the memory used by the object.
@@ -279,8 +275,8 @@ private:
     Messaging::ExchangeContext * mExchangeCtxt = nullptr;
     SessionEstablishmentExchangeDispatch mMessageDispatch;
 
-    Transport::FabricTable * mFabricsTable = nullptr;
-    Transport::FabricInfo * mFabricInfo    = nullptr;
+    FabricTable * mFabricsTable = nullptr;
+    FabricInfo * mFabricInfo    = nullptr;
 
     uint8_t mResumptionId[kCASEResumptionIDSize];
     // Sigma1 initiator random, maintained to be reused post-Sigma1, such as when generating Sigma2 S2RK key

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -31,8 +31,6 @@ namespace chip {
 using namespace Credentials;
 using namespace Crypto;
 
-namespace Transport {
-
 CHIP_ERROR FabricInfo::SetFabricLabel(const uint8_t * fabricLabel)
 {
     const char * charFabricLabel = Uint8::to_const_char(fabricLabel);
@@ -588,5 +586,4 @@ CHIP_ERROR FabricTable::SetFabricDelegate(FabricTableDelegate * delegate)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Transport
 } // namespace chip

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -32,16 +32,13 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/Span.h>
-#include <transport/raw/MessageHeader.h>
 
 #ifdef ENABLE_HSM_CASE_OPS_KEY
 #define CASE_OPS_KEY 0xCA5EECC0
 #endif
 
 namespace chip {
-namespace Transport {
 
-static constexpr FabricIndex kUndefinedFabricIndex    = 0;
 static constexpr FabricIndex kMinValidFabricIndex     = 1;
 static constexpr FabricIndex kMaxValidFabricIndex     = std::min(UINT8_MAX, CHIP_CONFIG_MAX_DEVICE_ADMINS);
 static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
@@ -403,5 +400,4 @@ private:
     uint8_t mFabricCount                  = 0;
 };
 
-} // namespace Transport
 } // namespace chip

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include <app/util/basic-types.h>
 #include <transport/CryptoContext.h>
-#include <transport/FabricTable.h>
 #include <transport/SessionMessageCounter.h>
 #include <transport/raw/Base.h>
 #include <transport/raw/MessageHeader.h>

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -19,7 +19,6 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <system/TimeSource.h>
-#include <transport/FabricTable.h>
 #include <transport/SecureSession.h>
 
 namespace chip {

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -20,7 +20,6 @@
 #include <app/util/basic-types.h>
 #include <lib/core/NodeId.h>
 #include <lib/core/Optional.h>
-#include <transport/FabricTable.h>
 #include <transport/UnauthenticatedSessionTable.h>
 #include <transport/raw/PeerAddress.h>
 
@@ -34,7 +33,7 @@ public:
     SessionHandle(NodeId peerNodeId, FabricIndex fabric) : mPeerNodeId(peerNodeId), mFabric(fabric) {}
 
     SessionHandle(Transport::UnauthenticatedSessionHandle session) :
-        mPeerNodeId(kPlaceholderNodeId), mFabric(Transport::kUndefinedFabricIndex), mUnauthenticatedSessionHandle(session)
+        mPeerNodeId(kPlaceholderNodeId), mFabric(kUndefinedFabricIndex), mUnauthenticatedSessionHandle(session)
     {}
 
     SessionHandle(NodeId peerNodeId, uint16_t localSessionId, uint16_t peerSessionId, FabricIndex fabric) :
@@ -46,7 +45,7 @@ public:
 
     bool IsSecure() const { return !mUnauthenticatedSessionHandle.HasValue(); }
 
-    bool HasFabricIndex() const { return (mFabric != Transport::kUndefinedFabricIndex); }
+    bool HasFabricIndex() const { return (mFabric != kUndefinedFabricIndex); }
     FabricIndex GetFabricIndex() const { return mFabric; }
     void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -36,7 +36,6 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/Constants.h>
-#include <transport/FabricTable.h>
 #include <transport/PairingSession.h>
 #include <transport/SecureMessageCodec.h>
 #include <transport/TransportMgr.h>
@@ -69,7 +68,7 @@ SessionManager::SessionManager() : mState(State::kNotReady) {}
 
 SessionManager::~SessionManager() {}
 
-CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * transportMgr, Transport::FabricTable * fabrics,
+CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * transportMgr,
                                 Transport::MessageCounterManagerInterface * messageCounterManager)
 {
     VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
@@ -78,7 +77,6 @@ CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * 
     mState                 = State::kInitialized;
     mSystemLayer           = systemLayer;
     mTransportMgr          = transportMgr;
-    mFabrics               = fabrics;
     mMessageCounterManager = messageCounterManager;
 
     mGlobalEncryptedMessageCounter.Init();
@@ -99,7 +97,6 @@ void SessionManager::Shutdown()
     mState        = State::kNotReady;
     mSystemLayer  = nullptr;
     mTransportMgr = nullptr;
-    mFabrics      = nullptr;
     mCB           = nullptr;
 }
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -34,7 +34,6 @@
 #include <lib/support/DLLUtil.h>
 #include <protocols/secure_channel/Constants.h>
 #include <transport/CryptoContext.h>
-#include <transport/FabricTable.h>
 #include <transport/MessageCounterManagerInterface.h>
 #include <transport/SecureSessionTable.h>
 #include <transport/SessionHandle.h>
@@ -241,10 +240,9 @@ public:
      *
      * @param systemLayer           System, layer to use
      * @param transportMgr          Transport to use
-     * @param fabrics                A table of device administrators
      * @param messageCounterManager The message counter manager
      */
-    CHIP_ERROR Init(System::Layer * systemLayer, TransportMgrBase * transportMgr, Transport::FabricTable * fabrics,
+    CHIP_ERROR Init(System::Layer * systemLayer, TransportMgrBase * transportMgr,
                     Transport::MessageCounterManagerInterface * messageCounterManager);
 
     /**
@@ -297,7 +295,6 @@ private:
 
     SessionManagerDelegate * mCB                                       = nullptr;
     TransportMgrBase * mTransportMgr                                   = nullptr;
-    Transport::FabricTable * mFabrics                                  = nullptr;
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;
 
     GlobalUnencryptedMessageCounter mGlobalUnencryptedMessageCounter;

--- a/src/transport/SessionMessageCounter.h
+++ b/src/transport/SessionMessageCounter.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <transport/CryptoContext.h>
-#include <transport/FabricTable.h>
 #include <transport/MessageCounter.h>
 #include <transport/PeerMessageCounter.h>
 #include <transport/raw/Base.h>

--- a/src/transport/tests/TestSessionHandle.cpp
+++ b/src/transport/tests/TestSessionHandle.cpp
@@ -28,7 +28,6 @@
 
 #include <protocols/secure_channel/PASESession.h>
 #include <transport/CryptoContext.h>
-#include <transport/FabricTable.h>
 #include <transport/SessionHandle.h>
 
 #include <lib/support/CodeUtils.h>

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -121,8 +121,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::FabricTable fabrics;
-    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
+    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
@@ -148,8 +147,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::FabricTable fabrics;
-    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
+    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -236,8 +234,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::FabricTable fabrics;
-    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
+    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -310,8 +307,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::FabricTable fabrics;
-    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
+    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -415,8 +411,7 @@ void StaleConnectionDropTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::FabricTable fabrics;
-    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
+    err = sessionManager.Init(ctx.GetInetLayer().SystemLayer(), &transportMgr, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;


### PR DESCRIPTION
#### Problem
A bunch of code is including `FabricTable.h` that's not really needed. The code could use some cleanup.

#### Change overview
Removed unnecessary dependency on classes in `FabricTable.h` file. Also moved FabricTable objects out of `Transport` namespace. Intention is to eventually move it out of `src/transport` to higher in the stack. 

#### Testing
Ran `gn_build.sh` and `gn_tests.sh` to ensure the builds and tests are not impacted.
Build m5stack image to test the device build.
Performed commissioning of m5stack using chip-tool
CI to test other device builds.