### PR TITLE
Convert to per-attribute namespaces for our Get/Set accessors

### DIFF
--- a/examples/lighting-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg/src/ZclCallbacks.cpp
@@ -90,14 +90,14 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
             {
                 xy.x = *reinterpret_cast<uint16_t *>(value);
                 // get Y from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::GetCurrentY(endpoint, &xy.y);
+                EmberAfStatus status = ColorControl::Attributes::CurrentY::Get(endpoint, &xy.y);
                 assert(status == EMBER_ZCL_STATUS_SUCCESS);
             }
             if (attributeId == ZCL_COLOR_CONTROL_CURRENT_Y_ATTRIBUTE_ID)
             {
                 xy.y = *reinterpret_cast<uint16_t *>(value);
                 // get X from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::GetCurrentX(endpoint, &xy.x);
+                EmberAfStatus status = ColorControl::Attributes::CurrentX::Get(endpoint, &xy.x);
                 assert(status == EMBER_ZCL_STATUS_SUCCESS);
             }
             ChipLogProgress(Zcl, "New XY color: %u|%u", xy.x, xy.y);
@@ -110,14 +110,14 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
             {
                 hsv.h = *value;
                 // get saturation from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::GetCurrentSaturation(endpoint, &hsv.s);
+                EmberAfStatus status = ColorControl::Attributes::CurrentSaturation::Get(endpoint, &hsv.s);
                 assert(status == EMBER_ZCL_STATUS_SUCCESS);
             }
             if (attributeId == ZCL_COLOR_CONTROL_CURRENT_SATURATION_ATTRIBUTE_ID)
             {
                 hsv.s = *value;
                 // get hue from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::GetCurrentHue(endpoint, &hsv.h);
+                EmberAfStatus status = ColorControl::Attributes::CurrentHue::Get(endpoint, &hsv.h);
                 assert(status == EMBER_ZCL_STATUS_SUCCESS);
             }
             ChipLogProgress(Zcl, "New HSV color: %u|%u", hsv.h, hsv.s);

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -335,11 +335,11 @@ void WindowApp::Cover::Init(chip::EndpointId endpoint)
     mLiftTimer = WindowApp::Instance().CreateTimer("Timer:Lift", COVER_LIFT_TILT_TIMEOUT, OnLiftTimeout, this);
     mTiltTimer = WindowApp::Instance().CreateTimer("Timer:Tilt", COVER_LIFT_TILT_TIMEOUT, OnTiltTimeout, this);
 
-    Attributes::SetInstalledOpenLimitLift(endpoint, LIFT_OPEN_LIMIT);
-    Attributes::SetInstalledClosedLimitLift(endpoint, LIFT_CLOSED_LIMIT);
+    Attributes::InstalledOpenLimitLift::Set(endpoint, LIFT_OPEN_LIMIT);
+    Attributes::InstalledClosedLimitLift::Set(endpoint, LIFT_CLOSED_LIMIT);
     LiftPositionSet(endpoint, LiftToPercent100ths(endpoint, LIFT_CLOSED_LIMIT));
-    Attributes::SetInstalledOpenLimitTilt(endpoint, TILT_OPEN_LIMIT);
-    Attributes::SetInstalledClosedLimitTilt(endpoint, TILT_CLOSED_LIMIT);
+    Attributes::InstalledOpenLimitTilt::Set(endpoint, TILT_OPEN_LIMIT);
+    Attributes::InstalledClosedLimitTilt::Set(endpoint, TILT_CLOSED_LIMIT);
     TiltPositionSet(endpoint, TiltToPercent100ths(endpoint, TILT_CLOSED_LIMIT));
 
     // Attribute: Id  0 Type
@@ -383,7 +383,7 @@ void WindowApp::Cover::LiftUp()
 {
     uint16_t percent100ths = 0;
 
-    Attributes::GetCurrentPositionLiftPercent100ths(mEndpoint, &percent100ths);
+    Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, &percent100ths);
     if (percent100ths < 9000)
     {
         percent100ths += 1000;
@@ -399,7 +399,7 @@ void WindowApp::Cover::LiftDown()
 {
     uint16_t percent100ths = 0;
 
-    Attributes::GetCurrentPositionLiftPercent100ths(mEndpoint, &percent100ths);
+    Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, &percent100ths);
     if (percent100ths > 1000)
     {
         percent100ths -= 1000;
@@ -415,8 +415,8 @@ void WindowApp::Cover::GotoLift(EventId action)
 {
     uint16_t current = 0;
     uint16_t target  = 0;
-    Attributes::GetTargetPositionLiftPercent100ths(mEndpoint, &target);
-    Attributes::GetCurrentPositionLiftPercent100ths(mEndpoint, &current);
+    Attributes::TargetPositionLiftPercent100ths::Get(mEndpoint, &target);
+    Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, &current);
 
     if (EventId::None != action)
     {
@@ -455,7 +455,7 @@ void WindowApp::Cover::GotoLift(EventId action)
 void WindowApp::Cover::TiltUp()
 {
     uint16_t percent100ths = 0;
-    Attributes::GetCurrentPositionTiltPercent100ths(mEndpoint, &percent100ths);
+    Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, &percent100ths);
     if (percent100ths < 9000)
     {
         percent100ths += 1000;
@@ -470,7 +470,7 @@ void WindowApp::Cover::TiltUp()
 void WindowApp::Cover::TiltDown()
 {
     uint16_t percent100ths = 0;
-    Attributes::GetCurrentPositionTiltPercent100ths(mEndpoint, &percent100ths);
+    Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, &percent100ths);
     if (percent100ths > 1000)
     {
         percent100ths -= 1000;
@@ -487,8 +487,8 @@ void WindowApp::Cover::GotoTilt(EventId action)
     uint16_t current = 0;
     uint16_t target  = 0;
 
-    Attributes::GetTargetPositionTiltPercent100ths(mEndpoint, &target);
-    Attributes::GetCurrentPositionTiltPercent100ths(mEndpoint, &current);
+    Attributes::TargetPositionTiltPercent100ths::Get(mEndpoint, &target);
+    Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, &current);
 
     if (EventId::None != action)
     {

--- a/examples/window-app/common/src/ZclCallbacks.cpp
+++ b/examples/window-app/common/src/ZclCallbacks.cpp
@@ -56,8 +56,8 @@ void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::Cluster
             break;
 
         case ZCL_WC_TARGET_POSITION_LIFT_PERCENT100_THS_ATTRIBUTE_ID:
-            Attributes::GetTargetPositionLiftPercent100ths(endpoint, &target);
-            Attributes::GetCurrentPositionLiftPercent100ths(endpoint, &current);
+            Attributes::TargetPositionLiftPercent100ths::Get(endpoint, &target);
+            Attributes::CurrentPositionLiftPercent100ths::Get(endpoint, &current);
             if (current > target)
             {
                 app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftDown, endpoint));
@@ -69,8 +69,8 @@ void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::Cluster
             break;
 
         case ZCL_WC_TARGET_POSITION_TILT_PERCENT100_THS_ATTRIBUTE_ID:
-            Attributes::GetTargetPositionTiltPercent100ths(endpoint, &target);
-            Attributes::GetCurrentPositionTiltPercent100ths(endpoint, &current);
+            Attributes::TargetPositionTiltPercent100ths::Get(endpoint, &target);
+            Attributes::CurrentPositionTiltPercent100ths::Get(endpoint, &current);
             if (current > target)
             {
                 app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltDown, endpoint));

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -342,8 +342,8 @@ void WindowAppImpl::UpdateLCD()
         EmberAfWcType type = TypeGet(cover.mEndpoint);
         uint16_t lift      = 0;
         uint16_t tilt      = 0;
-        Attributes::GetCurrentPositionLift(cover.mEndpoint, &lift);
-        Attributes::GetCurrentPositionTilt(cover.mEndpoint, &tilt);
+        Attributes::CurrentPositionLift::Get(cover.mEndpoint, &lift);
+        Attributes::CurrentPositionTilt::Get(cover.mEndpoint, &tilt);
         LcdPainter::Paint(type, static_cast<uint8_t>(lift), static_cast<uint8_t>(tilt), mIcon);
     }
     else

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -85,21 +85,21 @@ void emberAfPluginBarrierControlServerInitCallback(void) {}
 uint8_t emAfPluginBarrierControlServerGetBarrierPosition(EndpointId endpoint)
 {
     uint8_t position;
-    EmberAfStatus status = BarrierControl::Attributes::GetBarrierPosition(endpoint, &position);
+    EmberAfStatus status = BarrierControl::Attributes::BarrierPosition::Get(endpoint, &position);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return position;
 }
 
 void emAfPluginBarrierControlServerSetBarrierPosition(EndpointId endpoint, uint8_t position)
 {
-    EmberAfStatus status = BarrierControl::Attributes::SetBarrierPosition(endpoint, position);
+    EmberAfStatus status = BarrierControl::Attributes::BarrierPosition::Set(endpoint, position);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
 }
 
 bool emAfPluginBarrierControlServerIsPartialBarrierSupported(EndpointId endpoint)
 {
     uint8_t bitmap;
-    EmberAfStatus status = BarrierControl::Attributes::GetBarrierCapabilities(endpoint, &bitmap);
+    EmberAfStatus status = BarrierControl::Attributes::BarrierCapabilities::Get(endpoint, &bitmap);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return READBITS(bitmap, EMBER_AF_BARRIER_CONTROL_CAPABILITIES_PARTIAL_BARRIER);
 }
@@ -111,13 +111,13 @@ static uint16_t getOpenOrClosePeriod(EndpointId endpoint, bool open)
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_PERIOD_ATTRIBUTE)
     if (open)
     {
-        status = BarrierControl::Attributes::GetBarrierOpenPeriod(endpoint, &period);
+        status = BarrierControl::Attributes::BarrierOpenPeriod::Get(endpoint, &period);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_CLOSE_PERIOD_ATTRIBUTE)
     if (!open)
     {
-        status = BarrierControl::Attributes::GetBarrierClosePeriod(endpoint, &period);
+        status = BarrierControl::Attributes::BarrierClosePeriod::Get(endpoint, &period);
     }
 #endif
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
@@ -126,14 +126,14 @@ static uint16_t getOpenOrClosePeriod(EndpointId endpoint, bool open)
 
 static void setMovingState(EndpointId endpoint, uint8_t newState)
 {
-    EmberAfStatus status = BarrierControl::Attributes::SetBarrierMovingState(endpoint, newState);
+    EmberAfStatus status = BarrierControl::Attributes::BarrierMovingState::Set(endpoint, newState);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
 }
 
 uint16_t emAfPluginBarrierControlServerGetSafetyStatus(EndpointId endpoint)
 {
     uint16_t safetyStatus;
-    EmberAfStatus status = BarrierControl::Attributes::GetBarrierSafetyStatus(endpoint, &safetyStatus);
+    EmberAfStatus status = BarrierControl::Attributes::BarrierSafetyStatus::Get(endpoint, &safetyStatus);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return safetyStatus;
 }
@@ -152,25 +152,25 @@ void emAfPluginBarrierControlServerIncrementEvents(EndpointId endpoint, bool ope
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_EVENTS_ATTRIBUTE)
     if (open && !command)
     {
-        status = BarrierControl::Attributes::GetBarrierOpenEvents(endpoint, &events);
+        status = BarrierControl::Attributes::BarrierOpenEvents::Get(endpoint, &events);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_CLOSE_EVENTS_ATTRIBUTE)
     if (!open && !command)
     {
-        status = BarrierControl::Attributes::GetBarrierCloseEvents(endpoint, &events);
+        status = BarrierControl::Attributes::BarrierCloseEvents::Get(endpoint, &events);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_OPEN_EVENTS_ATTRIBUTE)
     if (open && command)
     {
-        status = BarrierControl::Attributes::GetBarrierCommandOpenEvents(endpoint, &events);
+        status = BarrierControl::Attributes::BarrierCommandOpenEvents::Get(endpoint, &events);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_CLOSE_EVENTS_ATTRIBUTE)
     if (!open && command)
     {
-        status = BarrierControl::Attributes::GetBarrierCommandCloseEvents(endpoint, &events);
+        status = BarrierControl::Attributes::BarrierCommandCloseEvents::Get(endpoint, &events);
     }
 #endif
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
@@ -187,25 +187,25 @@ void emAfPluginBarrierControlServerIncrementEvents(EndpointId endpoint, bool ope
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_EVENTS_ATTRIBUTE)
     if (open && !command)
     {
-        status = BarrierControl::Attributes::SetBarrierOpenEvents(endpoint, events);
+        status = BarrierControl::Attributes::BarrierOpenEvents::Set(endpoint, events);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_CLOSE_EVENTS_ATTRIBUTE)
     if (!open && !command)
     {
-        status = BarrierControl::Attributes::SetBarrierCloseEvents(endpoint, events);
+        status = BarrierControl::Attributes::BarrierCloseEvents::Set(endpoint, events);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_OPEN_EVENTS_ATTRIBUTE)
     if (open && command)
     {
-        status = BarrierControl::Attributes::SetBarrierCommandOpenEvents(endpoint, events);
+        status = BarrierControl::Attributes::BarrierCommandOpenEvents::Set(endpoint, events);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_CLOSE_EVENTS_ATTRIBUTE)
     if (!open && command)
     {
-        status = BarrierControl::Attributes::SetBarrierCommandCloseEvents(endpoint, events);
+        status = BarrierControl::Attributes::BarrierCommandCloseEvents::Set(endpoint, events);
     }
 #endif
     assert(status == EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -97,10 +97,10 @@ bool ColorControlServer::shouldExecuteIfOff(EndpointId endpoint, uint8_t optionM
     }
 
     uint8_t options = 0x00;
-    ColorControl::Attributes::GetColorControlOptions(endpoint, &options);
+    ColorControl::Attributes::ColorControlOptions::Get(endpoint, &options);
 
     bool on = true;
-    OnOff::Attributes::GetOnOff(endpoint, &on);
+    OnOff::Attributes::OnOff::Get(endpoint, &on);
 
     // The device is on - hence ExecuteIfOff does not matter
     if (on)
@@ -156,7 +156,7 @@ bool ColorControlServer::shouldExecuteIfOff(EndpointId endpoint, uint8_t optionM
 void ColorControlServer::handleModeSwitch(EndpointId endpoint, uint8_t newColorMode)
 {
     uint8_t oldColorMode = 0;
-    ColorControl::Attributes::GetColorMode(endpoint, &oldColorMode);
+    ColorControl::Attributes::ColorMode::Get(endpoint, &oldColorMode);
 
     uint8_t colorModeTransition;
 
@@ -166,8 +166,8 @@ void ColorControlServer::handleModeSwitch(EndpointId endpoint, uint8_t newColorM
     }
     else
     {
-        ColorControl::Attributes::SetEnhancedColorMode(endpoint, newColorMode);
-        ColorControl::Attributes::SetColorMode(endpoint, newColorMode);
+        ColorControl::Attributes::EnhancedColorMode::Set(endpoint, newColorMode);
+        ColorControl::Attributes::ColorMode::Set(endpoint, newColorMode);
     }
 
     colorModeTransition = static_cast<uint8_t>((newColorMode << 4) + oldColorMode);
@@ -303,7 +303,7 @@ bool ColorControlServer::computeNewColor16uValue(ColorControlServer::Color16uTra
 
     (p->stepsRemaining)--;
 
-    ColorControl::Attributes::SetRemainingTime(p->endpoint, p->stepsRemaining);
+    ColorControl::Attributes::RemainingTime::Set(p->endpoint, p->stepsRemaining);
 
     // handle sign
     if (p->finalValue == p->currentValue)
@@ -379,7 +379,7 @@ ColorControlServer::Color16uTransitionState * ColorControlServer::getSaturationT
 uint8_t ColorControlServer::getSaturation(EndpointId endpoint)
 {
     uint8_t saturation = 0;
-    ColorControl::Attributes::GetCurrentSaturation(endpoint, &saturation);
+    ColorControl::Attributes::CurrentSaturation::Get(endpoint, &saturation);
 
     return saturation;
 }
@@ -504,26 +504,26 @@ void ColorControlServer::startColorLoop(EndpointId endpoint, uint8_t startFromSt
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionState(endpoint);
 
     uint8_t direction = 0;
-    ColorControl::Attributes::GetColorLoopDirection(endpoint, &direction);
+    ColorControl::Attributes::ColorLoopDirection::Get(endpoint, &direction);
 
     uint16_t time = 0x0019;
-    ColorControl::Attributes::GetColorLoopTime(endpoint, &time);
+    ColorControl::Attributes::ColorLoopTime::Get(endpoint, &time);
 
     uint16_t currentHue = 0;
-    ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &currentHue);
+    ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &currentHue);
 
     u_int16_t startHue = 0x2300;
     if (startFromStartHue)
     {
-        ColorControl::Attributes::GetColorLoopStartEnhancedHue(endpoint, &startHue);
+        ColorControl::Attributes::ColorLoopStartEnhancedHue::Get(endpoint, &startHue);
     }
     else
     {
         startHue = currentHue;
     }
 
-    ColorControl::Attributes::SetColorLoopStoredEnhancedHue(endpoint, currentHue);
-    ColorControl::Attributes::SetColorLoopActive(endpoint, true);
+    ColorControl::Attributes::ColorLoopStoredEnhancedHue::Set(endpoint, currentHue);
+    ColorControl::Attributes::ColorLoopActive::Set(endpoint, true);
 
     initHueSat(endpoint, colorHueTransitionState, colorSaturationTransitionState);
 
@@ -548,7 +548,7 @@ void ColorControlServer::startColorLoop(EndpointId endpoint, uint8_t startFromSt
     colorHueTransitionState->stepsTotal     = static_cast<uint16_t>(time * TRANSITION_TIME_1S);
     colorHueTransitionState->endpoint       = endpoint;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, MAX_INT16U_VALUE);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, MAX_INT16U_VALUE);
 
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
 }
@@ -564,10 +564,10 @@ void ColorControlServer::initHueSat(EndpointId endpoint, ColorControlServer::Col
                                     ColorControlServer::Color16uTransitionState * colorSatTransitionState)
 {
     colorHueTransitionState->stepsRemaining = 0;
-    ColorControl::Attributes::GetCurrentHue(endpoint, &(colorHueTransitionState->currentHue));
+    ColorControl::Attributes::CurrentHue::Get(endpoint, &(colorHueTransitionState->currentHue));
     colorHueTransitionState->endpoint = endpoint;
 
-    ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &(colorHueTransitionState->currentEnhancedHue));
+    ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &(colorHueTransitionState->currentEnhancedHue));
     colorHueTransitionState->isEnhancedHue = false;
 
     colorSatTransitionState->stepsRemaining = 0;
@@ -597,7 +597,7 @@ bool ColorControlServer::computeNewHueValue(ColorControlServer::ColorHueTransiti
 
     if (p->repeat == false)
     {
-        ColorControl::Attributes::SetRemainingTime(p->endpoint, p->stepsRemaining);
+        ColorControl::Attributes::RemainingTime::Set(p->endpoint, p->stepsRemaining);
     }
 
     // are we going up or down?
@@ -649,7 +649,7 @@ bool ColorControlServer::computeNewHueValue(ColorControlServer::ColorHueTransiti
         {
             // Check if we are in a color loop. If not, we are in a moveHue
             uint8_t isColorLoop = 0;
-            ColorControl::Attributes::GetColorLoopActive(p->endpoint, &isColorLoop);
+            ColorControl::Attributes::ColorLoopActive::Get(p->endpoint, &isColorLoop);
 
             if (isColorLoop)
             {
@@ -766,13 +766,13 @@ bool ColorControlServer::moveHueCommand(uint8_t moveMode, uint16_t rate, uint8_t
     colorHueTransitionState->isEnhancedHue = isEnhanced;
     if (isEnhanced)
     {
-        ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &currentEnhancedHue);
+        ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &currentEnhancedHue);
         colorHueTransitionState->initialEnhancedHue = currentEnhancedHue;
         colorHueTransitionState->currentEnhancedHue = currentEnhancedHue;
     }
     else
     {
-        ColorControl::Attributes::GetCurrentHue(endpoint, &currentHue);
+        ColorControl::Attributes::CurrentHue::Get(endpoint, &currentHue);
         colorHueTransitionState->initialHue = currentHue;
         colorHueTransitionState->currentHue = currentHue;
     }
@@ -814,7 +814,7 @@ bool ColorControlServer::moveHueCommand(uint8_t moveMode, uint16_t rate, uint8_t
     colorHueTransitionState->repeat         = true;
 
     // hue movement can last forever. Indicate this with a remaining time of maxint
-    ColorControl::Attributes::SetRemainingTime(endpoint, MAX_INT16U_VALUE);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, MAX_INT16U_VALUE);
     colorSaturationTransitionState->stepsRemaining = 0;
 
     // kick off the state machine:
@@ -853,12 +853,12 @@ bool ColorControlServer::moveToHueCommand(uint16_t hue, uint8_t hueMoveMode, uin
     uint16_t currentHue = 0;
     if (isEnhanced)
     {
-        ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &currentHue);
+        ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &currentHue);
     }
     else
     {
         uint8_t current8bitHue = 0;
-        ColorControl::Attributes::GetCurrentHue(endpoint, &current8bitHue);
+        ColorControl::Attributes::CurrentHue::Get(endpoint, &current8bitHue);
 
         currentHue = static_cast<uint16_t>(current8bitHue);
     }
@@ -928,15 +928,15 @@ bool ColorControlServer::moveToHueCommand(uint16_t hue, uint8_t hueMoveMode, uin
 
     if (isEnhanced)
     {
-        ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &(colorHueTransitionState->initialEnhancedHue));
-        ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &(colorHueTransitionState->currentEnhancedHue));
+        ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &(colorHueTransitionState->initialEnhancedHue));
+        ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &(colorHueTransitionState->currentEnhancedHue));
 
         colorHueTransitionState->finalEnhancedHue = hue;
     }
     else
     {
-        ColorControl::Attributes::GetCurrentHue(endpoint, &(colorHueTransitionState->initialHue));
-        ColorControl::Attributes::GetCurrentHue(endpoint, &(colorHueTransitionState->currentHue));
+        ColorControl::Attributes::CurrentHue::Get(endpoint, &(colorHueTransitionState->initialHue));
+        ColorControl::Attributes::CurrentHue::Get(endpoint, &(colorHueTransitionState->currentHue));
 
         colorHueTransitionState->finalHue = static_cast<uint8_t>(hue);
     }
@@ -948,7 +948,7 @@ bool ColorControlServer::moveToHueCommand(uint16_t hue, uint8_t hueMoveMode, uin
     colorHueTransitionState->repeat                = false;
     colorSaturationTransitionState->stepsRemaining = 0;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
@@ -980,12 +980,12 @@ bool ColorControlServer::moveToHueAndSaturationCommand(uint16_t hue, uint8_t sat
     uint16_t currentHue = 0;
     if (isEnhanced)
     {
-        ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &currentHue);
+        ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &currentHue);
     }
     else
     {
         uint8_t current8bitHue = 0;
-        ColorControl::Attributes::GetCurrentHue(endpoint, &current8bitHue);
+        ColorControl::Attributes::CurrentHue::Get(endpoint, &current8bitHue);
 
         currentHue = static_cast<uint16_t>(current8bitHue);
     }
@@ -1060,7 +1060,7 @@ bool ColorControlServer::moveToHueAndSaturationCommand(uint16_t hue, uint8_t sat
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
@@ -1118,7 +1118,7 @@ bool ColorControlServer::stepHueCommand(uint8_t stepMode, uint16_t stepSize, uin
 
     if (isEnhanced)
     {
-        ColorControl::Attributes::GetEnhancedCurrentHue(endpoint, &(colorHueTransitionState->currentEnhancedHue));
+        ColorControl::Attributes::EnhancedCurrentHue::Get(endpoint, &(colorHueTransitionState->currentEnhancedHue));
         colorHueTransitionState->initialEnhancedHue = colorHueTransitionState->currentEnhancedHue;
 
         if (stepMode == MOVE_MODE_UP)
@@ -1134,7 +1134,7 @@ bool ColorControlServer::stepHueCommand(uint8_t stepMode, uint16_t stepSize, uin
     }
     else
     {
-        ColorControl::Attributes::GetCurrentHue(endpoint, &(colorHueTransitionState->currentHue));
+        ColorControl::Attributes::CurrentHue::Get(endpoint, &(colorHueTransitionState->currentHue));
         colorHueTransitionState->initialHue = colorHueTransitionState->currentHue;
 
         if (stepMode == MOVE_MODE_UP)
@@ -1155,7 +1155,7 @@ bool ColorControlServer::stepHueCommand(uint8_t stepMode, uint16_t stepSize, uin
     colorHueTransitionState->repeat                = false;
     colorSaturationTransitionState->stepsRemaining = 0;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
@@ -1214,7 +1214,7 @@ bool ColorControlServer::moveSaturationCommand(uint8_t moveMode, uint8_t rate, u
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
@@ -1279,7 +1279,7 @@ bool ColorControlServer::moveToSaturationCommand(uint8_t saturation, uint16_t tr
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
@@ -1342,7 +1342,7 @@ bool ColorControlServer::stepSaturationCommand(uint8_t stepMode, uint8_t stepSiz
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureHSVEventControl(endpoint), UPDATE_TIME_MS);
@@ -1364,14 +1364,14 @@ bool ColorControlServer::colorLoopCommand(uint8_t updateFlags, uint8_t action, u
     }
 
     uint8_t isColorLoopActive = 0;
-    ColorControl::Attributes::GetColorLoopActive(endpoint, &isColorLoopActive);
+    ColorControl::Attributes::ColorLoopActive::Get(endpoint, &isColorLoopActive);
 
     uint8_t deactiveColorLoop =
         (updateFlags & EMBER_AF_COLOR_LOOP_UPDATE_FLAGS_UPDATE_ACTION) && (action == EMBER_ZCL_COLOR_LOOP_ACTION_DEACTIVATE);
 
     if (updateFlags & EMBER_AF_COLOR_LOOP_UPDATE_FLAGS_UPDATE_DIRECTION)
     {
-        ColorControl::Attributes::SetColorLoopDirection(endpoint, direction);
+        ColorControl::Attributes::ColorLoopDirection::Set(endpoint, direction);
 
         // Checks if color loop is active and stays active
         if (isColorLoopActive && !deactiveColorLoop)
@@ -1393,7 +1393,7 @@ bool ColorControlServer::colorLoopCommand(uint8_t updateFlags, uint8_t action, u
 
     if (updateFlags & EMBER_AF_COLOR_LOOP_UPDATE_FLAGS_UPDATE_TIME)
     {
-        ColorControl::Attributes::SetColorLoopTime(endpoint, time);
+        ColorControl::Attributes::ColorLoopTime::Set(endpoint, time);
 
         // Checks if color loop is active and stays active
         if (isColorLoopActive && !deactiveColorLoop)
@@ -1415,7 +1415,7 @@ bool ColorControlServer::colorLoopCommand(uint8_t updateFlags, uint8_t action, u
 
     if (updateFlags & EMBER_AF_COLOR_LOOP_UPDATE_FLAGS_UPDATE_START_HUE)
     {
-        ColorControl::Attributes::SetColorLoopStartEnhancedHue(endpoint, startHue);
+        ColorControl::Attributes::ColorLoopStartEnhancedHue::Set(endpoint, startHue);
     }
 
     if (updateFlags & EMBER_AF_COLOR_LOOP_UPDATE_FLAGS_UPDATE_ACTION)
@@ -1426,11 +1426,11 @@ bool ColorControlServer::colorLoopCommand(uint8_t updateFlags, uint8_t action, u
             {
                 stopAllColorTransitions(endpoint);
 
-                ColorControl::Attributes::SetColorLoopActive(endpoint, false);
+                ColorControl::Attributes::ColorLoopActive::Set(endpoint, false);
 
                 uint16_t storedEnhancedHue = 0;
-                ColorControl::Attributes::GetColorLoopStoredEnhancedHue(endpoint, &storedEnhancedHue);
-                ColorControl::Attributes::SetEnhancedCurrentHue(endpoint, storedEnhancedHue);
+                ColorControl::Attributes::ColorLoopStoredEnhancedHue::Get(endpoint, &storedEnhancedHue);
+                ColorControl::Attributes::EnhancedCurrentHue::Set(endpoint, storedEnhancedHue);
             }
             else
             {
@@ -1482,16 +1482,16 @@ void ColorControlServer::updateHueSatCommand(EndpointId endpoint)
 
     if (colorHueTransitionState->isEnhancedHue)
     {
-        ColorControl::Attributes::SetEnhancedCurrentHue(endpoint, colorHueTransitionState->currentEnhancedHue);
-        ColorControl::Attributes::SetCurrentHue(endpoint, static_cast<uint8_t>(colorHueTransitionState->currentEnhancedHue >> 8));
+        ColorControl::Attributes::EnhancedCurrentHue::Set(endpoint, colorHueTransitionState->currentEnhancedHue);
+        ColorControl::Attributes::CurrentHue::Set(endpoint, static_cast<uint8_t>(colorHueTransitionState->currentEnhancedHue >> 8));
     }
     else
     {
-        ColorControl::Attributes::SetCurrentHue(colorHueTransitionState->endpoint, colorHueTransitionState->currentHue);
+        ColorControl::Attributes::CurrentHue::Set(colorHueTransitionState->endpoint, colorHueTransitionState->currentHue);
     }
 
-    ColorControl::Attributes::SetCurrentSaturation(colorSaturationTransitionState->endpoint,
-                                                   (uint8_t) colorSaturationTransitionState->currentValue);
+    ColorControl::Attributes::CurrentSaturation::Set(colorSaturationTransitionState->endpoint,
+                                                     (uint8_t) colorSaturationTransitionState->currentValue);
     if (colorHueTransitionState->isEnhancedHue)
     {
         emberAfColorControlClusterPrintln("Enhanced Hue %d Saturation %d endpoint %d", colorHueTransitionState->currentEnhancedHue,
@@ -1596,8 +1596,8 @@ bool ColorControlServer::moveToColorCommand(uint16_t colorX, uint16_t colorY, ui
     handleModeSwitch(endpoint, COLOR_MODE_CIE_XY);
 
     // now, kick off the state machine.
-    ColorControl::Attributes::GetCurrentX(endpoint, &(colorXTransitionState->initialValue));
-    ColorControl::Attributes::GetCurrentX(endpoint, &(colorXTransitionState->currentValue));
+    ColorControl::Attributes::CurrentX::Get(endpoint, &(colorXTransitionState->initialValue));
+    ColorControl::Attributes::CurrentX::Get(endpoint, &(colorXTransitionState->currentValue));
     colorXTransitionState->finalValue     = colorX;
     colorXTransitionState->stepsRemaining = transitionTime;
     colorXTransitionState->stepsTotal     = transitionTime;
@@ -1605,8 +1605,8 @@ bool ColorControlServer::moveToColorCommand(uint16_t colorX, uint16_t colorY, ui
     colorXTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorXTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    ColorControl::Attributes::GetCurrentY(endpoint, &(colorYTransitionState->initialValue));
-    ColorControl::Attributes::GetCurrentY(endpoint, &(colorYTransitionState->currentValue));
+    ColorControl::Attributes::CurrentY::Get(endpoint, &(colorYTransitionState->initialValue));
+    ColorControl::Attributes::CurrentY::Get(endpoint, &(colorYTransitionState->currentValue));
     colorYTransitionState->finalValue     = colorY;
     colorYTransitionState->stepsRemaining = transitionTime;
     colorYTransitionState->stepsTotal     = transitionTime;
@@ -1614,7 +1614,7 @@ bool ColorControlServer::moveToColorCommand(uint16_t colorX, uint16_t colorY, ui
     colorYTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorYTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureXYEventControl(endpoint), UPDATE_TIME_MS);
@@ -1651,7 +1651,7 @@ bool ColorControlServer::moveColorCommand(int16_t rateX, int16_t rateY, uint8_t 
     handleModeSwitch(endpoint, COLOR_MODE_CIE_XY);
 
     // now, kick off the state machine.
-    ColorControl::Attributes::GetCurrentX(endpoint, &(colorXTransitionState->initialValue));
+    ColorControl::Attributes::CurrentX::Get(endpoint, &(colorXTransitionState->initialValue));
     colorXTransitionState->currentValue = colorXTransitionState->initialValue;
     if (rateX > 0)
     {
@@ -1670,7 +1670,7 @@ bool ColorControlServer::moveColorCommand(int16_t rateX, int16_t rateY, uint8_t 
     colorXTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorXTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    ColorControl::Attributes::GetCurrentY(endpoint, &(colorYTransitionState->initialValue));
+    ColorControl::Attributes::CurrentY::Get(endpoint, &(colorYTransitionState->initialValue));
     colorYTransitionState->currentValue = colorYTransitionState->initialValue;
     if (rateY > 0)
     {
@@ -1691,11 +1691,11 @@ bool ColorControlServer::moveColorCommand(int16_t rateX, int16_t rateY, uint8_t 
 
     if (transitionTimeX < transitionTimeY)
     {
-        ColorControl::Attributes::SetRemainingTime(endpoint, transitionTimeX);
+        ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTimeX);
     }
     else
     {
-        ColorControl::Attributes::SetRemainingTime(endpoint, transitionTimeY);
+        ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTimeY);
     }
 
     // kick off the state machine:
@@ -1719,10 +1719,10 @@ bool ColorControlServer::stepColorCommand(int16_t stepX, int16_t stepY, uint16_t
     }
 
     uint16_t currentColorX = 0;
-    ColorControl::Attributes::GetCurrentX(endpoint, &currentColorX);
+    ColorControl::Attributes::CurrentX::Get(endpoint, &currentColorX);
 
     uint16_t currentColorY = 0;
-    ColorControl::Attributes::GetCurrentY(endpoint, &currentColorY);
+    ColorControl::Attributes::CurrentY::Get(endpoint, &currentColorY);
 
     uint16_t colorX = findNewColorValueFromStep(currentColorX, stepX);
     uint16_t colorY = findNewColorValueFromStep(currentColorY, stepY);
@@ -1757,7 +1757,7 @@ bool ColorControlServer::stepColorCommand(int16_t stepX, int16_t stepY, uint16_t
     colorYTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorYTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureXYEventControl(endpoint), UPDATE_TIME_MS);
@@ -1792,8 +1792,8 @@ void ColorControlServer::updateXYCommand(EndpointId endpoint)
     }
 
     // update the attributes
-    ColorControl::Attributes::SetCurrentX(endpoint, colorXTransitionState->currentValue);
-    ColorControl::Attributes::SetCurrentY(endpoint, colorYTransitionState->currentValue);
+    ColorControl::Attributes::CurrentX::Set(endpoint, colorXTransitionState->currentValue);
+    ColorControl::Attributes::CurrentY::Set(endpoint, colorYTransitionState->currentValue);
 
     emberAfColorControlClusterPrintln("Color X %d Color Y %d", colorXTransitionState->currentValue,
                                       colorYTransitionState->currentValue);
@@ -1829,10 +1829,10 @@ void ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorTem
     Color16uTransitionState * colorTempTransitionState = getTempTransitionState(endpoint);
 
     uint16_t temperatureMin = MIN_TEMPERATURE_VALUE;
-    ColorControl::Attributes::GetColorTempPhysicalMin(endpoint, &temperatureMin);
+    ColorControl::Attributes::ColorTempPhysicalMin::Get(endpoint, &temperatureMin);
 
     uint16_t temperatureMax = MAX_TEMPERATURE_VALUE;
-    ColorControl::Attributes::GetColorTempPhysicalMax(endpoint, &temperatureMax);
+    ColorControl::Attributes::ColorTempPhysicalMax::Get(endpoint, &temperatureMax);
 
     if (transitionTime == 0)
     {
@@ -1856,8 +1856,8 @@ void ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorTem
     }
 
     // now, kick off the state machine.
-    ColorControl::Attributes::GetColorTemperature(endpoint, &(colorTempTransitionState->initialValue));
-    ColorControl::Attributes::GetColorTemperature(endpoint, &(colorTempTransitionState->currentValue));
+    ColorControl::Attributes::ColorTemperature::Get(endpoint, &(colorTempTransitionState->initialValue));
+    ColorControl::Attributes::ColorTemperature::Get(endpoint, &(colorTempTransitionState->currentValue));
 
     colorTempTransitionState->finalValue     = colorTemperature;
     colorTempTransitionState->stepsRemaining = transitionTime;
@@ -1881,12 +1881,12 @@ uint16_t ColorControlServer::getTemperatureCoupleToLevelMin(EndpointId endpoint)
     uint16_t colorTemperatureCoupleToLevelMin;
     EmberAfStatus status;
 
-    status = ColorControl::Attributes::GetCoupleColorTempToLevelMinMireds(endpoint, &colorTemperatureCoupleToLevelMin);
+    status = ColorControl::Attributes::CoupleColorTempToLevelMinMireds::Get(endpoint, &colorTemperatureCoupleToLevelMin);
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         // Not less than the physical min.
-        ColorControl::Attributes::GetColorTempPhysicalMin(endpoint, &colorTemperatureCoupleToLevelMin);
+        ColorControl::Attributes::ColorTempPhysicalMin::Get(endpoint, &colorTemperatureCoupleToLevelMin);
     }
 
     return colorTemperatureCoupleToLevelMin;
@@ -1921,20 +1921,20 @@ void ColorControlServer::startUpColorTempCommand(EndpointId endpoint)
 
     // Initialize startUpColorTempMireds to "maintain previous value" value 0xFFFF
     uint16_t startUpColorTemp = 0xFFFF;
-    EmberAfStatus status      = ColorControl::Attributes::GetStartUpColorTemperatureMireds(endpoint, &startUpColorTemp);
+    EmberAfStatus status      = ColorControl::Attributes::StartUpColorTemperatureMireds::Get(endpoint, &startUpColorTemp);
 
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
         uint16_t updatedColorTemp = MAX_TEMPERATURE_VALUE;
-        status                    = ColorControl::Attributes::GetColorTemperature(endpoint, &updatedColorTemp);
+        status                    = ColorControl::Attributes::ColorTemperature::Get(endpoint, &updatedColorTemp);
 
         if (status == EMBER_ZCL_STATUS_SUCCESS)
         {
             uint16_t tempPhysicalMin = MIN_TEMPERATURE_VALUE;
-            ColorControl::Attributes::GetColorTempPhysicalMin(endpoint, &tempPhysicalMin);
+            ColorControl::Attributes::ColorTempPhysicalMin::Get(endpoint, &tempPhysicalMin);
 
             uint16_t tempPhysicalMax = MAX_TEMPERATURE_VALUE;
-            ColorControl::Attributes::GetColorTempPhysicalMax(endpoint, &tempPhysicalMax);
+            ColorControl::Attributes::ColorTempPhysicalMax::Get(endpoint, &tempPhysicalMax);
 
             if (tempPhysicalMin <= startUpColorTemp && startUpColorTemp <= tempPhysicalMax)
             {
@@ -1943,16 +1943,16 @@ void ColorControlServer::startUpColorTempCommand(EndpointId endpoint)
                 // existing setting of ColorTemp attribute will be left unchanged (i.e., treated as
                 // if startup color temp was set to 0xFFFF).
                 updatedColorTemp = startUpColorTemp;
-                status           = ColorControl::Attributes::SetColorTemperature(endpoint, updatedColorTemp);
+                status           = ColorControl::Attributes::ColorTemperature::Set(endpoint, updatedColorTemp);
 
                 if (status == EMBER_ZCL_STATUS_SUCCESS)
                 {
                     // Set ColorMode attributes to reflect ColorTemperature.
                     uint8_t updateColorMode = EMBER_ZCL_COLOR_MODE_COLOR_TEMPERATURE;
-                    ColorControl::Attributes::SetColorMode(endpoint, updateColorMode);
+                    ColorControl::Attributes::ColorMode::Set(endpoint, updateColorMode);
 
                     updateColorMode = EMBER_ZCL_ENHANCED_COLOR_MODE_COLOR_TEMPERATURE;
-                    ColorControl::Attributes::SetEnhancedColorMode(endpoint, updateColorMode);
+                    ColorControl::Attributes::EnhancedColorMode::Set(endpoint, updateColorMode);
                 }
             }
         }
@@ -1980,7 +1980,7 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
         emberEventControlSetDelayMS(configureTempEventControl(endpoint), UPDATE_TIME_MS);
     }
 
-    ColorControl::Attributes::SetColorTemperature(endpoint, colorTempTransitionState->currentValue);
+    ColorControl::Attributes::ColorTemperature::Set(endpoint, colorTempTransitionState->currentValue);
 
     emberAfColorControlClusterPrintln("Color Temperature %d", colorTempTransitionState->currentValue);
 
@@ -2012,10 +2012,10 @@ bool ColorControlServer::moveColorTempCommand(uint8_t moveMode, uint16_t rate, u
     }
 
     uint16_t tempPhysicalMin = MIN_TEMPERATURE_VALUE;
-    ColorControl::Attributes::GetColorTempPhysicalMin(endpoint, &tempPhysicalMin);
+    ColorControl::Attributes::ColorTempPhysicalMin::Get(endpoint, &tempPhysicalMin);
 
     uint16_t tempPhysicalMax = MAX_TEMPERATURE_VALUE;
-    ColorControl::Attributes::GetColorTempPhysicalMax(endpoint, &tempPhysicalMax);
+    ColorControl::Attributes::ColorTempPhysicalMax::Get(endpoint, &tempPhysicalMax);
 
     uint16_t transitionTime;
 
@@ -2048,7 +2048,7 @@ bool ColorControlServer::moveColorTempCommand(uint8_t moveMode, uint16_t rate, u
 
     // now, kick off the state machine.
     colorTempTransitionState->initialValue = 0;
-    ColorControl::Attributes::GetColorTemperature(endpoint, &colorTempTransitionState->initialValue);
+    ColorControl::Attributes::ColorTemperature::Get(endpoint, &colorTempTransitionState->initialValue);
     colorTempTransitionState->currentValue = colorTempTransitionState->initialValue;
 
     if (moveMode == MOVE_MODE_UP)
@@ -2080,7 +2080,7 @@ bool ColorControlServer::moveColorTempCommand(uint8_t moveMode, uint16_t rate, u
     colorTempTransitionState->lowLimit       = colorTemperatureMinimum;
     colorTempTransitionState->highLimit      = colorTemperatureMaximum;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureTempEventControl(endpoint), UPDATE_TIME_MS);
@@ -2120,10 +2120,10 @@ bool ColorControlServer::stepColorTempCommand(uint8_t stepMode, uint16_t stepSiz
     }
 
     uint16_t tempPhysicalMin = MIN_TEMPERATURE_VALUE;
-    ColorControl::Attributes::GetColorTempPhysicalMin(endpoint, &tempPhysicalMin);
+    ColorControl::Attributes::ColorTempPhysicalMin::Get(endpoint, &tempPhysicalMin);
 
     uint16_t tempPhysicalMax = MAX_TEMPERATURE_VALUE;
-    ColorControl::Attributes::GetColorTempPhysicalMax(endpoint, &tempPhysicalMax);
+    ColorControl::Attributes::ColorTempPhysicalMax::Get(endpoint, &tempPhysicalMax);
 
     if (transitionTime == 0)
     {
@@ -2153,7 +2153,7 @@ bool ColorControlServer::stepColorTempCommand(uint8_t stepMode, uint16_t stepSiz
 
     // now, kick off the state machine.
     colorTempTransitionState->initialValue = 0;
-    ColorControl::Attributes::GetColorTemperature(endpoint, &colorTempTransitionState->initialValue);
+    ColorControl::Attributes::ColorTemperature::Get(endpoint, &colorTempTransitionState->initialValue);
     colorTempTransitionState->currentValue = colorTempTransitionState->initialValue;
 
     if (stepMode == MOVE_MODE_UP)
@@ -2186,7 +2186,7 @@ bool ColorControlServer::stepColorTempCommand(uint8_t stepMode, uint16_t stepSiz
     colorTempTransitionState->lowLimit       = colorTemperatureMinimum;
     colorTempTransitionState->highLimit      = colorTemperatureMaximum;
 
-    ColorControl::Attributes::SetRemainingTime(endpoint, transitionTime);
+    ColorControl::Attributes::RemainingTime::Set(endpoint, transitionTime);
 
     // kick off the state machine:
     emberEventControlSetDelayMS(configureTempEventControl(endpoint), UPDATE_TIME_MS);
@@ -2234,17 +2234,17 @@ void ColorControlServer::levelControlColorTempChangeCommand(EndpointId endpoint)
     }
 
     uint8_t colorMode = 0;
-    ColorControl::Attributes::GetColorMode(endpoint, &colorMode);
+    ColorControl::Attributes::ColorMode::Get(endpoint, &colorMode);
 
     if (colorMode == COLOR_MODE_TEMPERATURE)
     {
         uint16_t tempCoupleMin = getTemperatureCoupleToLevelMin(endpoint);
 
         uint8_t currentLevel = 0x7F;
-        LevelControl::Attributes::GetCurrentLevel(endpoint, &currentLevel);
+        LevelControl::Attributes::CurrentLevel::Get(endpoint, &currentLevel);
 
         uint16_t tempPhysMax = MAX_TEMPERATURE_VALUE;
-        ColorControl::Attributes::GetColorTempPhysicalMax(endpoint, &tempPhysMax);
+        ColorControl::Attributes::ColorTempPhysicalMax::Get(endpoint, &tempPhysMax);
 
         // Scale color temp setting between the coupling min and the physical max.
         // Note that mireds varies inversely with level: low level -> high mireds.

--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -102,19 +102,19 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (Connectivit
 
 bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
-    EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::SetPacketRxCount(endpoint, 0);
+    EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketRxCount attribute"));
 
-    status = EthernetNetworkDiagnostics::Attributes::SetPacketTxCount(endpoint, 0);
+    status = EthernetNetworkDiagnostics::Attributes::PacketTxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketTxCount attribute"));
 
-    status = EthernetNetworkDiagnostics::Attributes::SetTxErrCount(endpoint, 0);
+    status = EthernetNetworkDiagnostics::Attributes::TxErrCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset TxErrCount attribute"));
 
-    status = EthernetNetworkDiagnostics::Attributes::SetCollisionCount(endpoint, 0);
+    status = EthernetNetworkDiagnostics::Attributes::CollisionCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset CollisionCount attribute"));
 
-    status = EthernetNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
+    status = EthernetNetworkDiagnostics::Attributes::OverrunCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset OverrunCount attribute"));
 
 exit:

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -114,13 +114,13 @@ static void onIdentifyClusterTick(chip::System::Layer * systemLayer, void * appS
     {
         EndpointId endpoint = identify->mEndpoint;
 
-        if (EMBER_ZCL_STATUS_SUCCESS == Clusters::Identify::Attributes::GetIdentifyTime(endpoint, &identifyTime) &&
+        if (EMBER_ZCL_STATUS_SUCCESS == Clusters::Identify::Attributes::IdentifyTime::Get(endpoint, &identifyTime) &&
             0 != identifyTime)
         {
             identifyTime = static_cast<uint16_t>(identifyTime == 0 ? 0 : identifyTime - 1);
             // This tick writes the new attribute, which will trigger the Attribute
             // Changed callback.
-            (void) Clusters::Identify::Attributes::SetIdentifyTime(endpoint, identifyTime);
+            (void) Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, identifyTime);
         }
     }
 }
@@ -155,7 +155,7 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, A
             return;
         }
 
-        if (EMBER_ZCL_STATUS_SUCCESS == Clusters::Identify::Attributes::GetIdentifyTime(endpoint, &identifyTime))
+        if (EMBER_ZCL_STATUS_SUCCESS == Clusters::Identify::Attributes::IdentifyTime::Get(endpoint, &identifyTime))
         {
             /* effect identifier changed during identify */
             if (identify->mTargetEffectIdentifier != identify->mCurrentEffectIdentifier)
@@ -172,14 +172,14 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, A
                 /* stop identify process */
                 else if (EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT == identify->mCurrentEffectIdentifier && identifyTime > 0)
                 {
-                    Clusters::Identify::Attributes::SetIdentifyTime(endpoint, 0);
+                    Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, 0);
                     identify_deactivate(identify);
                 }
                 /* change from e.g. Breathe to Blink during identify */
                 else
                 {
                     /* cancel identify */
-                    Clusters::Identify::Attributes::SetIdentifyTime(endpoint, 0);
+                    Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, 0);
                     identify_deactivate(identify);
 
                     /* trigger effect identifier callback */
@@ -209,7 +209,7 @@ bool emberAfIdentifyClusterIdentifyCallback(EndpointId endpoint, CommandHandler 
 {
     // cmd Identify
     return EMBER_SUCCESS ==
-        emberAfSendImmediateDefaultResponse(Clusters::Identify::Attributes::SetIdentifyTime(endpoint, identifyTime));
+        emberAfSendImmediateDefaultResponse(Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, identifyTime));
 }
 
 bool emberAfIdentifyClusterIdentifyQueryCallback(EndpointId endpoint, CommandHandler * commandObj)
@@ -220,7 +220,7 @@ bool emberAfIdentifyClusterIdentifyQueryCallback(EndpointId endpoint, CommandHan
     EmberStatus sendStatus = EMBER_SUCCESS;
     CHIP_ERROR err         = CHIP_NO_ERROR;
 
-    status = Clusters::Identify::Attributes::GetIdentifyTime(endpoint, &identifyTime);
+    status = Clusters::Identify::Attributes::IdentifyTime::Get(endpoint, &identifyTime);
 
     if (status != EMBER_ZCL_STATUS_SUCCESS || 0 == identifyTime)
     {
@@ -285,7 +285,7 @@ bool emberAfIdentifyClusterTriggerEffectCallback(EndpointId endpoint, CommandHan
 
     /* only call the callback if no identify is in progress */
     if (nullptr != identify->mOnEffectIdentifier &&
-        EMBER_ZCL_STATUS_SUCCESS == Clusters::Identify::Attributes::GetIdentifyTime(endpoint, &identifyTime) && 0 == identifyTime)
+        EMBER_ZCL_STATUS_SUCCESS == Clusters::Identify::Attributes::IdentifyTime::Get(endpoint, &identifyTime) && 0 == identifyTime)
     {
         identify->mCurrentEffectIdentifier = identify->mTargetEffectIdentifier;
         identify->mOnEffectIdentifier(identify);
@@ -303,7 +303,7 @@ Identify::Identify(chip::EndpointId endpoint, onIdentifyStartCb onIdentifyStart,
     mCurrentEffectIdentifier(effectIdentifier), mTargetEffectIdentifier(effectIdentifier),
     mEffectVariant(static_cast<uint8_t>(effectVariant))
 {
-    (void) Clusters::Identify::Attributes::SetIdentifyType(endpoint, identifyType);
+    (void) Clusters::Identify::Attributes::IdentifyType::Set(endpoint, identifyType);
     reg(this);
 };
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -170,7 +170,7 @@ CHIP_ERROR writeFabricsIntoFabricsListAttribute()
     }
 
     if (err == CHIP_NO_ERROR &&
-        app::Clusters::OperationalCredentials::Attributes::SetCommissionedFabrics(0, fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
+        app::Clusters::OperationalCredentials::Attributes::CommissionedFabrics::Set(0, fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write fabrics count %" PRIu8 " in commissioned fabrics",
                        fabricIndex);
@@ -178,7 +178,7 @@ CHIP_ERROR writeFabricsIntoFabricsListAttribute()
     }
 
     if (err == CHIP_NO_ERROR &&
-        app::Clusters::OperationalCredentials::Attributes::SetSupportedFabrics(0, CHIP_CONFIG_MAX_DEVICE_ADMINS) !=
+        app::Clusters::OperationalCredentials::Attributes::SupportedFabrics::Set(0, CHIP_CONFIG_MAX_DEVICE_ADMINS) !=
             EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write %" PRIu8 " in supported fabrics count attribute",

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -98,10 +98,10 @@ bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(EndpointId endpoin
 {
     uint64_t currentHeapUsed;
 
-    EmberAfStatus status = SoftwareDiagnostics::Attributes::GetCurrentHeapUsed(endpoint, &currentHeapUsed);
+    EmberAfStatus status = SoftwareDiagnostics::Attributes::CurrentHeapUsed::Get(endpoint, &currentHeapUsed);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to get the value of the CurrentHeapUsed attribute"));
 
-    status = SoftwareDiagnostics::Attributes::SetCurrentHeapHighWatermark(endpoint, currentHeapUsed);
+    status = SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::Set(endpoint, currentHeapUsed);
     VerifyOrExit(
         status == EMBER_ZCL_STATUS_SUCCESS,
         ChipLogError(

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -78,25 +78,25 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         int16_t MinHeatSetpointLimit;
         int16_t MaxHeatSetpointLimit;
 
-        status = GetAbsMinHeatSetpointLimit(endpoint, &AbsMinHeatSetpointLimit);
+        status = AbsMinHeatSetpointLimit::Get(endpoint, &AbsMinHeatSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMinHeatSetpointLimit = kDefaultAbsMinHeatSetpointLimit;
         }
 
-        status = GetAbsMaxHeatSetpointLimit(endpoint, &AbsMaxHeatSetpointLimit);
+        status = AbsMaxHeatSetpointLimit::Get(endpoint, &AbsMaxHeatSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMaxHeatSetpointLimit = kDefaultAbsMaxHeatSetpointLimit;
         }
 
-        status = GetMinHeatSetpointLimit(endpoint, &MinHeatSetpointLimit);
+        status = MinHeatSetpointLimit::Get(endpoint, &MinHeatSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             MinHeatSetpointLimit = AbsMinHeatSetpointLimit;
         }
 
-        status = GetMaxHeatSetpointLimit(endpoint, &MaxHeatSetpointLimit);
+        status = MaxHeatSetpointLimit::Get(endpoint, &MaxHeatSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             MaxHeatSetpointLimit = AbsMaxHeatSetpointLimit;
@@ -118,25 +118,25 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         int16_t MinCoolSetpointLimit;
         int16_t MaxCoolSetpointLimit;
 
-        status = GetAbsMinCoolSetpointLimit(endpoint, &AbsMinCoolSetpointLimit);
+        status = AbsMinCoolSetpointLimit::Get(endpoint, &AbsMinCoolSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMinCoolSetpointLimit = kDefaultAbsMinCoolSetpointLimit;
         }
 
-        status = GetAbsMaxCoolSetpointLimit(endpoint, &AbsMaxCoolSetpointLimit);
+        status = AbsMaxCoolSetpointLimit::Get(endpoint, &AbsMaxCoolSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMaxCoolSetpointLimit = kDefaultAbsMaxCoolSetpointLimit;
         }
 
-        status = GetMinCoolSetpointLimit(endpoint, &MinCoolSetpointLimit);
+        status = MinCoolSetpointLimit::Get(endpoint, &MinCoolSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             MinCoolSetpointLimit = AbsMinCoolSetpointLimit;
         }
 
-        status = GetMaxCoolSetpointLimit(endpoint, &MaxCoolSetpointLimit);
+        status = MaxCoolSetpointLimit::Get(endpoint, &MaxCoolSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             MaxCoolSetpointLimit = AbsMaxCoolSetpointLimit;
@@ -156,13 +156,13 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         int16_t AbsMinHeatSetpointLimit;
         int16_t AbsMaxHeatSetpointLimit;
 
-        status = GetAbsMinHeatSetpointLimit(endpoint, &AbsMinHeatSetpointLimit);
+        status = AbsMinHeatSetpointLimit::Get(endpoint, &AbsMinHeatSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMinHeatSetpointLimit = kDefaultAbsMinHeatSetpointLimit;
         }
 
-        status = GetAbsMaxHeatSetpointLimit(endpoint, &AbsMaxHeatSetpointLimit);
+        status = AbsMaxHeatSetpointLimit::Get(endpoint, &AbsMaxHeatSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMaxHeatSetpointLimit = kDefaultAbsMaxHeatSetpointLimit;
@@ -181,13 +181,13 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         int16_t AbsMinCoolSetpointLimit;
         int16_t AbsMaxCoolSetpointLimit;
 
-        status = GetAbsMinCoolSetpointLimit(endpoint, &AbsMinCoolSetpointLimit);
+        status = AbsMinCoolSetpointLimit::Get(endpoint, &AbsMinCoolSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMinCoolSetpointLimit = kDefaultAbsMinCoolSetpointLimit;
         }
 
-        status = GetAbsMaxCoolSetpointLimit(endpoint, &AbsMaxCoolSetpointLimit);
+        status = AbsMaxCoolSetpointLimit::Get(endpoint, &AbsMaxCoolSetpointLimit);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             AbsMaxCoolSetpointLimit = kDefaultAbsMaxCoolSetpointLimit;
@@ -216,7 +216,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
     case SystemMode::Id: {
         uint8_t ControlSequenceOfOperation = kInvalidControlSequenceOfOperation;
         uint8_t RequestedSystemMode        = kInvalidRequestedSystemMode;
-        GetControlSequenceOfOperation(endpoint, &ControlSequenceOfOperation);
+        ControlSequenceOfOperation::Get(endpoint, &ControlSequenceOfOperation);
         RequestedSystemMode = *value;
         if (ControlSequenceOfOperation > EMBER_ZCL_THERMOSTAT_CONTROL_SEQUENCE_COOLING_AND_HEATING_WITH_REHEAT ||
             RequestedSystemMode > EMBER_ZCL_THERMOSTAT_SYSTEM_MODE_FAN_ONLY)
@@ -306,24 +306,24 @@ int16_t EnforceHeatingSetpointLimits(int16_t HeatingSetpoint, EndpointId endpoin
     // Per global matter data model policy
     // if a attribute is not present then it's default shall be used.
 
-    status = GetAbsMinHeatSetpointLimit(endpoint, &AbsMinHeatSetpointLimit);
+    status = AbsMinHeatSetpointLimit::Get(endpoint, &AbsMinHeatSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Warning: AbsMinHeatSetpointLimit missing using default");
     }
 
-    status = GetAbsMaxHeatSetpointLimit(endpoint, &AbsMaxHeatSetpointLimit);
+    status = AbsMaxHeatSetpointLimit::Get(endpoint, &AbsMaxHeatSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Warning: AbsMaxHeatSetpointLimit missing using default");
     }
-    status = GetMinHeatSetpointLimit(endpoint, &MinHeatSetpointLimit);
+    status = MinHeatSetpointLimit::Get(endpoint, &MinHeatSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         MinHeatSetpointLimit = AbsMinHeatSetpointLimit;
     }
 
-    status = GetMaxHeatSetpointLimit(endpoint, &MaxHeatSetpointLimit);
+    status = MaxHeatSetpointLimit::Get(endpoint, &MaxHeatSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         MaxHeatSetpointLimit = AbsMaxHeatSetpointLimit;
@@ -377,25 +377,25 @@ int16_t EnforceCoolingSetpointLimits(int16_t CoolingSetpoint, EndpointId endpoin
     // Per global matter data model policy
     // if a attribute is not present then it's default shall be used.
 
-    status = GetAbsMinCoolSetpointLimit(endpoint, &AbsMinCoolSetpointLimit);
+    status = AbsMinCoolSetpointLimit::Get(endpoint, &AbsMinCoolSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Warning: AbsMinCoolSetpointLimit missing using default");
     }
 
-    status = GetAbsMaxCoolSetpointLimit(endpoint, &AbsMaxCoolSetpointLimit);
+    status = AbsMaxCoolSetpointLimit::Get(endpoint, &AbsMaxCoolSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Warning: AbsMaxCoolSetpointLimit missing using default");
     }
 
-    status = GetMinCoolSetpointLimit(endpoint, &MinCoolSetpointLimit);
+    status = MinCoolSetpointLimit::Get(endpoint, &MinCoolSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         MinCoolSetpointLimit = AbsMinCoolSetpointLimit;
     }
 
-    status = GetMaxCoolSetpointLimit(endpoint, &MaxCoolSetpointLimit);
+    status = MaxCoolSetpointLimit::Get(endpoint, &MaxCoolSetpointLimit);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         MaxCoolSetpointLimit = AbsMaxCoolSetpointLimit;
@@ -446,24 +446,24 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(EndpointId aEndpointId, 
         // Implementation assumes that the attribute will NOT be present if the device does not support that mode.
 
         // In auto mode we will need to change both the heating and cooling setpoints
-        ReadStatus = GetOccupiedCoolingSetpoint(aEndpointId, &CoolingSetpoint);
+        ReadStatus = OccupiedCoolingSetpoint::Get(aEndpointId, &CoolingSetpoint);
         if (ReadStatus == EMBER_ZCL_STATUS_SUCCESS)
         {
             CoolingSetpoint            = static_cast<int16_t>(CoolingSetpoint + amount * 10);
             CoolingSetpoint            = EnforceCoolingSetpointLimits(CoolingSetpoint, aEndpointId);
-            WriteCoolingSetpointStatus = SetOccupiedCoolingSetpoint(aEndpointId, CoolingSetpoint);
+            WriteCoolingSetpointStatus = OccupiedCoolingSetpoint::Set(aEndpointId, CoolingSetpoint);
             if (WriteCoolingSetpointStatus != EMBER_ZCL_STATUS_SUCCESS)
             {
                 ChipLogError(Zcl, "Error: SetOccupiedCoolingSetpoint failed!");
             }
         }
 
-        ReadStatus = GetOccupiedHeatingSetpoint(aEndpointId, &HeatingSetpoint);
+        ReadStatus = OccupiedHeatingSetpoint::Get(aEndpointId, &HeatingSetpoint);
         if (ReadStatus == EMBER_ZCL_STATUS_SUCCESS)
         {
             HeatingSetpoint            = static_cast<int16_t>(HeatingSetpoint + amount * 10);
             HeatingSetpoint            = EnforceHeatingSetpointLimits(HeatingSetpoint, aEndpointId);
-            WriteHeatingSetpointStatus = SetOccupiedHeatingSetpoint(aEndpointId, HeatingSetpoint);
+            WriteHeatingSetpointStatus = OccupiedHeatingSetpoint::Set(aEndpointId, HeatingSetpoint);
             if (WriteHeatingSetpointStatus != EMBER_ZCL_STATUS_SUCCESS)
             {
                 ChipLogError(Zcl, "Error: SetOccupiedHeatingSetpoint failed!");
@@ -478,24 +478,24 @@ bool emberAfThermostatClusterSetpointRaiseLowerCallback(EndpointId aEndpointId, 
 
     case EMBER_ZCL_SETPOINT_ADJUST_MODE_COOL_SETPOINT:
         // In cooling mode we will need to change only the cooling setpoint
-        ReadStatus = GetOccupiedCoolingSetpoint(aEndpointId, &CoolingSetpoint);
+        ReadStatus = OccupiedCoolingSetpoint::Get(aEndpointId, &CoolingSetpoint);
 
         if (ReadStatus == EMBER_ZCL_STATUS_SUCCESS)
         {
             CoolingSetpoint = static_cast<int16_t>(CoolingSetpoint + amount * 10);
             CoolingSetpoint = EnforceCoolingSetpointLimits(CoolingSetpoint, aEndpointId);
-            status          = SetOccupiedCoolingSetpoint(aEndpointId, CoolingSetpoint);
+            status          = OccupiedCoolingSetpoint::Set(aEndpointId, CoolingSetpoint);
         }
         break;
 
     case EMBER_ZCL_SETPOINT_ADJUST_MODE_HEAT_SETPOINT:
         // In cooling mode we will need to change only the cooling setpoint
-        ReadStatus = GetOccupiedHeatingSetpoint(aEndpointId, &HeatingSetpoint);
+        ReadStatus = OccupiedHeatingSetpoint::Get(aEndpointId, &HeatingSetpoint);
         if (ReadStatus == EMBER_ZCL_STATUS_SUCCESS)
         {
             HeatingSetpoint = static_cast<int16_t>(HeatingSetpoint + amount * 10);
             HeatingSetpoint = EnforceHeatingSetpointLimits(HeatingSetpoint, aEndpointId);
-            status          = SetOccupiedHeatingSetpoint(aEndpointId, HeatingSetpoint);
+            status          = OccupiedHeatingSetpoint::Set(aEndpointId, HeatingSetpoint);
         }
         break;
 

--- a/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
+++ b/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
@@ -76,7 +76,7 @@ CHIP_ERROR ThreadDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const At
 
 bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
-    EmberAfStatus status = ThreadNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
+    EmberAfStatus status = ThreadNetworkDiagnostics::Attributes::OverrunCount::Set(endpoint, 0);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Failed to reset OverrunCount attribute");

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -130,25 +130,25 @@ bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint
     VerifyOrExit(DeviceLayer::ConnectivityMgr().ResetWiFiNetworkDiagnosticsCounts() == CHIP_NO_ERROR,
                  status = EMBER_ZCL_STATUS_FAILURE);
 
-    status = WiFiNetworkDiagnostics::Attributes::SetBeaconLostCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::BeaconLostCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconLostCount attribute"));
 
-    status = WiFiNetworkDiagnostics::Attributes::SetBeaconRxCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::BeaconRxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconRxCount attribute"));
 
-    status = WiFiNetworkDiagnostics::Attributes::SetPacketMulticastRxCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::PacketMulticastRxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketMulticastRxCount attribute"));
 
-    status = WiFiNetworkDiagnostics::Attributes::SetPacketMulticastTxCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::PacketMulticastTxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketMulticastTxCount attribute"));
 
-    status = WiFiNetworkDiagnostics::Attributes::SetPacketUnicastRxCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::PacketUnicastRxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketUnicastRxCount attribute"));
 
-    status = WiFiNetworkDiagnostics::Attributes::SetPacketUnicastTxCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::PacketUnicastTxCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketUnicastTxCount attribute"));
 
-    status = WiFiNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
+    status = WiFiNetworkDiagnostics::Attributes::OverrunCount::Set(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset OverrunCount attribute"));
 
 exit:

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -156,10 +156,10 @@ bool IsOpen(chip::EndpointId endpoint)
     uint16_t tiltPosition = 0;
     uint16_t tiltLimit    = 0;
 
-    Attributes::GetTargetPositionLiftPercent100ths(endpoint, &liftPosition);
-    Attributes::GetInstalledOpenLimitLift(endpoint, &liftLimit);
-    Attributes::GetTargetPositionTiltPercent100ths(endpoint, &tiltPosition);
-    Attributes::GetInstalledOpenLimitTilt(endpoint, &tiltLimit);
+    Attributes::TargetPositionLiftPercent100ths::Get(endpoint, &liftPosition);
+    Attributes::InstalledOpenLimitLift::Get(endpoint, &liftLimit);
+    Attributes::TargetPositionTiltPercent100ths::Get(endpoint, &tiltPosition);
+    Attributes::InstalledOpenLimitTilt::Get(endpoint, &tiltLimit);
     return liftPosition == liftLimit && tiltPosition == tiltLimit;
 }
 
@@ -170,22 +170,22 @@ bool IsClosed(chip::EndpointId endpoint)
     uint16_t tiltPosition = 0;
     uint16_t tiltLimit    = 0;
 
-    Attributes::GetTargetPositionLiftPercent100ths(endpoint, &liftPosition);
-    Attributes::GetInstalledClosedLimitLift(endpoint, &liftLimit);
-    Attributes::GetTargetPositionTiltPercent100ths(endpoint, &tiltPosition);
-    Attributes::GetInstalledClosedLimitTilt(endpoint, &tiltLimit);
+    Attributes::TargetPositionLiftPercent100ths::Get(endpoint, &liftPosition);
+    Attributes::InstalledClosedLimitLift::Get(endpoint, &liftLimit);
+    Attributes::TargetPositionTiltPercent100ths::Get(endpoint, &tiltPosition);
+    Attributes::InstalledClosedLimitTilt::Get(endpoint, &tiltLimit);
     return liftPosition == liftLimit && tiltPosition == tiltLimit;
 }
 
 void TypeSet(chip::EndpointId endpoint, EmberAfWcType type)
 {
-    Attributes::SetType(endpoint, chip::to_underlying(type));
+    Attributes::Type::Set(endpoint, chip::to_underlying(type));
 }
 
 EmberAfWcType TypeGet(chip::EndpointId endpoint)
 {
     std::underlying_type<EmberAfWcType>::type value;
-    Attributes::GetType(endpoint, &value);
+    Attributes::Type::Get(endpoint, &value);
     return static_cast<EmberAfWcType>(value);
 }
 
@@ -194,7 +194,7 @@ void ConfigStatusSet(chip::EndpointId endpoint, const ConfigStatus & status)
     uint8_t value = (status.operational ? 0x01 : 0) | (status.online ? 0x02 : 0) | (status.liftIsReversed ? 0x04 : 0) |
         (status.liftIsPA ? 0x08 : 0) | (status.tiltIsPA ? 0x10 : 0) | (status.liftIsEncoderControlled ? 0x20 : 0) |
         (status.tiltIsEncoderControlled ? 0x40 : 0);
-    Attributes::SetConfigStatus(endpoint, value);
+    Attributes::ConfigStatus::Set(endpoint, value);
 }
 
 const ConfigStatus ConfigStatusGet(chip::EndpointId endpoint)
@@ -202,7 +202,7 @@ const ConfigStatus ConfigStatusGet(chip::EndpointId endpoint)
     uint8_t value = 0;
     ConfigStatus status;
 
-    Attributes::GetConfigStatus(endpoint, &value);
+    Attributes::ConfigStatus::Get(endpoint, &value);
     status.operational             = (value & 0x01) ? 1 : 0;
     status.online                  = (value & 0x02) ? 1 : 0;
     status.liftIsReversed          = (value & 0x04) ? 1 : 0;
@@ -219,7 +219,7 @@ void OperationalStatusSet(chip::EndpointId endpoint, const OperationalStatus & s
     uint8_t lift   = OperationalStateToValue(status.lift);
     uint8_t tilt   = OperationalStateToValue(status.tilt);
     uint8_t value  = (global & 0x03) | static_cast<uint8_t>((lift & 0x03) << 2) | static_cast<uint8_t>((tilt & 0x03) << 4);
-    Attributes::SetOperationalStatus(endpoint, value);
+    Attributes::OperationalStatus::Set(endpoint, value);
 }
 
 const OperationalStatus OperationalStatusGet(chip::EndpointId endpoint)
@@ -227,7 +227,7 @@ const OperationalStatus OperationalStatusGet(chip::EndpointId endpoint)
     uint8_t value = 0;
     OperationalStatus status;
 
-    Attributes::GetOperationalStatus(endpoint, &value);
+    Attributes::OperationalStatus::Get(endpoint, &value);
     status.global = ValueToOperationalState(value & 0x03);
     status.lift   = ValueToOperationalState((value >> 2) & 0x03);
     status.tilt   = ValueToOperationalState((value >> 4) & 0x03);
@@ -236,13 +236,13 @@ const OperationalStatus OperationalStatusGet(chip::EndpointId endpoint)
 
 void EndProductTypeSet(chip::EndpointId endpoint, EmberAfWcEndProductType type)
 {
-    Attributes::SetEndProductType(endpoint, chip::to_underlying(type));
+    Attributes::EndProductType::Set(endpoint, chip::to_underlying(type));
 }
 
 EmberAfWcEndProductType EndProductTypeGet(chip::EndpointId endpoint)
 {
     std::underlying_type<EmberAfWcType>::type value;
-    Attributes::GetEndProductType(endpoint, &value);
+    Attributes::EndProductType::Get(endpoint, &value);
     return static_cast<EmberAfWcEndProductType>(value);
 }
 
@@ -250,7 +250,7 @@ void ModeSet(chip::EndpointId endpoint, const Mode & mode)
 {
     uint8_t value = (mode.motorDirReversed ? 0x01 : 0) | (mode.calibrationMode ? 0x02 : 0) | (mode.maintenanceMode ? 0x04 : 0) |
         (mode.ledDisplay ? 0x08 : 0);
-    Attributes::SetMode(endpoint, value);
+    Attributes::Mode::Set(endpoint, value);
 }
 
 const Mode ModeGet(chip::EndpointId endpoint)
@@ -258,7 +258,7 @@ const Mode ModeGet(chip::EndpointId endpoint)
     uint8_t value = 0;
     Mode mode;
 
-    Attributes::GetMode(endpoint, &value);
+    Attributes::Mode::Get(endpoint, &value);
     mode.motorDirReversed = (value & 0x01) ? 1 : 0;
     mode.calibrationMode  = (value & 0x02) ? 1 : 0;
     mode.maintenanceMode  = (value & 0x04) ? 1 : 0;
@@ -274,7 +274,7 @@ void SafetyStatusSet(chip::EndpointId endpoint, SafetyStatus & status)
         (status.stopInput ? 0x0080 : 0);
     value |= (uint16_t)(status.motorJammed ? 0x0100 : 0) | (uint16_t)(status.hardwareFailure ? 0x0200 : 0) |
         (uint16_t)(status.manualOperation ? 0x0400 : 0);
-    Attributes::SetSafetyStatus(endpoint, value);
+    Attributes::SafetyStatus::Set(endpoint, value);
 }
 
 const SafetyStatus SafetyStatusGet(chip::EndpointId endpoint)
@@ -282,7 +282,7 @@ const SafetyStatus SafetyStatusGet(chip::EndpointId endpoint)
     uint16_t value = 0;
     SafetyStatus status;
 
-    Attributes::GetSafetyStatus(endpoint, &value);
+    Attributes::SafetyStatus::Get(endpoint, &value);
     status.remoteLockout       = (value & 0x0001) ? 1 : 0;
     status.tamperDetection     = (value & 0x0002) ? 1 : 0;
     status.failedCommunication = (value & 0x0004) ? 1 : 0;
@@ -301,8 +301,8 @@ uint16_t LiftToPercent100ths(chip::EndpointId endpoint, uint16_t lift)
 {
     uint16_t openLimit   = 0;
     uint16_t closedLimit = 0;
-    Attributes::GetInstalledOpenLimitLift(endpoint, &openLimit);
-    Attributes::GetInstalledClosedLimitLift(endpoint, &closedLimit);
+    Attributes::InstalledOpenLimitLift::Get(endpoint, &openLimit);
+    Attributes::InstalledClosedLimitLift::Get(endpoint, &closedLimit);
     return ValueToPercent100ths(openLimit, closedLimit, lift);
 }
 
@@ -310,8 +310,8 @@ uint16_t Percent100thsToLift(chip::EndpointId endpoint, uint16_t percent100ths)
 {
     uint16_t openLimit   = 0;
     uint16_t closedLimit = 0;
-    Attributes::GetInstalledOpenLimitLift(endpoint, &openLimit);
-    Attributes::GetInstalledClosedLimitLift(endpoint, &closedLimit);
+    Attributes::InstalledOpenLimitLift::Get(endpoint, &openLimit);
+    Attributes::InstalledClosedLimitLift::Get(endpoint, &closedLimit);
     return Percent100thsToValue(openLimit, closedLimit, percent100ths);
 }
 
@@ -320,9 +320,9 @@ void LiftPositionSet(chip::EndpointId endpoint, uint16_t percent100ths)
     uint8_t percent = static_cast<uint8_t>(percent100ths / 100);
     uint16_t lift   = Percent100thsToLift(endpoint, percent100ths);
 
-    Attributes::SetCurrentPositionLift(endpoint, lift);
-    Attributes::SetCurrentPositionLiftPercentage(endpoint, percent);
-    Attributes::SetCurrentPositionLiftPercent100ths(endpoint, percent100ths);
+    Attributes::CurrentPositionLift::Set(endpoint, lift);
+    Attributes::CurrentPositionLiftPercentage::Set(endpoint, percent);
+    Attributes::CurrentPositionLiftPercent100ths::Set(endpoint, percent100ths);
     emberAfWindowCoveringClusterPrint("Lift Position Set: %u%%", percent);
 }
 
@@ -330,8 +330,8 @@ uint16_t TiltToPercent100ths(chip::EndpointId endpoint, uint16_t tilt)
 {
     uint16_t openLimit   = 0;
     uint16_t closedLimit = 0;
-    Attributes::GetInstalledOpenLimitTilt(endpoint, &openLimit);
-    Attributes::GetInstalledClosedLimitTilt(endpoint, &closedLimit);
+    Attributes::InstalledOpenLimitTilt::Get(endpoint, &openLimit);
+    Attributes::InstalledClosedLimitTilt::Get(endpoint, &closedLimit);
     return ValueToPercent100ths(openLimit, closedLimit, tilt);
 }
 
@@ -339,8 +339,8 @@ uint16_t Percent100thsToTilt(chip::EndpointId endpoint, uint16_t percent100ths)
 {
     uint16_t openLimit   = 0;
     uint16_t closedLimit = 0;
-    Attributes::GetInstalledOpenLimitTilt(endpoint, &openLimit);
-    Attributes::GetInstalledClosedLimitTilt(endpoint, &closedLimit);
+    Attributes::InstalledOpenLimitTilt::Get(endpoint, &openLimit);
+    Attributes::InstalledClosedLimitTilt::Get(endpoint, &closedLimit);
     return Percent100thsToValue(openLimit, closedLimit, percent100ths);
 }
 
@@ -349,9 +349,9 @@ void TiltPositionSet(chip::EndpointId endpoint, uint16_t percent100ths)
     uint8_t percent = static_cast<uint8_t>(percent100ths / 100);
     uint16_t tilt   = Percent100thsToTilt(endpoint, percent100ths);
 
-    Attributes::SetCurrentPositionTilt(endpoint, tilt);
-    Attributes::SetCurrentPositionTiltPercentage(endpoint, percent);
-    Attributes::SetCurrentPositionTiltPercent100ths(endpoint, percent100ths);
+    Attributes::CurrentPositionTilt::Set(endpoint, tilt);
+    Attributes::CurrentPositionTiltPercentage::Set(endpoint, percent);
+    Attributes::CurrentPositionTiltPercent100ths::Set(endpoint, percent100ths);
     emberAfWindowCoveringClusterPrint("Tilt Position Set: %u%%", percent);
 }
 
@@ -383,11 +383,11 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(chip::EndpointId endpoint, chi
     emberAfWindowCoveringClusterPrint("UpOrOpen command received");
     if (HasFeature(endpoint, Features::Lift))
     {
-        Attributes::SetTargetPositionLiftPercent100ths(endpoint, 0);
+        Attributes::TargetPositionLiftPercent100ths::Set(endpoint, 0);
     }
     if (HasFeature(endpoint, Features::Tilt))
     {
-        Attributes::SetTargetPositionTiltPercent100ths(endpoint, 0);
+        Attributes::TargetPositionTiltPercent100ths::Set(endpoint, 0);
     }
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -401,11 +401,11 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(chip::EndpointId endpoint, 
     emberAfWindowCoveringClusterPrint("DownOrClose command received");
     if (HasFeature(endpoint, Features::Lift))
     {
-        Attributes::SetTargetPositionLiftPercent100ths(endpoint, WC_PERCENT100THS_MAX);
+        Attributes::TargetPositionLiftPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX);
     }
     if (HasFeature(endpoint, Features::Tilt))
     {
-        Attributes::SetTargetPositionTiltPercent100ths(endpoint, WC_PERCENT100THS_MAX);
+        Attributes::TargetPositionTiltPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX);
     }
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -435,7 +435,7 @@ bool emberAfWindowCoveringClusterGoToLiftValueCallback(chip::EndpointId endpoint
     emberAfWindowCoveringClusterPrint("GoToLiftValue Value command received");
     if (hasLift && isPositionAware)
     {
-        Attributes::SetTargetPositionLiftPercent100ths(endpoint, LiftToPercent100ths(endpoint, liftValue));
+        Attributes::TargetPositionLiftPercent100ths::Set(endpoint, LiftToPercent100ths(endpoint, liftValue));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     }
     else
@@ -458,7 +458,7 @@ bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::EndpointId end
     emberAfWindowCoveringClusterPrint("GoToLiftPercentage Percentage command received");
     if (hasLift && isPositionAware)
     {
-        Attributes::SetTargetPositionLiftPercent100ths(
+        Attributes::TargetPositionLiftPercent100ths::Set(
             endpoint, static_cast<uint16_t>(liftPercentageValue > 100 ? liftPercent100thsValue : liftPercentageValue * 100));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     }
@@ -482,7 +482,7 @@ bool emberAfWindowCoveringClusterGoToTiltValueCallback(chip::EndpointId endpoint
     emberAfWindowCoveringClusterPrint("GoToTiltValue command received");
     if (hasTilt && isPositionAware)
     {
-        Attributes::SetTargetPositionTiltPercent100ths(endpoint, TiltToPercent100ths(endpoint, tiltValue));
+        Attributes::TargetPositionTiltPercent100ths::Set(endpoint, TiltToPercent100ths(endpoint, tiltValue));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     }
     else
@@ -505,7 +505,7 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::EndpointId end
     emberAfWindowCoveringClusterPrint("GoToTiltPercentage command received");
     if (hasTilt && isPositionAware)
     {
-        Attributes::SetTargetPositionTiltPercent100ths(
+        Attributes::TargetPositionTiltPercent100ths::Set(
             endpoint, static_cast<uint16_t>(tiltPercentageValue > 100 ? tiltPercent100thsValue : tiltPercentageValue * 100));
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     }

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -22,18 +22,24 @@ namespace Clusters {
 {{#first}}
 namespace {{asUpperCamelCase parent.label}} {
 namespace Attributes {
+
 {{/first}}
 {{#if clusterRef}}
 {{#if (canHaveSimpleAccessors type)}}
-EmberAfStatus Get{{asUpperCamelCase label}}(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}})
+namespace {{asUpperCamelCase label}} {
+
+EmberAfStatus Get(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}})
 {
     return emberAfReadServerAttribute(endpoint, {{asUpperCamelCase parent.label}}::Id, {{asUpperCamelCase label}}::Id, (uint8_t *) {{asLowerCamelCase label}}, sizeof(*{{asLowerCamelCase label}}));
 
 }
-EmberAfStatus Set{{asUpperCamelCase label}}(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}})
+EmberAfStatus Set(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}})
 {
     return emberAfWriteServerAttribute(endpoint, {{asUpperCamelCase parent.label}}::Id, {{asUpperCamelCase label}}::Id, (uint8_t *) &{{asLowerCamelCase label}}, ZCL_{{asDelimitedMacro type}}_ATTRIBUTE_TYPE);
 }
+
+} // namespace {{asUpperCamelCase label}}
+
 {{/if}}
 {{/if}}
 {{#last}}

--- a/src/app/zap-templates/templates/app/attributes/Accessors.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors.zapt
@@ -20,11 +20,15 @@ namespace Clusters {
 {{#first}}
 namespace {{asUpperCamelCase parent.label}} {
 namespace Attributes {
+
 {{/first}}
 {{#if clusterRef}}
 {{#if (canHaveSimpleAccessors type)}}
-EmberAfStatus Get{{asUpperCamelCase label}}(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}}); // {{type}} {{isArray}}
-EmberAfStatus Set{{asUpperCamelCase label}}(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}});
+namespace {{asUpperCamelCase label}} {
+EmberAfStatus Get(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}}); // {{type}} {{isArray}}
+EmberAfStatus Set(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}});
+} // namespace {{asUpperCamelCase label}}
+
 {{/if}}
 {{/if}}
 {{#last}}

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -35,8435 +35,12575 @@ namespace Clusters {
 
 namespace PowerConfiguration {
 namespace Attributes {
-EmberAfStatus GetMainsVoltage(chip::EndpointId endpoint, uint16_t * mainsVoltage)
+
+namespace MainsVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltage::Id, (uint8_t *) mainsVoltage,
                                       sizeof(*mainsVoltage));
 }
-EmberAfStatus SetMainsVoltage(chip::EndpointId endpoint, uint16_t mainsVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltage::Id, (uint8_t *) &mainsVoltage,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMainsFrequency(chip::EndpointId endpoint, uint8_t * mainsFrequency)
+
+} // namespace MainsVoltage
+
+namespace MainsFrequency {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsFrequency)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsFrequency::Id, (uint8_t *) mainsFrequency,
                                       sizeof(*mainsFrequency));
 }
-EmberAfStatus SetMainsFrequency(chip::EndpointId endpoint, uint8_t mainsFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsFrequency)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsFrequency::Id, (uint8_t *) &mainsFrequency,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMainsAlarmMask(chip::EndpointId endpoint, uint8_t * mainsAlarmMask)
+
+} // namespace MainsFrequency
+
+namespace MainsAlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsAlarmMask)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsAlarmMask::Id, (uint8_t *) mainsAlarmMask,
                                       sizeof(*mainsAlarmMask));
 }
-EmberAfStatus SetMainsAlarmMask(chip::EndpointId endpoint, uint8_t mainsAlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsAlarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsAlarmMask::Id, (uint8_t *) &mainsAlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMainsVoltageMinThreshold(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold)
+
+} // namespace MainsAlarmMask
+
+namespace MainsVoltageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMinThreshold::Id,
                                       (uint8_t *) mainsVoltageMinThreshold, sizeof(*mainsVoltageMinThreshold));
 }
-EmberAfStatus SetMainsVoltageMinThreshold(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMinThreshold::Id,
                                        (uint8_t *) &mainsVoltageMinThreshold, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMainsVoltageMaxThreshold(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold)
+
+} // namespace MainsVoltageMinThreshold
+
+namespace MainsVoltageMaxThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMaxThreshold::Id,
                                       (uint8_t *) mainsVoltageMaxThreshold, sizeof(*mainsVoltageMaxThreshold));
 }
-EmberAfStatus SetMainsVoltageMaxThreshold(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageMaxThreshold::Id,
                                        (uint8_t *) &mainsVoltageMaxThreshold, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMainsVoltageDwellTrip(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip)
+
+} // namespace MainsVoltageMaxThreshold
+
+namespace MainsVoltageDwellTrip {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageDwellTrip::Id,
                                       (uint8_t *) mainsVoltageDwellTrip, sizeof(*mainsVoltageDwellTrip));
 }
-EmberAfStatus SetMainsVoltageDwellTrip(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, MainsVoltageDwellTrip::Id,
                                        (uint8_t *) &mainsVoltageDwellTrip, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryVoltage(chip::EndpointId endpoint, uint8_t * batteryVoltage)
+
+} // namespace MainsVoltageDwellTrip
+
+namespace BatteryVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltage::Id, (uint8_t *) batteryVoltage,
                                       sizeof(*batteryVoltage));
 }
-EmberAfStatus SetBatteryVoltage(chip::EndpointId endpoint, uint8_t batteryVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltage::Id, (uint8_t *) &batteryVoltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPercentageRemaining(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining)
+
+} // namespace BatteryVoltage
+
+namespace BatteryPercentageRemaining {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageRemaining::Id,
                                       (uint8_t *) batteryPercentageRemaining, sizeof(*batteryPercentageRemaining));
 }
-EmberAfStatus SetBatteryPercentageRemaining(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageRemaining::Id,
                                        (uint8_t *) &batteryPercentageRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatterySize(chip::EndpointId endpoint, uint8_t * batterySize)
+
+} // namespace BatteryPercentageRemaining
+
+namespace BatterySize {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batterySize)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatterySize::Id, (uint8_t *) batterySize,
                                       sizeof(*batterySize));
 }
-EmberAfStatus SetBatterySize(chip::EndpointId endpoint, uint8_t batterySize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batterySize)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatterySize::Id, (uint8_t *) &batterySize,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryAhrRating(chip::EndpointId endpoint, uint16_t * batteryAhrRating)
+
+} // namespace BatterySize
+
+namespace BatteryAhrRating {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * batteryAhrRating)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryAhrRating::Id, (uint8_t *) batteryAhrRating,
                                       sizeof(*batteryAhrRating));
 }
-EmberAfStatus SetBatteryAhrRating(chip::EndpointId endpoint, uint16_t batteryAhrRating)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t batteryAhrRating)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryAhrRating::Id, (uint8_t *) &batteryAhrRating,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryQuantity(chip::EndpointId endpoint, uint8_t * batteryQuantity)
+
+} // namespace BatteryAhrRating
+
+namespace BatteryQuantity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryQuantity::Id, (uint8_t *) batteryQuantity,
                                       sizeof(*batteryQuantity));
 }
-EmberAfStatus SetBatteryQuantity(chip::EndpointId endpoint, uint8_t batteryQuantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryQuantity::Id, (uint8_t *) &batteryQuantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryRatedVoltage(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage)
+
+} // namespace BatteryQuantity
+
+namespace BatteryRatedVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryRatedVoltage::Id, (uint8_t *) batteryRatedVoltage,
                                       sizeof(*batteryRatedVoltage));
 }
-EmberAfStatus SetBatteryRatedVoltage(chip::EndpointId endpoint, uint8_t batteryRatedVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryRatedVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryRatedVoltage::Id, (uint8_t *) &batteryRatedVoltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryAlarmMask(chip::EndpointId endpoint, uint8_t * batteryAlarmMask)
+
+} // namespace BatteryRatedVoltage
+
+namespace BatteryAlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryAlarmMask)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmMask::Id, (uint8_t *) batteryAlarmMask,
                                       sizeof(*batteryAlarmMask));
 }
-EmberAfStatus SetBatteryAlarmMask(chip::EndpointId endpoint, uint8_t batteryAlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryAlarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmMask::Id, (uint8_t *) &batteryAlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryVoltageMinThreshold(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold)
+
+} // namespace BatteryAlarmMask
+
+namespace BatteryVoltageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageMinThreshold::Id,
                                       (uint8_t *) batteryVoltageMinThreshold, sizeof(*batteryVoltageMinThreshold));
 }
-EmberAfStatus SetBatteryVoltageMinThreshold(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageMinThreshold::Id,
                                        (uint8_t *) &batteryVoltageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryVoltageThreshold1(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1)
+
+} // namespace BatteryVoltageMinThreshold
+
+namespace BatteryVoltageThreshold1 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold1::Id,
                                       (uint8_t *) batteryVoltageThreshold1, sizeof(*batteryVoltageThreshold1));
 }
-EmberAfStatus SetBatteryVoltageThreshold1(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold1::Id,
                                        (uint8_t *) &batteryVoltageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryVoltageThreshold2(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2)
+
+} // namespace BatteryVoltageThreshold1
+
+namespace BatteryVoltageThreshold2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold2::Id,
                                       (uint8_t *) batteryVoltageThreshold2, sizeof(*batteryVoltageThreshold2));
 }
-EmberAfStatus SetBatteryVoltageThreshold2(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold2::Id,
                                        (uint8_t *) &batteryVoltageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryVoltageThreshold3(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3)
+
+} // namespace BatteryVoltageThreshold2
+
+namespace BatteryVoltageThreshold3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold3::Id,
                                       (uint8_t *) batteryVoltageThreshold3, sizeof(*batteryVoltageThreshold3));
 }
-EmberAfStatus SetBatteryVoltageThreshold3(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryVoltageThreshold3::Id,
                                        (uint8_t *) &batteryVoltageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPercentageMinThreshold(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold)
+
+} // namespace BatteryVoltageThreshold3
+
+namespace BatteryPercentageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageMinThreshold::Id,
                                       (uint8_t *) batteryPercentageMinThreshold, sizeof(*batteryPercentageMinThreshold));
 }
-EmberAfStatus SetBatteryPercentageMinThreshold(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageMinThreshold::Id,
                                        (uint8_t *) &batteryPercentageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPercentageThreshold1(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1)
+
+} // namespace BatteryPercentageMinThreshold
+
+namespace BatteryPercentageThreshold1 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold1::Id,
                                       (uint8_t *) batteryPercentageThreshold1, sizeof(*batteryPercentageThreshold1));
 }
-EmberAfStatus SetBatteryPercentageThreshold1(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold1::Id,
                                        (uint8_t *) &batteryPercentageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPercentageThreshold2(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2)
+
+} // namespace BatteryPercentageThreshold1
+
+namespace BatteryPercentageThreshold2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold2::Id,
                                       (uint8_t *) batteryPercentageThreshold2, sizeof(*batteryPercentageThreshold2));
 }
-EmberAfStatus SetBatteryPercentageThreshold2(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold2::Id,
                                        (uint8_t *) &batteryPercentageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPercentageThreshold3(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3)
+
+} // namespace BatteryPercentageThreshold2
+
+namespace BatteryPercentageThreshold3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold3::Id,
                                       (uint8_t *) batteryPercentageThreshold3, sizeof(*batteryPercentageThreshold3));
 }
-EmberAfStatus SetBatteryPercentageThreshold3(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryPercentageThreshold3::Id,
                                        (uint8_t *) &batteryPercentageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryAlarmState(chip::EndpointId endpoint, uint32_t * batteryAlarmState)
+
+} // namespace BatteryPercentageThreshold3
+
+namespace BatteryAlarmState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryAlarmState)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmState::Id, (uint8_t *) batteryAlarmState,
                                       sizeof(*batteryAlarmState));
 }
-EmberAfStatus SetBatteryAlarmState(chip::EndpointId endpoint, uint32_t batteryAlarmState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryAlarmState)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, BatteryAlarmState::Id, (uint8_t *) &batteryAlarmState,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2Voltage(chip::EndpointId endpoint, uint8_t * battery2Voltage)
+
+} // namespace BatteryAlarmState
+
+namespace Battery2Voltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Voltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2Voltage::Id, (uint8_t *) battery2Voltage,
                                       sizeof(*battery2Voltage));
 }
-EmberAfStatus SetBattery2Voltage(chip::EndpointId endpoint, uint8_t battery2Voltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Voltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2Voltage::Id, (uint8_t *) &battery2Voltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2PercentageRemaining(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining)
+
+} // namespace Battery2Voltage
+
+namespace Battery2PercentageRemaining {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageRemaining::Id,
                                       (uint8_t *) battery2PercentageRemaining, sizeof(*battery2PercentageRemaining));
 }
-EmberAfStatus SetBattery2PercentageRemaining(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageRemaining::Id,
                                        (uint8_t *) &battery2PercentageRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2Size(chip::EndpointId endpoint, uint8_t * battery2Size)
+
+} // namespace Battery2PercentageRemaining
+
+namespace Battery2Size {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Size)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2Size::Id, (uint8_t *) battery2Size,
                                       sizeof(*battery2Size));
 }
-EmberAfStatus SetBattery2Size(chip::EndpointId endpoint, uint8_t battery2Size)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Size)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2Size::Id, (uint8_t *) &battery2Size,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2AhrRating(chip::EndpointId endpoint, uint16_t * battery2AhrRating)
+
+} // namespace Battery2Size
+
+namespace Battery2AhrRating {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery2AhrRating)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2AhrRating::Id, (uint8_t *) battery2AhrRating,
                                       sizeof(*battery2AhrRating));
 }
-EmberAfStatus SetBattery2AhrRating(chip::EndpointId endpoint, uint16_t battery2AhrRating)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery2AhrRating)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2AhrRating::Id, (uint8_t *) &battery2AhrRating,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2Quantity(chip::EndpointId endpoint, uint8_t * battery2Quantity)
+
+} // namespace Battery2AhrRating
+
+namespace Battery2Quantity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Quantity)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2Quantity::Id, (uint8_t *) battery2Quantity,
                                       sizeof(*battery2Quantity));
 }
-EmberAfStatus SetBattery2Quantity(chip::EndpointId endpoint, uint8_t battery2Quantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Quantity)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2Quantity::Id, (uint8_t *) &battery2Quantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2RatedVoltage(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage)
+
+} // namespace Battery2Quantity
+
+namespace Battery2RatedVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2RatedVoltage::Id, (uint8_t *) battery2RatedVoltage,
                                       sizeof(*battery2RatedVoltage));
 }
-EmberAfStatus SetBattery2RatedVoltage(chip::EndpointId endpoint, uint8_t battery2RatedVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2RatedVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2RatedVoltage::Id,
                                        (uint8_t *) &battery2RatedVoltage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2AlarmMask(chip::EndpointId endpoint, uint8_t * battery2AlarmMask)
+
+} // namespace Battery2RatedVoltage
+
+namespace Battery2AlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2AlarmMask)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmMask::Id, (uint8_t *) battery2AlarmMask,
                                       sizeof(*battery2AlarmMask));
 }
-EmberAfStatus SetBattery2AlarmMask(chip::EndpointId endpoint, uint8_t battery2AlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2AlarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmMask::Id, (uint8_t *) &battery2AlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2VoltageMinThreshold(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold)
+
+} // namespace Battery2AlarmMask
+
+namespace Battery2VoltageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageMinThreshold::Id,
                                       (uint8_t *) battery2VoltageMinThreshold, sizeof(*battery2VoltageMinThreshold));
 }
-EmberAfStatus SetBattery2VoltageMinThreshold(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageMinThreshold::Id,
                                        (uint8_t *) &battery2VoltageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2VoltageThreshold1(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1)
+
+} // namespace Battery2VoltageMinThreshold
+
+namespace Battery2VoltageThreshold1 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold1::Id,
                                       (uint8_t *) battery2VoltageThreshold1, sizeof(*battery2VoltageThreshold1));
 }
-EmberAfStatus SetBattery2VoltageThreshold1(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold1::Id,
                                        (uint8_t *) &battery2VoltageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2VoltageThreshold2(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2)
+
+} // namespace Battery2VoltageThreshold1
+
+namespace Battery2VoltageThreshold2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold2::Id,
                                       (uint8_t *) battery2VoltageThreshold2, sizeof(*battery2VoltageThreshold2));
 }
-EmberAfStatus SetBattery2VoltageThreshold2(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold2::Id,
                                        (uint8_t *) &battery2VoltageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2VoltageThreshold3(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3)
+
+} // namespace Battery2VoltageThreshold2
+
+namespace Battery2VoltageThreshold3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold3::Id,
                                       (uint8_t *) battery2VoltageThreshold3, sizeof(*battery2VoltageThreshold3));
 }
-EmberAfStatus SetBattery2VoltageThreshold3(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2VoltageThreshold3::Id,
                                        (uint8_t *) &battery2VoltageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2PercentageMinThreshold(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold)
+
+} // namespace Battery2VoltageThreshold3
+
+namespace Battery2PercentageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageMinThreshold::Id,
                                       (uint8_t *) battery2PercentageMinThreshold, sizeof(*battery2PercentageMinThreshold));
 }
-EmberAfStatus SetBattery2PercentageMinThreshold(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageMinThreshold::Id,
                                        (uint8_t *) &battery2PercentageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2PercentageThreshold1(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1)
+
+} // namespace Battery2PercentageMinThreshold
+
+namespace Battery2PercentageThreshold1 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold1::Id,
                                       (uint8_t *) battery2PercentageThreshold1, sizeof(*battery2PercentageThreshold1));
 }
-EmberAfStatus SetBattery2PercentageThreshold1(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold1::Id,
                                        (uint8_t *) &battery2PercentageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2PercentageThreshold2(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2)
+
+} // namespace Battery2PercentageThreshold1
+
+namespace Battery2PercentageThreshold2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold2::Id,
                                       (uint8_t *) battery2PercentageThreshold2, sizeof(*battery2PercentageThreshold2));
 }
-EmberAfStatus SetBattery2PercentageThreshold2(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold2::Id,
                                        (uint8_t *) &battery2PercentageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2PercentageThreshold3(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3)
+
+} // namespace Battery2PercentageThreshold2
+
+namespace Battery2PercentageThreshold3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold3::Id,
                                       (uint8_t *) battery2PercentageThreshold3, sizeof(*battery2PercentageThreshold3));
 }
-EmberAfStatus SetBattery2PercentageThreshold3(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2PercentageThreshold3::Id,
                                        (uint8_t *) &battery2PercentageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery2AlarmState(chip::EndpointId endpoint, uint32_t * battery2AlarmState)
+
+} // namespace Battery2PercentageThreshold3
+
+namespace Battery2AlarmState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery2AlarmState)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmState::Id, (uint8_t *) battery2AlarmState,
                                       sizeof(*battery2AlarmState));
 }
-EmberAfStatus SetBattery2AlarmState(chip::EndpointId endpoint, uint32_t battery2AlarmState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery2AlarmState)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery2AlarmState::Id, (uint8_t *) &battery2AlarmState,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3Voltage(chip::EndpointId endpoint, uint8_t * battery3Voltage)
+
+} // namespace Battery2AlarmState
+
+namespace Battery3Voltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Voltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3Voltage::Id, (uint8_t *) battery3Voltage,
                                       sizeof(*battery3Voltage));
 }
-EmberAfStatus SetBattery3Voltage(chip::EndpointId endpoint, uint8_t battery3Voltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Voltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3Voltage::Id, (uint8_t *) &battery3Voltage,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3PercentageRemaining(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining)
+
+} // namespace Battery3Voltage
+
+namespace Battery3PercentageRemaining {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageRemaining::Id,
                                       (uint8_t *) battery3PercentageRemaining, sizeof(*battery3PercentageRemaining));
 }
-EmberAfStatus SetBattery3PercentageRemaining(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageRemaining::Id,
                                        (uint8_t *) &battery3PercentageRemaining, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3Size(chip::EndpointId endpoint, uint8_t * battery3Size)
+
+} // namespace Battery3PercentageRemaining
+
+namespace Battery3Size {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Size)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3Size::Id, (uint8_t *) battery3Size,
                                       sizeof(*battery3Size));
 }
-EmberAfStatus SetBattery3Size(chip::EndpointId endpoint, uint8_t battery3Size)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Size)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3Size::Id, (uint8_t *) &battery3Size,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3AhrRating(chip::EndpointId endpoint, uint16_t * battery3AhrRating)
+
+} // namespace Battery3Size
+
+namespace Battery3AhrRating {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery3AhrRating)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3AhrRating::Id, (uint8_t *) battery3AhrRating,
                                       sizeof(*battery3AhrRating));
 }
-EmberAfStatus SetBattery3AhrRating(chip::EndpointId endpoint, uint16_t battery3AhrRating)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery3AhrRating)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3AhrRating::Id, (uint8_t *) &battery3AhrRating,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3Quantity(chip::EndpointId endpoint, uint8_t * battery3Quantity)
+
+} // namespace Battery3AhrRating
+
+namespace Battery3Quantity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Quantity)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3Quantity::Id, (uint8_t *) battery3Quantity,
                                       sizeof(*battery3Quantity));
 }
-EmberAfStatus SetBattery3Quantity(chip::EndpointId endpoint, uint8_t battery3Quantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Quantity)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3Quantity::Id, (uint8_t *) &battery3Quantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3RatedVoltage(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage)
+
+} // namespace Battery3Quantity
+
+namespace Battery3RatedVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3RatedVoltage::Id, (uint8_t *) battery3RatedVoltage,
                                       sizeof(*battery3RatedVoltage));
 }
-EmberAfStatus SetBattery3RatedVoltage(chip::EndpointId endpoint, uint8_t battery3RatedVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3RatedVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3RatedVoltage::Id,
                                        (uint8_t *) &battery3RatedVoltage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3AlarmMask(chip::EndpointId endpoint, uint8_t * battery3AlarmMask)
+
+} // namespace Battery3RatedVoltage
+
+namespace Battery3AlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3AlarmMask)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmMask::Id, (uint8_t *) battery3AlarmMask,
                                       sizeof(*battery3AlarmMask));
 }
-EmberAfStatus SetBattery3AlarmMask(chip::EndpointId endpoint, uint8_t battery3AlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3AlarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmMask::Id, (uint8_t *) &battery3AlarmMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3VoltageMinThreshold(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold)
+
+} // namespace Battery3AlarmMask
+
+namespace Battery3VoltageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageMinThreshold::Id,
                                       (uint8_t *) battery3VoltageMinThreshold, sizeof(*battery3VoltageMinThreshold));
 }
-EmberAfStatus SetBattery3VoltageMinThreshold(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageMinThreshold::Id,
                                        (uint8_t *) &battery3VoltageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3VoltageThreshold1(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1)
+
+} // namespace Battery3VoltageMinThreshold
+
+namespace Battery3VoltageThreshold1 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold1::Id,
                                       (uint8_t *) battery3VoltageThreshold1, sizeof(*battery3VoltageThreshold1));
 }
-EmberAfStatus SetBattery3VoltageThreshold1(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold1::Id,
                                        (uint8_t *) &battery3VoltageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3VoltageThreshold2(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2)
+
+} // namespace Battery3VoltageThreshold1
+
+namespace Battery3VoltageThreshold2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold2::Id,
                                       (uint8_t *) battery3VoltageThreshold2, sizeof(*battery3VoltageThreshold2));
 }
-EmberAfStatus SetBattery3VoltageThreshold2(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold2::Id,
                                        (uint8_t *) &battery3VoltageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3VoltageThreshold3(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3)
+
+} // namespace Battery3VoltageThreshold2
+
+namespace Battery3VoltageThreshold3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold3::Id,
                                       (uint8_t *) battery3VoltageThreshold3, sizeof(*battery3VoltageThreshold3));
 }
-EmberAfStatus SetBattery3VoltageThreshold3(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3VoltageThreshold3::Id,
                                        (uint8_t *) &battery3VoltageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3PercentageMinThreshold(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold)
+
+} // namespace Battery3VoltageThreshold3
+
+namespace Battery3PercentageMinThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageMinThreshold::Id,
                                       (uint8_t *) battery3PercentageMinThreshold, sizeof(*battery3PercentageMinThreshold));
 }
-EmberAfStatus SetBattery3PercentageMinThreshold(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageMinThreshold::Id,
                                        (uint8_t *) &battery3PercentageMinThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3PercentageThreshold1(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1)
+
+} // namespace Battery3PercentageMinThreshold
+
+namespace Battery3PercentageThreshold1 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold1::Id,
                                       (uint8_t *) battery3PercentageThreshold1, sizeof(*battery3PercentageThreshold1));
 }
-EmberAfStatus SetBattery3PercentageThreshold1(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold1::Id,
                                        (uint8_t *) &battery3PercentageThreshold1, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3PercentageThreshold2(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2)
+
+} // namespace Battery3PercentageThreshold1
+
+namespace Battery3PercentageThreshold2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold2::Id,
                                       (uint8_t *) battery3PercentageThreshold2, sizeof(*battery3PercentageThreshold2));
 }
-EmberAfStatus SetBattery3PercentageThreshold2(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold2::Id,
                                        (uint8_t *) &battery3PercentageThreshold2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3PercentageThreshold3(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3)
+
+} // namespace Battery3PercentageThreshold2
+
+namespace Battery3PercentageThreshold3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold3::Id,
                                       (uint8_t *) battery3PercentageThreshold3, sizeof(*battery3PercentageThreshold3));
 }
-EmberAfStatus SetBattery3PercentageThreshold3(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3PercentageThreshold3::Id,
                                        (uint8_t *) &battery3PercentageThreshold3, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBattery3AlarmState(chip::EndpointId endpoint, uint32_t * battery3AlarmState)
+
+} // namespace Battery3PercentageThreshold3
+
+namespace Battery3AlarmState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery3AlarmState)
 {
     return emberAfReadServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmState::Id, (uint8_t *) battery3AlarmState,
                                       sizeof(*battery3AlarmState));
 }
-EmberAfStatus SetBattery3AlarmState(chip::EndpointId endpoint, uint32_t battery3AlarmState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery3AlarmState)
 {
     return emberAfWriteServerAttribute(endpoint, PowerConfiguration::Id, Battery3AlarmState::Id, (uint8_t *) &battery3AlarmState,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
+
+} // namespace Battery3AlarmState
+
 } // namespace Attributes
 } // namespace PowerConfiguration
 
 namespace DeviceTemperatureConfiguration {
 namespace Attributes {
-EmberAfStatus GetCurrentTemperature(chip::EndpointId endpoint, int16_t * currentTemperature)
+
+namespace CurrentTemperature {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentTemperature)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, CurrentTemperature::Id,
                                       (uint8_t *) currentTemperature, sizeof(*currentTemperature));
 }
-EmberAfStatus SetCurrentTemperature(chip::EndpointId endpoint, int16_t currentTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentTemperature)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, CurrentTemperature::Id,
                                        (uint8_t *) &currentTemperature, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinTempExperienced(chip::EndpointId endpoint, int16_t * minTempExperienced)
+
+} // namespace CurrentTemperature
+
+namespace MinTempExperienced {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minTempExperienced)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MinTempExperienced::Id,
                                       (uint8_t *) minTempExperienced, sizeof(*minTempExperienced));
 }
-EmberAfStatus SetMinTempExperienced(chip::EndpointId endpoint, int16_t minTempExperienced)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minTempExperienced)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MinTempExperienced::Id,
                                        (uint8_t *) &minTempExperienced, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxTempExperienced(chip::EndpointId endpoint, int16_t * maxTempExperienced)
+
+} // namespace MinTempExperienced
+
+namespace MaxTempExperienced {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxTempExperienced)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MaxTempExperienced::Id,
                                       (uint8_t *) maxTempExperienced, sizeof(*maxTempExperienced));
 }
-EmberAfStatus SetMaxTempExperienced(chip::EndpointId endpoint, int16_t maxTempExperienced)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxTempExperienced)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, MaxTempExperienced::Id,
                                        (uint8_t *) &maxTempExperienced, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOverTempTotalDwell(chip::EndpointId endpoint, uint16_t * overTempTotalDwell)
+
+} // namespace MaxTempExperienced
+
+namespace OverTempTotalDwell {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * overTempTotalDwell)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, OverTempTotalDwell::Id,
                                       (uint8_t *) overTempTotalDwell, sizeof(*overTempTotalDwell));
 }
-EmberAfStatus SetOverTempTotalDwell(chip::EndpointId endpoint, uint16_t overTempTotalDwell)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t overTempTotalDwell)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, OverTempTotalDwell::Id,
                                        (uint8_t *) &overTempTotalDwell, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDeviceTempAlarmMask(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask)
+
+} // namespace OverTempTotalDwell
+
+namespace DeviceTempAlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, DeviceTempAlarmMask::Id,
                                       (uint8_t *) deviceTempAlarmMask, sizeof(*deviceTempAlarmMask));
 }
-EmberAfStatus SetDeviceTempAlarmMask(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, DeviceTempAlarmMask::Id,
                                        (uint8_t *) &deviceTempAlarmMask, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLowTempThreshold(chip::EndpointId endpoint, int16_t * lowTempThreshold)
+
+} // namespace DeviceTempAlarmMask
+
+namespace LowTempThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * lowTempThreshold)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, LowTempThreshold::Id,
                                       (uint8_t *) lowTempThreshold, sizeof(*lowTempThreshold));
 }
-EmberAfStatus SetLowTempThreshold(chip::EndpointId endpoint, int16_t lowTempThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t lowTempThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, LowTempThreshold::Id,
                                        (uint8_t *) &lowTempThreshold, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetHighTempThreshold(chip::EndpointId endpoint, int16_t * highTempThreshold)
+
+} // namespace LowTempThreshold
+
+namespace HighTempThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * highTempThreshold)
 {
     return emberAfReadServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, HighTempThreshold::Id,
                                       (uint8_t *) highTempThreshold, sizeof(*highTempThreshold));
 }
-EmberAfStatus SetHighTempThreshold(chip::EndpointId endpoint, int16_t highTempThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t highTempThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, DeviceTemperatureConfiguration::Id, HighTempThreshold::Id,
                                        (uint8_t *) &highTempThreshold, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
+
+} // namespace HighTempThreshold
+
 } // namespace Attributes
 } // namespace DeviceTemperatureConfiguration
 
 namespace Identify {
 namespace Attributes {
-EmberAfStatus GetIdentifyTime(chip::EndpointId endpoint, uint16_t * identifyTime)
+
+namespace IdentifyTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * identifyTime)
 {
     return emberAfReadServerAttribute(endpoint, Identify::Id, IdentifyTime::Id, (uint8_t *) identifyTime, sizeof(*identifyTime));
 }
-EmberAfStatus SetIdentifyTime(chip::EndpointId endpoint, uint16_t identifyTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t identifyTime)
 {
     return emberAfWriteServerAttribute(endpoint, Identify::Id, IdentifyTime::Id, (uint8_t *) &identifyTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetIdentifyType(chip::EndpointId endpoint, uint8_t * identifyType)
+
+} // namespace IdentifyTime
+
+namespace IdentifyType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * identifyType)
 {
     return emberAfReadServerAttribute(endpoint, Identify::Id, IdentifyType::Id, (uint8_t *) identifyType, sizeof(*identifyType));
 }
-EmberAfStatus SetIdentifyType(chip::EndpointId endpoint, uint8_t identifyType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t identifyType)
 {
     return emberAfWriteServerAttribute(endpoint, Identify::Id, IdentifyType::Id, (uint8_t *) &identifyType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace IdentifyType
+
 } // namespace Attributes
 } // namespace Identify
 
 namespace Groups {
 namespace Attributes {
-EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport)
+
+namespace NameSupport {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport)
 {
     return emberAfReadServerAttribute(endpoint, Groups::Id, NameSupport::Id, (uint8_t *) nameSupport, sizeof(*nameSupport));
 }
-EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport)
 {
     return emberAfWriteServerAttribute(endpoint, Groups::Id, NameSupport::Id, (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
+
+} // namespace NameSupport
+
 } // namespace Attributes
 } // namespace Groups
 
 namespace Scenes {
 namespace Attributes {
-EmberAfStatus GetSceneCount(chip::EndpointId endpoint, uint8_t * sceneCount)
+
+namespace SceneCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sceneCount)
 {
     return emberAfReadServerAttribute(endpoint, Scenes::Id, SceneCount::Id, (uint8_t *) sceneCount, sizeof(*sceneCount));
 }
-EmberAfStatus SetSceneCount(chip::EndpointId endpoint, uint8_t sceneCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sceneCount)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, SceneCount::Id, (uint8_t *) &sceneCount, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentScene(chip::EndpointId endpoint, uint8_t * currentScene)
+
+} // namespace SceneCount
+
+namespace CurrentScene {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentScene)
 {
     return emberAfReadServerAttribute(endpoint, Scenes::Id, CurrentScene::Id, (uint8_t *) currentScene, sizeof(*currentScene));
 }
-EmberAfStatus SetCurrentScene(chip::EndpointId endpoint, uint8_t currentScene)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentScene)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, CurrentScene::Id, (uint8_t *) &currentScene, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentGroup(chip::EndpointId endpoint, uint16_t * currentGroup)
+
+} // namespace CurrentScene
+
+namespace CurrentGroup {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentGroup)
 {
     return emberAfReadServerAttribute(endpoint, Scenes::Id, CurrentGroup::Id, (uint8_t *) currentGroup, sizeof(*currentGroup));
 }
-EmberAfStatus SetCurrentGroup(chip::EndpointId endpoint, uint16_t currentGroup)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentGroup)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, CurrentGroup::Id, (uint8_t *) &currentGroup,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSceneValid(chip::EndpointId endpoint, bool * sceneValid)
+
+} // namespace CurrentGroup
+
+namespace SceneValid {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * sceneValid)
 {
     return emberAfReadServerAttribute(endpoint, Scenes::Id, SceneValid::Id, (uint8_t *) sceneValid, sizeof(*sceneValid));
 }
-EmberAfStatus SetSceneValid(chip::EndpointId endpoint, bool sceneValid)
+EmberAfStatus Set(chip::EndpointId endpoint, bool sceneValid)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, SceneValid::Id, (uint8_t *) &sceneValid, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport)
+
+} // namespace SceneValid
+
+namespace NameSupport {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport)
 {
     return emberAfReadServerAttribute(endpoint, Scenes::Id, NameSupport::Id, (uint8_t *) nameSupport, sizeof(*nameSupport));
 }
-EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, NameSupport::Id, (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
+
+} // namespace NameSupport
+
 } // namespace Attributes
 } // namespace Scenes
 
 namespace OnOff {
 namespace Attributes {
-EmberAfStatus GetOnOff(chip::EndpointId endpoint, bool * onOff)
+
+namespace OnOff {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * onOff)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, OnOff::Id, (uint8_t *) onOff, sizeof(*onOff));
 }
-EmberAfStatus SetOnOff(chip::EndpointId endpoint, bool onOff)
+EmberAfStatus Set(chip::EndpointId endpoint, bool onOff)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, OnOff::Id, (uint8_t *) &onOff, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint,
-                                                        uint16_t * sampleMfgSpecificAttribute0x00000x1002)
+
+} // namespace OnOff
+
+namespace SampleMfgSpecificAttribute0x00000x1002 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00000x1002)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1002::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00000x1002,
                                       sizeof(*sampleMfgSpecificAttribute0x00000x1002));
 }
-EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1002::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00000x1002, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1049(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00000x1049)
+
+} // namespace SampleMfgSpecificAttribute0x00000x1002
+
+namespace SampleMfgSpecificAttribute0x00000x1049 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00000x1049)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1049::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00000x1049,
                                       sizeof(*sampleMfgSpecificAttribute0x00000x1049));
 }
-EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1049(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00000x1049::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00000x1049, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00010x1002)
+
+} // namespace SampleMfgSpecificAttribute0x00000x1049
+
+namespace SampleMfgSpecificAttribute0x00010x1002 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00010x1002)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1002::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00010x1002,
                                       sizeof(*sampleMfgSpecificAttribute0x00010x1002));
 }
-EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1002::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00010x1002, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint,
-                                                        uint16_t * sampleMfgSpecificAttribute0x00010x1040)
+
+} // namespace SampleMfgSpecificAttribute0x00010x1002
+
+namespace SampleMfgSpecificAttribute0x00010x1040 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00010x1040)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1040::Id,
                                       (uint8_t *) sampleMfgSpecificAttribute0x00010x1040,
                                       sizeof(*sampleMfgSpecificAttribute0x00010x1040));
 }
-EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, SampleMfgSpecificAttribute0x00010x1040::Id,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00010x1040, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, bool * globalSceneControl)
+
+} // namespace SampleMfgSpecificAttribute0x00010x1040
+
+namespace GlobalSceneControl {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * globalSceneControl)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, GlobalSceneControl::Id, (uint8_t *) globalSceneControl,
                                       sizeof(*globalSceneControl));
 }
-EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, bool globalSceneControl)
+EmberAfStatus Set(chip::EndpointId endpoint, bool globalSceneControl)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, GlobalSceneControl::Id, (uint8_t *) &globalSceneControl,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOnTime(chip::EndpointId endpoint, uint16_t * onTime)
+
+} // namespace GlobalSceneControl
+
+namespace OnTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTime)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, OnTime::Id, (uint8_t *) onTime, sizeof(*onTime));
 }
-EmberAfStatus SetOnTime(chip::EndpointId endpoint, uint16_t onTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTime)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, OnTime::Id, (uint8_t *) &onTime, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOffWaitTime(chip::EndpointId endpoint, uint16_t * offWaitTime)
+
+} // namespace OnTime
+
+namespace OffWaitTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offWaitTime)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, OffWaitTime::Id, (uint8_t *) offWaitTime, sizeof(*offWaitTime));
 }
-EmberAfStatus SetOffWaitTime(chip::EndpointId endpoint, uint16_t offWaitTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offWaitTime)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, OffWaitTime::Id, (uint8_t *) &offWaitTime, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStartUpOnOff(chip::EndpointId endpoint, uint8_t * startUpOnOff)
+
+} // namespace OffWaitTime
+
+namespace StartUpOnOff {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpOnOff)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, StartUpOnOff::Id, (uint8_t *) startUpOnOff, sizeof(*startUpOnOff));
 }
-EmberAfStatus SetStartUpOnOff(chip::EndpointId endpoint, uint8_t startUpOnOff)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpOnOff)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, StartUpOnOff::Id, (uint8_t *) &startUpOnOff, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace StartUpOnOff
+
 } // namespace Attributes
 } // namespace OnOff
 
 namespace OnOffSwitchConfiguration {
 namespace Attributes {
-EmberAfStatus GetSwitchType(chip::EndpointId endpoint, uint8_t * switchType)
+
+namespace SwitchType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchType)
 {
     return emberAfReadServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchType::Id, (uint8_t *) switchType,
                                       sizeof(*switchType));
 }
-EmberAfStatus SetSwitchType(chip::EndpointId endpoint, uint8_t switchType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchType)
 {
     return emberAfWriteServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchType::Id, (uint8_t *) &switchType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSwitchActions(chip::EndpointId endpoint, uint8_t * switchActions)
+
+} // namespace SwitchType
+
+namespace SwitchActions {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchActions)
 {
     return emberAfReadServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchActions::Id, (uint8_t *) switchActions,
                                       sizeof(*switchActions));
 }
-EmberAfStatus SetSwitchActions(chip::EndpointId endpoint, uint8_t switchActions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchActions)
 {
     return emberAfWriteServerAttribute(endpoint, OnOffSwitchConfiguration::Id, SwitchActions::Id, (uint8_t *) &switchActions,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace SwitchActions
+
 } // namespace Attributes
 } // namespace OnOffSwitchConfiguration
 
 namespace LevelControl {
 namespace Attributes {
-EmberAfStatus GetCurrentLevel(chip::EndpointId endpoint, uint8_t * currentLevel)
+
+namespace CurrentLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentLevel)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, CurrentLevel::Id, (uint8_t *) currentLevel,
                                       sizeof(*currentLevel));
 }
-EmberAfStatus SetCurrentLevel(chip::EndpointId endpoint, uint8_t currentLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentLevel)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, CurrentLevel::Id, (uint8_t *) &currentLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime)
+
+} // namespace CurrentLevel
+
+namespace RemainingTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, RemainingTime::Id, (uint8_t *) remainingTime,
                                       sizeof(*remainingTime));
 }
-EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, RemainingTime::Id, (uint8_t *) &remainingTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOptions(chip::EndpointId endpoint, uint8_t * options)
+
+} // namespace RemainingTime
+
+namespace Options {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * options)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, Options::Id, (uint8_t *) options, sizeof(*options));
 }
-EmberAfStatus SetOptions(chip::EndpointId endpoint, uint8_t options)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t options)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, Options::Id, (uint8_t *) &options, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOnOffTransitionTime(chip::EndpointId endpoint, uint16_t * onOffTransitionTime)
+
+} // namespace Options
+
+namespace OnOffTransitionTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onOffTransitionTime)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, OnOffTransitionTime::Id, (uint8_t *) onOffTransitionTime,
                                       sizeof(*onOffTransitionTime));
 }
-EmberAfStatus SetOnOffTransitionTime(chip::EndpointId endpoint, uint16_t onOffTransitionTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onOffTransitionTime)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OnOffTransitionTime::Id, (uint8_t *) &onOffTransitionTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOnLevel(chip::EndpointId endpoint, uint8_t * onLevel)
+
+} // namespace OnOffTransitionTime
+
+namespace OnLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * onLevel)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, OnLevel::Id, (uint8_t *) onLevel, sizeof(*onLevel));
 }
-EmberAfStatus SetOnLevel(chip::EndpointId endpoint, uint8_t onLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t onLevel)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OnLevel::Id, (uint8_t *) &onLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOnTransitionTime(chip::EndpointId endpoint, uint16_t * onTransitionTime)
+
+} // namespace OnLevel
+
+namespace OnTransitionTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTransitionTime)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, OnTransitionTime::Id, (uint8_t *) onTransitionTime,
                                       sizeof(*onTransitionTime));
 }
-EmberAfStatus SetOnTransitionTime(chip::EndpointId endpoint, uint16_t onTransitionTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTransitionTime)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OnTransitionTime::Id, (uint8_t *) &onTransitionTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOffTransitionTime(chip::EndpointId endpoint, uint16_t * offTransitionTime)
+
+} // namespace OnTransitionTime
+
+namespace OffTransitionTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offTransitionTime)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, OffTransitionTime::Id, (uint8_t *) offTransitionTime,
                                       sizeof(*offTransitionTime));
 }
-EmberAfStatus SetOffTransitionTime(chip::EndpointId endpoint, uint16_t offTransitionTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offTransitionTime)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, OffTransitionTime::Id, (uint8_t *) &offTransitionTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDefaultMoveRate(chip::EndpointId endpoint, uint8_t * defaultMoveRate)
+
+} // namespace OffTransitionTime
+
+namespace DefaultMoveRate {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * defaultMoveRate)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, DefaultMoveRate::Id, (uint8_t *) defaultMoveRate,
                                       sizeof(*defaultMoveRate));
 }
-EmberAfStatus SetDefaultMoveRate(chip::EndpointId endpoint, uint8_t defaultMoveRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t defaultMoveRate)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, DefaultMoveRate::Id, (uint8_t *) &defaultMoveRate,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStartUpCurrentLevel(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel)
+
+} // namespace DefaultMoveRate
+
+namespace StartUpCurrentLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel)
 {
     return emberAfReadServerAttribute(endpoint, LevelControl::Id, StartUpCurrentLevel::Id, (uint8_t *) startUpCurrentLevel,
                                       sizeof(*startUpCurrentLevel));
 }
-EmberAfStatus SetStartUpCurrentLevel(chip::EndpointId endpoint, uint8_t startUpCurrentLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpCurrentLevel)
 {
     return emberAfWriteServerAttribute(endpoint, LevelControl::Id, StartUpCurrentLevel::Id, (uint8_t *) &startUpCurrentLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace StartUpCurrentLevel
+
 } // namespace Attributes
 } // namespace LevelControl
 
 namespace Alarms {
 namespace Attributes {
-EmberAfStatus GetAlarmCount(chip::EndpointId endpoint, uint16_t * alarmCount)
+
+namespace AlarmCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmCount)
 {
     return emberAfReadServerAttribute(endpoint, Alarms::Id, AlarmCount::Id, (uint8_t *) alarmCount, sizeof(*alarmCount));
 }
-EmberAfStatus SetAlarmCount(chip::EndpointId endpoint, uint16_t alarmCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmCount)
 {
     return emberAfWriteServerAttribute(endpoint, Alarms::Id, AlarmCount::Id, (uint8_t *) &alarmCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace AlarmCount
+
 } // namespace Attributes
 } // namespace Alarms
 
 namespace Time {
 namespace Attributes {
-EmberAfStatus GetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** time)
+
+namespace Time {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** time)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, Time::Id, (uint8_t *) time, sizeof(*time));
 }
-EmberAfStatus SetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * time)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * time)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, Time::Id, (uint8_t *) &time, ZCL_UTC_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTimeStatus(chip::EndpointId endpoint, uint8_t * timeStatus)
+
+} // namespace Time
+
+namespace TimeStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * timeStatus)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, TimeStatus::Id, (uint8_t *) timeStatus, sizeof(*timeStatus));
 }
-EmberAfStatus SetTimeStatus(chip::EndpointId endpoint, uint8_t timeStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t timeStatus)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, TimeStatus::Id, (uint8_t *) &timeStatus, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTimeZone(chip::EndpointId endpoint, int32_t * timeZone)
+
+} // namespace TimeStatus
+
+namespace TimeZone {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * timeZone)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, TimeZone::Id, (uint8_t *) timeZone, sizeof(*timeZone));
 }
-EmberAfStatus SetTimeZone(chip::EndpointId endpoint, int32_t timeZone)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t timeZone)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, TimeZone::Id, (uint8_t *) &timeZone, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDstStart(chip::EndpointId endpoint, uint32_t * dstStart)
+
+} // namespace TimeZone
+
+namespace DstStart {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstStart)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, DstStart::Id, (uint8_t *) dstStart, sizeof(*dstStart));
 }
-EmberAfStatus SetDstStart(chip::EndpointId endpoint, uint32_t dstStart)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstStart)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, DstStart::Id, (uint8_t *) &dstStart, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDstEnd(chip::EndpointId endpoint, uint32_t * dstEnd)
+
+} // namespace DstStart
+
+namespace DstEnd {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstEnd)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, DstEnd::Id, (uint8_t *) dstEnd, sizeof(*dstEnd));
 }
-EmberAfStatus SetDstEnd(chip::EndpointId endpoint, uint32_t dstEnd)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstEnd)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, DstEnd::Id, (uint8_t *) &dstEnd, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDstShift(chip::EndpointId endpoint, int32_t * dstShift)
+
+} // namespace DstEnd
+
+namespace DstShift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * dstShift)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, DstShift::Id, (uint8_t *) dstShift, sizeof(*dstShift));
 }
-EmberAfStatus SetDstShift(chip::EndpointId endpoint, int32_t dstShift)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t dstShift)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, DstShift::Id, (uint8_t *) &dstShift, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStandardTime(chip::EndpointId endpoint, uint32_t * standardTime)
+
+} // namespace DstShift
+
+namespace StandardTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * standardTime)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, StandardTime::Id, (uint8_t *) standardTime, sizeof(*standardTime));
 }
-EmberAfStatus SetStandardTime(chip::EndpointId endpoint, uint32_t standardTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t standardTime)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, StandardTime::Id, (uint8_t *) &standardTime, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLocalTime(chip::EndpointId endpoint, uint32_t * localTime)
+
+} // namespace StandardTime
+
+namespace LocalTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * localTime)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, LocalTime::Id, (uint8_t *) localTime, sizeof(*localTime));
 }
-EmberAfStatus SetLocalTime(chip::EndpointId endpoint, uint32_t localTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t localTime)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, LocalTime::Id, (uint8_t *) &localTime, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLastSetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** lastSetTime)
+
+} // namespace LocalTime
+
+namespace LastSetTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** lastSetTime)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, LastSetTime::Id, (uint8_t *) lastSetTime, sizeof(*lastSetTime));
 }
-EmberAfStatus SetLastSetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * lastSetTime)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * lastSetTime)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, LastSetTime::Id, (uint8_t *) &lastSetTime, ZCL_UTC_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** validUntilTime)
+
+} // namespace LastSetTime
+
+namespace ValidUntilTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** validUntilTime)
 {
     return emberAfReadServerAttribute(endpoint, Time::Id, ValidUntilTime::Id, (uint8_t *) validUntilTime, sizeof(*validUntilTime));
 }
-EmberAfStatus SetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * validUntilTime)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * validUntilTime)
 {
     return emberAfWriteServerAttribute(endpoint, Time::Id, ValidUntilTime::Id, (uint8_t *) &validUntilTime, ZCL_UTC_ATTRIBUTE_TYPE);
 }
+
+} // namespace ValidUntilTime
+
 } // namespace Attributes
 } // namespace Time
 
 namespace BinaryInputBasic {
 namespace Attributes {
-EmberAfStatus GetOutOfService(chip::EndpointId endpoint, bool * outOfService)
+
+namespace OutOfService {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * outOfService)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, OutOfService::Id, (uint8_t *) outOfService,
                                       sizeof(*outOfService));
 }
-EmberAfStatus SetOutOfService(chip::EndpointId endpoint, bool outOfService)
+EmberAfStatus Set(chip::EndpointId endpoint, bool outOfService)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, OutOfService::Id, (uint8_t *) &outOfService,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPolarity(chip::EndpointId endpoint, uint8_t * polarity)
+
+} // namespace OutOfService
+
+namespace Polarity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * polarity)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Polarity::Id, (uint8_t *) polarity, sizeof(*polarity));
 }
-EmberAfStatus SetPolarity(chip::EndpointId endpoint, uint8_t polarity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t polarity)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Polarity::Id, (uint8_t *) &polarity,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPresentValue(chip::EndpointId endpoint, bool * presentValue)
+
+} // namespace Polarity
+
+namespace PresentValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * presentValue)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, PresentValue::Id, (uint8_t *) presentValue,
                                       sizeof(*presentValue));
 }
-EmberAfStatus SetPresentValue(chip::EndpointId endpoint, bool presentValue)
+EmberAfStatus Set(chip::EndpointId endpoint, bool presentValue)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, PresentValue::Id, (uint8_t *) &presentValue,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReliability(chip::EndpointId endpoint, uint8_t * reliability)
+
+} // namespace PresentValue
+
+namespace Reliability {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * reliability)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Reliability::Id, (uint8_t *) reliability,
                                       sizeof(*reliability));
 }
-EmberAfStatus SetReliability(chip::EndpointId endpoint, uint8_t reliability)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t reliability)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Reliability::Id, (uint8_t *) &reliability,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStatusFlags(chip::EndpointId endpoint, uint8_t * statusFlags)
+
+} // namespace Reliability
+
+namespace StatusFlags {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * statusFlags)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, StatusFlags::Id, (uint8_t *) statusFlags,
                                       sizeof(*statusFlags));
 }
-EmberAfStatus SetStatusFlags(chip::EndpointId endpoint, uint8_t statusFlags)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t statusFlags)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, StatusFlags::Id, (uint8_t *) &statusFlags,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetApplicationType(chip::EndpointId endpoint, uint32_t * applicationType)
+
+} // namespace StatusFlags
+
+namespace ApplicationType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * applicationType)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, ApplicationType::Id, (uint8_t *) applicationType,
                                       sizeof(*applicationType));
 }
-EmberAfStatus SetApplicationType(chip::EndpointId endpoint, uint32_t applicationType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t applicationType)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, ApplicationType::Id, (uint8_t *) &applicationType,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
+
+} // namespace ApplicationType
+
 } // namespace Attributes
 } // namespace BinaryInputBasic
 
 namespace PowerProfile {
 namespace Attributes {
-EmberAfStatus GetTotalProfileNum(chip::EndpointId endpoint, uint8_t * totalProfileNum)
+
+namespace TotalProfileNum {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * totalProfileNum)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, TotalProfileNum::Id, (uint8_t *) totalProfileNum,
                                       sizeof(*totalProfileNum));
 }
-EmberAfStatus SetTotalProfileNum(chip::EndpointId endpoint, uint8_t totalProfileNum)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t totalProfileNum)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, TotalProfileNum::Id, (uint8_t *) &totalProfileNum,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, bool * multipleScheduling)
+
+} // namespace TotalProfileNum
+
+namespace MultipleScheduling {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * multipleScheduling)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, MultipleScheduling::Id, (uint8_t *) multipleScheduling,
                                       sizeof(*multipleScheduling));
 }
-EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, bool multipleScheduling)
+EmberAfStatus Set(chip::EndpointId endpoint, bool multipleScheduling)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, MultipleScheduling::Id, (uint8_t *) &multipleScheduling,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnergyFormatting(chip::EndpointId endpoint, uint8_t * energyFormatting)
+
+} // namespace MultipleScheduling
+
+namespace EnergyFormatting {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * energyFormatting)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, EnergyFormatting::Id, (uint8_t *) energyFormatting,
                                       sizeof(*energyFormatting));
 }
-EmberAfStatus SetEnergyFormatting(chip::EndpointId endpoint, uint8_t energyFormatting)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t energyFormatting)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, EnergyFormatting::Id, (uint8_t *) &energyFormatting,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, bool * energyRemote)
+
+} // namespace EnergyFormatting
+
+namespace EnergyRemote {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * energyRemote)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, EnergyRemote::Id, (uint8_t *) energyRemote,
                                       sizeof(*energyRemote));
 }
-EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, bool energyRemote)
+EmberAfStatus Set(chip::EndpointId endpoint, bool energyRemote)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, EnergyRemote::Id, (uint8_t *) &energyRemote,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetScheduleMode(chip::EndpointId endpoint, uint8_t * scheduleMode)
+
+} // namespace EnergyRemote
+
+namespace ScheduleMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleMode)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, ScheduleMode::Id, (uint8_t *) scheduleMode,
                                       sizeof(*scheduleMode));
 }
-EmberAfStatus SetScheduleMode(chip::EndpointId endpoint, uint8_t scheduleMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleMode)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, ScheduleMode::Id, (uint8_t *) &scheduleMode,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
+
+} // namespace ScheduleMode
+
 } // namespace Attributes
 } // namespace PowerProfile
 
 namespace ApplianceControl {
 namespace Attributes {
-EmberAfStatus GetStartTime(chip::EndpointId endpoint, uint16_t * startTime)
+
+namespace StartTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startTime)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, StartTime::Id, (uint8_t *) startTime, sizeof(*startTime));
 }
-EmberAfStatus SetStartTime(chip::EndpointId endpoint, uint16_t startTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startTime)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, StartTime::Id, (uint8_t *) &startTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetFinishTime(chip::EndpointId endpoint, uint16_t * finishTime)
+
+} // namespace StartTime
+
+namespace FinishTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * finishTime)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, FinishTime::Id, (uint8_t *) finishTime, sizeof(*finishTime));
 }
-EmberAfStatus SetFinishTime(chip::EndpointId endpoint, uint16_t finishTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t finishTime)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, FinishTime::Id, (uint8_t *) &finishTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime)
+
+} // namespace FinishTime
+
+namespace RemainingTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceControl::Id, RemainingTime::Id, (uint8_t *) remainingTime,
                                       sizeof(*remainingTime));
 }
-EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceControl::Id, RemainingTime::Id, (uint8_t *) &remainingTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace RemainingTime
+
 } // namespace Attributes
 } // namespace ApplianceControl
 
 namespace Descriptor {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace Descriptor
 
 namespace PollControl {
 namespace Attributes {
-EmberAfStatus GetCheckInInterval(chip::EndpointId endpoint, uint32_t * checkInInterval)
+
+namespace CheckInInterval {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInInterval)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, CheckInInterval::Id, (uint8_t *) checkInInterval,
                                       sizeof(*checkInInterval));
 }
-EmberAfStatus SetCheckInInterval(chip::EndpointId endpoint, uint32_t checkInInterval)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInInterval)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, CheckInInterval::Id, (uint8_t *) &checkInInterval,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLongPollInterval(chip::EndpointId endpoint, uint32_t * longPollInterval)
+
+} // namespace CheckInInterval
+
+namespace LongPollInterval {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollInterval)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, LongPollInterval::Id, (uint8_t *) longPollInterval,
                                       sizeof(*longPollInterval));
 }
-EmberAfStatus SetLongPollInterval(chip::EndpointId endpoint, uint32_t longPollInterval)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollInterval)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, LongPollInterval::Id, (uint8_t *) &longPollInterval,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetShortPollInterval(chip::EndpointId endpoint, uint16_t * shortPollInterval)
+
+} // namespace LongPollInterval
+
+namespace ShortPollInterval {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * shortPollInterval)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, ShortPollInterval::Id, (uint8_t *) shortPollInterval,
                                       sizeof(*shortPollInterval));
 }
-EmberAfStatus SetShortPollInterval(chip::EndpointId endpoint, uint16_t shortPollInterval)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t shortPollInterval)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, ShortPollInterval::Id, (uint8_t *) &shortPollInterval,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetFastPollTimeout(chip::EndpointId endpoint, uint16_t * fastPollTimeout)
+
+} // namespace ShortPollInterval
+
+namespace FastPollTimeout {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeout)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, FastPollTimeout::Id, (uint8_t *) fastPollTimeout,
                                       sizeof(*fastPollTimeout));
 }
-EmberAfStatus SetFastPollTimeout(chip::EndpointId endpoint, uint16_t fastPollTimeout)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeout)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, FastPollTimeout::Id, (uint8_t *) &fastPollTimeout,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCheckInIntervalMin(chip::EndpointId endpoint, uint32_t * checkInIntervalMin)
+
+} // namespace FastPollTimeout
+
+namespace CheckInIntervalMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInIntervalMin)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, CheckInIntervalMin::Id, (uint8_t *) checkInIntervalMin,
                                       sizeof(*checkInIntervalMin));
 }
-EmberAfStatus SetCheckInIntervalMin(chip::EndpointId endpoint, uint32_t checkInIntervalMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInIntervalMin)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, CheckInIntervalMin::Id, (uint8_t *) &checkInIntervalMin,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLongPollIntervalMin(chip::EndpointId endpoint, uint32_t * longPollIntervalMin)
+
+} // namespace CheckInIntervalMin
+
+namespace LongPollIntervalMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollIntervalMin)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, LongPollIntervalMin::Id, (uint8_t *) longPollIntervalMin,
                                       sizeof(*longPollIntervalMin));
 }
-EmberAfStatus SetLongPollIntervalMin(chip::EndpointId endpoint, uint32_t longPollIntervalMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollIntervalMin)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, LongPollIntervalMin::Id, (uint8_t *) &longPollIntervalMin,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetFastPollTimeoutMax(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax)
+
+} // namespace LongPollIntervalMin
+
+namespace FastPollTimeoutMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax)
 {
     return emberAfReadServerAttribute(endpoint, PollControl::Id, FastPollTimeoutMax::Id, (uint8_t *) fastPollTimeoutMax,
                                       sizeof(*fastPollTimeoutMax));
 }
-EmberAfStatus SetFastPollTimeoutMax(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax)
 {
     return emberAfWriteServerAttribute(endpoint, PollControl::Id, FastPollTimeoutMax::Id, (uint8_t *) &fastPollTimeoutMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace FastPollTimeoutMax
+
 } // namespace Attributes
 } // namespace PollControl
 
 namespace Basic {
 namespace Attributes {
-EmberAfStatus GetInteractionModelVersion(chip::EndpointId endpoint, uint16_t * interactionModelVersion)
+
+namespace InteractionModelVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * interactionModelVersion)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, InteractionModelVersion::Id, (uint8_t *) interactionModelVersion,
                                       sizeof(*interactionModelVersion));
 }
-EmberAfStatus SetInteractionModelVersion(chip::EndpointId endpoint, uint16_t interactionModelVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t interactionModelVersion)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, InteractionModelVersion::Id, (uint8_t *) &interactionModelVersion,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetVendorID(chip::EndpointId endpoint, uint16_t * vendorID)
+
+} // namespace InteractionModelVersion
+
+namespace VendorID {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, VendorID::Id, (uint8_t *) vendorID, sizeof(*vendorID));
 }
-EmberAfStatus SetVendorID(chip::EndpointId endpoint, uint16_t vendorID)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, VendorID::Id, (uint8_t *) &vendorID, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetProductID(chip::EndpointId endpoint, uint16_t * productID)
+
+} // namespace VendorID
+
+namespace ProductID {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productID)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, ProductID::Id, (uint8_t *) productID, sizeof(*productID));
 }
-EmberAfStatus SetProductID(chip::EndpointId endpoint, uint16_t productID)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productID)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, ProductID::Id, (uint8_t *) &productID, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareVersion)
+
+} // namespace ProductID
+
+namespace HardwareVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, HardwareVersion::Id, (uint8_t *) hardwareVersion,
                                       sizeof(*hardwareVersion));
 }
-EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, HardwareVersion::Id, (uint8_t *) &hardwareVersion,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion)
+
+} // namespace HardwareVersion
+
+namespace SoftwareVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, SoftwareVersion::Id, (uint8_t *) softwareVersion,
                                       sizeof(*softwareVersion));
 }
-EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, SoftwareVersion::Id, (uint8_t *) &softwareVersion,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, bool * localConfigDisabled)
+
+} // namespace SoftwareVersion
+
+namespace LocalConfigDisabled {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * localConfigDisabled)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, LocalConfigDisabled::Id, (uint8_t *) localConfigDisabled,
                                       sizeof(*localConfigDisabled));
 }
-EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, bool localConfigDisabled)
+EmberAfStatus Set(chip::EndpointId endpoint, bool localConfigDisabled)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, LocalConfigDisabled::Id, (uint8_t *) &localConfigDisabled,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable)
+
+} // namespace LocalConfigDisabled
+
+namespace Reachable {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, Reachable::Id, (uint8_t *) reachable, sizeof(*reachable));
 }
-EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable)
+EmberAfStatus Set(chip::EndpointId endpoint, bool reachable)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, Reachable::Id, (uint8_t *) &reachable, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
+
+} // namespace Reachable
+
 } // namespace Attributes
 } // namespace Basic
 
 namespace OtaSoftwareUpdateRequestor {
 namespace Attributes {
-EmberAfStatus GetUpdatePossible(chip::EndpointId endpoint, bool * updatePossible)
+
+namespace UpdatePossible {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * updatePossible)
 {
     return emberAfReadServerAttribute(endpoint, OtaSoftwareUpdateRequestor::Id, UpdatePossible::Id, (uint8_t *) updatePossible,
                                       sizeof(*updatePossible));
 }
-EmberAfStatus SetUpdatePossible(chip::EndpointId endpoint, bool updatePossible)
+EmberAfStatus Set(chip::EndpointId endpoint, bool updatePossible)
 {
     return emberAfWriteServerAttribute(endpoint, OtaSoftwareUpdateRequestor::Id, UpdatePossible::Id, (uint8_t *) &updatePossible,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
+
+} // namespace UpdatePossible
+
 } // namespace Attributes
 } // namespace OtaSoftwareUpdateRequestor
 
 namespace PowerSource {
 namespace Attributes {
-EmberAfStatus GetStatus(chip::EndpointId endpoint, uint8_t * status)
+
+namespace Status {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, Status::Id, (uint8_t *) status, sizeof(*status));
 }
-EmberAfStatus SetStatus(chip::EndpointId endpoint, uint8_t status)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Status::Id, (uint8_t *) &status, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOrder(chip::EndpointId endpoint, uint8_t * order)
+
+} // namespace Status
+
+namespace Order {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * order)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, Order::Id, (uint8_t *) order, sizeof(*order));
 }
-EmberAfStatus SetOrder(chip::EndpointId endpoint, uint8_t order)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t order)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, Order::Id, (uint8_t *) &order, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredAssessedInputVoltage(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage)
+
+} // namespace Order
+
+namespace WiredAssessedInputVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputVoltage::Id,
                                       (uint8_t *) wiredAssessedInputVoltage, sizeof(*wiredAssessedInputVoltage));
 }
-EmberAfStatus SetWiredAssessedInputVoltage(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputVoltage::Id,
                                        (uint8_t *) &wiredAssessedInputVoltage, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredAssessedInputFrequency(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency)
+
+} // namespace WiredAssessedInputVoltage
+
+namespace WiredAssessedInputFrequency {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputFrequency::Id,
                                       (uint8_t *) wiredAssessedInputFrequency, sizeof(*wiredAssessedInputFrequency));
 }
-EmberAfStatus SetWiredAssessedInputFrequency(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredAssessedInputFrequency::Id,
                                        (uint8_t *) &wiredAssessedInputFrequency, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredCurrentType(chip::EndpointId endpoint, uint8_t * wiredCurrentType)
+
+} // namespace WiredAssessedInputFrequency
+
+namespace WiredCurrentType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiredCurrentType)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredCurrentType::Id, (uint8_t *) wiredCurrentType,
                                       sizeof(*wiredCurrentType));
 }
-EmberAfStatus SetWiredCurrentType(chip::EndpointId endpoint, uint8_t wiredCurrentType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiredCurrentType)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredCurrentType::Id, (uint8_t *) &wiredCurrentType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredAssessedCurrent(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent)
+
+} // namespace WiredCurrentType
+
+namespace WiredAssessedCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredAssessedCurrent::Id, (uint8_t *) wiredAssessedCurrent,
                                       sizeof(*wiredAssessedCurrent));
 }
-EmberAfStatus SetWiredAssessedCurrent(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredAssessedCurrent::Id, (uint8_t *) &wiredAssessedCurrent,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredNominalVoltage(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage)
+
+} // namespace WiredAssessedCurrent
+
+namespace WiredNominalVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredNominalVoltage::Id, (uint8_t *) wiredNominalVoltage,
                                       sizeof(*wiredNominalVoltage));
 }
-EmberAfStatus SetWiredNominalVoltage(chip::EndpointId endpoint, uint32_t wiredNominalVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredNominalVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredNominalVoltage::Id, (uint8_t *) &wiredNominalVoltage,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredMaximumCurrent(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent)
+
+} // namespace WiredNominalVoltage
+
+namespace WiredMaximumCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredMaximumCurrent::Id, (uint8_t *) wiredMaximumCurrent,
                                       sizeof(*wiredMaximumCurrent));
 }
-EmberAfStatus SetWiredMaximumCurrent(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredMaximumCurrent::Id, (uint8_t *) &wiredMaximumCurrent,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiredPresent(chip::EndpointId endpoint, bool * wiredPresent)
+
+} // namespace WiredMaximumCurrent
+
+namespace WiredPresent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * wiredPresent)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, WiredPresent::Id, (uint8_t *) wiredPresent, sizeof(*wiredPresent));
 }
-EmberAfStatus SetWiredPresent(chip::EndpointId endpoint, bool wiredPresent)
+EmberAfStatus Set(chip::EndpointId endpoint, bool wiredPresent)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, WiredPresent::Id, (uint8_t *) &wiredPresent,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryVoltage(chip::EndpointId endpoint, uint32_t * batteryVoltage)
+
+} // namespace WiredPresent
+
+namespace BatteryVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryVoltage)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryVoltage::Id, (uint8_t *) batteryVoltage,
                                       sizeof(*batteryVoltage));
 }
-EmberAfStatus SetBatteryVoltage(chip::EndpointId endpoint, uint32_t batteryVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryVoltage::Id, (uint8_t *) &batteryVoltage,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPercentRemaining(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining)
+
+} // namespace BatteryVoltage
+
+namespace BatteryPercentRemaining {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryPercentRemaining::Id, (uint8_t *) batteryPercentRemaining,
                                       sizeof(*batteryPercentRemaining));
 }
-EmberAfStatus SetBatteryPercentRemaining(chip::EndpointId endpoint, uint8_t batteryPercentRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentRemaining)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryPercentRemaining::Id, (uint8_t *) &batteryPercentRemaining,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryTimeRemaining(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining)
+
+} // namespace BatteryPercentRemaining
+
+namespace BatteryTimeRemaining {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryTimeRemaining::Id, (uint8_t *) batteryTimeRemaining,
                                       sizeof(*batteryTimeRemaining));
 }
-EmberAfStatus SetBatteryTimeRemaining(chip::EndpointId endpoint, uint32_t batteryTimeRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeRemaining)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryTimeRemaining::Id, (uint8_t *) &batteryTimeRemaining,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryChargeLevel(chip::EndpointId endpoint, uint8_t * batteryChargeLevel)
+
+} // namespace BatteryTimeRemaining
+
+namespace BatteryChargeLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeLevel)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryChargeLevel::Id, (uint8_t *) batteryChargeLevel,
                                       sizeof(*batteryChargeLevel));
 }
-EmberAfStatus SetBatteryChargeLevel(chip::EndpointId endpoint, uint8_t batteryChargeLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeLevel)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryChargeLevel::Id, (uint8_t *) &batteryChargeLevel,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryReplacementNeeded(chip::EndpointId endpoint, bool * batteryReplacementNeeded)
+
+} // namespace BatteryChargeLevel
+
+namespace BatteryReplacementNeeded {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryReplacementNeeded)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryReplacementNeeded::Id, (uint8_t *) batteryReplacementNeeded,
                                       sizeof(*batteryReplacementNeeded));
 }
-EmberAfStatus SetBatteryReplacementNeeded(chip::EndpointId endpoint, bool batteryReplacementNeeded)
+EmberAfStatus Set(chip::EndpointId endpoint, bool batteryReplacementNeeded)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryReplacementNeeded::Id,
                                        (uint8_t *) &batteryReplacementNeeded, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryReplaceability(chip::EndpointId endpoint, uint8_t * batteryReplaceability)
+
+} // namespace BatteryReplacementNeeded
+
+namespace BatteryReplaceability {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryReplaceability)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryReplaceability::Id, (uint8_t *) batteryReplaceability,
                                       sizeof(*batteryReplaceability));
 }
-EmberAfStatus SetBatteryReplaceability(chip::EndpointId endpoint, uint8_t batteryReplaceability)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryReplaceability)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryReplaceability::Id, (uint8_t *) &batteryReplaceability,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryPresent(chip::EndpointId endpoint, bool * batteryPresent)
+
+} // namespace BatteryReplaceability
+
+namespace BatteryPresent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryPresent)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryPresent::Id, (uint8_t *) batteryPresent,
                                       sizeof(*batteryPresent));
 }
-EmberAfStatus SetBatteryPresent(chip::EndpointId endpoint, bool batteryPresent)
+EmberAfStatus Set(chip::EndpointId endpoint, bool batteryPresent)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryPresent::Id, (uint8_t *) &batteryPresent,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryCommonDesignation(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation)
+
+} // namespace BatteryPresent
+
+namespace BatteryCommonDesignation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryCommonDesignation::Id, (uint8_t *) batteryCommonDesignation,
                                       sizeof(*batteryCommonDesignation));
 }
-EmberAfStatus SetBatteryCommonDesignation(chip::EndpointId endpoint, uint32_t batteryCommonDesignation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCommonDesignation)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryCommonDesignation::Id,
                                        (uint8_t *) &batteryCommonDesignation, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryApprovedChemistry(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry)
+
+} // namespace BatteryCommonDesignation
+
+namespace BatteryApprovedChemistry {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryApprovedChemistry::Id, (uint8_t *) batteryApprovedChemistry,
                                       sizeof(*batteryApprovedChemistry));
 }
-EmberAfStatus SetBatteryApprovedChemistry(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryApprovedChemistry::Id,
                                        (uint8_t *) &batteryApprovedChemistry, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryCapacity(chip::EndpointId endpoint, uint32_t * batteryCapacity)
+
+} // namespace BatteryApprovedChemistry
+
+namespace BatteryCapacity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCapacity)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryCapacity::Id, (uint8_t *) batteryCapacity,
                                       sizeof(*batteryCapacity));
 }
-EmberAfStatus SetBatteryCapacity(chip::EndpointId endpoint, uint32_t batteryCapacity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCapacity)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryCapacity::Id, (uint8_t *) &batteryCapacity,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryQuantity(chip::EndpointId endpoint, uint8_t * batteryQuantity)
+
+} // namespace BatteryCapacity
+
+namespace BatteryQuantity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryQuantity::Id, (uint8_t *) batteryQuantity,
                                       sizeof(*batteryQuantity));
 }
-EmberAfStatus SetBatteryQuantity(chip::EndpointId endpoint, uint8_t batteryQuantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryQuantity::Id, (uint8_t *) &batteryQuantity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryChargeState(chip::EndpointId endpoint, uint8_t * batteryChargeState)
+
+} // namespace BatteryQuantity
+
+namespace BatteryChargeState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeState)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryChargeState::Id, (uint8_t *) batteryChargeState,
                                       sizeof(*batteryChargeState));
 }
-EmberAfStatus SetBatteryChargeState(chip::EndpointId endpoint, uint8_t batteryChargeState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeState)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryChargeState::Id, (uint8_t *) &batteryChargeState,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryTimeToFullCharge(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge)
+
+} // namespace BatteryChargeState
+
+namespace BatteryTimeToFullCharge {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryTimeToFullCharge::Id, (uint8_t *) batteryTimeToFullCharge,
                                       sizeof(*batteryTimeToFullCharge));
 }
-EmberAfStatus SetBatteryTimeToFullCharge(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryTimeToFullCharge::Id, (uint8_t *) &batteryTimeToFullCharge,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryFunctionalWhileCharging(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging)
+
+} // namespace BatteryTimeToFullCharge
+
+namespace BatteryFunctionalWhileCharging {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryFunctionalWhileCharging::Id,
                                       (uint8_t *) batteryFunctionalWhileCharging, sizeof(*batteryFunctionalWhileCharging));
 }
-EmberAfStatus SetBatteryFunctionalWhileCharging(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging)
+EmberAfStatus Set(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryFunctionalWhileCharging::Id,
                                        (uint8_t *) &batteryFunctionalWhileCharging, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBatteryChargingCurrent(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent)
+
+} // namespace BatteryFunctionalWhileCharging
+
+namespace BatteryChargingCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent)
 {
     return emberAfReadServerAttribute(endpoint, PowerSource::Id, BatteryChargingCurrent::Id, (uint8_t *) batteryChargingCurrent,
                                       sizeof(*batteryChargingCurrent));
 }
-EmberAfStatus SetBatteryChargingCurrent(chip::EndpointId endpoint, uint32_t batteryChargingCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryChargingCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, PowerSource::Id, BatteryChargingCurrent::Id, (uint8_t *) &batteryChargingCurrent,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
+
+} // namespace BatteryChargingCurrent
+
 } // namespace Attributes
 } // namespace PowerSource
 
 namespace GeneralCommissioning {
 namespace Attributes {
-EmberAfStatus GetBreadcrumb(chip::EndpointId endpoint, uint64_t * breadcrumb)
+
+namespace Breadcrumb {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * breadcrumb)
 {
     return emberAfReadServerAttribute(endpoint, GeneralCommissioning::Id, Breadcrumb::Id, (uint8_t *) breadcrumb,
                                       sizeof(*breadcrumb));
 }
-EmberAfStatus SetBreadcrumb(chip::EndpointId endpoint, uint64_t breadcrumb)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t breadcrumb)
 {
     return emberAfWriteServerAttribute(endpoint, GeneralCommissioning::Id, Breadcrumb::Id, (uint8_t *) &breadcrumb,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
+
+} // namespace Breadcrumb
+
 } // namespace Attributes
 } // namespace GeneralCommissioning
 
 namespace GeneralDiagnostics {
 namespace Attributes {
-EmberAfStatus GetRebootCount(chip::EndpointId endpoint, uint16_t * rebootCount)
+
+namespace RebootCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rebootCount)
 {
     return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, RebootCount::Id, (uint8_t *) rebootCount,
                                       sizeof(*rebootCount));
 }
-EmberAfStatus SetRebootCount(chip::EndpointId endpoint, uint16_t rebootCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rebootCount)
 {
     return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, RebootCount::Id, (uint8_t *) &rebootCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUpTime(chip::EndpointId endpoint, uint64_t * upTime)
+
+} // namespace RebootCount
+
+namespace UpTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * upTime)
 {
     return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, UpTime::Id, (uint8_t *) upTime, sizeof(*upTime));
 }
-EmberAfStatus SetUpTime(chip::EndpointId endpoint, uint64_t upTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t upTime)
 {
     return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, UpTime::Id, (uint8_t *) &upTime,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTotalOperationalHours(chip::EndpointId endpoint, uint32_t * totalOperationalHours)
+
+} // namespace UpTime
+
+namespace TotalOperationalHours {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalOperationalHours)
 {
     return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, TotalOperationalHours::Id,
                                       (uint8_t *) totalOperationalHours, sizeof(*totalOperationalHours));
 }
-EmberAfStatus SetTotalOperationalHours(chip::EndpointId endpoint, uint32_t totalOperationalHours)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalOperationalHours)
 {
     return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, TotalOperationalHours::Id,
                                        (uint8_t *) &totalOperationalHours, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBootReasons(chip::EndpointId endpoint, uint8_t * bootReasons)
+
+} // namespace TotalOperationalHours
+
+namespace BootReasons {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bootReasons)
 {
     return emberAfReadServerAttribute(endpoint, GeneralDiagnostics::Id, BootReasons::Id, (uint8_t *) bootReasons,
                                       sizeof(*bootReasons));
 }
-EmberAfStatus SetBootReasons(chip::EndpointId endpoint, uint8_t bootReasons)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bootReasons)
 {
     return emberAfWriteServerAttribute(endpoint, GeneralDiagnostics::Id, BootReasons::Id, (uint8_t *) &bootReasons,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace BootReasons
+
 } // namespace Attributes
 } // namespace GeneralDiagnostics
 
 namespace SoftwareDiagnostics {
 namespace Attributes {
-EmberAfStatus GetCurrentHeapFree(chip::EndpointId endpoint, uint64_t * currentHeapFree)
+
+namespace CurrentHeapFree {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapFree)
 {
     return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapFree::Id, (uint8_t *) currentHeapFree,
                                       sizeof(*currentHeapFree));
 }
-EmberAfStatus SetCurrentHeapFree(chip::EndpointId endpoint, uint64_t currentHeapFree)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapFree)
 {
     return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapFree::Id, (uint8_t *) &currentHeapFree,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentHeapUsed(chip::EndpointId endpoint, uint64_t * currentHeapUsed)
+
+} // namespace CurrentHeapFree
+
+namespace CurrentHeapUsed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapUsed)
 {
     return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapUsed::Id, (uint8_t *) currentHeapUsed,
                                       sizeof(*currentHeapUsed));
 }
-EmberAfStatus SetCurrentHeapUsed(chip::EndpointId endpoint, uint64_t currentHeapUsed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapUsed)
 {
     return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapUsed::Id, (uint8_t *) &currentHeapUsed,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentHeapHighWatermark(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark)
+
+} // namespace CurrentHeapUsed
+
+namespace CurrentHeapHighWatermark {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark)
 {
     return emberAfReadServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapHighWatermark::Id,
                                       (uint8_t *) currentHeapHighWatermark, sizeof(*currentHeapHighWatermark));
 }
-EmberAfStatus SetCurrentHeapHighWatermark(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark)
 {
     return emberAfWriteServerAttribute(endpoint, SoftwareDiagnostics::Id, CurrentHeapHighWatermark::Id,
                                        (uint8_t *) &currentHeapHighWatermark, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CurrentHeapHighWatermark
+
 } // namespace Attributes
 } // namespace SoftwareDiagnostics
 
 namespace ThreadNetworkDiagnostics {
 namespace Attributes {
-EmberAfStatus GetChannel(chip::EndpointId endpoint, uint8_t * channel)
+
+namespace Channel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * channel)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Channel::Id, (uint8_t *) channel, sizeof(*channel));
 }
-EmberAfStatus SetChannel(chip::EndpointId endpoint, uint8_t channel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t channel)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Channel::Id, (uint8_t *) &channel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRoutingRole(chip::EndpointId endpoint, uint8_t * routingRole)
+
+} // namespace Channel
+
+namespace RoutingRole {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * routingRole)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RoutingRole::Id, (uint8_t *) routingRole,
                                       sizeof(*routingRole));
 }
-EmberAfStatus SetRoutingRole(chip::EndpointId endpoint, uint8_t routingRole)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t routingRole)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RoutingRole::Id, (uint8_t *) &routingRole,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPanId(chip::EndpointId endpoint, uint16_t * panId)
+
+} // namespace RoutingRole
+
+namespace PanId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * panId)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PanId::Id, (uint8_t *) panId, sizeof(*panId));
 }
-EmberAfStatus SetPanId(chip::EndpointId endpoint, uint16_t panId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t panId)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PanId::Id, (uint8_t *) &panId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetExtendedPanId(chip::EndpointId endpoint, uint64_t * extendedPanId)
+
+} // namespace PanId
+
+namespace ExtendedPanId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * extendedPanId)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ExtendedPanId::Id, (uint8_t *) extendedPanId,
                                       sizeof(*extendedPanId));
 }
-EmberAfStatus SetExtendedPanId(chip::EndpointId endpoint, uint64_t extendedPanId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t extendedPanId)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ExtendedPanId::Id, (uint8_t *) &extendedPanId,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount)
+
+} // namespace ExtendedPanId
+
+namespace OverrunCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) overrunCount,
                                       sizeof(*overrunCount));
 }
-EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPartitionId(chip::EndpointId endpoint, uint32_t * partitionId)
+
+} // namespace OverrunCount
+
+namespace PartitionId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * partitionId)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionId::Id, (uint8_t *) partitionId,
                                       sizeof(*partitionId));
 }
-EmberAfStatus SetPartitionId(chip::EndpointId endpoint, uint32_t partitionId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t partitionId)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionId::Id, (uint8_t *) &partitionId,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWeighting(chip::EndpointId endpoint, uint8_t * weighting)
+
+} // namespace PartitionId
+
+namespace Weighting {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * weighting)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Weighting::Id, (uint8_t *) weighting,
                                       sizeof(*weighting));
 }
-EmberAfStatus SetWeighting(chip::EndpointId endpoint, uint8_t weighting)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t weighting)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Weighting::Id, (uint8_t *) &weighting,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDataVersion(chip::EndpointId endpoint, uint8_t * dataVersion)
+
+} // namespace Weighting
+
+namespace DataVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dataVersion)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DataVersion::Id, (uint8_t *) dataVersion,
                                       sizeof(*dataVersion));
 }
-EmberAfStatus SetDataVersion(chip::EndpointId endpoint, uint8_t dataVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dataVersion)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DataVersion::Id, (uint8_t *) &dataVersion,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStableDataVersion(chip::EndpointId endpoint, uint8_t * stableDataVersion)
+
+} // namespace DataVersion
+
+namespace StableDataVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * stableDataVersion)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, StableDataVersion::Id, (uint8_t *) stableDataVersion,
                                       sizeof(*stableDataVersion));
 }
-EmberAfStatus SetStableDataVersion(chip::EndpointId endpoint, uint8_t stableDataVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t stableDataVersion)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, StableDataVersion::Id,
                                        (uint8_t *) &stableDataVersion, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLeaderRouterId(chip::EndpointId endpoint, uint8_t * leaderRouterId)
+
+} // namespace StableDataVersion
+
+namespace LeaderRouterId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * leaderRouterId)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRouterId::Id, (uint8_t *) leaderRouterId,
                                       sizeof(*leaderRouterId));
 }
-EmberAfStatus SetLeaderRouterId(chip::EndpointId endpoint, uint8_t leaderRouterId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t leaderRouterId)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRouterId::Id, (uint8_t *) &leaderRouterId,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDetachedRoleCount(chip::EndpointId endpoint, uint16_t * detachedRoleCount)
+
+} // namespace LeaderRouterId
+
+namespace DetachedRoleCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * detachedRoleCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DetachedRoleCount::Id, (uint8_t *) detachedRoleCount,
                                       sizeof(*detachedRoleCount));
 }
-EmberAfStatus SetDetachedRoleCount(chip::EndpointId endpoint, uint16_t detachedRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t detachedRoleCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, DetachedRoleCount::Id,
                                        (uint8_t *) &detachedRoleCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetChildRoleCount(chip::EndpointId endpoint, uint16_t * childRoleCount)
+
+} // namespace DetachedRoleCount
+
+namespace ChildRoleCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * childRoleCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ChildRoleCount::Id, (uint8_t *) childRoleCount,
                                       sizeof(*childRoleCount));
 }
-EmberAfStatus SetChildRoleCount(chip::EndpointId endpoint, uint16_t childRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t childRoleCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ChildRoleCount::Id, (uint8_t *) &childRoleCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRouterRoleCount(chip::EndpointId endpoint, uint16_t * routerRoleCount)
+
+} // namespace ChildRoleCount
+
+namespace RouterRoleCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * routerRoleCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RouterRoleCount::Id, (uint8_t *) routerRoleCount,
                                       sizeof(*routerRoleCount));
 }
-EmberAfStatus SetRouterRoleCount(chip::EndpointId endpoint, uint16_t routerRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t routerRoleCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RouterRoleCount::Id, (uint8_t *) &routerRoleCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLeaderRoleCount(chip::EndpointId endpoint, uint16_t * leaderRoleCount)
+
+} // namespace RouterRoleCount
+
+namespace LeaderRoleCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * leaderRoleCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRoleCount::Id, (uint8_t *) leaderRoleCount,
                                       sizeof(*leaderRoleCount));
 }
-EmberAfStatus SetLeaderRoleCount(chip::EndpointId endpoint, uint16_t leaderRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t leaderRoleCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, LeaderRoleCount::Id, (uint8_t *) &leaderRoleCount,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAttachAttemptCount(chip::EndpointId endpoint, uint16_t * attachAttemptCount)
+
+} // namespace LeaderRoleCount
+
+namespace AttachAttemptCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * attachAttemptCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, AttachAttemptCount::Id,
                                       (uint8_t *) attachAttemptCount, sizeof(*attachAttemptCount));
 }
-EmberAfStatus SetAttachAttemptCount(chip::EndpointId endpoint, uint16_t attachAttemptCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t attachAttemptCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, AttachAttemptCount::Id,
                                        (uint8_t *) &attachAttemptCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPartitionIdChangeCount(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount)
+
+} // namespace AttachAttemptCount
+
+namespace PartitionIdChangeCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionIdChangeCount::Id,
                                       (uint8_t *) partitionIdChangeCount, sizeof(*partitionIdChangeCount));
 }
-EmberAfStatus SetPartitionIdChangeCount(chip::EndpointId endpoint, uint16_t partitionIdChangeCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t partitionIdChangeCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PartitionIdChangeCount::Id,
                                        (uint8_t *) &partitionIdChangeCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBetterPartitionAttachAttemptCount(chip::EndpointId endpoint, uint16_t * betterPartitionAttachAttemptCount)
+
+} // namespace PartitionIdChangeCount
+
+namespace BetterPartitionAttachAttemptCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * betterPartitionAttachAttemptCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, BetterPartitionAttachAttemptCount::Id,
                                       (uint8_t *) betterPartitionAttachAttemptCount, sizeof(*betterPartitionAttachAttemptCount));
 }
-EmberAfStatus SetBetterPartitionAttachAttemptCount(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, BetterPartitionAttachAttemptCount::Id,
                                        (uint8_t *) &betterPartitionAttachAttemptCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetParentChangeCount(chip::EndpointId endpoint, uint16_t * parentChangeCount)
+
+} // namespace BetterPartitionAttachAttemptCount
+
+namespace ParentChangeCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * parentChangeCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ParentChangeCount::Id, (uint8_t *) parentChangeCount,
                                       sizeof(*parentChangeCount));
 }
-EmberAfStatus SetParentChangeCount(chip::EndpointId endpoint, uint16_t parentChangeCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t parentChangeCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ParentChangeCount::Id,
                                        (uint8_t *) &parentChangeCount, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxTotalCount(chip::EndpointId endpoint, uint32_t * txTotalCount)
+
+} // namespace ParentChangeCount
+
+namespace TxTotalCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txTotalCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxTotalCount::Id, (uint8_t *) txTotalCount,
                                       sizeof(*txTotalCount));
 }
-EmberAfStatus SetTxTotalCount(chip::EndpointId endpoint, uint32_t txTotalCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txTotalCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxTotalCount::Id, (uint8_t *) &txTotalCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxUnicastCount(chip::EndpointId endpoint, uint32_t * txUnicastCount)
+
+} // namespace TxTotalCount
+
+namespace TxUnicastCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txUnicastCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxUnicastCount::Id, (uint8_t *) txUnicastCount,
                                       sizeof(*txUnicastCount));
 }
-EmberAfStatus SetTxUnicastCount(chip::EndpointId endpoint, uint32_t txUnicastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txUnicastCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxUnicastCount::Id, (uint8_t *) &txUnicastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxBroadcastCount(chip::EndpointId endpoint, uint32_t * txBroadcastCount)
+
+} // namespace TxUnicastCount
+
+namespace TxBroadcastCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBroadcastCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBroadcastCount::Id, (uint8_t *) txBroadcastCount,
                                       sizeof(*txBroadcastCount));
 }
-EmberAfStatus SetTxBroadcastCount(chip::EndpointId endpoint, uint32_t txBroadcastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBroadcastCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBroadcastCount::Id, (uint8_t *) &txBroadcastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxAckRequestedCount(chip::EndpointId endpoint, uint32_t * txAckRequestedCount)
+
+} // namespace TxBroadcastCount
+
+namespace TxAckRequestedCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckRequestedCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckRequestedCount::Id,
                                       (uint8_t *) txAckRequestedCount, sizeof(*txAckRequestedCount));
 }
-EmberAfStatus SetTxAckRequestedCount(chip::EndpointId endpoint, uint32_t txAckRequestedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckRequestedCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckRequestedCount::Id,
                                        (uint8_t *) &txAckRequestedCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxAckedCount(chip::EndpointId endpoint, uint32_t * txAckedCount)
+
+} // namespace TxAckRequestedCount
+
+namespace TxAckedCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckedCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckedCount::Id, (uint8_t *) txAckedCount,
                                       sizeof(*txAckedCount));
 }
-EmberAfStatus SetTxAckedCount(chip::EndpointId endpoint, uint32_t txAckedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckedCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxAckedCount::Id, (uint8_t *) &txAckedCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxNoAckRequestedCount(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount)
+
+} // namespace TxAckedCount
+
+namespace TxNoAckRequestedCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxNoAckRequestedCount::Id,
                                       (uint8_t *) txNoAckRequestedCount, sizeof(*txNoAckRequestedCount));
 }
-EmberAfStatus SetTxNoAckRequestedCount(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxNoAckRequestedCount::Id,
                                        (uint8_t *) &txNoAckRequestedCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxDataCount(chip::EndpointId endpoint, uint32_t * txDataCount)
+
+} // namespace TxNoAckRequestedCount
+
+namespace TxDataCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataCount::Id, (uint8_t *) txDataCount,
                                       sizeof(*txDataCount));
 }
-EmberAfStatus SetTxDataCount(chip::EndpointId endpoint, uint32_t txDataCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataCount::Id, (uint8_t *) &txDataCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxDataPollCount(chip::EndpointId endpoint, uint32_t * txDataPollCount)
+
+} // namespace TxDataCount
+
+namespace TxDataPollCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataPollCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataPollCount::Id, (uint8_t *) txDataPollCount,
                                       sizeof(*txDataPollCount));
 }
-EmberAfStatus SetTxDataPollCount(chip::EndpointId endpoint, uint32_t txDataPollCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataPollCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDataPollCount::Id, (uint8_t *) &txDataPollCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxBeaconCount(chip::EndpointId endpoint, uint32_t * txBeaconCount)
+
+} // namespace TxDataPollCount
+
+namespace TxBeaconCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconCount::Id, (uint8_t *) txBeaconCount,
                                       sizeof(*txBeaconCount));
 }
-EmberAfStatus SetTxBeaconCount(chip::EndpointId endpoint, uint32_t txBeaconCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconCount::Id, (uint8_t *) &txBeaconCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxBeaconRequestCount(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount)
+
+} // namespace TxBeaconCount
+
+namespace TxBeaconRequestCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconRequestCount::Id,
                                       (uint8_t *) txBeaconRequestCount, sizeof(*txBeaconRequestCount));
 }
-EmberAfStatus SetTxBeaconRequestCount(chip::EndpointId endpoint, uint32_t txBeaconRequestCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconRequestCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxBeaconRequestCount::Id,
                                        (uint8_t *) &txBeaconRequestCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxOtherCount(chip::EndpointId endpoint, uint32_t * txOtherCount)
+
+} // namespace TxBeaconRequestCount
+
+namespace TxOtherCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txOtherCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxOtherCount::Id, (uint8_t *) txOtherCount,
                                       sizeof(*txOtherCount));
 }
-EmberAfStatus SetTxOtherCount(chip::EndpointId endpoint, uint32_t txOtherCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txOtherCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxOtherCount::Id, (uint8_t *) &txOtherCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxRetryCount(chip::EndpointId endpoint, uint32_t * txRetryCount)
+
+} // namespace TxOtherCount
+
+namespace TxRetryCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txRetryCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxRetryCount::Id, (uint8_t *) txRetryCount,
                                       sizeof(*txRetryCount));
 }
-EmberAfStatus SetTxRetryCount(chip::EndpointId endpoint, uint32_t txRetryCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txRetryCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxRetryCount::Id, (uint8_t *) &txRetryCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxDirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount)
+
+} // namespace TxRetryCount
+
+namespace TxDirectMaxRetryExpiryCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDirectMaxRetryExpiryCount::Id,
                                       (uint8_t *) txDirectMaxRetryExpiryCount, sizeof(*txDirectMaxRetryExpiryCount));
 }
-EmberAfStatus SetTxDirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxDirectMaxRetryExpiryCount::Id,
                                        (uint8_t *) &txDirectMaxRetryExpiryCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxIndirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount)
+
+} // namespace TxDirectMaxRetryExpiryCount
+
+namespace TxIndirectMaxRetryExpiryCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxIndirectMaxRetryExpiryCount::Id,
                                       (uint8_t *) txIndirectMaxRetryExpiryCount, sizeof(*txIndirectMaxRetryExpiryCount));
 }
-EmberAfStatus SetTxIndirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxIndirectMaxRetryExpiryCount::Id,
                                        (uint8_t *) &txIndirectMaxRetryExpiryCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxErrCcaCount(chip::EndpointId endpoint, uint32_t * txErrCcaCount)
+
+} // namespace TxIndirectMaxRetryExpiryCount
+
+namespace TxErrCcaCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrCcaCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrCcaCount::Id, (uint8_t *) txErrCcaCount,
                                       sizeof(*txErrCcaCount));
 }
-EmberAfStatus SetTxErrCcaCount(chip::EndpointId endpoint, uint32_t txErrCcaCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrCcaCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrCcaCount::Id, (uint8_t *) &txErrCcaCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxErrAbortCount(chip::EndpointId endpoint, uint32_t * txErrAbortCount)
+
+} // namespace TxErrCcaCount
+
+namespace TxErrAbortCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrAbortCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrAbortCount::Id, (uint8_t *) txErrAbortCount,
                                       sizeof(*txErrAbortCount));
 }
-EmberAfStatus SetTxErrAbortCount(chip::EndpointId endpoint, uint32_t txErrAbortCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrAbortCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrAbortCount::Id, (uint8_t *) &txErrAbortCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxErrBusyChannelCount(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount)
+
+} // namespace TxErrAbortCount
+
+namespace TxErrBusyChannelCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrBusyChannelCount::Id,
                                       (uint8_t *) txErrBusyChannelCount, sizeof(*txErrBusyChannelCount));
 }
-EmberAfStatus SetTxErrBusyChannelCount(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, TxErrBusyChannelCount::Id,
                                        (uint8_t *) &txErrBusyChannelCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxTotalCount(chip::EndpointId endpoint, uint32_t * rxTotalCount)
+
+} // namespace TxErrBusyChannelCount
+
+namespace RxTotalCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxTotalCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxTotalCount::Id, (uint8_t *) rxTotalCount,
                                       sizeof(*rxTotalCount));
 }
-EmberAfStatus SetRxTotalCount(chip::EndpointId endpoint, uint32_t rxTotalCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxTotalCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxTotalCount::Id, (uint8_t *) &rxTotalCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxUnicastCount(chip::EndpointId endpoint, uint32_t * rxUnicastCount)
+
+} // namespace RxTotalCount
+
+namespace RxUnicastCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxUnicastCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxUnicastCount::Id, (uint8_t *) rxUnicastCount,
                                       sizeof(*rxUnicastCount));
 }
-EmberAfStatus SetRxUnicastCount(chip::EndpointId endpoint, uint32_t rxUnicastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxUnicastCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxUnicastCount::Id, (uint8_t *) &rxUnicastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxBroadcastCount(chip::EndpointId endpoint, uint32_t * rxBroadcastCount)
+
+} // namespace RxUnicastCount
+
+namespace RxBroadcastCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBroadcastCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBroadcastCount::Id, (uint8_t *) rxBroadcastCount,
                                       sizeof(*rxBroadcastCount));
 }
-EmberAfStatus SetRxBroadcastCount(chip::EndpointId endpoint, uint32_t rxBroadcastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBroadcastCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBroadcastCount::Id, (uint8_t *) &rxBroadcastCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxDataCount(chip::EndpointId endpoint, uint32_t * rxDataCount)
+
+} // namespace RxBroadcastCount
+
+namespace RxDataCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataCount::Id, (uint8_t *) rxDataCount,
                                       sizeof(*rxDataCount));
 }
-EmberAfStatus SetRxDataCount(chip::EndpointId endpoint, uint32_t rxDataCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataCount::Id, (uint8_t *) &rxDataCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxDataPollCount(chip::EndpointId endpoint, uint32_t * rxDataPollCount)
+
+} // namespace RxDataCount
+
+namespace RxDataPollCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataPollCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataPollCount::Id, (uint8_t *) rxDataPollCount,
                                       sizeof(*rxDataPollCount));
 }
-EmberAfStatus SetRxDataPollCount(chip::EndpointId endpoint, uint32_t rxDataPollCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataPollCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDataPollCount::Id, (uint8_t *) &rxDataPollCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxBeaconCount(chip::EndpointId endpoint, uint32_t * rxBeaconCount)
+
+} // namespace RxDataPollCount
+
+namespace RxBeaconCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconCount::Id, (uint8_t *) rxBeaconCount,
                                       sizeof(*rxBeaconCount));
 }
-EmberAfStatus SetRxBeaconCount(chip::EndpointId endpoint, uint32_t rxBeaconCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconCount::Id, (uint8_t *) &rxBeaconCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxBeaconRequestCount(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount)
+
+} // namespace RxBeaconCount
+
+namespace RxBeaconRequestCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconRequestCount::Id,
                                       (uint8_t *) rxBeaconRequestCount, sizeof(*rxBeaconRequestCount));
 }
-EmberAfStatus SetRxBeaconRequestCount(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxBeaconRequestCount::Id,
                                        (uint8_t *) &rxBeaconRequestCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxOtherCount(chip::EndpointId endpoint, uint32_t * rxOtherCount)
+
+} // namespace RxBeaconRequestCount
+
+namespace RxOtherCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxOtherCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxOtherCount::Id, (uint8_t *) rxOtherCount,
                                       sizeof(*rxOtherCount));
 }
-EmberAfStatus SetRxOtherCount(chip::EndpointId endpoint, uint32_t rxOtherCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxOtherCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxOtherCount::Id, (uint8_t *) &rxOtherCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxAddressFilteredCount(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount)
+
+} // namespace RxOtherCount
+
+namespace RxAddressFilteredCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxAddressFilteredCount::Id,
                                       (uint8_t *) rxAddressFilteredCount, sizeof(*rxAddressFilteredCount));
 }
-EmberAfStatus SetRxAddressFilteredCount(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxAddressFilteredCount::Id,
                                        (uint8_t *) &rxAddressFilteredCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxDestAddrFilteredCount(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount)
+
+} // namespace RxAddressFilteredCount
+
+namespace RxDestAddrFilteredCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDestAddrFilteredCount::Id,
                                       (uint8_t *) rxDestAddrFilteredCount, sizeof(*rxDestAddrFilteredCount));
 }
-EmberAfStatus SetRxDestAddrFilteredCount(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDestAddrFilteredCount::Id,
                                        (uint8_t *) &rxDestAddrFilteredCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxDuplicatedCount(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount)
+
+} // namespace RxDestAddrFilteredCount
+
+namespace RxDuplicatedCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDuplicatedCount::Id, (uint8_t *) rxDuplicatedCount,
                                       sizeof(*rxDuplicatedCount));
 }
-EmberAfStatus SetRxDuplicatedCount(chip::EndpointId endpoint, uint32_t rxDuplicatedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDuplicatedCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxDuplicatedCount::Id,
                                        (uint8_t *) &rxDuplicatedCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxErrNoFrameCount(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount)
+
+} // namespace RxDuplicatedCount
+
+namespace RxErrNoFrameCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrNoFrameCount::Id, (uint8_t *) rxErrNoFrameCount,
                                       sizeof(*rxErrNoFrameCount));
 }
-EmberAfStatus SetRxErrNoFrameCount(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrNoFrameCount::Id,
                                        (uint8_t *) &rxErrNoFrameCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxErrUnknownNeighborCount(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount)
+
+} // namespace RxErrNoFrameCount
+
+namespace RxErrUnknownNeighborCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrUnknownNeighborCount::Id,
                                       (uint8_t *) rxErrUnknownNeighborCount, sizeof(*rxErrUnknownNeighborCount));
 }
-EmberAfStatus SetRxErrUnknownNeighborCount(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrUnknownNeighborCount::Id,
                                        (uint8_t *) &rxErrUnknownNeighborCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxErrInvalidSrcAddrCount(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount)
+
+} // namespace RxErrUnknownNeighborCount
+
+namespace RxErrInvalidSrcAddrCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrInvalidSrcAddrCount::Id,
                                       (uint8_t *) rxErrInvalidSrcAddrCount, sizeof(*rxErrInvalidSrcAddrCount));
 }
-EmberAfStatus SetRxErrInvalidSrcAddrCount(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrInvalidSrcAddrCount::Id,
                                        (uint8_t *) &rxErrInvalidSrcAddrCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxErrSecCount(chip::EndpointId endpoint, uint32_t * rxErrSecCount)
+
+} // namespace RxErrInvalidSrcAddrCount
+
+namespace RxErrSecCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrSecCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrSecCount::Id, (uint8_t *) rxErrSecCount,
                                       sizeof(*rxErrSecCount));
 }
-EmberAfStatus SetRxErrSecCount(chip::EndpointId endpoint, uint32_t rxErrSecCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrSecCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrSecCount::Id, (uint8_t *) &rxErrSecCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxErrFcsCount(chip::EndpointId endpoint, uint32_t * rxErrFcsCount)
+
+} // namespace RxErrSecCount
+
+namespace RxErrFcsCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrFcsCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrFcsCount::Id, (uint8_t *) rxErrFcsCount,
                                       sizeof(*rxErrFcsCount));
 }
-EmberAfStatus SetRxErrFcsCount(chip::EndpointId endpoint, uint32_t rxErrFcsCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrFcsCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrFcsCount::Id, (uint8_t *) &rxErrFcsCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRxErrOtherCount(chip::EndpointId endpoint, uint32_t * rxErrOtherCount)
+
+} // namespace RxErrFcsCount
+
+namespace RxErrOtherCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrOtherCount)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrOtherCount::Id, (uint8_t *) rxErrOtherCount,
                                       sizeof(*rxErrOtherCount));
 }
-EmberAfStatus SetRxErrOtherCount(chip::EndpointId endpoint, uint32_t rxErrOtherCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrOtherCount)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, RxErrOtherCount::Id, (uint8_t *) &rxErrOtherCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActiveTimestamp(chip::EndpointId endpoint, uint64_t * activeTimestamp)
+
+} // namespace RxErrOtherCount
+
+namespace ActiveTimestamp {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * activeTimestamp)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ActiveTimestamp::Id, (uint8_t *) activeTimestamp,
                                       sizeof(*activeTimestamp));
 }
-EmberAfStatus SetActiveTimestamp(chip::EndpointId endpoint, uint64_t activeTimestamp)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t activeTimestamp)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, ActiveTimestamp::Id, (uint8_t *) &activeTimestamp,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPendingTimestamp(chip::EndpointId endpoint, uint64_t * pendingTimestamp)
+
+} // namespace ActiveTimestamp
+
+namespace PendingTimestamp {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * pendingTimestamp)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PendingTimestamp::Id, (uint8_t *) pendingTimestamp,
                                       sizeof(*pendingTimestamp));
 }
-EmberAfStatus SetPendingTimestamp(chip::EndpointId endpoint, uint64_t pendingTimestamp)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t pendingTimestamp)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, PendingTimestamp::Id, (uint8_t *) &pendingTimestamp,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDelay(chip::EndpointId endpoint, uint32_t * delay)
+
+} // namespace PendingTimestamp
+
+namespace Delay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * delay)
 {
     return emberAfReadServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Delay::Id, (uint8_t *) delay, sizeof(*delay));
 }
-EmberAfStatus SetDelay(chip::EndpointId endpoint, uint32_t delay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t delay)
 {
     return emberAfWriteServerAttribute(endpoint, ThreadNetworkDiagnostics::Id, Delay::Id, (uint8_t *) &delay,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
+
+} // namespace Delay
+
 } // namespace Attributes
 } // namespace ThreadNetworkDiagnostics
 
 namespace WiFiNetworkDiagnostics {
 namespace Attributes {
-EmberAfStatus GetSecurityType(chip::EndpointId endpoint, uint8_t * securityType)
+
+namespace SecurityType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * securityType)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, SecurityType::Id, (uint8_t *) securityType,
                                       sizeof(*securityType));
 }
-EmberAfStatus SetSecurityType(chip::EndpointId endpoint, uint8_t securityType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t securityType)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, SecurityType::Id, (uint8_t *) &securityType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWiFiVersion(chip::EndpointId endpoint, uint8_t * wiFiVersion)
+
+} // namespace SecurityType
+
+namespace WiFiVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiFiVersion)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, WiFiVersion::Id, (uint8_t *) wiFiVersion,
                                       sizeof(*wiFiVersion));
 }
-EmberAfStatus SetWiFiVersion(chip::EndpointId endpoint, uint8_t wiFiVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiFiVersion)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, WiFiVersion::Id, (uint8_t *) &wiFiVersion,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetChannelNumber(chip::EndpointId endpoint, uint16_t * channelNumber)
+
+} // namespace WiFiVersion
+
+namespace ChannelNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * channelNumber)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, ChannelNumber::Id, (uint8_t *) channelNumber,
                                       sizeof(*channelNumber));
 }
-EmberAfStatus SetChannelNumber(chip::EndpointId endpoint, uint16_t channelNumber)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t channelNumber)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, ChannelNumber::Id, (uint8_t *) &channelNumber,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRssi(chip::EndpointId endpoint, int8_t * rssi)
+
+} // namespace ChannelNumber
+
+namespace Rssi {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * rssi)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Rssi::Id, (uint8_t *) rssi, sizeof(*rssi));
 }
-EmberAfStatus SetRssi(chip::EndpointId endpoint, int8_t rssi)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t rssi)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, Rssi::Id, (uint8_t *) &rssi, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBeaconLostCount(chip::EndpointId endpoint, uint32_t * beaconLostCount)
+
+} // namespace Rssi
+
+namespace BeaconLostCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconLostCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconLostCount::Id, (uint8_t *) beaconLostCount,
                                       sizeof(*beaconLostCount));
 }
-EmberAfStatus SetBeaconLostCount(chip::EndpointId endpoint, uint32_t beaconLostCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconLostCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconLostCount::Id, (uint8_t *) &beaconLostCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBeaconRxCount(chip::EndpointId endpoint, uint32_t * beaconRxCount)
+
+} // namespace BeaconLostCount
+
+namespace BeaconRxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconRxCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconRxCount::Id, (uint8_t *) beaconRxCount,
                                       sizeof(*beaconRxCount));
 }
-EmberAfStatus SetBeaconRxCount(chip::EndpointId endpoint, uint32_t beaconRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconRxCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, BeaconRxCount::Id, (uint8_t *) &beaconRxCount,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPacketMulticastRxCount(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount)
+
+} // namespace BeaconRxCount
+
+namespace PacketMulticastRxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastRxCount::Id,
                                       (uint8_t *) packetMulticastRxCount, sizeof(*packetMulticastRxCount));
 }
-EmberAfStatus SetPacketMulticastRxCount(chip::EndpointId endpoint, uint32_t packetMulticastRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastRxCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastRxCount::Id,
                                        (uint8_t *) &packetMulticastRxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPacketMulticastTxCount(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount)
+
+} // namespace PacketMulticastRxCount
+
+namespace PacketMulticastTxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastTxCount::Id,
                                       (uint8_t *) packetMulticastTxCount, sizeof(*packetMulticastTxCount));
 }
-EmberAfStatus SetPacketMulticastTxCount(chip::EndpointId endpoint, uint32_t packetMulticastTxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastTxCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketMulticastTxCount::Id,
                                        (uint8_t *) &packetMulticastTxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPacketUnicastRxCount(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount)
+
+} // namespace PacketMulticastTxCount
+
+namespace PacketUnicastRxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastRxCount::Id,
                                       (uint8_t *) packetUnicastRxCount, sizeof(*packetUnicastRxCount));
 }
-EmberAfStatus SetPacketUnicastRxCount(chip::EndpointId endpoint, uint32_t packetUnicastRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastRxCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastRxCount::Id,
                                        (uint8_t *) &packetUnicastRxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPacketUnicastTxCount(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount)
+
+} // namespace PacketUnicastRxCount
+
+namespace PacketUnicastTxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastTxCount::Id,
                                       (uint8_t *) packetUnicastTxCount, sizeof(*packetUnicastTxCount));
 }
-EmberAfStatus SetPacketUnicastTxCount(chip::EndpointId endpoint, uint32_t packetUnicastTxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastTxCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, PacketUnicastTxCount::Id,
                                        (uint8_t *) &packetUnicastTxCount, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentMaxRate(chip::EndpointId endpoint, uint64_t * currentMaxRate)
+
+} // namespace PacketUnicastTxCount
+
+namespace CurrentMaxRate {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentMaxRate)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, CurrentMaxRate::Id, (uint8_t *) currentMaxRate,
                                       sizeof(*currentMaxRate));
 }
-EmberAfStatus SetCurrentMaxRate(chip::EndpointId endpoint, uint64_t currentMaxRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentMaxRate)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, CurrentMaxRate::Id, (uint8_t *) &currentMaxRate,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount)
+
+} // namespace CurrentMaxRate
+
+namespace OverrunCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount)
 {
     return emberAfReadServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) overrunCount,
                                       sizeof(*overrunCount));
 }
-EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
 {
     return emberAfWriteServerAttribute(endpoint, WiFiNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
+
+} // namespace OverrunCount
+
 } // namespace Attributes
 } // namespace WiFiNetworkDiagnostics
 
 namespace EthernetNetworkDiagnostics {
 namespace Attributes {
-EmberAfStatus GetPHYRate(chip::EndpointId endpoint, uint8_t * pHYRate)
+
+namespace PHYRate {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pHYRate)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) pHYRate, sizeof(*pHYRate));
 }
-EmberAfStatus SetPHYRate(chip::EndpointId endpoint, uint8_t pHYRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pHYRate)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) &pHYRate,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, bool * fullDuplex)
+
+} // namespace PHYRate
+
+namespace FullDuplex {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * fullDuplex)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, FullDuplex::Id, (uint8_t *) fullDuplex,
                                       sizeof(*fullDuplex));
 }
-EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, bool fullDuplex)
+EmberAfStatus Set(chip::EndpointId endpoint, bool fullDuplex)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, FullDuplex::Id, (uint8_t *) &fullDuplex,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPacketRxCount(chip::EndpointId endpoint, uint64_t * packetRxCount)
+
+} // namespace FullDuplex
+
+namespace PacketRxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetRxCount)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketRxCount::Id, (uint8_t *) packetRxCount,
                                       sizeof(*packetRxCount));
 }
-EmberAfStatus SetPacketRxCount(chip::EndpointId endpoint, uint64_t packetRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetRxCount)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketRxCount::Id, (uint8_t *) &packetRxCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPacketTxCount(chip::EndpointId endpoint, uint64_t * packetTxCount)
+
+} // namespace PacketRxCount
+
+namespace PacketTxCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetTxCount)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketTxCount::Id, (uint8_t *) packetTxCount,
                                       sizeof(*packetTxCount));
 }
-EmberAfStatus SetPacketTxCount(chip::EndpointId endpoint, uint64_t packetTxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetTxCount)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PacketTxCount::Id, (uint8_t *) &packetTxCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTxErrCount(chip::EndpointId endpoint, uint64_t * txErrCount)
+
+} // namespace PacketTxCount
+
+namespace TxErrCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * txErrCount)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TxErrCount::Id, (uint8_t *) txErrCount,
                                       sizeof(*txErrCount));
 }
-EmberAfStatus SetTxErrCount(chip::EndpointId endpoint, uint64_t txErrCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t txErrCount)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TxErrCount::Id, (uint8_t *) &txErrCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCollisionCount(chip::EndpointId endpoint, uint64_t * collisionCount)
+
+} // namespace TxErrCount
+
+namespace CollisionCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * collisionCount)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CollisionCount::Id, (uint8_t *) collisionCount,
                                       sizeof(*collisionCount));
 }
-EmberAfStatus SetCollisionCount(chip::EndpointId endpoint, uint64_t collisionCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t collisionCount)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CollisionCount::Id, (uint8_t *) &collisionCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount)
+
+} // namespace CollisionCount
+
+namespace OverrunCount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) overrunCount,
                                       sizeof(*overrunCount));
 }
-EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, OverrunCount::Id, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, bool * carrierDetect)
+
+} // namespace OverrunCount
+
+namespace CarrierDetect {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * carrierDetect)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CarrierDetect::Id, (uint8_t *) carrierDetect,
                                       sizeof(*carrierDetect));
 }
-EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, bool carrierDetect)
+EmberAfStatus Set(chip::EndpointId endpoint, bool carrierDetect)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, CarrierDetect::Id, (uint8_t *) &carrierDetect,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTimeSinceReset(chip::EndpointId endpoint, uint64_t * timeSinceReset)
+
+} // namespace CarrierDetect
+
+namespace TimeSinceReset {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * timeSinceReset)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TimeSinceReset::Id, (uint8_t *) timeSinceReset,
                                       sizeof(*timeSinceReset));
 }
-EmberAfStatus SetTimeSinceReset(chip::EndpointId endpoint, uint64_t timeSinceReset)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t timeSinceReset)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, TimeSinceReset::Id, (uint8_t *) &timeSinceReset,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
+
+} // namespace TimeSinceReset
+
 } // namespace Attributes
 } // namespace EthernetNetworkDiagnostics
 
 namespace BridgedDeviceBasic {
 namespace Attributes {
-EmberAfStatus GetVendorID(chip::EndpointId endpoint, uint16_t * vendorID)
+
+namespace VendorID {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID)
 {
     return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, VendorID::Id, (uint8_t *) vendorID, sizeof(*vendorID));
 }
-EmberAfStatus SetVendorID(chip::EndpointId endpoint, uint16_t vendorID)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID)
 {
     return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, VendorID::Id, (uint8_t *) &vendorID,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareVersion)
+
+} // namespace VendorID
+
+namespace HardwareVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion)
 {
     return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, HardwareVersion::Id, (uint8_t *) hardwareVersion,
                                       sizeof(*hardwareVersion));
 }
-EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion)
 {
     return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, HardwareVersion::Id, (uint8_t *) &hardwareVersion,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion)
+
+} // namespace HardwareVersion
+
+namespace SoftwareVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion)
 {
     return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, SoftwareVersion::Id, (uint8_t *) softwareVersion,
                                       sizeof(*softwareVersion));
 }
-EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion)
 {
     return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, SoftwareVersion::Id, (uint8_t *) &softwareVersion,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable)
+
+} // namespace SoftwareVersion
+
+namespace Reachable {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable)
 {
     return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Reachable::Id, (uint8_t *) reachable, sizeof(*reachable));
 }
-EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable)
+EmberAfStatus Set(chip::EndpointId endpoint, bool reachable)
 {
     return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Reachable::Id, (uint8_t *) &reachable,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
+
+} // namespace Reachable
+
 } // namespace Attributes
 } // namespace BridgedDeviceBasic
 
 namespace Switch {
 namespace Attributes {
-EmberAfStatus GetNumberOfPositions(chip::EndpointId endpoint, uint8_t * numberOfPositions)
+
+namespace NumberOfPositions {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPositions)
 {
     return emberAfReadServerAttribute(endpoint, Switch::Id, NumberOfPositions::Id, (uint8_t *) numberOfPositions,
                                       sizeof(*numberOfPositions));
 }
-EmberAfStatus SetNumberOfPositions(chip::EndpointId endpoint, uint8_t numberOfPositions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPositions)
 {
     return emberAfWriteServerAttribute(endpoint, Switch::Id, NumberOfPositions::Id, (uint8_t *) &numberOfPositions,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPosition(chip::EndpointId endpoint, uint8_t * currentPosition)
+
+} // namespace NumberOfPositions
+
+namespace CurrentPosition {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPosition)
 {
     return emberAfReadServerAttribute(endpoint, Switch::Id, CurrentPosition::Id, (uint8_t *) currentPosition,
                                       sizeof(*currentPosition));
 }
-EmberAfStatus SetCurrentPosition(chip::EndpointId endpoint, uint8_t currentPosition)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPosition)
 {
     return emberAfWriteServerAttribute(endpoint, Switch::Id, CurrentPosition::Id, (uint8_t *) &currentPosition,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMultiPressMax(chip::EndpointId endpoint, uint8_t * multiPressMax)
+
+} // namespace CurrentPosition
+
+namespace MultiPressMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * multiPressMax)
 {
     return emberAfReadServerAttribute(endpoint, Switch::Id, MultiPressMax::Id, (uint8_t *) multiPressMax, sizeof(*multiPressMax));
 }
-EmberAfStatus SetMultiPressMax(chip::EndpointId endpoint, uint8_t multiPressMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t multiPressMax)
 {
     return emberAfWriteServerAttribute(endpoint, Switch::Id, MultiPressMax::Id, (uint8_t *) &multiPressMax,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace MultiPressMax
+
 } // namespace Attributes
 } // namespace Switch
 
 namespace OperationalCredentials {
 namespace Attributes {
-EmberAfStatus GetSupportedFabrics(chip::EndpointId endpoint, uint8_t * supportedFabrics)
+
+namespace SupportedFabrics {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * supportedFabrics)
 {
     return emberAfReadServerAttribute(endpoint, OperationalCredentials::Id, SupportedFabrics::Id, (uint8_t *) supportedFabrics,
                                       sizeof(*supportedFabrics));
 }
-EmberAfStatus SetSupportedFabrics(chip::EndpointId endpoint, uint8_t supportedFabrics)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t supportedFabrics)
 {
     return emberAfWriteServerAttribute(endpoint, OperationalCredentials::Id, SupportedFabrics::Id, (uint8_t *) &supportedFabrics,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCommissionedFabrics(chip::EndpointId endpoint, uint8_t * commissionedFabrics)
+
+} // namespace SupportedFabrics
+
+namespace CommissionedFabrics {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * commissionedFabrics)
 {
     return emberAfReadServerAttribute(endpoint, OperationalCredentials::Id, CommissionedFabrics::Id,
                                       (uint8_t *) commissionedFabrics, sizeof(*commissionedFabrics));
 }
-EmberAfStatus SetCommissionedFabrics(chip::EndpointId endpoint, uint8_t commissionedFabrics)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t commissionedFabrics)
 {
     return emberAfWriteServerAttribute(endpoint, OperationalCredentials::Id, CommissionedFabrics::Id,
                                        (uint8_t *) &commissionedFabrics, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CommissionedFabrics
+
 } // namespace Attributes
 } // namespace OperationalCredentials
 
 namespace FixedLabel {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace FixedLabel
 
 namespace ShadeConfiguration {
 namespace Attributes {
-EmberAfStatus GetPhysicalClosedLimit(chip::EndpointId endpoint, uint16_t * physicalClosedLimit)
+
+namespace PhysicalClosedLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimit)
 {
     return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, PhysicalClosedLimit::Id, (uint8_t *) physicalClosedLimit,
                                       sizeof(*physicalClosedLimit));
 }
-EmberAfStatus SetPhysicalClosedLimit(chip::EndpointId endpoint, uint16_t physicalClosedLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimit)
 {
     return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, PhysicalClosedLimit::Id, (uint8_t *) &physicalClosedLimit,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMotorStepSize(chip::EndpointId endpoint, uint8_t * motorStepSize)
+
+} // namespace PhysicalClosedLimit
+
+namespace MotorStepSize {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * motorStepSize)
 {
     return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, MotorStepSize::Id, (uint8_t *) motorStepSize,
                                       sizeof(*motorStepSize));
 }
-EmberAfStatus SetMotorStepSize(chip::EndpointId endpoint, uint8_t motorStepSize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t motorStepSize)
 {
     return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, MotorStepSize::Id, (uint8_t *) &motorStepSize,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStatus(chip::EndpointId endpoint, uint8_t * status)
+
+} // namespace MotorStepSize
+
+namespace Status {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status)
 {
     return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Status::Id, (uint8_t *) status, sizeof(*status));
 }
-EmberAfStatus SetStatus(chip::EndpointId endpoint, uint8_t status)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status)
 {
     return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Status::Id, (uint8_t *) &status,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetClosedLimit(chip::EndpointId endpoint, uint16_t * closedLimit)
+
+} // namespace Status
+
+namespace ClosedLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * closedLimit)
 {
     return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, ClosedLimit::Id, (uint8_t *) closedLimit,
                                       sizeof(*closedLimit));
 }
-EmberAfStatus SetClosedLimit(chip::EndpointId endpoint, uint16_t closedLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t closedLimit)
 {
     return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, ClosedLimit::Id, (uint8_t *) &closedLimit,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMode(chip::EndpointId endpoint, uint8_t * mode)
+
+} // namespace ClosedLimit
+
+namespace Mode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode)
 {
     return emberAfReadServerAttribute(endpoint, ShadeConfiguration::Id, Mode::Id, (uint8_t *) mode, sizeof(*mode));
 }
-EmberAfStatus SetMode(chip::EndpointId endpoint, uint8_t mode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode)
 {
     return emberAfWriteServerAttribute(endpoint, ShadeConfiguration::Id, Mode::Id, (uint8_t *) &mode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace Mode
+
 } // namespace Attributes
 } // namespace ShadeConfiguration
 
 namespace DoorLock {
 namespace Attributes {
-EmberAfStatus GetLockState(chip::EndpointId endpoint, uint8_t * lockState)
+
+namespace LockState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockState)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, LockState::Id, (uint8_t *) lockState, sizeof(*lockState));
 }
-EmberAfStatus SetLockState(chip::EndpointId endpoint, uint8_t lockState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockState)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, LockState::Id, (uint8_t *) &lockState, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLockType(chip::EndpointId endpoint, uint8_t * lockType)
+
+} // namespace LockState
+
+namespace LockType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockType)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, LockType::Id, (uint8_t *) lockType, sizeof(*lockType));
 }
-EmberAfStatus SetLockType(chip::EndpointId endpoint, uint8_t lockType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockType)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, LockType::Id, (uint8_t *) &lockType, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, bool * actuatorEnabled)
+
+} // namespace LockType
+
+namespace ActuatorEnabled {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * actuatorEnabled)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, ActuatorEnabled::Id, (uint8_t *) actuatorEnabled,
                                       sizeof(*actuatorEnabled));
 }
-EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, bool actuatorEnabled)
+EmberAfStatus Set(chip::EndpointId endpoint, bool actuatorEnabled)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, ActuatorEnabled::Id, (uint8_t *) &actuatorEnabled,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDoorState(chip::EndpointId endpoint, uint8_t * doorState)
+
+} // namespace ActuatorEnabled
+
+namespace DoorState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * doorState)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, DoorState::Id, (uint8_t *) doorState, sizeof(*doorState));
 }
-EmberAfStatus SetDoorState(chip::EndpointId endpoint, uint8_t doorState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t doorState)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DoorState::Id, (uint8_t *) &doorState, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDoorOpenEvents(chip::EndpointId endpoint, uint32_t * doorOpenEvents)
+
+} // namespace DoorState
+
+namespace DoorOpenEvents {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorOpenEvents)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, DoorOpenEvents::Id, (uint8_t *) doorOpenEvents,
                                       sizeof(*doorOpenEvents));
 }
-EmberAfStatus SetDoorOpenEvents(chip::EndpointId endpoint, uint32_t doorOpenEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorOpenEvents)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DoorOpenEvents::Id, (uint8_t *) &doorOpenEvents,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDoorClosedEvents(chip::EndpointId endpoint, uint32_t * doorClosedEvents)
+
+} // namespace DoorOpenEvents
+
+namespace DoorClosedEvents {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorClosedEvents)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, DoorClosedEvents::Id, (uint8_t *) doorClosedEvents,
                                       sizeof(*doorClosedEvents));
 }
-EmberAfStatus SetDoorClosedEvents(chip::EndpointId endpoint, uint32_t doorClosedEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorClosedEvents)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DoorClosedEvents::Id, (uint8_t *) &doorClosedEvents,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOpenPeriod(chip::EndpointId endpoint, uint16_t * openPeriod)
+
+} // namespace DoorClosedEvents
+
+namespace OpenPeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * openPeriod)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, OpenPeriod::Id, (uint8_t *) openPeriod, sizeof(*openPeriod));
 }
-EmberAfStatus SetOpenPeriod(chip::EndpointId endpoint, uint16_t openPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t openPeriod)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, OpenPeriod::Id, (uint8_t *) &openPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumLockRecordsSupported(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported)
+
+} // namespace OpenPeriod
+
+namespace NumLockRecordsSupported {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumLockRecordsSupported::Id, (uint8_t *) numLockRecordsSupported,
                                       sizeof(*numLockRecordsSupported));
 }
-EmberAfStatus SetNumLockRecordsSupported(chip::EndpointId endpoint, uint16_t numLockRecordsSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numLockRecordsSupported)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumLockRecordsSupported::Id, (uint8_t *) &numLockRecordsSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumTotalUsersSupported(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported)
+
+} // namespace NumLockRecordsSupported
+
+namespace NumTotalUsersSupported {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumTotalUsersSupported::Id, (uint8_t *) numTotalUsersSupported,
                                       sizeof(*numTotalUsersSupported));
 }
-EmberAfStatus SetNumTotalUsersSupported(chip::EndpointId endpoint, uint16_t numTotalUsersSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numTotalUsersSupported)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumTotalUsersSupported::Id, (uint8_t *) &numTotalUsersSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumPinUsersSupported(chip::EndpointId endpoint, uint16_t * numPinUsersSupported)
+
+} // namespace NumTotalUsersSupported
+
+namespace NumPinUsersSupported {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numPinUsersSupported)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumPinUsersSupported::Id, (uint8_t *) numPinUsersSupported,
                                       sizeof(*numPinUsersSupported));
 }
-EmberAfStatus SetNumPinUsersSupported(chip::EndpointId endpoint, uint16_t numPinUsersSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numPinUsersSupported)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumPinUsersSupported::Id, (uint8_t *) &numPinUsersSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumRfidUsersSupported(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported)
+
+} // namespace NumPinUsersSupported
+
+namespace NumRfidUsersSupported {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumRfidUsersSupported::Id, (uint8_t *) numRfidUsersSupported,
                                       sizeof(*numRfidUsersSupported));
 }
-EmberAfStatus SetNumRfidUsersSupported(chip::EndpointId endpoint, uint16_t numRfidUsersSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numRfidUsersSupported)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumRfidUsersSupported::Id, (uint8_t *) &numRfidUsersSupported,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumWeekdaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t * numWeekdaySchedulesSupportedPerUser)
+
+} // namespace NumRfidUsersSupported
+
+namespace NumWeekdaySchedulesSupportedPerUser {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numWeekdaySchedulesSupportedPerUser)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumWeekdaySchedulesSupportedPerUser::Id,
                                       (uint8_t *) numWeekdaySchedulesSupportedPerUser,
                                       sizeof(*numWeekdaySchedulesSupportedPerUser));
 }
-EmberAfStatus SetNumWeekdaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumWeekdaySchedulesSupportedPerUser::Id,
                                        (uint8_t *) &numWeekdaySchedulesSupportedPerUser, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumYeardaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t * numYeardaySchedulesSupportedPerUser)
+
+} // namespace NumWeekdaySchedulesSupportedPerUser
+
+namespace NumYeardaySchedulesSupportedPerUser {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numYeardaySchedulesSupportedPerUser)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumYeardaySchedulesSupportedPerUser::Id,
                                       (uint8_t *) numYeardaySchedulesSupportedPerUser,
                                       sizeof(*numYeardaySchedulesSupportedPerUser));
 }
-EmberAfStatus SetNumYeardaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumYeardaySchedulesSupportedPerUser::Id,
                                        (uint8_t *) &numYeardaySchedulesSupportedPerUser, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumHolidaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t * numHolidaySchedulesSupportedPerUser)
+
+} // namespace NumYeardaySchedulesSupportedPerUser
+
+namespace NumHolidaySchedulesSupportedPerUser {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numHolidaySchedulesSupportedPerUser)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, NumHolidaySchedulesSupportedPerUser::Id,
                                       (uint8_t *) numHolidaySchedulesSupportedPerUser,
                                       sizeof(*numHolidaySchedulesSupportedPerUser));
 }
-EmberAfStatus SetNumHolidaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, NumHolidaySchedulesSupportedPerUser::Id,
                                        (uint8_t *) &numHolidaySchedulesSupportedPerUser, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxPinLength(chip::EndpointId endpoint, uint8_t * maxPinLength)
+
+} // namespace NumHolidaySchedulesSupportedPerUser
+
+namespace MaxPinLength {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxPinLength)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, MaxPinLength::Id, (uint8_t *) maxPinLength, sizeof(*maxPinLength));
 }
-EmberAfStatus SetMaxPinLength(chip::EndpointId endpoint, uint8_t maxPinLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxPinLength)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MaxPinLength::Id, (uint8_t *) &maxPinLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinPinLength(chip::EndpointId endpoint, uint8_t * minPinLength)
+
+} // namespace MaxPinLength
+
+namespace MinPinLength {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minPinLength)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, MinPinLength::Id, (uint8_t *) minPinLength, sizeof(*minPinLength));
 }
-EmberAfStatus SetMinPinLength(chip::EndpointId endpoint, uint8_t minPinLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minPinLength)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MinPinLength::Id, (uint8_t *) &minPinLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength)
+
+} // namespace MinPinLength
+
+namespace MaxRfidCodeLength {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, MaxRfidCodeLength::Id, (uint8_t *) maxRfidCodeLength,
                                       sizeof(*maxRfidCodeLength));
 }
-EmberAfStatus SetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t maxRfidCodeLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxRfidCodeLength)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MaxRfidCodeLength::Id, (uint8_t *) &maxRfidCodeLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t * minRfidCodeLength)
+
+} // namespace MaxRfidCodeLength
+
+namespace MinRfidCodeLength {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minRfidCodeLength)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, MinRfidCodeLength::Id, (uint8_t *) minRfidCodeLength,
                                       sizeof(*minRfidCodeLength));
 }
-EmberAfStatus SetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t minRfidCodeLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minRfidCodeLength)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, MinRfidCodeLength::Id, (uint8_t *) &minRfidCodeLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, bool * enableLogging)
+
+} // namespace MinRfidCodeLength
+
+namespace EnableLogging {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLogging)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableLogging::Id, (uint8_t *) enableLogging, sizeof(*enableLogging));
 }
-EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, bool enableLogging)
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableLogging)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableLogging::Id, (uint8_t *) &enableLogging,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLedSettings(chip::EndpointId endpoint, uint8_t * ledSettings)
+
+} // namespace EnableLogging
+
+namespace LedSettings {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ledSettings)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, LedSettings::Id, (uint8_t *) ledSettings, sizeof(*ledSettings));
 }
-EmberAfStatus SetLedSettings(chip::EndpointId endpoint, uint8_t ledSettings)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ledSettings)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, LedSettings::Id, (uint8_t *) &ledSettings, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAutoRelockTime(chip::EndpointId endpoint, uint32_t * autoRelockTime)
+
+} // namespace LedSettings
+
+namespace AutoRelockTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * autoRelockTime)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, AutoRelockTime::Id, (uint8_t *) autoRelockTime,
                                       sizeof(*autoRelockTime));
 }
-EmberAfStatus SetAutoRelockTime(chip::EndpointId endpoint, uint32_t autoRelockTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t autoRelockTime)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, AutoRelockTime::Id, (uint8_t *) &autoRelockTime,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSoundVolume(chip::EndpointId endpoint, uint8_t * soundVolume)
+
+} // namespace AutoRelockTime
+
+namespace SoundVolume {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * soundVolume)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, SoundVolume::Id, (uint8_t *) soundVolume, sizeof(*soundVolume));
 }
-EmberAfStatus SetSoundVolume(chip::EndpointId endpoint, uint8_t soundVolume)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t soundVolume)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, SoundVolume::Id, (uint8_t *) &soundVolume, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOperatingMode(chip::EndpointId endpoint, uint8_t * operatingMode)
+
+} // namespace SoundVolume
+
+namespace OperatingMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operatingMode)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, OperatingMode::Id, (uint8_t *) operatingMode, sizeof(*operatingMode));
 }
-EmberAfStatus SetOperatingMode(chip::EndpointId endpoint, uint8_t operatingMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operatingMode)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, OperatingMode::Id, (uint8_t *) &operatingMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t * supportedOperatingModes)
+
+} // namespace OperatingMode
+
+namespace SupportedOperatingModes {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * supportedOperatingModes)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, SupportedOperatingModes::Id, (uint8_t *) supportedOperatingModes,
                                       sizeof(*supportedOperatingModes));
 }
-EmberAfStatus SetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t supportedOperatingModes)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t supportedOperatingModes)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, SupportedOperatingModes::Id, (uint8_t *) &supportedOperatingModes,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister)
+
+} // namespace SupportedOperatingModes
+
+namespace DefaultConfigurationRegister {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, DefaultConfigurationRegister::Id,
                                       (uint8_t *) defaultConfigurationRegister, sizeof(*defaultConfigurationRegister));
 }
-EmberAfStatus SetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, DefaultConfigurationRegister::Id,
                                        (uint8_t *) &defaultConfigurationRegister, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, bool * enableLocalProgramming)
+
+} // namespace DefaultConfigurationRegister
+
+namespace EnableLocalProgramming {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLocalProgramming)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableLocalProgramming::Id, (uint8_t *) enableLocalProgramming,
                                       sizeof(*enableLocalProgramming));
 }
-EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, bool enableLocalProgramming)
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableLocalProgramming)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableLocalProgramming::Id, (uint8_t *) &enableLocalProgramming,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, bool * enableOneTouchLocking)
+
+} // namespace EnableLocalProgramming
+
+namespace EnableOneTouchLocking {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableOneTouchLocking)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableOneTouchLocking::Id, (uint8_t *) enableOneTouchLocking,
                                       sizeof(*enableOneTouchLocking));
 }
-EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, bool enableOneTouchLocking)
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableOneTouchLocking)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableOneTouchLocking::Id, (uint8_t *) &enableOneTouchLocking,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, bool * enableInsideStatusLed)
+
+} // namespace EnableOneTouchLocking
+
+namespace EnableInsideStatusLed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableInsideStatusLed)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnableInsideStatusLed::Id, (uint8_t *) enableInsideStatusLed,
                                       sizeof(*enableInsideStatusLed));
 }
-EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, bool enableInsideStatusLed)
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableInsideStatusLed)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnableInsideStatusLed::Id, (uint8_t *) &enableInsideStatusLed,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, bool * enablePrivacyModeButton)
+
+} // namespace EnableInsideStatusLed
+
+namespace EnablePrivacyModeButton {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enablePrivacyModeButton)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, EnablePrivacyModeButton::Id, (uint8_t *) enablePrivacyModeButton,
                                       sizeof(*enablePrivacyModeButton));
 }
-EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, bool enablePrivacyModeButton)
+EmberAfStatus Set(chip::EndpointId endpoint, bool enablePrivacyModeButton)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, EnablePrivacyModeButton::Id, (uint8_t *) &enablePrivacyModeButton,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit)
+
+} // namespace EnablePrivacyModeButton
+
+namespace WrongCodeEntryLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, WrongCodeEntryLimit::Id, (uint8_t *) wrongCodeEntryLimit,
                                       sizeof(*wrongCodeEntryLimit));
 }
-EmberAfStatus SetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, WrongCodeEntryLimit::Id, (uint8_t *) &wrongCodeEntryLimit,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime)
+
+} // namespace WrongCodeEntryLimit
+
+namespace UserCodeTemporaryDisableTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, UserCodeTemporaryDisableTime::Id,
                                       (uint8_t *) userCodeTemporaryDisableTime, sizeof(*userCodeTemporaryDisableTime));
 }
-EmberAfStatus SetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, UserCodeTemporaryDisableTime::Id,
                                        (uint8_t *) &userCodeTemporaryDisableTime, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, bool * sendPinOverTheAir)
+
+} // namespace UserCodeTemporaryDisableTime
+
+namespace SendPinOverTheAir {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * sendPinOverTheAir)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, SendPinOverTheAir::Id, (uint8_t *) sendPinOverTheAir,
                                       sizeof(*sendPinOverTheAir));
 }
-EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, bool sendPinOverTheAir)
+EmberAfStatus Set(chip::EndpointId endpoint, bool sendPinOverTheAir)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, SendPinOverTheAir::Id, (uint8_t *) &sendPinOverTheAir,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, bool * requirePinForRfOperation)
+
+} // namespace SendPinOverTheAir
+
+namespace RequirePinForRfOperation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * requirePinForRfOperation)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, RequirePinForRfOperation::Id, (uint8_t *) requirePinForRfOperation,
                                       sizeof(*requirePinForRfOperation));
 }
-EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, bool requirePinForRfOperation)
+EmberAfStatus Set(chip::EndpointId endpoint, bool requirePinForRfOperation)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RequirePinForRfOperation::Id, (uint8_t *) &requirePinForRfOperation,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel)
+
+} // namespace RequirePinForRfOperation
+
+namespace ZigbeeSecurityLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, ZigbeeSecurityLevel::Id, (uint8_t *) zigbeeSecurityLevel,
                                       sizeof(*zigbeeSecurityLevel));
 }
-EmberAfStatus SetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, ZigbeeSecurityLevel::Id, (uint8_t *) &zigbeeSecurityLevel,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask)
+
+} // namespace ZigbeeSecurityLevel
+
+namespace AlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, AlarmMask::Id, (uint8_t *) alarmMask, sizeof(*alarmMask));
 }
-EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint16_t alarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, AlarmMask::Id, (uint8_t *) &alarmMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetKeypadOperationEventMask(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask)
+
+} // namespace AlarmMask
+
+namespace KeypadOperationEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, KeypadOperationEventMask::Id, (uint8_t *) keypadOperationEventMask,
                                       sizeof(*keypadOperationEventMask));
 }
-EmberAfStatus SetKeypadOperationEventMask(chip::EndpointId endpoint, uint16_t keypadOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadOperationEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, KeypadOperationEventMask::Id, (uint8_t *) &keypadOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRfOperationEventMask(chip::EndpointId endpoint, uint16_t * rfOperationEventMask)
+
+} // namespace KeypadOperationEventMask
+
+namespace RfOperationEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfOperationEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfOperationEventMask::Id, (uint8_t *) rfOperationEventMask,
                                       sizeof(*rfOperationEventMask));
 }
-EmberAfStatus SetRfOperationEventMask(chip::EndpointId endpoint, uint16_t rfOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfOperationEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfOperationEventMask::Id, (uint8_t *) &rfOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetManualOperationEventMask(chip::EndpointId endpoint, uint16_t * manualOperationEventMask)
+
+} // namespace RfOperationEventMask
+
+namespace ManualOperationEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * manualOperationEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, ManualOperationEventMask::Id, (uint8_t *) manualOperationEventMask,
                                       sizeof(*manualOperationEventMask));
 }
-EmberAfStatus SetManualOperationEventMask(chip::EndpointId endpoint, uint16_t manualOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t manualOperationEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, ManualOperationEventMask::Id, (uint8_t *) &manualOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRfidOperationEventMask(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask)
+
+} // namespace ManualOperationEventMask
+
+namespace RfidOperationEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfidOperationEventMask::Id, (uint8_t *) rfidOperationEventMask,
                                       sizeof(*rfidOperationEventMask));
 }
-EmberAfStatus SetRfidOperationEventMask(chip::EndpointId endpoint, uint16_t rfidOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidOperationEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfidOperationEventMask::Id, (uint8_t *) &rfidOperationEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetKeypadProgrammingEventMask(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask)
+
+} // namespace RfidOperationEventMask
+
+namespace KeypadProgrammingEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, KeypadProgrammingEventMask::Id,
                                       (uint8_t *) keypadProgrammingEventMask, sizeof(*keypadProgrammingEventMask));
 }
-EmberAfStatus SetKeypadProgrammingEventMask(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, KeypadProgrammingEventMask::Id,
                                        (uint8_t *) &keypadProgrammingEventMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRfProgrammingEventMask(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask)
+
+} // namespace KeypadProgrammingEventMask
+
+namespace RfProgrammingEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfProgrammingEventMask::Id, (uint8_t *) rfProgrammingEventMask,
                                       sizeof(*rfProgrammingEventMask));
 }
-EmberAfStatus SetRfProgrammingEventMask(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfProgrammingEventMask::Id, (uint8_t *) &rfProgrammingEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRfidProgrammingEventMask(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask)
+
+} // namespace RfProgrammingEventMask
+
+namespace RfidProgrammingEventMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, RfidProgrammingEventMask::Id, (uint8_t *) rfidProgrammingEventMask,
                                       sizeof(*rfidProgrammingEventMask));
 }
-EmberAfStatus SetRfidProgrammingEventMask(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, RfidProgrammingEventMask::Id, (uint8_t *) &rfidProgrammingEventMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
+
+} // namespace RfidProgrammingEventMask
+
 } // namespace Attributes
 } // namespace DoorLock
 
 namespace WindowCovering {
 namespace Attributes {
-EmberAfStatus GetType(chip::EndpointId endpoint, uint8_t * type)
+
+namespace Type {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * type)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Type::Id, (uint8_t *) type, sizeof(*type));
 }
-EmberAfStatus SetType(chip::EndpointId endpoint, uint8_t type)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t type)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Type::Id, (uint8_t *) &type, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhysicalClosedLimitLift(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift)
+
+} // namespace Type
+
+namespace PhysicalClosedLimitLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitLift::Id,
                                       (uint8_t *) physicalClosedLimitLift, sizeof(*physicalClosedLimitLift));
 }
-EmberAfStatus SetPhysicalClosedLimitLift(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitLift::Id,
                                        (uint8_t *) &physicalClosedLimitLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhysicalClosedLimitTilt(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt)
+
+} // namespace PhysicalClosedLimitLift
+
+namespace PhysicalClosedLimitTilt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitTilt::Id,
                                       (uint8_t *) physicalClosedLimitTilt, sizeof(*physicalClosedLimitTilt));
 }
-EmberAfStatus SetPhysicalClosedLimitTilt(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, PhysicalClosedLimitTilt::Id,
                                        (uint8_t *) &physicalClosedLimitTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPositionLift(chip::EndpointId endpoint, uint16_t * currentPositionLift)
+
+} // namespace PhysicalClosedLimitTilt
+
+namespace CurrentPositionLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLift::Id, (uint8_t *) currentPositionLift,
                                       sizeof(*currentPositionLift));
 }
-EmberAfStatus SetCurrentPositionLift(chip::EndpointId endpoint, uint16_t currentPositionLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLift::Id, (uint8_t *) &currentPositionLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPositionTilt(chip::EndpointId endpoint, uint16_t * currentPositionTilt)
+
+} // namespace CurrentPositionLift
+
+namespace CurrentPositionTilt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTilt)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTilt::Id, (uint8_t *) currentPositionTilt,
                                       sizeof(*currentPositionTilt));
 }
-EmberAfStatus SetCurrentPositionTilt(chip::EndpointId endpoint, uint16_t currentPositionTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTilt)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTilt::Id, (uint8_t *) &currentPositionTilt,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumberOfActuationsLift(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift)
+
+} // namespace CurrentPositionTilt
+
+namespace NumberOfActuationsLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsLift::Id, (uint8_t *) numberOfActuationsLift,
                                       sizeof(*numberOfActuationsLift));
 }
-EmberAfStatus SetNumberOfActuationsLift(chip::EndpointId endpoint, uint16_t numberOfActuationsLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsLift::Id,
                                        (uint8_t *) &numberOfActuationsLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumberOfActuationsTilt(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt)
+
+} // namespace NumberOfActuationsLift
+
+namespace NumberOfActuationsTilt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsTilt::Id, (uint8_t *) numberOfActuationsTilt,
                                       sizeof(*numberOfActuationsTilt));
 }
-EmberAfStatus SetNumberOfActuationsTilt(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, NumberOfActuationsTilt::Id,
                                        (uint8_t *) &numberOfActuationsTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetConfigStatus(chip::EndpointId endpoint, uint8_t * configStatus)
+
+} // namespace NumberOfActuationsTilt
+
+namespace ConfigStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * configStatus)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, ConfigStatus::Id, (uint8_t *) configStatus,
                                       sizeof(*configStatus));
 }
-EmberAfStatus SetConfigStatus(chip::EndpointId endpoint, uint8_t configStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t configStatus)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, ConfigStatus::Id, (uint8_t *) &configStatus,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPositionLiftPercentage(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage)
+
+} // namespace ConfigStatus
+
+namespace CurrentPositionLiftPercentage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercentage::Id,
                                       (uint8_t *) currentPositionLiftPercentage, sizeof(*currentPositionLiftPercentage));
 }
-EmberAfStatus SetCurrentPositionLiftPercentage(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercentage::Id,
                                        (uint8_t *) &currentPositionLiftPercentage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPositionTiltPercentage(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage)
+
+} // namespace CurrentPositionLiftPercentage
+
+namespace CurrentPositionTiltPercentage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercentage::Id,
                                       (uint8_t *) currentPositionTiltPercentage, sizeof(*currentPositionTiltPercentage));
 }
-EmberAfStatus SetCurrentPositionTiltPercentage(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercentage::Id,
                                        (uint8_t *) &currentPositionTiltPercentage, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOperationalStatus(chip::EndpointId endpoint, uint8_t * operationalStatus)
+
+} // namespace CurrentPositionTiltPercentage
+
+namespace OperationalStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationalStatus)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, OperationalStatus::Id, (uint8_t *) operationalStatus,
                                       sizeof(*operationalStatus));
 }
-EmberAfStatus SetOperationalStatus(chip::EndpointId endpoint, uint8_t operationalStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationalStatus)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, OperationalStatus::Id, (uint8_t *) &operationalStatus,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTargetPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths)
+
+} // namespace OperationalStatus
+
+namespace TargetPositionLiftPercent100ths {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, TargetPositionLiftPercent100ths::Id,
                                       (uint8_t *) targetPositionLiftPercent100ths, sizeof(*targetPositionLiftPercent100ths));
 }
-EmberAfStatus SetTargetPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, TargetPositionLiftPercent100ths::Id,
                                        (uint8_t *) &targetPositionLiftPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTargetPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths)
+
+} // namespace TargetPositionLiftPercent100ths
+
+namespace TargetPositionTiltPercent100ths {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, TargetPositionTiltPercent100ths::Id,
                                       (uint8_t *) targetPositionTiltPercent100ths, sizeof(*targetPositionTiltPercent100ths));
 }
-EmberAfStatus SetTargetPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, TargetPositionTiltPercent100ths::Id,
                                        (uint8_t *) &targetPositionTiltPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEndProductType(chip::EndpointId endpoint, uint8_t * endProductType)
+
+} // namespace TargetPositionTiltPercent100ths
+
+namespace EndProductType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * endProductType)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, EndProductType::Id, (uint8_t *) endProductType,
                                       sizeof(*endProductType));
 }
-EmberAfStatus SetEndProductType(chip::EndpointId endpoint, uint8_t endProductType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t endProductType)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, EndProductType::Id, (uint8_t *) &endProductType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths)
+
+} // namespace EndProductType
+
+namespace CurrentPositionLiftPercent100ths {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercent100ths::Id,
                                       (uint8_t *) currentPositionLiftPercent100ths, sizeof(*currentPositionLiftPercent100ths));
 }
-EmberAfStatus SetCurrentPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionLiftPercent100ths::Id,
                                        (uint8_t *) &currentPositionLiftPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths)
+
+} // namespace CurrentPositionLiftPercent100ths
+
+namespace CurrentPositionTiltPercent100ths {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercent100ths::Id,
                                       (uint8_t *) currentPositionTiltPercent100ths, sizeof(*currentPositionTiltPercent100ths));
 }
-EmberAfStatus SetCurrentPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, CurrentPositionTiltPercent100ths::Id,
                                        (uint8_t *) &currentPositionTiltPercent100ths, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstalledOpenLimitLift(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift)
+
+} // namespace CurrentPositionTiltPercent100ths
+
+namespace InstalledOpenLimitLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitLift::Id, (uint8_t *) installedOpenLimitLift,
                                       sizeof(*installedOpenLimitLift));
 }
-EmberAfStatus SetInstalledOpenLimitLift(chip::EndpointId endpoint, uint16_t installedOpenLimitLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitLift::Id,
                                        (uint8_t *) &installedOpenLimitLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstalledClosedLimitLift(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift)
+
+} // namespace InstalledOpenLimitLift
+
+namespace InstalledClosedLimitLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitLift::Id,
                                       (uint8_t *) installedClosedLimitLift, sizeof(*installedClosedLimitLift));
 }
-EmberAfStatus SetInstalledClosedLimitLift(chip::EndpointId endpoint, uint16_t installedClosedLimitLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitLift::Id,
                                        (uint8_t *) &installedClosedLimitLift, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstalledOpenLimitTilt(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt)
+
+} // namespace InstalledClosedLimitLift
+
+namespace InstalledOpenLimitTilt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitTilt::Id, (uint8_t *) installedOpenLimitTilt,
                                       sizeof(*installedOpenLimitTilt));
 }
-EmberAfStatus SetInstalledOpenLimitTilt(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledOpenLimitTilt::Id,
                                        (uint8_t *) &installedOpenLimitTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstalledClosedLimitTilt(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt)
+
+} // namespace InstalledOpenLimitTilt
+
+namespace InstalledClosedLimitTilt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitTilt::Id,
                                       (uint8_t *) installedClosedLimitTilt, sizeof(*installedClosedLimitTilt));
 }
-EmberAfStatus SetInstalledClosedLimitTilt(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, InstalledClosedLimitTilt::Id,
                                        (uint8_t *) &installedClosedLimitTilt, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetVelocityLift(chip::EndpointId endpoint, uint16_t * velocityLift)
+
+} // namespace InstalledClosedLimitTilt
+
+namespace VelocityLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * velocityLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, VelocityLift::Id, (uint8_t *) velocityLift,
                                       sizeof(*velocityLift));
 }
-EmberAfStatus SetVelocityLift(chip::EndpointId endpoint, uint16_t velocityLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t velocityLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, VelocityLift::Id, (uint8_t *) &velocityLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAccelerationTimeLift(chip::EndpointId endpoint, uint16_t * accelerationTimeLift)
+
+} // namespace VelocityLift
+
+namespace AccelerationTimeLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * accelerationTimeLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, AccelerationTimeLift::Id, (uint8_t *) accelerationTimeLift,
                                       sizeof(*accelerationTimeLift));
 }
-EmberAfStatus SetAccelerationTimeLift(chip::EndpointId endpoint, uint16_t accelerationTimeLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t accelerationTimeLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, AccelerationTimeLift::Id, (uint8_t *) &accelerationTimeLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDecelerationTimeLift(chip::EndpointId endpoint, uint16_t * decelerationTimeLift)
+
+} // namespace AccelerationTimeLift
+
+namespace DecelerationTimeLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * decelerationTimeLift)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, DecelerationTimeLift::Id, (uint8_t *) decelerationTimeLift,
                                       sizeof(*decelerationTimeLift));
 }
-EmberAfStatus SetDecelerationTimeLift(chip::EndpointId endpoint, uint16_t decelerationTimeLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t decelerationTimeLift)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, DecelerationTimeLift::Id, (uint8_t *) &decelerationTimeLift,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMode(chip::EndpointId endpoint, uint8_t * mode)
+
+} // namespace DecelerationTimeLift
+
+namespace Mode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, Mode::Id, (uint8_t *) mode, sizeof(*mode));
 }
-EmberAfStatus SetMode(chip::EndpointId endpoint, uint8_t mode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, Mode::Id, (uint8_t *) &mode, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSafetyStatus(chip::EndpointId endpoint, uint16_t * safetyStatus)
+
+} // namespace Mode
+
+namespace SafetyStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * safetyStatus)
 {
     return emberAfReadServerAttribute(endpoint, WindowCovering::Id, SafetyStatus::Id, (uint8_t *) safetyStatus,
                                       sizeof(*safetyStatus));
 }
-EmberAfStatus SetSafetyStatus(chip::EndpointId endpoint, uint16_t safetyStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t safetyStatus)
 {
     return emberAfWriteServerAttribute(endpoint, WindowCovering::Id, SafetyStatus::Id, (uint8_t *) &safetyStatus,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
+
+} // namespace SafetyStatus
+
 } // namespace Attributes
 } // namespace WindowCovering
 
 namespace BarrierControl {
 namespace Attributes {
-EmberAfStatus GetBarrierMovingState(chip::EndpointId endpoint, uint8_t * barrierMovingState)
+
+namespace BarrierMovingState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierMovingState)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierMovingState::Id, (uint8_t *) barrierMovingState,
                                       sizeof(*barrierMovingState));
 }
-EmberAfStatus SetBarrierMovingState(chip::EndpointId endpoint, uint8_t barrierMovingState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierMovingState)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierMovingState::Id, (uint8_t *) &barrierMovingState,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierSafetyStatus(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus)
+
+} // namespace BarrierMovingState
+
+namespace BarrierSafetyStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierSafetyStatus::Id, (uint8_t *) barrierSafetyStatus,
                                       sizeof(*barrierSafetyStatus));
 }
-EmberAfStatus SetBarrierSafetyStatus(chip::EndpointId endpoint, uint16_t barrierSafetyStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierSafetyStatus)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierSafetyStatus::Id, (uint8_t *) &barrierSafetyStatus,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierCapabilities(chip::EndpointId endpoint, uint8_t * barrierCapabilities)
+
+} // namespace BarrierSafetyStatus
+
+namespace BarrierCapabilities {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierCapabilities)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCapabilities::Id, (uint8_t *) barrierCapabilities,
                                       sizeof(*barrierCapabilities));
 }
-EmberAfStatus SetBarrierCapabilities(chip::EndpointId endpoint, uint8_t barrierCapabilities)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierCapabilities)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCapabilities::Id, (uint8_t *) &barrierCapabilities,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierOpenEvents(chip::EndpointId endpoint, uint16_t * barrierOpenEvents)
+
+} // namespace BarrierCapabilities
+
+namespace BarrierOpenEvents {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenEvents)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierOpenEvents::Id, (uint8_t *) barrierOpenEvents,
                                       sizeof(*barrierOpenEvents));
 }
-EmberAfStatus SetBarrierOpenEvents(chip::EndpointId endpoint, uint16_t barrierOpenEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenEvents)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierOpenEvents::Id, (uint8_t *) &barrierOpenEvents,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierCloseEvents(chip::EndpointId endpoint, uint16_t * barrierCloseEvents)
+
+} // namespace BarrierOpenEvents
+
+namespace BarrierCloseEvents {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCloseEvents)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCloseEvents::Id, (uint8_t *) barrierCloseEvents,
                                       sizeof(*barrierCloseEvents));
 }
-EmberAfStatus SetBarrierCloseEvents(chip::EndpointId endpoint, uint16_t barrierCloseEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCloseEvents)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCloseEvents::Id, (uint8_t *) &barrierCloseEvents,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierCommandOpenEvents(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents)
+
+} // namespace BarrierCloseEvents
+
+namespace BarrierCommandOpenEvents {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCommandOpenEvents::Id,
                                       (uint8_t *) barrierCommandOpenEvents, sizeof(*barrierCommandOpenEvents));
 }
-EmberAfStatus SetBarrierCommandOpenEvents(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCommandOpenEvents::Id,
                                        (uint8_t *) &barrierCommandOpenEvents, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierCommandCloseEvents(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents)
+
+} // namespace BarrierCommandOpenEvents
+
+namespace BarrierCommandCloseEvents {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierCommandCloseEvents::Id,
                                       (uint8_t *) barrierCommandCloseEvents, sizeof(*barrierCommandCloseEvents));
 }
-EmberAfStatus SetBarrierCommandCloseEvents(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierCommandCloseEvents::Id,
                                        (uint8_t *) &barrierCommandCloseEvents, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierOpenPeriod(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod)
+
+} // namespace BarrierCommandCloseEvents
+
+namespace BarrierOpenPeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierOpenPeriod::Id, (uint8_t *) barrierOpenPeriod,
                                       sizeof(*barrierOpenPeriod));
 }
-EmberAfStatus SetBarrierOpenPeriod(chip::EndpointId endpoint, uint16_t barrierOpenPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenPeriod)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierOpenPeriod::Id, (uint8_t *) &barrierOpenPeriod,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierClosePeriod(chip::EndpointId endpoint, uint16_t * barrierClosePeriod)
+
+} // namespace BarrierOpenPeriod
+
+namespace BarrierClosePeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierClosePeriod)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierClosePeriod::Id, (uint8_t *) barrierClosePeriod,
                                       sizeof(*barrierClosePeriod));
 }
-EmberAfStatus SetBarrierClosePeriod(chip::EndpointId endpoint, uint16_t barrierClosePeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierClosePeriod)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierClosePeriod::Id, (uint8_t *) &barrierClosePeriod,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBarrierPosition(chip::EndpointId endpoint, uint8_t * barrierPosition)
+
+} // namespace BarrierClosePeriod
+
+namespace BarrierPosition {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierPosition)
 {
     return emberAfReadServerAttribute(endpoint, BarrierControl::Id, BarrierPosition::Id, (uint8_t *) barrierPosition,
                                       sizeof(*barrierPosition));
 }
-EmberAfStatus SetBarrierPosition(chip::EndpointId endpoint, uint8_t barrierPosition)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierPosition)
 {
     return emberAfWriteServerAttribute(endpoint, BarrierControl::Id, BarrierPosition::Id, (uint8_t *) &barrierPosition,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace BarrierPosition
+
 } // namespace Attributes
 } // namespace BarrierControl
 
 namespace PumpConfigurationAndControl {
 namespace Attributes {
-EmberAfStatus GetMaxPressure(chip::EndpointId endpoint, int16_t * maxPressure)
+
+namespace MaxPressure {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxPressure)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxPressure::Id, (uint8_t *) maxPressure,
                                       sizeof(*maxPressure));
 }
-EmberAfStatus SetMaxPressure(chip::EndpointId endpoint, int16_t maxPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxPressure)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxPressure::Id, (uint8_t *) &maxPressure,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxSpeed(chip::EndpointId endpoint, uint16_t * maxSpeed)
+
+} // namespace MaxPressure
+
+namespace MaxSpeed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxSpeed)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxSpeed::Id, (uint8_t *) maxSpeed,
                                       sizeof(*maxSpeed));
 }
-EmberAfStatus SetMaxSpeed(chip::EndpointId endpoint, uint16_t maxSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxSpeed)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxSpeed::Id, (uint8_t *) &maxSpeed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxFlow(chip::EndpointId endpoint, uint16_t * maxFlow)
+
+} // namespace MaxSpeed
+
+namespace MaxFlow {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxFlow)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxFlow::Id, (uint8_t *) maxFlow,
                                       sizeof(*maxFlow));
 }
-EmberAfStatus SetMaxFlow(chip::EndpointId endpoint, uint16_t maxFlow)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFlow)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxFlow::Id, (uint8_t *) &maxFlow,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinConstPressure(chip::EndpointId endpoint, int16_t * minConstPressure)
+
+} // namespace MaxFlow
+
+namespace MinConstPressure {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstPressure)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstPressure::Id, (uint8_t *) minConstPressure,
                                       sizeof(*minConstPressure));
 }
-EmberAfStatus SetMinConstPressure(chip::EndpointId endpoint, int16_t minConstPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstPressure)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstPressure::Id,
                                        (uint8_t *) &minConstPressure, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxConstPressure(chip::EndpointId endpoint, int16_t * maxConstPressure)
+
+} // namespace MinConstPressure
+
+namespace MaxConstPressure {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstPressure)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstPressure::Id, (uint8_t *) maxConstPressure,
                                       sizeof(*maxConstPressure));
 }
-EmberAfStatus SetMaxConstPressure(chip::EndpointId endpoint, int16_t maxConstPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstPressure)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstPressure::Id,
                                        (uint8_t *) &maxConstPressure, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinCompPressure(chip::EndpointId endpoint, int16_t * minCompPressure)
+
+} // namespace MaxConstPressure
+
+namespace MinCompPressure {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCompPressure)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinCompPressure::Id, (uint8_t *) minCompPressure,
                                       sizeof(*minCompPressure));
 }
-EmberAfStatus SetMinCompPressure(chip::EndpointId endpoint, int16_t minCompPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCompPressure)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinCompPressure::Id, (uint8_t *) &minCompPressure,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxCompPressure(chip::EndpointId endpoint, int16_t * maxCompPressure)
+
+} // namespace MinCompPressure
+
+namespace MaxCompPressure {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCompPressure)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxCompPressure::Id, (uint8_t *) maxCompPressure,
                                       sizeof(*maxCompPressure));
 }
-EmberAfStatus SetMaxCompPressure(chip::EndpointId endpoint, int16_t maxCompPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCompPressure)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxCompPressure::Id, (uint8_t *) &maxCompPressure,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinConstSpeed(chip::EndpointId endpoint, uint16_t * minConstSpeed)
+
+} // namespace MaxCompPressure
+
+namespace MinConstSpeed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstSpeed)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstSpeed::Id, (uint8_t *) minConstSpeed,
                                       sizeof(*minConstSpeed));
 }
-EmberAfStatus SetMinConstSpeed(chip::EndpointId endpoint, uint16_t minConstSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstSpeed)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstSpeed::Id, (uint8_t *) &minConstSpeed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxConstSpeed(chip::EndpointId endpoint, uint16_t * maxConstSpeed)
+
+} // namespace MinConstSpeed
+
+namespace MaxConstSpeed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstSpeed)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstSpeed::Id, (uint8_t *) maxConstSpeed,
                                       sizeof(*maxConstSpeed));
 }
-EmberAfStatus SetMaxConstSpeed(chip::EndpointId endpoint, uint16_t maxConstSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstSpeed)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstSpeed::Id, (uint8_t *) &maxConstSpeed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinConstFlow(chip::EndpointId endpoint, uint16_t * minConstFlow)
+
+} // namespace MaxConstSpeed
+
+namespace MinConstFlow {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstFlow)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstFlow::Id, (uint8_t *) minConstFlow,
                                       sizeof(*minConstFlow));
 }
-EmberAfStatus SetMinConstFlow(chip::EndpointId endpoint, uint16_t minConstFlow)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstFlow)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstFlow::Id, (uint8_t *) &minConstFlow,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxConstFlow(chip::EndpointId endpoint, uint16_t * maxConstFlow)
+
+} // namespace MinConstFlow
+
+namespace MaxConstFlow {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstFlow)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstFlow::Id, (uint8_t *) maxConstFlow,
                                       sizeof(*maxConstFlow));
 }
-EmberAfStatus SetMaxConstFlow(chip::EndpointId endpoint, uint16_t maxConstFlow)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstFlow)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstFlow::Id, (uint8_t *) &maxConstFlow,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinConstTemp(chip::EndpointId endpoint, int16_t * minConstTemp)
+
+} // namespace MaxConstFlow
+
+namespace MinConstTemp {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstTemp)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstTemp::Id, (uint8_t *) minConstTemp,
                                       sizeof(*minConstTemp));
 }
-EmberAfStatus SetMinConstTemp(chip::EndpointId endpoint, int16_t minConstTemp)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstTemp)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MinConstTemp::Id, (uint8_t *) &minConstTemp,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxConstTemp(chip::EndpointId endpoint, int16_t * maxConstTemp)
+
+} // namespace MinConstTemp
+
+namespace MaxConstTemp {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstTemp)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstTemp::Id, (uint8_t *) maxConstTemp,
                                       sizeof(*maxConstTemp));
 }
-EmberAfStatus SetMaxConstTemp(chip::EndpointId endpoint, int16_t maxConstTemp)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstTemp)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, MaxConstTemp::Id, (uint8_t *) &maxConstTemp,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPumpStatus(chip::EndpointId endpoint, uint16_t * pumpStatus)
+
+} // namespace MaxConstTemp
+
+namespace PumpStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pumpStatus)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, PumpStatus::Id, (uint8_t *) pumpStatus,
                                       sizeof(*pumpStatus));
 }
-EmberAfStatus SetPumpStatus(chip::EndpointId endpoint, uint16_t pumpStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pumpStatus)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, PumpStatus::Id, (uint8_t *) &pumpStatus,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEffectiveOperationMode(chip::EndpointId endpoint, uint8_t * effectiveOperationMode)
+
+} // namespace PumpStatus
+
+namespace EffectiveOperationMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveOperationMode)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveOperationMode::Id,
                                       (uint8_t *) effectiveOperationMode, sizeof(*effectiveOperationMode));
 }
-EmberAfStatus SetEffectiveOperationMode(chip::EndpointId endpoint, uint8_t effectiveOperationMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveOperationMode)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveOperationMode::Id,
                                        (uint8_t *) &effectiveOperationMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEffectiveControlMode(chip::EndpointId endpoint, uint8_t * effectiveControlMode)
+
+} // namespace EffectiveOperationMode
+
+namespace EffectiveControlMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveControlMode)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveControlMode::Id,
                                       (uint8_t *) effectiveControlMode, sizeof(*effectiveControlMode));
 }
-EmberAfStatus SetEffectiveControlMode(chip::EndpointId endpoint, uint8_t effectiveControlMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveControlMode)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, EffectiveControlMode::Id,
                                        (uint8_t *) &effectiveControlMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCapacity(chip::EndpointId endpoint, int16_t * capacity)
+
+} // namespace EffectiveControlMode
+
+namespace Capacity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * capacity)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Capacity::Id, (uint8_t *) capacity,
                                       sizeof(*capacity));
 }
-EmberAfStatus SetCapacity(chip::EndpointId endpoint, int16_t capacity)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t capacity)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Capacity::Id, (uint8_t *) &capacity,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSpeed(chip::EndpointId endpoint, uint16_t * speed)
+
+} // namespace Capacity
+
+namespace Speed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * speed)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, Speed::Id, (uint8_t *) speed, sizeof(*speed));
 }
-EmberAfStatus SetSpeed(chip::EndpointId endpoint, uint16_t speed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t speed)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, Speed::Id, (uint8_t *) &speed,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLifetimeEnergyConsumed(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed)
+
+} // namespace Speed
+
+namespace LifetimeEnergyConsumed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, LifetimeEnergyConsumed::Id,
                                       (uint8_t *) lifetimeEnergyConsumed, sizeof(*lifetimeEnergyConsumed));
 }
-EmberAfStatus SetLifetimeEnergyConsumed(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, LifetimeEnergyConsumed::Id,
                                        (uint8_t *) &lifetimeEnergyConsumed, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOperationMode(chip::EndpointId endpoint, uint8_t * operationMode)
+
+} // namespace LifetimeEnergyConsumed
+
+namespace OperationMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationMode)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, OperationMode::Id, (uint8_t *) operationMode,
                                       sizeof(*operationMode));
 }
-EmberAfStatus SetOperationMode(chip::EndpointId endpoint, uint8_t operationMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationMode)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, OperationMode::Id, (uint8_t *) &operationMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetControlMode(chip::EndpointId endpoint, uint8_t * controlMode)
+
+} // namespace OperationMode
+
+namespace ControlMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlMode)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, ControlMode::Id, (uint8_t *) controlMode,
                                       sizeof(*controlMode));
 }
-EmberAfStatus SetControlMode(chip::EndpointId endpoint, uint8_t controlMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlMode)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, ControlMode::Id, (uint8_t *) &controlMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask)
+
+} // namespace ControlMode
+
+namespace AlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask)
 {
     return emberAfReadServerAttribute(endpoint, PumpConfigurationAndControl::Id, AlarmMask::Id, (uint8_t *) alarmMask,
                                       sizeof(*alarmMask));
 }
-EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint16_t alarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, PumpConfigurationAndControl::Id, AlarmMask::Id, (uint8_t *) &alarmMask,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
+
+} // namespace AlarmMask
+
 } // namespace Attributes
 } // namespace PumpConfigurationAndControl
 
 namespace Thermostat {
 namespace Attributes {
-EmberAfStatus GetLocalTemperature(chip::EndpointId endpoint, int16_t * localTemperature)
+
+namespace LocalTemperature {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * localTemperature)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, LocalTemperature::Id, (uint8_t *) localTemperature,
                                       sizeof(*localTemperature));
 }
-EmberAfStatus SetLocalTemperature(chip::EndpointId endpoint, int16_t localTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t localTemperature)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, LocalTemperature::Id, (uint8_t *) &localTemperature,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOutdoorTemperature(chip::EndpointId endpoint, int16_t * outdoorTemperature)
+
+} // namespace LocalTemperature
+
+namespace OutdoorTemperature {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * outdoorTemperature)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, OutdoorTemperature::Id, (uint8_t *) outdoorTemperature,
                                       sizeof(*outdoorTemperature));
 }
-EmberAfStatus SetOutdoorTemperature(chip::EndpointId endpoint, int16_t outdoorTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t outdoorTemperature)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, OutdoorTemperature::Id, (uint8_t *) &outdoorTemperature,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOccupancy(chip::EndpointId endpoint, uint8_t * occupancy)
+
+} // namespace OutdoorTemperature
+
+namespace Occupancy {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, Occupancy::Id, (uint8_t *) occupancy, sizeof(*occupancy));
 }
-EmberAfStatus SetOccupancy(chip::EndpointId endpoint, uint8_t occupancy)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, Occupancy::Id, (uint8_t *) &occupancy, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAbsMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit)
+
+} // namespace Occupancy
+
+namespace AbsMinHeatSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMinHeatSetpointLimit::Id, (uint8_t *) absMinHeatSetpointLimit,
                                       sizeof(*absMinHeatSetpointLimit));
 }
-EmberAfStatus SetAbsMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMinHeatSetpointLimit::Id, (uint8_t *) &absMinHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAbsMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit)
+
+} // namespace AbsMinHeatSetpointLimit
+
+namespace AbsMaxHeatSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMaxHeatSetpointLimit::Id, (uint8_t *) absMaxHeatSetpointLimit,
                                       sizeof(*absMaxHeatSetpointLimit));
 }
-EmberAfStatus SetAbsMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMaxHeatSetpointLimit::Id, (uint8_t *) &absMaxHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAbsMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit)
+
+} // namespace AbsMaxHeatSetpointLimit
+
+namespace AbsMinCoolSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMinCoolSetpointLimit::Id, (uint8_t *) absMinCoolSetpointLimit,
                                       sizeof(*absMinCoolSetpointLimit));
 }
-EmberAfStatus SetAbsMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMinCoolSetpointLimit::Id, (uint8_t *) &absMinCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAbsMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit)
+
+} // namespace AbsMinCoolSetpointLimit
+
+namespace AbsMaxCoolSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AbsMaxCoolSetpointLimit::Id, (uint8_t *) absMaxCoolSetpointLimit,
                                       sizeof(*absMaxCoolSetpointLimit));
 }
-EmberAfStatus SetAbsMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AbsMaxCoolSetpointLimit::Id, (uint8_t *) &absMaxCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPiCoolingDemand(chip::EndpointId endpoint, uint8_t * piCoolingDemand)
+
+} // namespace AbsMaxCoolSetpointLimit
+
+namespace PiCoolingDemand {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piCoolingDemand)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, PiCoolingDemand::Id, (uint8_t *) piCoolingDemand,
                                       sizeof(*piCoolingDemand));
 }
-EmberAfStatus SetPiCoolingDemand(chip::EndpointId endpoint, uint8_t piCoolingDemand)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piCoolingDemand)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, PiCoolingDemand::Id, (uint8_t *) &piCoolingDemand,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPiHeatingDemand(chip::EndpointId endpoint, uint8_t * piHeatingDemand)
+
+} // namespace PiCoolingDemand
+
+namespace PiHeatingDemand {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piHeatingDemand)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, PiHeatingDemand::Id, (uint8_t *) piHeatingDemand,
                                       sizeof(*piHeatingDemand));
 }
-EmberAfStatus SetPiHeatingDemand(chip::EndpointId endpoint, uint8_t piHeatingDemand)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piHeatingDemand)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, PiHeatingDemand::Id, (uint8_t *) &piHeatingDemand,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetHvacSystemTypeConfiguration(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration)
+
+} // namespace PiHeatingDemand
+
+namespace HvacSystemTypeConfiguration {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, HvacSystemTypeConfiguration::Id,
                                       (uint8_t *) hvacSystemTypeConfiguration, sizeof(*hvacSystemTypeConfiguration));
 }
-EmberAfStatus SetHvacSystemTypeConfiguration(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, HvacSystemTypeConfiguration::Id,
                                        (uint8_t *) &hvacSystemTypeConfiguration, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLocalTemperatureCalibration(chip::EndpointId endpoint, int8_t * localTemperatureCalibration)
+
+} // namespace HvacSystemTypeConfiguration
+
+namespace LocalTemperatureCalibration {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * localTemperatureCalibration)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, LocalTemperatureCalibration::Id,
                                       (uint8_t *) localTemperatureCalibration, sizeof(*localTemperatureCalibration));
 }
-EmberAfStatus SetLocalTemperatureCalibration(chip::EndpointId endpoint, int8_t localTemperatureCalibration)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t localTemperatureCalibration)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, LocalTemperatureCalibration::Id,
                                        (uint8_t *) &localTemperatureCalibration, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint)
+
+} // namespace LocalTemperatureCalibration
+
+namespace OccupiedCoolingSetpoint {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id, (uint8_t *) occupiedCoolingSetpoint,
                                       sizeof(*occupiedCoolingSetpoint));
 }
-EmberAfStatus SetOccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id, (uint8_t *) &occupiedCoolingSetpoint,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint)
+
+} // namespace OccupiedCoolingSetpoint
+
+namespace OccupiedHeatingSetpoint {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id, (uint8_t *) occupiedHeatingSetpoint,
                                       sizeof(*occupiedHeatingSetpoint));
 }
-EmberAfStatus SetOccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id, (uint8_t *) &occupiedHeatingSetpoint,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUnoccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint)
+
+} // namespace OccupiedHeatingSetpoint
+
+namespace UnoccupiedCoolingSetpoint {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, UnoccupiedCoolingSetpoint::Id,
                                       (uint8_t *) unoccupiedCoolingSetpoint, sizeof(*unoccupiedCoolingSetpoint));
 }
-EmberAfStatus SetUnoccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, UnoccupiedCoolingSetpoint::Id,
                                        (uint8_t *) &unoccupiedCoolingSetpoint, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUnoccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint)
+
+} // namespace UnoccupiedCoolingSetpoint
+
+namespace UnoccupiedHeatingSetpoint {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, UnoccupiedHeatingSetpoint::Id,
                                       (uint8_t *) unoccupiedHeatingSetpoint, sizeof(*unoccupiedHeatingSetpoint));
 }
-EmberAfStatus SetUnoccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, UnoccupiedHeatingSetpoint::Id,
                                        (uint8_t *) &unoccupiedHeatingSetpoint, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit)
+
+} // namespace UnoccupiedHeatingSetpoint
+
+namespace MinHeatSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, MinHeatSetpointLimit::Id, (uint8_t *) minHeatSetpointLimit,
                                       sizeof(*minHeatSetpointLimit));
 }
-EmberAfStatus SetMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t minHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minHeatSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MinHeatSetpointLimit::Id, (uint8_t *) &minHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit)
+
+} // namespace MinHeatSetpointLimit
+
+namespace MaxHeatSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, MaxHeatSetpointLimit::Id, (uint8_t *) maxHeatSetpointLimit,
                                       sizeof(*maxHeatSetpointLimit));
 }
-EmberAfStatus SetMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MaxHeatSetpointLimit::Id, (uint8_t *) &maxHeatSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit)
+
+} // namespace MaxHeatSetpointLimit
+
+namespace MinCoolSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, MinCoolSetpointLimit::Id, (uint8_t *) minCoolSetpointLimit,
                                       sizeof(*minCoolSetpointLimit));
 }
-EmberAfStatus SetMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t minCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCoolSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MinCoolSetpointLimit::Id, (uint8_t *) &minCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit)
+
+} // namespace MinCoolSetpointLimit
+
+namespace MaxCoolSetpointLimit {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, MaxCoolSetpointLimit::Id, (uint8_t *) maxCoolSetpointLimit,
                                       sizeof(*maxCoolSetpointLimit));
 }
-EmberAfStatus SetMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MaxCoolSetpointLimit::Id, (uint8_t *) &maxCoolSetpointLimit,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinSetpointDeadBand(chip::EndpointId endpoint, int8_t * minSetpointDeadBand)
+
+} // namespace MaxCoolSetpointLimit
+
+namespace MinSetpointDeadBand {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * minSetpointDeadBand)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, MinSetpointDeadBand::Id, (uint8_t *) minSetpointDeadBand,
                                       sizeof(*minSetpointDeadBand));
 }
-EmberAfStatus SetMinSetpointDeadBand(chip::EndpointId endpoint, int8_t minSetpointDeadBand)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t minSetpointDeadBand)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, MinSetpointDeadBand::Id, (uint8_t *) &minSetpointDeadBand,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRemoteSensing(chip::EndpointId endpoint, uint8_t * remoteSensing)
+
+} // namespace MinSetpointDeadBand
+
+namespace RemoteSensing {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * remoteSensing)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, RemoteSensing::Id, (uint8_t *) remoteSensing,
                                       sizeof(*remoteSensing));
 }
-EmberAfStatus SetRemoteSensing(chip::EndpointId endpoint, uint8_t remoteSensing)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t remoteSensing)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, RemoteSensing::Id, (uint8_t *) &remoteSensing,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetControlSequenceOfOperation(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation)
+
+} // namespace RemoteSensing
+
+namespace ControlSequenceOfOperation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, ControlSequenceOfOperation::Id,
                                       (uint8_t *) controlSequenceOfOperation, sizeof(*controlSequenceOfOperation));
 }
-EmberAfStatus SetControlSequenceOfOperation(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, ControlSequenceOfOperation::Id,
                                        (uint8_t *) &controlSequenceOfOperation, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSystemMode(chip::EndpointId endpoint, uint8_t * systemMode)
+
+} // namespace ControlSequenceOfOperation
+
+namespace SystemMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * systemMode)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, SystemMode::Id, (uint8_t *) systemMode, sizeof(*systemMode));
 }
-EmberAfStatus SetSystemMode(chip::EndpointId endpoint, uint8_t systemMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t systemMode)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SystemMode::Id, (uint8_t *) &systemMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint8_t * alarmMask)
+
+} // namespace SystemMode
+
+namespace AlarmMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * alarmMask)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AlarmMask::Id, (uint8_t *) alarmMask, sizeof(*alarmMask));
 }
-EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint8_t alarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t alarmMask)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AlarmMask::Id, (uint8_t *) &alarmMask, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetThermostatRunningMode(chip::EndpointId endpoint, uint8_t * thermostatRunningMode)
+
+} // namespace AlarmMask
+
+namespace ThermostatRunningMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatRunningMode)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, ThermostatRunningMode::Id, (uint8_t *) thermostatRunningMode,
                                       sizeof(*thermostatRunningMode));
 }
-EmberAfStatus SetThermostatRunningMode(chip::EndpointId endpoint, uint8_t thermostatRunningMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatRunningMode)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, ThermostatRunningMode::Id, (uint8_t *) &thermostatRunningMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStartOfWeek(chip::EndpointId endpoint, uint8_t * startOfWeek)
+
+} // namespace ThermostatRunningMode
+
+namespace StartOfWeek {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startOfWeek)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, StartOfWeek::Id, (uint8_t *) startOfWeek, sizeof(*startOfWeek));
 }
-EmberAfStatus SetStartOfWeek(chip::EndpointId endpoint, uint8_t startOfWeek)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startOfWeek)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, StartOfWeek::Id, (uint8_t *) &startOfWeek,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumberOfWeeklyTransitions(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions)
+
+} // namespace StartOfWeek
+
+namespace NumberOfWeeklyTransitions {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, NumberOfWeeklyTransitions::Id,
                                       (uint8_t *) numberOfWeeklyTransitions, sizeof(*numberOfWeeklyTransitions));
 }
-EmberAfStatus SetNumberOfWeeklyTransitions(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, NumberOfWeeklyTransitions::Id,
                                        (uint8_t *) &numberOfWeeklyTransitions, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumberOfDailyTransitions(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions)
+
+} // namespace NumberOfWeeklyTransitions
+
+namespace NumberOfDailyTransitions {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, NumberOfDailyTransitions::Id, (uint8_t *) numberOfDailyTransitions,
                                       sizeof(*numberOfDailyTransitions));
 }
-EmberAfStatus SetNumberOfDailyTransitions(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, NumberOfDailyTransitions::Id,
                                        (uint8_t *) &numberOfDailyTransitions, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTemperatureSetpointHold(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold)
+
+} // namespace NumberOfDailyTransitions
+
+namespace TemperatureSetpointHold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHold::Id, (uint8_t *) temperatureSetpointHold,
                                       sizeof(*temperatureSetpointHold));
 }
-EmberAfStatus SetTemperatureSetpointHold(chip::EndpointId endpoint, uint8_t temperatureSetpointHold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureSetpointHold)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHold::Id, (uint8_t *) &temperatureSetpointHold,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTemperatureSetpointHoldDuration(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration)
+
+} // namespace TemperatureSetpointHold
+
+namespace TemperatureSetpointHoldDuration {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHoldDuration::Id,
                                       (uint8_t *) temperatureSetpointHoldDuration, sizeof(*temperatureSetpointHoldDuration));
 }
-EmberAfStatus SetTemperatureSetpointHoldDuration(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, TemperatureSetpointHoldDuration::Id,
                                        (uint8_t *) &temperatureSetpointHoldDuration, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetThermostatProgrammingOperationMode(chip::EndpointId endpoint, uint8_t * thermostatProgrammingOperationMode)
+
+} // namespace TemperatureSetpointHoldDuration
+
+namespace ThermostatProgrammingOperationMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatProgrammingOperationMode)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, ThermostatProgrammingOperationMode::Id,
                                       (uint8_t *) thermostatProgrammingOperationMode, sizeof(*thermostatProgrammingOperationMode));
 }
-EmberAfStatus SetThermostatProgrammingOperationMode(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, ThermostatProgrammingOperationMode::Id,
                                        (uint8_t *) &thermostatProgrammingOperationMode, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetHvacRelayState(chip::EndpointId endpoint, uint16_t * hvacRelayState)
+
+} // namespace ThermostatProgrammingOperationMode
+
+namespace HvacRelayState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hvacRelayState)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, HvacRelayState::Id, (uint8_t *) hvacRelayState,
                                       sizeof(*hvacRelayState));
 }
-EmberAfStatus SetHvacRelayState(chip::EndpointId endpoint, uint16_t hvacRelayState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hvacRelayState)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, HvacRelayState::Id, (uint8_t *) &hvacRelayState,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSetpointChangeSource(chip::EndpointId endpoint, uint8_t * setpointChangeSource)
+
+} // namespace HvacRelayState
+
+namespace SetpointChangeSource {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * setpointChangeSource)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, SetpointChangeSource::Id, (uint8_t *) setpointChangeSource,
                                       sizeof(*setpointChangeSource));
 }
-EmberAfStatus SetSetpointChangeSource(chip::EndpointId endpoint, uint8_t setpointChangeSource)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t setpointChangeSource)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SetpointChangeSource::Id, (uint8_t *) &setpointChangeSource,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSetpointChangeAmount(chip::EndpointId endpoint, int16_t * setpointChangeAmount)
+
+} // namespace SetpointChangeSource
+
+namespace SetpointChangeAmount {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * setpointChangeAmount)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, SetpointChangeAmount::Id, (uint8_t *) setpointChangeAmount,
                                       sizeof(*setpointChangeAmount));
 }
-EmberAfStatus SetSetpointChangeAmount(chip::EndpointId endpoint, int16_t setpointChangeAmount)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t setpointChangeAmount)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SetpointChangeAmount::Id, (uint8_t *) &setpointChangeAmount,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSetpointChangeSourceTimestamp(chip::EndpointId endpoint,
-                                               /* TYPE WARNING: utc defaults to */ uint8_t ** setpointChangeSourceTimestamp)
+
+} // namespace SetpointChangeAmount
+
+namespace SetpointChangeSourceTimestamp {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** setpointChangeSourceTimestamp)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, SetpointChangeSourceTimestamp::Id,
                                       (uint8_t *) setpointChangeSourceTimestamp, sizeof(*setpointChangeSourceTimestamp));
 }
-EmberAfStatus SetSetpointChangeSourceTimestamp(chip::EndpointId endpoint,
-                                               /* TYPE WARNING: utc defaults to */ uint8_t * setpointChangeSourceTimestamp)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * setpointChangeSourceTimestamp)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, SetpointChangeSourceTimestamp::Id,
                                        (uint8_t *) &setpointChangeSourceTimestamp, ZCL_UTC_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcType(chip::EndpointId endpoint, uint8_t * acType)
+
+} // namespace SetpointChangeSourceTimestamp
+
+namespace AcType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acType)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcType::Id, (uint8_t *) acType, sizeof(*acType));
 }
-EmberAfStatus SetAcType(chip::EndpointId endpoint, uint8_t acType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acType)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcType::Id, (uint8_t *) &acType, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCapacity(chip::EndpointId endpoint, uint16_t * acCapacity)
+
+} // namespace AcType
+
+namespace AcCapacity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCapacity)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCapacity::Id, (uint8_t *) acCapacity, sizeof(*acCapacity));
 }
-EmberAfStatus SetAcCapacity(chip::EndpointId endpoint, uint16_t acCapacity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCapacity)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCapacity::Id, (uint8_t *) &acCapacity,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcRefrigerantType(chip::EndpointId endpoint, uint8_t * acRefrigerantType)
+
+} // namespace AcCapacity
+
+namespace AcRefrigerantType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acRefrigerantType)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcRefrigerantType::Id, (uint8_t *) acRefrigerantType,
                                       sizeof(*acRefrigerantType));
 }
-EmberAfStatus SetAcRefrigerantType(chip::EndpointId endpoint, uint8_t acRefrigerantType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acRefrigerantType)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcRefrigerantType::Id, (uint8_t *) &acRefrigerantType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCompressor(chip::EndpointId endpoint, uint8_t * acCompressor)
+
+} // namespace AcRefrigerantType
+
+namespace AcCompressor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCompressor)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCompressor::Id, (uint8_t *) acCompressor, sizeof(*acCompressor));
 }
-EmberAfStatus SetAcCompressor(chip::EndpointId endpoint, uint8_t acCompressor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCompressor)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCompressor::Id, (uint8_t *) &acCompressor,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcErrorCode(chip::EndpointId endpoint, uint32_t * acErrorCode)
+
+} // namespace AcCompressor
+
+namespace AcErrorCode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * acErrorCode)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcErrorCode::Id, (uint8_t *) acErrorCode, sizeof(*acErrorCode));
 }
-EmberAfStatus SetAcErrorCode(chip::EndpointId endpoint, uint32_t acErrorCode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t acErrorCode)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcErrorCode::Id, (uint8_t *) &acErrorCode,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcLouverPosition(chip::EndpointId endpoint, uint8_t * acLouverPosition)
+
+} // namespace AcErrorCode
+
+namespace AcLouverPosition {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acLouverPosition)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcLouverPosition::Id, (uint8_t *) acLouverPosition,
                                       sizeof(*acLouverPosition));
 }
-EmberAfStatus SetAcLouverPosition(chip::EndpointId endpoint, uint8_t acLouverPosition)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acLouverPosition)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcLouverPosition::Id, (uint8_t *) &acLouverPosition,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCoilTemperature(chip::EndpointId endpoint, int16_t * acCoilTemperature)
+
+} // namespace AcLouverPosition
+
+namespace AcCoilTemperature {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCoilTemperature)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCoilTemperature::Id, (uint8_t *) acCoilTemperature,
                                       sizeof(*acCoilTemperature));
 }
-EmberAfStatus SetAcCoilTemperature(chip::EndpointId endpoint, int16_t acCoilTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCoilTemperature)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCoilTemperature::Id, (uint8_t *) &acCoilTemperature,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCapacityFormat(chip::EndpointId endpoint, uint8_t * acCapacityFormat)
+
+} // namespace AcCoilTemperature
+
+namespace AcCapacityFormat {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCapacityFormat)
 {
     return emberAfReadServerAttribute(endpoint, Thermostat::Id, AcCapacityFormat::Id, (uint8_t *) acCapacityFormat,
                                       sizeof(*acCapacityFormat));
 }
-EmberAfStatus SetAcCapacityFormat(chip::EndpointId endpoint, uint8_t acCapacityFormat)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCapacityFormat)
 {
     return emberAfWriteServerAttribute(endpoint, Thermostat::Id, AcCapacityFormat::Id, (uint8_t *) &acCapacityFormat,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace AcCapacityFormat
+
 } // namespace Attributes
 } // namespace Thermostat
 
 namespace FanControl {
 namespace Attributes {
-EmberAfStatus GetFanMode(chip::EndpointId endpoint, uint8_t * fanMode)
+
+namespace FanMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanMode)
 {
     return emberAfReadServerAttribute(endpoint, FanControl::Id, FanMode::Id, (uint8_t *) fanMode, sizeof(*fanMode));
 }
-EmberAfStatus SetFanMode(chip::EndpointId endpoint, uint8_t fanMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanMode)
 {
     return emberAfWriteServerAttribute(endpoint, FanControl::Id, FanMode::Id, (uint8_t *) &fanMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetFanModeSequence(chip::EndpointId endpoint, uint8_t * fanModeSequence)
+
+} // namespace FanMode
+
+namespace FanModeSequence {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanModeSequence)
 {
     return emberAfReadServerAttribute(endpoint, FanControl::Id, FanModeSequence::Id, (uint8_t *) fanModeSequence,
                                       sizeof(*fanModeSequence));
 }
-EmberAfStatus SetFanModeSequence(chip::EndpointId endpoint, uint8_t fanModeSequence)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanModeSequence)
 {
     return emberAfWriteServerAttribute(endpoint, FanControl::Id, FanModeSequence::Id, (uint8_t *) &fanModeSequence,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace FanModeSequence
+
 } // namespace Attributes
 } // namespace FanControl
 
 namespace DehumidificationControl {
 namespace Attributes {
-EmberAfStatus GetRelativeHumidity(chip::EndpointId endpoint, uint8_t * relativeHumidity)
+
+namespace RelativeHumidity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidity)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidity::Id, (uint8_t *) relativeHumidity,
                                       sizeof(*relativeHumidity));
 }
-EmberAfStatus SetRelativeHumidity(chip::EndpointId endpoint, uint8_t relativeHumidity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidity)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidity::Id, (uint8_t *) &relativeHumidity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDehumidificationCooling(chip::EndpointId endpoint, uint8_t * dehumidificationCooling)
+
+} // namespace RelativeHumidity
+
+namespace DehumidificationCooling {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationCooling)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationCooling::Id,
                                       (uint8_t *) dehumidificationCooling, sizeof(*dehumidificationCooling));
 }
-EmberAfStatus SetDehumidificationCooling(chip::EndpointId endpoint, uint8_t dehumidificationCooling)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationCooling)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationCooling::Id,
                                        (uint8_t *) &dehumidificationCooling, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRhDehumidificationSetpoint(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint)
+
+} // namespace DehumidificationCooling
+
+namespace RhDehumidificationSetpoint {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RhDehumidificationSetpoint::Id,
                                       (uint8_t *) rhDehumidificationSetpoint, sizeof(*rhDehumidificationSetpoint));
 }
-EmberAfStatus SetRhDehumidificationSetpoint(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RhDehumidificationSetpoint::Id,
                                        (uint8_t *) &rhDehumidificationSetpoint, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRelativeHumidityMode(chip::EndpointId endpoint, uint8_t * relativeHumidityMode)
+
+} // namespace RhDehumidificationSetpoint
+
+namespace RelativeHumidityMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityMode)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityMode::Id,
                                       (uint8_t *) relativeHumidityMode, sizeof(*relativeHumidityMode));
 }
-EmberAfStatus SetRelativeHumidityMode(chip::EndpointId endpoint, uint8_t relativeHumidityMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityMode)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityMode::Id,
                                        (uint8_t *) &relativeHumidityMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDehumidificationLockout(chip::EndpointId endpoint, uint8_t * dehumidificationLockout)
+
+} // namespace RelativeHumidityMode
+
+namespace DehumidificationLockout {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationLockout)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationLockout::Id,
                                       (uint8_t *) dehumidificationLockout, sizeof(*dehumidificationLockout));
 }
-EmberAfStatus SetDehumidificationLockout(chip::EndpointId endpoint, uint8_t dehumidificationLockout)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationLockout)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationLockout::Id,
                                        (uint8_t *) &dehumidificationLockout, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDehumidificationHysteresis(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis)
+
+} // namespace DehumidificationLockout
+
+namespace DehumidificationHysteresis {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationHysteresis::Id,
                                       (uint8_t *) dehumidificationHysteresis, sizeof(*dehumidificationHysteresis));
 }
-EmberAfStatus SetDehumidificationHysteresis(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationHysteresis::Id,
                                        (uint8_t *) &dehumidificationHysteresis, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDehumidificationMaxCool(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool)
+
+} // namespace DehumidificationHysteresis
+
+namespace DehumidificationMaxCool {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationMaxCool::Id,
                                       (uint8_t *) dehumidificationMaxCool, sizeof(*dehumidificationMaxCool));
 }
-EmberAfStatus SetDehumidificationMaxCool(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, DehumidificationMaxCool::Id,
                                        (uint8_t *) &dehumidificationMaxCool, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRelativeHumidityDisplay(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay)
+
+} // namespace DehumidificationMaxCool
+
+namespace RelativeHumidityDisplay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay)
 {
     return emberAfReadServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityDisplay::Id,
                                       (uint8_t *) relativeHumidityDisplay, sizeof(*relativeHumidityDisplay));
 }
-EmberAfStatus SetRelativeHumidityDisplay(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay)
 {
     return emberAfWriteServerAttribute(endpoint, DehumidificationControl::Id, RelativeHumidityDisplay::Id,
                                        (uint8_t *) &relativeHumidityDisplay, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace RelativeHumidityDisplay
+
 } // namespace Attributes
 } // namespace DehumidificationControl
 
 namespace ThermostatUserInterfaceConfiguration {
 namespace Attributes {
-EmberAfStatus GetTemperatureDisplayMode(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode)
+
+namespace TemperatureDisplayMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode)
 {
     return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, TemperatureDisplayMode::Id,
                                       (uint8_t *) temperatureDisplayMode, sizeof(*temperatureDisplayMode));
 }
-EmberAfStatus SetTemperatureDisplayMode(chip::EndpointId endpoint, uint8_t temperatureDisplayMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureDisplayMode)
 {
     return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, TemperatureDisplayMode::Id,
                                        (uint8_t *) &temperatureDisplayMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetKeypadLockout(chip::EndpointId endpoint, uint8_t * keypadLockout)
+
+} // namespace TemperatureDisplayMode
+
+namespace KeypadLockout {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * keypadLockout)
 {
     return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, KeypadLockout::Id,
                                       (uint8_t *) keypadLockout, sizeof(*keypadLockout));
 }
-EmberAfStatus SetKeypadLockout(chip::EndpointId endpoint, uint8_t keypadLockout)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t keypadLockout)
 {
     return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, KeypadLockout::Id,
                                        (uint8_t *) &keypadLockout, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetScheduleProgrammingVisibility(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility)
+
+} // namespace KeypadLockout
+
+namespace ScheduleProgrammingVisibility {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility)
 {
     return emberAfReadServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, ScheduleProgrammingVisibility::Id,
                                       (uint8_t *) scheduleProgrammingVisibility, sizeof(*scheduleProgrammingVisibility));
 }
-EmberAfStatus SetScheduleProgrammingVisibility(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility)
 {
     return emberAfWriteServerAttribute(endpoint, ThermostatUserInterfaceConfiguration::Id, ScheduleProgrammingVisibility::Id,
                                        (uint8_t *) &scheduleProgrammingVisibility, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace ScheduleProgrammingVisibility
+
 } // namespace Attributes
 } // namespace ThermostatUserInterfaceConfiguration
 
 namespace ColorControl {
 namespace Attributes {
-EmberAfStatus GetCurrentHue(chip::EndpointId endpoint, uint8_t * currentHue)
+
+namespace CurrentHue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentHue)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentHue::Id, (uint8_t *) currentHue, sizeof(*currentHue));
 }
-EmberAfStatus SetCurrentHue(chip::EndpointId endpoint, uint8_t currentHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentHue)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentHue::Id, (uint8_t *) &currentHue,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentSaturation(chip::EndpointId endpoint, uint8_t * currentSaturation)
+
+} // namespace CurrentHue
+
+namespace CurrentSaturation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentSaturation)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentSaturation::Id, (uint8_t *) currentSaturation,
                                       sizeof(*currentSaturation));
 }
-EmberAfStatus SetCurrentSaturation(chip::EndpointId endpoint, uint8_t currentSaturation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentSaturation)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentSaturation::Id, (uint8_t *) &currentSaturation,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime)
+
+} // namespace CurrentSaturation
+
+namespace RemainingTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, RemainingTime::Id, (uint8_t *) remainingTime,
                                       sizeof(*remainingTime));
 }
-EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, RemainingTime::Id, (uint8_t *) &remainingTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentX(chip::EndpointId endpoint, uint16_t * currentX)
+
+} // namespace RemainingTime
+
+namespace CurrentX {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentX)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentX::Id, (uint8_t *) currentX, sizeof(*currentX));
 }
-EmberAfStatus SetCurrentX(chip::EndpointId endpoint, uint16_t currentX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentX)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentX::Id, (uint8_t *) &currentX, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentY(chip::EndpointId endpoint, uint16_t * currentY)
+
+} // namespace CurrentX
+
+namespace CurrentY {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentY)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, CurrentY::Id, (uint8_t *) currentY, sizeof(*currentY));
 }
-EmberAfStatus SetCurrentY(chip::EndpointId endpoint, uint16_t currentY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentY)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CurrentY::Id, (uint8_t *) &currentY, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDriftCompensation(chip::EndpointId endpoint, uint8_t * driftCompensation)
+
+} // namespace CurrentY
+
+namespace DriftCompensation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * driftCompensation)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, DriftCompensation::Id, (uint8_t *) driftCompensation,
                                       sizeof(*driftCompensation));
 }
-EmberAfStatus SetDriftCompensation(chip::EndpointId endpoint, uint8_t driftCompensation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t driftCompensation)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, DriftCompensation::Id, (uint8_t *) &driftCompensation,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorTemperature(chip::EndpointId endpoint, uint16_t * colorTemperature)
+
+} // namespace DriftCompensation
+
+namespace ColorTemperature {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTemperature)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorTemperature::Id, (uint8_t *) colorTemperature,
                                       sizeof(*colorTemperature));
 }
-EmberAfStatus SetColorTemperature(chip::EndpointId endpoint, uint16_t colorTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTemperature)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorTemperature::Id, (uint8_t *) &colorTemperature,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorMode(chip::EndpointId endpoint, uint8_t * colorMode)
+
+} // namespace ColorTemperature
+
+namespace ColorMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorMode)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorMode::Id, (uint8_t *) colorMode, sizeof(*colorMode));
 }
-EmberAfStatus SetColorMode(chip::EndpointId endpoint, uint8_t colorMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorMode)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorMode::Id, (uint8_t *) &colorMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorControlOptions(chip::EndpointId endpoint, uint8_t * colorControlOptions)
+
+} // namespace ColorMode
+
+namespace ColorControlOptions {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorControlOptions)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorControlOptions::Id, (uint8_t *) colorControlOptions,
                                       sizeof(*colorControlOptions));
 }
-EmberAfStatus SetColorControlOptions(chip::EndpointId endpoint, uint8_t colorControlOptions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorControlOptions)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorControlOptions::Id, (uint8_t *) &colorControlOptions,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumberOfPrimaries(chip::EndpointId endpoint, uint8_t * numberOfPrimaries)
+
+} // namespace ColorControlOptions
+
+namespace NumberOfPrimaries {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPrimaries)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, NumberOfPrimaries::Id, (uint8_t *) numberOfPrimaries,
                                       sizeof(*numberOfPrimaries));
 }
-EmberAfStatus SetNumberOfPrimaries(chip::EndpointId endpoint, uint8_t numberOfPrimaries)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPrimaries)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, NumberOfPrimaries::Id, (uint8_t *) &numberOfPrimaries,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary1X(chip::EndpointId endpoint, uint16_t * primary1X)
+
+} // namespace NumberOfPrimaries
+
+namespace Primary1X {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1X)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary1X::Id, (uint8_t *) primary1X, sizeof(*primary1X));
 }
-EmberAfStatus SetPrimary1X(chip::EndpointId endpoint, uint16_t primary1X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1X)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary1X::Id, (uint8_t *) &primary1X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary1Y(chip::EndpointId endpoint, uint16_t * primary1Y)
+
+} // namespace Primary1X
+
+namespace Primary1Y {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1Y)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary1Y::Id, (uint8_t *) primary1Y, sizeof(*primary1Y));
 }
-EmberAfStatus SetPrimary1Y(chip::EndpointId endpoint, uint16_t primary1Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1Y)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary1Y::Id, (uint8_t *) &primary1Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary1Intensity(chip::EndpointId endpoint, uint8_t * primary1Intensity)
+
+} // namespace Primary1Y
+
+namespace Primary1Intensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary1Intensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary1Intensity::Id, (uint8_t *) primary1Intensity,
                                       sizeof(*primary1Intensity));
 }
-EmberAfStatus SetPrimary1Intensity(chip::EndpointId endpoint, uint8_t primary1Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary1Intensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary1Intensity::Id, (uint8_t *) &primary1Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary2X(chip::EndpointId endpoint, uint16_t * primary2X)
+
+} // namespace Primary1Intensity
+
+namespace Primary2X {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2X)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary2X::Id, (uint8_t *) primary2X, sizeof(*primary2X));
 }
-EmberAfStatus SetPrimary2X(chip::EndpointId endpoint, uint16_t primary2X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2X)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary2X::Id, (uint8_t *) &primary2X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary2Y(chip::EndpointId endpoint, uint16_t * primary2Y)
+
+} // namespace Primary2X
+
+namespace Primary2Y {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2Y)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary2Y::Id, (uint8_t *) primary2Y, sizeof(*primary2Y));
 }
-EmberAfStatus SetPrimary2Y(chip::EndpointId endpoint, uint16_t primary2Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2Y)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary2Y::Id, (uint8_t *) &primary2Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary2Intensity(chip::EndpointId endpoint, uint8_t * primary2Intensity)
+
+} // namespace Primary2Y
+
+namespace Primary2Intensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary2Intensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary2Intensity::Id, (uint8_t *) primary2Intensity,
                                       sizeof(*primary2Intensity));
 }
-EmberAfStatus SetPrimary2Intensity(chip::EndpointId endpoint, uint8_t primary2Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary2Intensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary2Intensity::Id, (uint8_t *) &primary2Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary3X(chip::EndpointId endpoint, uint16_t * primary3X)
+
+} // namespace Primary2Intensity
+
+namespace Primary3X {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3X)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary3X::Id, (uint8_t *) primary3X, sizeof(*primary3X));
 }
-EmberAfStatus SetPrimary3X(chip::EndpointId endpoint, uint16_t primary3X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3X)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary3X::Id, (uint8_t *) &primary3X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary3Y(chip::EndpointId endpoint, uint16_t * primary3Y)
+
+} // namespace Primary3X
+
+namespace Primary3Y {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3Y)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary3Y::Id, (uint8_t *) primary3Y, sizeof(*primary3Y));
 }
-EmberAfStatus SetPrimary3Y(chip::EndpointId endpoint, uint16_t primary3Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3Y)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary3Y::Id, (uint8_t *) &primary3Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary3Intensity(chip::EndpointId endpoint, uint8_t * primary3Intensity)
+
+} // namespace Primary3Y
+
+namespace Primary3Intensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary3Intensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary3Intensity::Id, (uint8_t *) primary3Intensity,
                                       sizeof(*primary3Intensity));
 }
-EmberAfStatus SetPrimary3Intensity(chip::EndpointId endpoint, uint8_t primary3Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary3Intensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary3Intensity::Id, (uint8_t *) &primary3Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary4X(chip::EndpointId endpoint, uint16_t * primary4X)
+
+} // namespace Primary3Intensity
+
+namespace Primary4X {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4X)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary4X::Id, (uint8_t *) primary4X, sizeof(*primary4X));
 }
-EmberAfStatus SetPrimary4X(chip::EndpointId endpoint, uint16_t primary4X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4X)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary4X::Id, (uint8_t *) &primary4X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary4Y(chip::EndpointId endpoint, uint16_t * primary4Y)
+
+} // namespace Primary4X
+
+namespace Primary4Y {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4Y)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary4Y::Id, (uint8_t *) primary4Y, sizeof(*primary4Y));
 }
-EmberAfStatus SetPrimary4Y(chip::EndpointId endpoint, uint16_t primary4Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4Y)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary4Y::Id, (uint8_t *) &primary4Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary4Intensity(chip::EndpointId endpoint, uint8_t * primary4Intensity)
+
+} // namespace Primary4Y
+
+namespace Primary4Intensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary4Intensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary4Intensity::Id, (uint8_t *) primary4Intensity,
                                       sizeof(*primary4Intensity));
 }
-EmberAfStatus SetPrimary4Intensity(chip::EndpointId endpoint, uint8_t primary4Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary4Intensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary4Intensity::Id, (uint8_t *) &primary4Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary5X(chip::EndpointId endpoint, uint16_t * primary5X)
+
+} // namespace Primary4Intensity
+
+namespace Primary5X {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5X)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary5X::Id, (uint8_t *) primary5X, sizeof(*primary5X));
 }
-EmberAfStatus SetPrimary5X(chip::EndpointId endpoint, uint16_t primary5X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5X)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary5X::Id, (uint8_t *) &primary5X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary5Y(chip::EndpointId endpoint, uint16_t * primary5Y)
+
+} // namespace Primary5X
+
+namespace Primary5Y {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5Y)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary5Y::Id, (uint8_t *) primary5Y, sizeof(*primary5Y));
 }
-EmberAfStatus SetPrimary5Y(chip::EndpointId endpoint, uint16_t primary5Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5Y)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary5Y::Id, (uint8_t *) &primary5Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary5Intensity(chip::EndpointId endpoint, uint8_t * primary5Intensity)
+
+} // namespace Primary5Y
+
+namespace Primary5Intensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary5Intensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary5Intensity::Id, (uint8_t *) primary5Intensity,
                                       sizeof(*primary5Intensity));
 }
-EmberAfStatus SetPrimary5Intensity(chip::EndpointId endpoint, uint8_t primary5Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary5Intensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary5Intensity::Id, (uint8_t *) &primary5Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary6X(chip::EndpointId endpoint, uint16_t * primary6X)
+
+} // namespace Primary5Intensity
+
+namespace Primary6X {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6X)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary6X::Id, (uint8_t *) primary6X, sizeof(*primary6X));
 }
-EmberAfStatus SetPrimary6X(chip::EndpointId endpoint, uint16_t primary6X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6X)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary6X::Id, (uint8_t *) &primary6X,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary6Y(chip::EndpointId endpoint, uint16_t * primary6Y)
+
+} // namespace Primary6X
+
+namespace Primary6Y {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6Y)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary6Y::Id, (uint8_t *) primary6Y, sizeof(*primary6Y));
 }
-EmberAfStatus SetPrimary6Y(chip::EndpointId endpoint, uint16_t primary6Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6Y)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary6Y::Id, (uint8_t *) &primary6Y,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPrimary6Intensity(chip::EndpointId endpoint, uint8_t * primary6Intensity)
+
+} // namespace Primary6Y
+
+namespace Primary6Intensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary6Intensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, Primary6Intensity::Id, (uint8_t *) primary6Intensity,
                                       sizeof(*primary6Intensity));
 }
-EmberAfStatus SetPrimary6Intensity(chip::EndpointId endpoint, uint8_t primary6Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary6Intensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, Primary6Intensity::Id, (uint8_t *) &primary6Intensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWhitePointX(chip::EndpointId endpoint, uint16_t * whitePointX)
+
+} // namespace Primary6Intensity
+
+namespace WhitePointX {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointX)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, WhitePointX::Id, (uint8_t *) whitePointX, sizeof(*whitePointX));
 }
-EmberAfStatus SetWhitePointX(chip::EndpointId endpoint, uint16_t whitePointX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointX)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, WhitePointX::Id, (uint8_t *) &whitePointX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetWhitePointY(chip::EndpointId endpoint, uint16_t * whitePointY)
+
+} // namespace WhitePointX
+
+namespace WhitePointY {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointY)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, WhitePointY::Id, (uint8_t *) whitePointY, sizeof(*whitePointY));
 }
-EmberAfStatus SetWhitePointY(chip::EndpointId endpoint, uint16_t whitePointY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointY)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, WhitePointY::Id, (uint8_t *) &whitePointY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointRX(chip::EndpointId endpoint, uint16_t * colorPointRX)
+
+} // namespace WhitePointY
+
+namespace ColorPointRX {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRX)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointRX::Id, (uint8_t *) colorPointRX,
                                       sizeof(*colorPointRX));
 }
-EmberAfStatus SetColorPointRX(chip::EndpointId endpoint, uint16_t colorPointRX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRX)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointRX::Id, (uint8_t *) &colorPointRX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointRY(chip::EndpointId endpoint, uint16_t * colorPointRY)
+
+} // namespace ColorPointRX
+
+namespace ColorPointRY {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRY)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointRY::Id, (uint8_t *) colorPointRY,
                                       sizeof(*colorPointRY));
 }
-EmberAfStatus SetColorPointRY(chip::EndpointId endpoint, uint16_t colorPointRY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRY)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointRY::Id, (uint8_t *) &colorPointRY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointRIntensity(chip::EndpointId endpoint, uint8_t * colorPointRIntensity)
+
+} // namespace ColorPointRY
+
+namespace ColorPointRIntensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointRIntensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointRIntensity::Id, (uint8_t *) colorPointRIntensity,
                                       sizeof(*colorPointRIntensity));
 }
-EmberAfStatus SetColorPointRIntensity(chip::EndpointId endpoint, uint8_t colorPointRIntensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointRIntensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointRIntensity::Id, (uint8_t *) &colorPointRIntensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointGX(chip::EndpointId endpoint, uint16_t * colorPointGX)
+
+} // namespace ColorPointRIntensity
+
+namespace ColorPointGX {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGX)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointGX::Id, (uint8_t *) colorPointGX,
                                       sizeof(*colorPointGX));
 }
-EmberAfStatus SetColorPointGX(chip::EndpointId endpoint, uint16_t colorPointGX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGX)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointGX::Id, (uint8_t *) &colorPointGX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointGY(chip::EndpointId endpoint, uint16_t * colorPointGY)
+
+} // namespace ColorPointGX
+
+namespace ColorPointGY {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGY)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointGY::Id, (uint8_t *) colorPointGY,
                                       sizeof(*colorPointGY));
 }
-EmberAfStatus SetColorPointGY(chip::EndpointId endpoint, uint16_t colorPointGY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGY)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointGY::Id, (uint8_t *) &colorPointGY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointGIntensity(chip::EndpointId endpoint, uint8_t * colorPointGIntensity)
+
+} // namespace ColorPointGY
+
+namespace ColorPointGIntensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointGIntensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointGIntensity::Id, (uint8_t *) colorPointGIntensity,
                                       sizeof(*colorPointGIntensity));
 }
-EmberAfStatus SetColorPointGIntensity(chip::EndpointId endpoint, uint8_t colorPointGIntensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointGIntensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointGIntensity::Id, (uint8_t *) &colorPointGIntensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointBX(chip::EndpointId endpoint, uint16_t * colorPointBX)
+
+} // namespace ColorPointGIntensity
+
+namespace ColorPointBX {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBX)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointBX::Id, (uint8_t *) colorPointBX,
                                       sizeof(*colorPointBX));
 }
-EmberAfStatus SetColorPointBX(chip::EndpointId endpoint, uint16_t colorPointBX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBX)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointBX::Id, (uint8_t *) &colorPointBX,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointBY(chip::EndpointId endpoint, uint16_t * colorPointBY)
+
+} // namespace ColorPointBX
+
+namespace ColorPointBY {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBY)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointBY::Id, (uint8_t *) colorPointBY,
                                       sizeof(*colorPointBY));
 }
-EmberAfStatus SetColorPointBY(chip::EndpointId endpoint, uint16_t colorPointBY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBY)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointBY::Id, (uint8_t *) &colorPointBY,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorPointBIntensity(chip::EndpointId endpoint, uint8_t * colorPointBIntensity)
+
+} // namespace ColorPointBY
+
+namespace ColorPointBIntensity {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointBIntensity)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorPointBIntensity::Id, (uint8_t *) colorPointBIntensity,
                                       sizeof(*colorPointBIntensity));
 }
-EmberAfStatus SetColorPointBIntensity(chip::EndpointId endpoint, uint8_t colorPointBIntensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointBIntensity)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorPointBIntensity::Id, (uint8_t *) &colorPointBIntensity,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnhancedCurrentHue(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue)
+
+} // namespace ColorPointBIntensity
+
+namespace EnhancedCurrentHue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, EnhancedCurrentHue::Id, (uint8_t *) enhancedCurrentHue,
                                       sizeof(*enhancedCurrentHue));
 }
-EmberAfStatus SetEnhancedCurrentHue(chip::EndpointId endpoint, uint16_t enhancedCurrentHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enhancedCurrentHue)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, EnhancedCurrentHue::Id, (uint8_t *) &enhancedCurrentHue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnhancedColorMode(chip::EndpointId endpoint, uint8_t * enhancedColorMode)
+
+} // namespace EnhancedCurrentHue
+
+namespace EnhancedColorMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enhancedColorMode)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, EnhancedColorMode::Id, (uint8_t *) enhancedColorMode,
                                       sizeof(*enhancedColorMode));
 }
-EmberAfStatus SetEnhancedColorMode(chip::EndpointId endpoint, uint8_t enhancedColorMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enhancedColorMode)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, EnhancedColorMode::Id, (uint8_t *) &enhancedColorMode,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorLoopActive(chip::EndpointId endpoint, uint8_t * colorLoopActive)
+
+} // namespace EnhancedColorMode
+
+namespace ColorLoopActive {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopActive)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopActive::Id, (uint8_t *) colorLoopActive,
                                       sizeof(*colorLoopActive));
 }
-EmberAfStatus SetColorLoopActive(chip::EndpointId endpoint, uint8_t colorLoopActive)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopActive)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopActive::Id, (uint8_t *) &colorLoopActive,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorLoopDirection(chip::EndpointId endpoint, uint8_t * colorLoopDirection)
+
+} // namespace ColorLoopActive
+
+namespace ColorLoopDirection {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopDirection)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopDirection::Id, (uint8_t *) colorLoopDirection,
                                       sizeof(*colorLoopDirection));
 }
-EmberAfStatus SetColorLoopDirection(chip::EndpointId endpoint, uint8_t colorLoopDirection)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopDirection)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopDirection::Id, (uint8_t *) &colorLoopDirection,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorLoopTime(chip::EndpointId endpoint, uint16_t * colorLoopTime)
+
+} // namespace ColorLoopDirection
+
+namespace ColorLoopTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopTime)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopTime::Id, (uint8_t *) colorLoopTime,
                                       sizeof(*colorLoopTime));
 }
-EmberAfStatus SetColorLoopTime(chip::EndpointId endpoint, uint16_t colorLoopTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopTime)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopTime::Id, (uint8_t *) &colorLoopTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorLoopStartEnhancedHue(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue)
+
+} // namespace ColorLoopTime
+
+namespace ColorLoopStartEnhancedHue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopStartEnhancedHue::Id,
                                       (uint8_t *) colorLoopStartEnhancedHue, sizeof(*colorLoopStartEnhancedHue));
 }
-EmberAfStatus SetColorLoopStartEnhancedHue(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopStartEnhancedHue::Id,
                                        (uint8_t *) &colorLoopStartEnhancedHue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorLoopStoredEnhancedHue(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue)
+
+} // namespace ColorLoopStartEnhancedHue
+
+namespace ColorLoopStoredEnhancedHue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorLoopStoredEnhancedHue::Id,
                                       (uint8_t *) colorLoopStoredEnhancedHue, sizeof(*colorLoopStoredEnhancedHue));
 }
-EmberAfStatus SetColorLoopStoredEnhancedHue(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorLoopStoredEnhancedHue::Id,
                                        (uint8_t *) &colorLoopStoredEnhancedHue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorCapabilities(chip::EndpointId endpoint, uint16_t * colorCapabilities)
+
+} // namespace ColorLoopStoredEnhancedHue
+
+namespace ColorCapabilities {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorCapabilities)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorCapabilities::Id, (uint8_t *) colorCapabilities,
                                       sizeof(*colorCapabilities));
 }
-EmberAfStatus SetColorCapabilities(chip::EndpointId endpoint, uint16_t colorCapabilities)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorCapabilities)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorCapabilities::Id, (uint8_t *) &colorCapabilities,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorTempPhysicalMin(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin)
+
+} // namespace ColorCapabilities
+
+namespace ColorTempPhysicalMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMin::Id, (uint8_t *) colorTempPhysicalMin,
                                       sizeof(*colorTempPhysicalMin));
 }
-EmberAfStatus SetColorTempPhysicalMin(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMin::Id, (uint8_t *) &colorTempPhysicalMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetColorTempPhysicalMax(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax)
+
+} // namespace ColorTempPhysicalMin
+
+namespace ColorTempPhysicalMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMax::Id, (uint8_t *) colorTempPhysicalMax,
                                       sizeof(*colorTempPhysicalMax));
 }
-EmberAfStatus SetColorTempPhysicalMax(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, ColorTempPhysicalMax::Id, (uint8_t *) &colorTempPhysicalMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCoupleColorTempToLevelMinMireds(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds)
+
+} // namespace ColorTempPhysicalMax
+
+namespace CoupleColorTempToLevelMinMireds {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, CoupleColorTempToLevelMinMireds::Id,
                                       (uint8_t *) coupleColorTempToLevelMinMireds, sizeof(*coupleColorTempToLevelMinMireds));
 }
-EmberAfStatus SetCoupleColorTempToLevelMinMireds(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, CoupleColorTempToLevelMinMireds::Id,
                                        (uint8_t *) &coupleColorTempToLevelMinMireds, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStartUpColorTemperatureMireds(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds)
+
+} // namespace CoupleColorTempToLevelMinMireds
+
+namespace StartUpColorTemperatureMireds {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds)
 {
     return emberAfReadServerAttribute(endpoint, ColorControl::Id, StartUpColorTemperatureMireds::Id,
                                       (uint8_t *) startUpColorTemperatureMireds, sizeof(*startUpColorTemperatureMireds));
 }
-EmberAfStatus SetStartUpColorTemperatureMireds(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds)
 {
     return emberAfWriteServerAttribute(endpoint, ColorControl::Id, StartUpColorTemperatureMireds::Id,
                                        (uint8_t *) &startUpColorTemperatureMireds, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace StartUpColorTemperatureMireds
+
 } // namespace Attributes
 } // namespace ColorControl
 
 namespace BallastConfiguration {
 namespace Attributes {
-EmberAfStatus GetPhysicalMinLevel(chip::EndpointId endpoint, uint8_t * physicalMinLevel)
+
+namespace PhysicalMinLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMinLevel)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMinLevel::Id, (uint8_t *) physicalMinLevel,
                                       sizeof(*physicalMinLevel));
 }
-EmberAfStatus SetPhysicalMinLevel(chip::EndpointId endpoint, uint8_t physicalMinLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMinLevel)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMinLevel::Id, (uint8_t *) &physicalMinLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhysicalMaxLevel(chip::EndpointId endpoint, uint8_t * physicalMaxLevel)
+
+} // namespace PhysicalMinLevel
+
+namespace PhysicalMaxLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMaxLevel)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMaxLevel::Id, (uint8_t *) physicalMaxLevel,
                                       sizeof(*physicalMaxLevel));
 }
-EmberAfStatus SetPhysicalMaxLevel(chip::EndpointId endpoint, uint8_t physicalMaxLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMaxLevel)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PhysicalMaxLevel::Id, (uint8_t *) &physicalMaxLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBallastStatus(chip::EndpointId endpoint, uint8_t * ballastStatus)
+
+} // namespace PhysicalMaxLevel
+
+namespace BallastStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastStatus)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, BallastStatus::Id, (uint8_t *) ballastStatus,
                                       sizeof(*ballastStatus));
 }
-EmberAfStatus SetBallastStatus(chip::EndpointId endpoint, uint8_t ballastStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastStatus)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, BallastStatus::Id, (uint8_t *) &ballastStatus,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinLevel(chip::EndpointId endpoint, uint8_t * minLevel)
+
+} // namespace BallastStatus
+
+namespace MinLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minLevel)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, MinLevel::Id, (uint8_t *) minLevel, sizeof(*minLevel));
 }
-EmberAfStatus SetMinLevel(chip::EndpointId endpoint, uint8_t minLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, MinLevel::Id, (uint8_t *) &minLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxLevel(chip::EndpointId endpoint, uint8_t * maxLevel)
+
+} // namespace MinLevel
+
+namespace MaxLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxLevel)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, MaxLevel::Id, (uint8_t *) maxLevel, sizeof(*maxLevel));
 }
-EmberAfStatus SetMaxLevel(chip::EndpointId endpoint, uint8_t maxLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, MaxLevel::Id, (uint8_t *) &maxLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerOnLevel(chip::EndpointId endpoint, uint8_t * powerOnLevel)
+
+} // namespace MaxLevel
+
+namespace PowerOnLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * powerOnLevel)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PowerOnLevel::Id, (uint8_t *) powerOnLevel,
                                       sizeof(*powerOnLevel));
 }
-EmberAfStatus SetPowerOnLevel(chip::EndpointId endpoint, uint8_t powerOnLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t powerOnLevel)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PowerOnLevel::Id, (uint8_t *) &powerOnLevel,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerOnFadeTime(chip::EndpointId endpoint, uint16_t * powerOnFadeTime)
+
+} // namespace PowerOnLevel
+
+namespace PowerOnFadeTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * powerOnFadeTime)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, PowerOnFadeTime::Id, (uint8_t *) powerOnFadeTime,
                                       sizeof(*powerOnFadeTime));
 }
-EmberAfStatus SetPowerOnFadeTime(chip::EndpointId endpoint, uint16_t powerOnFadeTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t powerOnFadeTime)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, PowerOnFadeTime::Id, (uint8_t *) &powerOnFadeTime,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetIntrinsicBallastFactor(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor)
+
+} // namespace PowerOnFadeTime
+
+namespace IntrinsicBallastFactor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, IntrinsicBallastFactor::Id,
                                       (uint8_t *) intrinsicBallastFactor, sizeof(*intrinsicBallastFactor));
 }
-EmberAfStatus SetIntrinsicBallastFactor(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, IntrinsicBallastFactor::Id,
                                        (uint8_t *) &intrinsicBallastFactor, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBallastFactorAdjustment(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment)
+
+} // namespace IntrinsicBallastFactor
+
+namespace BallastFactorAdjustment {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, BallastFactorAdjustment::Id,
                                       (uint8_t *) ballastFactorAdjustment, sizeof(*ballastFactorAdjustment));
 }
-EmberAfStatus SetBallastFactorAdjustment(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, BallastFactorAdjustment::Id,
                                        (uint8_t *) &ballastFactorAdjustment, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLampQuality(chip::EndpointId endpoint, uint8_t * lampQuality)
+
+} // namespace BallastFactorAdjustment
+
+namespace LampQuality {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampQuality)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, LampQuality::Id, (uint8_t *) lampQuality,
                                       sizeof(*lampQuality));
 }
-EmberAfStatus SetLampQuality(chip::EndpointId endpoint, uint8_t lampQuality)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampQuality)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, LampQuality::Id, (uint8_t *) &lampQuality,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLampAlarmMode(chip::EndpointId endpoint, uint8_t * lampAlarmMode)
+
+} // namespace LampQuality
+
+namespace LampAlarmMode {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampAlarmMode)
 {
     return emberAfReadServerAttribute(endpoint, BallastConfiguration::Id, LampAlarmMode::Id, (uint8_t *) lampAlarmMode,
                                       sizeof(*lampAlarmMode));
 }
-EmberAfStatus SetLampAlarmMode(chip::EndpointId endpoint, uint8_t lampAlarmMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampAlarmMode)
 {
     return emberAfWriteServerAttribute(endpoint, BallastConfiguration::Id, LampAlarmMode::Id, (uint8_t *) &lampAlarmMode,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
+
+} // namespace LampAlarmMode
+
 } // namespace Attributes
 } // namespace BallastConfiguration
 
 namespace IlluminanceMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, uint16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, uint16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLightSensorType(chip::EndpointId endpoint, uint8_t * lightSensorType)
+
+} // namespace Tolerance
+
+namespace LightSensorType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lightSensorType)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceMeasurement::Id, LightSensorType::Id, (uint8_t *) lightSensorType,
                                       sizeof(*lightSensorType));
 }
-EmberAfStatus SetLightSensorType(chip::EndpointId endpoint, uint8_t lightSensorType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lightSensorType)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceMeasurement::Id, LightSensorType::Id, (uint8_t *) &lightSensorType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace LightSensorType
+
 } // namespace Attributes
 } // namespace IlluminanceMeasurement
 
 namespace IlluminanceLevelSensing {
 namespace Attributes {
-EmberAfStatus GetLevelStatus(chip::EndpointId endpoint, uint8_t * levelStatus)
+
+namespace LevelStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * levelStatus)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, LevelStatus::Id, (uint8_t *) levelStatus,
                                       sizeof(*levelStatus));
 }
-EmberAfStatus SetLevelStatus(chip::EndpointId endpoint, uint8_t levelStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t levelStatus)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, LevelStatus::Id, (uint8_t *) &levelStatus,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLightSensorType(chip::EndpointId endpoint, uint8_t * lightSensorType)
+
+} // namespace LevelStatus
+
+namespace LightSensorType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lightSensorType)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, LightSensorType::Id, (uint8_t *) lightSensorType,
                                       sizeof(*lightSensorType));
 }
-EmberAfStatus SetLightSensorType(chip::EndpointId endpoint, uint8_t lightSensorType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lightSensorType)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, LightSensorType::Id, (uint8_t *) &lightSensorType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetIlluminanceLevelTarget(chip::EndpointId endpoint, uint16_t * illuminanceLevelTarget)
+
+} // namespace LightSensorType
+
+namespace IlluminanceLevelTarget {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * illuminanceLevelTarget)
 {
     return emberAfReadServerAttribute(endpoint, IlluminanceLevelSensing::Id, IlluminanceLevelTarget::Id,
                                       (uint8_t *) illuminanceLevelTarget, sizeof(*illuminanceLevelTarget));
 }
-EmberAfStatus SetIlluminanceLevelTarget(chip::EndpointId endpoint, uint16_t illuminanceLevelTarget)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t illuminanceLevelTarget)
 {
     return emberAfWriteServerAttribute(endpoint, IlluminanceLevelSensing::Id, IlluminanceLevelTarget::Id,
                                        (uint8_t *) &illuminanceLevelTarget, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace IlluminanceLevelTarget
+
 } // namespace Attributes
 } // namespace IlluminanceLevelSensing
 
 namespace TemperatureMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TemperatureMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TemperatureMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TemperatureMeasurement
 
 namespace PressureMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetScaledValue(chip::EndpointId endpoint, int16_t * scaledValue)
+
+} // namespace Tolerance
+
+namespace ScaledValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * scaledValue)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, ScaledValue::Id, (uint8_t *) scaledValue,
                                       sizeof(*scaledValue));
 }
-EmberAfStatus SetScaledValue(chip::EndpointId endpoint, int16_t scaledValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t scaledValue)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, ScaledValue::Id, (uint8_t *) &scaledValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinScaledValue(chip::EndpointId endpoint, int16_t * minScaledValue)
+
+} // namespace ScaledValue
+
+namespace MinScaledValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minScaledValue)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MinScaledValue::Id, (uint8_t *) minScaledValue,
                                       sizeof(*minScaledValue));
 }
-EmberAfStatus SetMinScaledValue(chip::EndpointId endpoint, int16_t minScaledValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minScaledValue)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MinScaledValue::Id, (uint8_t *) &minScaledValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxScaledValue(chip::EndpointId endpoint, int16_t * maxScaledValue)
+
+} // namespace MinScaledValue
+
+namespace MaxScaledValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxScaledValue)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, MaxScaledValue::Id, (uint8_t *) maxScaledValue,
                                       sizeof(*maxScaledValue));
 }
-EmberAfStatus SetMaxScaledValue(chip::EndpointId endpoint, int16_t maxScaledValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxScaledValue)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, MaxScaledValue::Id, (uint8_t *) &maxScaledValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetScaledTolerance(chip::EndpointId endpoint, uint16_t * scaledTolerance)
+
+} // namespace MaxScaledValue
+
+namespace ScaledTolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * scaledTolerance)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, ScaledTolerance::Id, (uint8_t *) scaledTolerance,
                                       sizeof(*scaledTolerance));
 }
-EmberAfStatus SetScaledTolerance(chip::EndpointId endpoint, uint16_t scaledTolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t scaledTolerance)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, ScaledTolerance::Id, (uint8_t *) &scaledTolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetScale(chip::EndpointId endpoint, int8_t * scale)
+
+} // namespace ScaledTolerance
+
+namespace Scale {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * scale)
 {
     return emberAfReadServerAttribute(endpoint, PressureMeasurement::Id, Scale::Id, (uint8_t *) scale, sizeof(*scale));
 }
-EmberAfStatus SetScale(chip::EndpointId endpoint, int8_t scale)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t scale)
 {
     return emberAfWriteServerAttribute(endpoint, PressureMeasurement::Id, Scale::Id, (uint8_t *) &scale, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
+
+} // namespace Scale
+
 } // namespace Attributes
 } // namespace PressureMeasurement
 
 namespace FlowMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) &maxMeasuredValue,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, FlowMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, FlowMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace FlowMeasurement
 
 namespace RelativeHumidityMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, uint16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MinMeasuredValue::Id, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, uint16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MaxMeasuredValue::Id, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, RelativeHumidityMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace RelativeHumidityMeasurement
 
 namespace OccupancySensing {
 namespace Attributes {
-EmberAfStatus GetOccupancy(chip::EndpointId endpoint, uint8_t * occupancy)
+
+namespace Occupancy {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, Occupancy::Id, (uint8_t *) occupancy, sizeof(*occupancy));
 }
-EmberAfStatus SetOccupancy(chip::EndpointId endpoint, uint8_t occupancy)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, Occupancy::Id, (uint8_t *) &occupancy,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOccupancySensorType(chip::EndpointId endpoint, uint8_t * occupancySensorType)
+
+} // namespace Occupancy
+
+namespace OccupancySensorType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorType)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorType::Id, (uint8_t *) occupancySensorType,
                                       sizeof(*occupancySensorType));
 }
-EmberAfStatus SetOccupancySensorType(chip::EndpointId endpoint, uint8_t occupancySensorType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorType)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorType::Id, (uint8_t *) &occupancySensorType,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOccupancySensorTypeBitmap(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap)
+
+} // namespace OccupancySensorType
+
+namespace OccupancySensorTypeBitmap {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorTypeBitmap::Id,
                                       (uint8_t *) occupancySensorTypeBitmap, sizeof(*occupancySensorTypeBitmap));
 }
-EmberAfStatus SetOccupancySensorTypeBitmap(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, OccupancySensorTypeBitmap::Id,
                                        (uint8_t *) &occupancySensorTypeBitmap, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPirOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay)
+
+} // namespace OccupancySensorTypeBitmap
+
+namespace PirOccupiedToUnoccupiedDelay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PirOccupiedToUnoccupiedDelay::Id,
                                       (uint8_t *) pirOccupiedToUnoccupiedDelay, sizeof(*pirOccupiedToUnoccupiedDelay));
 }
-EmberAfStatus SetPirOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PirOccupiedToUnoccupiedDelay::Id,
                                        (uint8_t *) &pirOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPirUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay)
+
+} // namespace PirOccupiedToUnoccupiedDelay
+
+namespace PirUnoccupiedToOccupiedDelay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedDelay::Id,
                                       (uint8_t *) pirUnoccupiedToOccupiedDelay, sizeof(*pirUnoccupiedToOccupiedDelay));
 }
-EmberAfStatus SetPirUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedDelay::Id,
                                        (uint8_t *) &pirUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPirUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold)
+
+} // namespace PirUnoccupiedToOccupiedDelay
+
+namespace PirUnoccupiedToOccupiedThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedThreshold::Id,
                                       (uint8_t *) pirUnoccupiedToOccupiedThreshold, sizeof(*pirUnoccupiedToOccupiedThreshold));
 }
-EmberAfStatus SetPirUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PirUnoccupiedToOccupiedThreshold::Id,
                                        (uint8_t *) &pirUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUltrasonicOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t * ultrasonicOccupiedToUnoccupiedDelay)
+
+} // namespace PirUnoccupiedToOccupiedThreshold
+
+namespace UltrasonicOccupiedToUnoccupiedDelay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicOccupiedToUnoccupiedDelay)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, UltrasonicOccupiedToUnoccupiedDelay::Id,
                                       (uint8_t *) ultrasonicOccupiedToUnoccupiedDelay,
                                       sizeof(*ultrasonicOccupiedToUnoccupiedDelay));
 }
-EmberAfStatus SetUltrasonicOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, UltrasonicOccupiedToUnoccupiedDelay::Id,
                                        (uint8_t *) &ultrasonicOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUltrasonicUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t * ultrasonicUnoccupiedToOccupiedDelay)
+
+} // namespace UltrasonicOccupiedToUnoccupiedDelay
+
+namespace UltrasonicUnoccupiedToOccupiedDelay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicUnoccupiedToOccupiedDelay)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedDelay::Id,
                                       (uint8_t *) ultrasonicUnoccupiedToOccupiedDelay,
                                       sizeof(*ultrasonicUnoccupiedToOccupiedDelay));
 }
-EmberAfStatus SetUltrasonicUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedDelay::Id,
                                        (uint8_t *) &ultrasonicUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUltrasonicUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                         uint8_t * ultrasonicUnoccupiedToOccupiedThreshold)
+
+} // namespace UltrasonicUnoccupiedToOccupiedDelay
+
+namespace UltrasonicUnoccupiedToOccupiedThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ultrasonicUnoccupiedToOccupiedThreshold)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedThreshold::Id,
                                       (uint8_t *) ultrasonicUnoccupiedToOccupiedThreshold,
                                       sizeof(*ultrasonicUnoccupiedToOccupiedThreshold));
 }
-EmberAfStatus SetUltrasonicUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t ultrasonicUnoccupiedToOccupiedThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ultrasonicUnoccupiedToOccupiedThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, UltrasonicUnoccupiedToOccupiedThreshold::Id,
                                        (uint8_t *) &ultrasonicUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhysicalContactOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t * physicalContactOccupiedToUnoccupiedDelay)
+
+} // namespace UltrasonicUnoccupiedToOccupiedThreshold
+
+namespace PhysicalContactOccupiedToUnoccupiedDelay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactOccupiedToUnoccupiedDelay)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactOccupiedToUnoccupiedDelay::Id,
                                       (uint8_t *) physicalContactOccupiedToUnoccupiedDelay,
                                       sizeof(*physicalContactOccupiedToUnoccupiedDelay));
 }
-EmberAfStatus SetPhysicalContactOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t physicalContactOccupiedToUnoccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactOccupiedToUnoccupiedDelay)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactOccupiedToUnoccupiedDelay::Id,
                                        (uint8_t *) &physicalContactOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhysicalContactUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t * physicalContactUnoccupiedToOccupiedDelay)
+
+} // namespace PhysicalContactOccupiedToUnoccupiedDelay
+
+namespace PhysicalContactUnoccupiedToOccupiedDelay {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactUnoccupiedToOccupiedDelay)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedDelay::Id,
                                       (uint8_t *) physicalContactUnoccupiedToOccupiedDelay,
                                       sizeof(*physicalContactUnoccupiedToOccupiedDelay));
 }
-EmberAfStatus SetPhysicalContactUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t physicalContactUnoccupiedToOccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactUnoccupiedToOccupiedDelay)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedDelay::Id,
                                        (uint8_t *) &physicalContactUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhysicalContactUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                              uint8_t * physicalContactUnoccupiedToOccupiedThreshold)
+
+} // namespace PhysicalContactUnoccupiedToOccupiedDelay
+
+namespace PhysicalContactUnoccupiedToOccupiedThreshold {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalContactUnoccupiedToOccupiedThreshold)
 {
     return emberAfReadServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedThreshold::Id,
                                       (uint8_t *) physicalContactUnoccupiedToOccupiedThreshold,
                                       sizeof(*physicalContactUnoccupiedToOccupiedThreshold));
 }
-EmberAfStatus SetPhysicalContactUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                              uint8_t physicalContactUnoccupiedToOccupiedThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalContactUnoccupiedToOccupiedThreshold)
 {
     return emberAfWriteServerAttribute(endpoint, OccupancySensing::Id, PhysicalContactUnoccupiedToOccupiedThreshold::Id,
                                        (uint8_t *) &physicalContactUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace PhysicalContactUnoccupiedToOccupiedThreshold
+
 } // namespace Attributes
 } // namespace OccupancySensing
 
 namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace CarbonMonoxideConcentrationMeasurement
 
 namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace CarbonDioxideConcentrationMeasurement
 
 namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace EthyleneConcentrationMeasurement
 
 namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace EthyleneOxideConcentrationMeasurement
 
 namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace HydrogenConcentrationMeasurement
 
 namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace HydrogenSulphideConcentrationMeasurement
 
 namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace NitricOxideConcentrationMeasurement
 
 namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace NitrogenDioxideConcentrationMeasurement
 
 namespace OxygenConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace OxygenConcentrationMeasurement
 
 namespace OzoneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace OzoneConcentrationMeasurement
 
 namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace SulfurDioxideConcentrationMeasurement
 
 namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace DissolvedOxygenConcentrationMeasurement
 
 namespace BromateConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace BromateConcentrationMeasurement
 
 namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChloraminesConcentrationMeasurement
 
 namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChlorineConcentrationMeasurement
 
 namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace FecalColiformAndEColiConcentrationMeasurement
 
 namespace FluorideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace FluorideConcentrationMeasurement
 
 namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace HaloaceticAcidsConcentrationMeasurement
 
 namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TotalTrihalomethanesConcentrationMeasurement
 
 namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TotalColiformBacteriaConcentrationMeasurement
 
 namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TurbidityConcentrationMeasurement
 
 namespace CopperConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace CopperConcentrationMeasurement
 
 namespace LeadConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace LeadConcentrationMeasurement
 
 namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ManganeseConcentrationMeasurement
 
 namespace SulfateConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace SulfateConcentrationMeasurement
 
 namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace BromodichloromethaneConcentrationMeasurement
 
 namespace BromoformConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace BromoformConcentrationMeasurement
 
 namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChlorodibromomethaneConcentrationMeasurement
 
 namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChloroformConcentrationMeasurement
 
 namespace SodiumConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+
+namespace MeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
+
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace SodiumConcentrationMeasurement
 
 namespace IasZone {
 namespace Attributes {
-EmberAfStatus GetZoneState(chip::EndpointId endpoint, uint8_t * zoneState)
+
+namespace ZoneState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneState)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneState::Id, (uint8_t *) zoneState, sizeof(*zoneState));
 }
-EmberAfStatus SetZoneState(chip::EndpointId endpoint, uint8_t zoneState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneState)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneState::Id, (uint8_t *) &zoneState, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetZoneType(chip::EndpointId endpoint, uint16_t * zoneType)
+
+} // namespace ZoneState
+
+namespace ZoneType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneType)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneType::Id, (uint8_t *) zoneType, sizeof(*zoneType));
 }
-EmberAfStatus SetZoneType(chip::EndpointId endpoint, uint16_t zoneType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneType)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneType::Id, (uint8_t *) &zoneType, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetZoneStatus(chip::EndpointId endpoint, uint16_t * zoneStatus)
+
+} // namespace ZoneType
+
+namespace ZoneStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneStatus)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneStatus::Id, (uint8_t *) zoneStatus, sizeof(*zoneStatus));
 }
-EmberAfStatus SetZoneStatus(chip::EndpointId endpoint, uint16_t zoneStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneStatus)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneStatus::Id, (uint8_t *) &zoneStatus, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetIasCieAddress(chip::EndpointId endpoint, chip::NodeId * iasCieAddress)
+
+} // namespace ZoneStatus
+
+namespace IasCieAddress {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * iasCieAddress)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, IasCieAddress::Id, (uint8_t *) iasCieAddress, sizeof(*iasCieAddress));
 }
-EmberAfStatus SetIasCieAddress(chip::EndpointId endpoint, chip::NodeId iasCieAddress)
+EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId iasCieAddress)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, IasCieAddress::Id, (uint8_t *) &iasCieAddress,
                                        ZCL_NODE_ID_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetZoneId(chip::EndpointId endpoint, uint8_t * zoneId)
+
+} // namespace IasCieAddress
+
+namespace ZoneId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneId)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, ZoneId::Id, (uint8_t *) zoneId, sizeof(*zoneId));
 }
-EmberAfStatus SetZoneId(chip::EndpointId endpoint, uint8_t zoneId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneId)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, ZoneId::Id, (uint8_t *) &zoneId, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNumberOfZoneSensitivityLevelsSupported(chip::EndpointId endpoint, uint8_t * numberOfZoneSensitivityLevelsSupported)
+
+} // namespace ZoneId
+
+namespace NumberOfZoneSensitivityLevelsSupported {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfZoneSensitivityLevelsSupported)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, NumberOfZoneSensitivityLevelsSupported::Id,
                                       (uint8_t *) numberOfZoneSensitivityLevelsSupported,
                                       sizeof(*numberOfZoneSensitivityLevelsSupported));
 }
-EmberAfStatus SetNumberOfZoneSensitivityLevelsSupported(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, NumberOfZoneSensitivityLevelsSupported::Id,
                                        (uint8_t *) &numberOfZoneSensitivityLevelsSupported, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentZoneSensitivityLevel(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel)
+
+} // namespace NumberOfZoneSensitivityLevelsSupported
+
+namespace CurrentZoneSensitivityLevel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel)
 {
     return emberAfReadServerAttribute(endpoint, IasZone::Id, CurrentZoneSensitivityLevel::Id,
                                       (uint8_t *) currentZoneSensitivityLevel, sizeof(*currentZoneSensitivityLevel));
 }
-EmberAfStatus SetCurrentZoneSensitivityLevel(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel)
 {
     return emberAfWriteServerAttribute(endpoint, IasZone::Id, CurrentZoneSensitivityLevel::Id,
                                        (uint8_t *) &currentZoneSensitivityLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CurrentZoneSensitivityLevel
+
 } // namespace Attributes
 } // namespace IasZone
 
 namespace IasWd {
 namespace Attributes {
-EmberAfStatus GetMaxDuration(chip::EndpointId endpoint, uint16_t * maxDuration)
+
+namespace MaxDuration {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxDuration)
 {
     return emberAfReadServerAttribute(endpoint, IasWd::Id, MaxDuration::Id, (uint8_t *) maxDuration, sizeof(*maxDuration));
 }
-EmberAfStatus SetMaxDuration(chip::EndpointId endpoint, uint16_t maxDuration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxDuration)
 {
     return emberAfWriteServerAttribute(endpoint, IasWd::Id, MaxDuration::Id, (uint8_t *) &maxDuration, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace MaxDuration
+
 } // namespace Attributes
 } // namespace IasWd
 
 namespace WakeOnLan {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace WakeOnLan
 
 namespace TvChannel {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace TvChannel
 
 namespace TargetNavigator {
 namespace Attributes {
-EmberAfStatus GetCurrentNavigatorTarget(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget)
+
+namespace CurrentNavigatorTarget {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget)
 {
     return emberAfReadServerAttribute(endpoint, TargetNavigator::Id, CurrentNavigatorTarget::Id, (uint8_t *) currentNavigatorTarget,
                                       sizeof(*currentNavigatorTarget));
 }
-EmberAfStatus SetCurrentNavigatorTarget(chip::EndpointId endpoint, uint8_t currentNavigatorTarget)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentNavigatorTarget)
 {
     return emberAfWriteServerAttribute(endpoint, TargetNavigator::Id, CurrentNavigatorTarget::Id,
                                        (uint8_t *) &currentNavigatorTarget, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CurrentNavigatorTarget
+
 } // namespace Attributes
 } // namespace TargetNavigator
 
 namespace MediaPlayback {
 namespace Attributes {
-EmberAfStatus GetPlaybackState(chip::EndpointId endpoint, uint8_t * playbackState)
+
+namespace PlaybackState {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * playbackState)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, PlaybackState::Id, (uint8_t *) playbackState,
                                       sizeof(*playbackState));
 }
-EmberAfStatus SetPlaybackState(chip::EndpointId endpoint, uint8_t playbackState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t playbackState)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, PlaybackState::Id, (uint8_t *) &playbackState,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetStartTime(chip::EndpointId endpoint, uint64_t * startTime)
+
+} // namespace PlaybackState
+
+namespace StartTime {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * startTime)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, StartTime::Id, (uint8_t *) startTime, sizeof(*startTime));
 }
-EmberAfStatus SetStartTime(chip::EndpointId endpoint, uint64_t startTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t startTime)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, StartTime::Id, (uint8_t *) &startTime,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDuration(chip::EndpointId endpoint, uint64_t * duration)
+
+} // namespace StartTime
+
+namespace Duration {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * duration)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Duration::Id, (uint8_t *) duration, sizeof(*duration));
 }
-EmberAfStatus SetDuration(chip::EndpointId endpoint, uint64_t duration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t duration)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Duration::Id, (uint8_t *) &duration, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPositionUpdatedAt(chip::EndpointId endpoint, uint64_t * positionUpdatedAt)
+
+} // namespace Duration
+
+namespace PositionUpdatedAt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * positionUpdatedAt)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, PositionUpdatedAt::Id, (uint8_t *) positionUpdatedAt,
                                       sizeof(*positionUpdatedAt));
 }
-EmberAfStatus SetPositionUpdatedAt(chip::EndpointId endpoint, uint64_t positionUpdatedAt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t positionUpdatedAt)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, PositionUpdatedAt::Id, (uint8_t *) &positionUpdatedAt,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPosition(chip::EndpointId endpoint, uint64_t * position)
+
+} // namespace PositionUpdatedAt
+
+namespace Position {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * position)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, Position::Id, (uint8_t *) position, sizeof(*position));
 }
-EmberAfStatus SetPosition(chip::EndpointId endpoint, uint64_t position)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t position)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, Position::Id, (uint8_t *) &position, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPlaybackSpeed(chip::EndpointId endpoint, uint64_t * playbackSpeed)
+
+} // namespace Position
+
+namespace PlaybackSpeed {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * playbackSpeed)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, PlaybackSpeed::Id, (uint8_t *) playbackSpeed,
                                       sizeof(*playbackSpeed));
 }
-EmberAfStatus SetPlaybackSpeed(chip::EndpointId endpoint, uint64_t playbackSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t playbackSpeed)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, PlaybackSpeed::Id, (uint8_t *) &playbackSpeed,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSeekRangeEnd(chip::EndpointId endpoint, uint64_t * seekRangeEnd)
+
+} // namespace PlaybackSpeed
+
+namespace SeekRangeEnd {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeEnd)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, SeekRangeEnd::Id, (uint8_t *) seekRangeEnd,
                                       sizeof(*seekRangeEnd));
 }
-EmberAfStatus SetSeekRangeEnd(chip::EndpointId endpoint, uint64_t seekRangeEnd)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeEnd)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, SeekRangeEnd::Id, (uint8_t *) &seekRangeEnd,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSeekRangeStart(chip::EndpointId endpoint, uint64_t * seekRangeStart)
+
+} // namespace SeekRangeEnd
+
+namespace SeekRangeStart {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeStart)
 {
     return emberAfReadServerAttribute(endpoint, MediaPlayback::Id, SeekRangeStart::Id, (uint8_t *) seekRangeStart,
                                       sizeof(*seekRangeStart));
 }
-EmberAfStatus SetSeekRangeStart(chip::EndpointId endpoint, uint64_t seekRangeStart)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeStart)
 {
     return emberAfWriteServerAttribute(endpoint, MediaPlayback::Id, SeekRangeStart::Id, (uint8_t *) &seekRangeStart,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
+
+} // namespace SeekRangeStart
+
 } // namespace Attributes
 } // namespace MediaPlayback
 
 namespace MediaInput {
 namespace Attributes {
-EmberAfStatus GetCurrentMediaInput(chip::EndpointId endpoint, uint8_t * currentMediaInput)
+
+namespace CurrentMediaInput {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentMediaInput)
 {
     return emberAfReadServerAttribute(endpoint, MediaInput::Id, CurrentMediaInput::Id, (uint8_t *) currentMediaInput,
                                       sizeof(*currentMediaInput));
 }
-EmberAfStatus SetCurrentMediaInput(chip::EndpointId endpoint, uint8_t currentMediaInput)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentMediaInput)
 {
     return emberAfWriteServerAttribute(endpoint, MediaInput::Id, CurrentMediaInput::Id, (uint8_t *) &currentMediaInput,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CurrentMediaInput
+
 } // namespace Attributes
 } // namespace MediaInput
 
 namespace ContentLauncher {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace ContentLauncher
 
 namespace AudioOutput {
 namespace Attributes {
-EmberAfStatus GetCurrentAudioOutput(chip::EndpointId endpoint, uint8_t * currentAudioOutput)
+
+namespace CurrentAudioOutput {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentAudioOutput)
 {
     return emberAfReadServerAttribute(endpoint, AudioOutput::Id, CurrentAudioOutput::Id, (uint8_t *) currentAudioOutput,
                                       sizeof(*currentAudioOutput));
 }
-EmberAfStatus SetCurrentAudioOutput(chip::EndpointId endpoint, uint8_t currentAudioOutput)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentAudioOutput)
 {
     return emberAfWriteServerAttribute(endpoint, AudioOutput::Id, CurrentAudioOutput::Id, (uint8_t *) &currentAudioOutput,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CurrentAudioOutput
+
 } // namespace Attributes
 } // namespace AudioOutput
 
 namespace ApplicationLauncher {
 namespace Attributes {
-EmberAfStatus GetCatalogVendorId(chip::EndpointId endpoint, uint8_t * catalogVendorId)
+
+namespace CatalogVendorId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * catalogVendorId)
 {
     return emberAfReadServerAttribute(endpoint, ApplicationLauncher::Id, CatalogVendorId::Id, (uint8_t *) catalogVendorId,
                                       sizeof(*catalogVendorId));
 }
-EmberAfStatus SetCatalogVendorId(chip::EndpointId endpoint, uint8_t catalogVendorId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t catalogVendorId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplicationLauncher::Id, CatalogVendorId::Id, (uint8_t *) &catalogVendorId,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetApplicationId(chip::EndpointId endpoint, uint8_t * applicationId)
+
+} // namespace CatalogVendorId
+
+namespace ApplicationId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationId)
 {
     return emberAfReadServerAttribute(endpoint, ApplicationLauncher::Id, ApplicationId::Id, (uint8_t *) applicationId,
                                       sizeof(*applicationId));
 }
-EmberAfStatus SetApplicationId(chip::EndpointId endpoint, uint8_t applicationId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplicationLauncher::Id, ApplicationId::Id, (uint8_t *) &applicationId,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace ApplicationId
+
 } // namespace Attributes
 } // namespace ApplicationLauncher
 
 namespace ApplicationBasic {
 namespace Attributes {
-EmberAfStatus GetVendorId(chip::EndpointId endpoint, uint16_t * vendorId)
+
+namespace VendorId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorId)
 {
     return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, VendorId::Id, (uint8_t *) vendorId, sizeof(*vendorId));
 }
-EmberAfStatus SetVendorId(chip::EndpointId endpoint, uint16_t vendorId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, VendorId::Id, (uint8_t *) &vendorId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetProductId(chip::EndpointId endpoint, uint16_t * productId)
+
+} // namespace VendorId
+
+namespace ProductId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productId)
 {
     return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, ProductId::Id, (uint8_t *) productId, sizeof(*productId));
 }
-EmberAfStatus SetProductId(chip::EndpointId endpoint, uint16_t productId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, ProductId::Id, (uint8_t *) &productId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCatalogVendorId(chip::EndpointId endpoint, uint16_t * catalogVendorId)
+
+} // namespace ProductId
+
+namespace CatalogVendorId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * catalogVendorId)
 {
     return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, CatalogVendorId::Id, (uint8_t *) catalogVendorId,
                                       sizeof(*catalogVendorId));
 }
-EmberAfStatus SetCatalogVendorId(chip::EndpointId endpoint, uint16_t catalogVendorId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t catalogVendorId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, CatalogVendorId::Id, (uint8_t *) &catalogVendorId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetApplicationStatus(chip::EndpointId endpoint, uint8_t * applicationStatus)
+
+} // namespace CatalogVendorId
+
+namespace ApplicationStatus {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationStatus)
 {
     return emberAfReadServerAttribute(endpoint, ApplicationBasic::Id, ApplicationStatus::Id, (uint8_t *) applicationStatus,
                                       sizeof(*applicationStatus));
 }
-EmberAfStatus SetApplicationStatus(chip::EndpointId endpoint, uint8_t applicationStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationStatus)
 {
     return emberAfWriteServerAttribute(endpoint, ApplicationBasic::Id, ApplicationStatus::Id, (uint8_t *) &applicationStatus,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
+
+} // namespace ApplicationStatus
+
 } // namespace Attributes
 } // namespace ApplicationBasic
 
 namespace TestCluster {
 namespace Attributes {
-EmberAfStatus GetBoolean(chip::EndpointId endpoint, bool * boolean)
+
+namespace Boolean {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * boolean)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Boolean::Id, (uint8_t *) boolean, sizeof(*boolean));
 }
-EmberAfStatus SetBoolean(chip::EndpointId endpoint, bool boolean)
+EmberAfStatus Set(chip::EndpointId endpoint, bool boolean)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Boolean::Id, (uint8_t *) &boolean, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBitmap8(chip::EndpointId endpoint, uint8_t * bitmap8)
+
+} // namespace Boolean
+
+namespace Bitmap8 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bitmap8)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap8::Id, (uint8_t *) bitmap8, sizeof(*bitmap8));
 }
-EmberAfStatus SetBitmap8(chip::EndpointId endpoint, uint8_t bitmap8)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bitmap8)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap8::Id, (uint8_t *) &bitmap8, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBitmap16(chip::EndpointId endpoint, uint16_t * bitmap16)
+
+} // namespace Bitmap8
+
+namespace Bitmap16 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * bitmap16)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap16::Id, (uint8_t *) bitmap16, sizeof(*bitmap16));
 }
-EmberAfStatus SetBitmap16(chip::EndpointId endpoint, uint16_t bitmap16)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t bitmap16)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap16::Id, (uint8_t *) &bitmap16, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBitmap32(chip::EndpointId endpoint, uint32_t * bitmap32)
+
+} // namespace Bitmap16
+
+namespace Bitmap32 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * bitmap32)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap32::Id, (uint8_t *) bitmap32, sizeof(*bitmap32));
 }
-EmberAfStatus SetBitmap32(chip::EndpointId endpoint, uint32_t bitmap32)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t bitmap32)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap32::Id, (uint8_t *) &bitmap32, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBitmap64(chip::EndpointId endpoint, uint64_t * bitmap64)
+
+} // namespace Bitmap32
+
+namespace Bitmap64 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * bitmap64)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Bitmap64::Id, (uint8_t *) bitmap64, sizeof(*bitmap64));
 }
-EmberAfStatus SetBitmap64(chip::EndpointId endpoint, uint64_t bitmap64)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t bitmap64)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Bitmap64::Id, (uint8_t *) &bitmap64, ZCL_BITMAP64_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt8u(chip::EndpointId endpoint, uint8_t * int8u)
+
+} // namespace Bitmap64
+
+namespace Int8u {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * int8u)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int8u::Id, (uint8_t *) int8u, sizeof(*int8u));
 }
-EmberAfStatus SetInt8u(chip::EndpointId endpoint, uint8_t int8u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t int8u)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int8u::Id, (uint8_t *) &int8u, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt16u(chip::EndpointId endpoint, uint16_t * int16u)
+
+} // namespace Int8u
+
+namespace Int16u {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * int16u)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int16u::Id, (uint8_t *) int16u, sizeof(*int16u));
 }
-EmberAfStatus SetInt16u(chip::EndpointId endpoint, uint16_t int16u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t int16u)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int16u::Id, (uint8_t *) &int16u, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt32u(chip::EndpointId endpoint, uint32_t * int32u)
+
+} // namespace Int16u
+
+namespace Int32u {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * int32u)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int32u::Id, (uint8_t *) int32u, sizeof(*int32u));
 }
-EmberAfStatus SetInt32u(chip::EndpointId endpoint, uint32_t int32u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t int32u)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int32u::Id, (uint8_t *) &int32u, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt64u(chip::EndpointId endpoint, uint64_t * int64u)
+
+} // namespace Int32u
+
+namespace Int64u {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * int64u)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int64u::Id, (uint8_t *) int64u, sizeof(*int64u));
 }
-EmberAfStatus SetInt64u(chip::EndpointId endpoint, uint64_t int64u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t int64u)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int64u::Id, (uint8_t *) &int64u, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt8s(chip::EndpointId endpoint, int8_t * int8s)
+
+} // namespace Int64u
+
+namespace Int8s {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * int8s)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int8s::Id, (uint8_t *) int8s, sizeof(*int8s));
 }
-EmberAfStatus SetInt8s(chip::EndpointId endpoint, int8_t int8s)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t int8s)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int8s::Id, (uint8_t *) &int8s, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt16s(chip::EndpointId endpoint, int16_t * int16s)
+
+} // namespace Int8s
+
+namespace Int16s {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * int16s)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int16s::Id, (uint8_t *) int16s, sizeof(*int16s));
 }
-EmberAfStatus SetInt16s(chip::EndpointId endpoint, int16_t int16s)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t int16s)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int16s::Id, (uint8_t *) &int16s, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt32s(chip::EndpointId endpoint, int32_t * int32s)
+
+} // namespace Int16s
+
+namespace Int32s {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * int32s)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int32s::Id, (uint8_t *) int32s, sizeof(*int32s));
 }
-EmberAfStatus SetInt32s(chip::EndpointId endpoint, int32_t int32s)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t int32s)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int32s::Id, (uint8_t *) &int32s, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInt64s(chip::EndpointId endpoint, int64_t * int64s)
+
+} // namespace Int32s
+
+namespace Int64s {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int64_t * int64s)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Int64s::Id, (uint8_t *) int64s, sizeof(*int64s));
 }
-EmberAfStatus SetInt64s(chip::EndpointId endpoint, int64_t int64s)
+EmberAfStatus Set(chip::EndpointId endpoint, int64_t int64s)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Int64s::Id, (uint8_t *) &int64s, ZCL_INT64S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnum8(chip::EndpointId endpoint, uint8_t * enum8)
+
+} // namespace Int64s
+
+namespace Enum8 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enum8)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Enum8::Id, (uint8_t *) enum8, sizeof(*enum8));
 }
-EmberAfStatus SetEnum8(chip::EndpointId endpoint, uint8_t enum8)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enum8)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Enum8::Id, (uint8_t *) &enum8, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnum16(chip::EndpointId endpoint, uint16_t * enum16)
+
+} // namespace Enum8
+
+namespace Enum16 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enum16)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Enum16::Id, (uint8_t *) enum16, sizeof(*enum16));
 }
-EmberAfStatus SetEnum16(chip::EndpointId endpoint, uint16_t enum16)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enum16)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Enum16::Id, (uint8_t *) &enum16, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEpochUs(chip::EndpointId endpoint, uint64_t * epochUs)
+
+} // namespace Enum16
+
+namespace EpochUs {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * epochUs)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, EpochUs::Id, (uint8_t *) epochUs, sizeof(*epochUs));
 }
-EmberAfStatus SetEpochUs(chip::EndpointId endpoint, uint64_t epochUs)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t epochUs)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, EpochUs::Id, (uint8_t *) &epochUs, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEpochS(chip::EndpointId endpoint, uint32_t * epochS)
+
+} // namespace EpochUs
+
+namespace EpochS {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * epochS)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, EpochS::Id, (uint8_t *) epochS, sizeof(*epochS));
 }
-EmberAfStatus SetEpochS(chip::EndpointId endpoint, uint32_t epochS)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t epochS)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, EpochS::Id, (uint8_t *) &epochS, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUnsupported(chip::EndpointId endpoint, bool * unsupported)
+
+} // namespace EpochS
+
+namespace Unsupported {
+
+EmberAfStatus Get(chip::EndpointId endpoint, bool * unsupported)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Unsupported::Id, (uint8_t *) unsupported, sizeof(*unsupported));
 }
-EmberAfStatus SetUnsupported(chip::EndpointId endpoint, bool unsupported)
+EmberAfStatus Set(chip::EndpointId endpoint, bool unsupported)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Unsupported::Id, (uint8_t *) &unsupported,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
+
+} // namespace Unsupported
+
 } // namespace Attributes
 } // namespace TestCluster
 
 namespace ApplianceIdentification {
 namespace Attributes {
-EmberAfStatus GetCompanyId(chip::EndpointId endpoint, uint16_t * companyId)
+
+namespace CompanyId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * companyId)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, CompanyId::Id, (uint8_t *) companyId,
                                       sizeof(*companyId));
 }
-EmberAfStatus SetCompanyId(chip::EndpointId endpoint, uint16_t companyId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t companyId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, CompanyId::Id, (uint8_t *) &companyId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetBrandId(chip::EndpointId endpoint, uint16_t * brandId)
+
+} // namespace CompanyId
+
+namespace BrandId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * brandId)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, BrandId::Id, (uint8_t *) brandId, sizeof(*brandId));
 }
-EmberAfStatus SetBrandId(chip::EndpointId endpoint, uint16_t brandId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t brandId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, BrandId::Id, (uint8_t *) &brandId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetProductTypeId(chip::EndpointId endpoint, uint16_t * productTypeId)
+
+} // namespace BrandId
+
+namespace ProductTypeId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productTypeId)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, ProductTypeId::Id, (uint8_t *) productTypeId,
                                       sizeof(*productTypeId));
 }
-EmberAfStatus SetProductTypeId(chip::EndpointId endpoint, uint16_t productTypeId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productTypeId)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, ProductTypeId::Id, (uint8_t *) &productTypeId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCecedSpecificationVersion(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion)
+
+} // namespace ProductTypeId
+
+namespace CecedSpecificationVersion {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceIdentification::Id, CecedSpecificationVersion::Id,
                                       (uint8_t *) cecedSpecificationVersion, sizeof(*cecedSpecificationVersion));
 }
-EmberAfStatus SetCecedSpecificationVersion(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceIdentification::Id, CecedSpecificationVersion::Id,
                                        (uint8_t *) &cecedSpecificationVersion, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace CecedSpecificationVersion
+
 } // namespace Attributes
 } // namespace ApplianceIdentification
 
 namespace MeterIdentification {
 namespace Attributes {
-EmberAfStatus GetMeterTypeId(chip::EndpointId endpoint, uint16_t * meterTypeId)
+
+namespace MeterTypeId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * meterTypeId)
 {
     return emberAfReadServerAttribute(endpoint, MeterIdentification::Id, MeterTypeId::Id, (uint8_t *) meterTypeId,
                                       sizeof(*meterTypeId));
 }
-EmberAfStatus SetMeterTypeId(chip::EndpointId endpoint, uint16_t meterTypeId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t meterTypeId)
 {
     return emberAfWriteServerAttribute(endpoint, MeterIdentification::Id, MeterTypeId::Id, (uint8_t *) &meterTypeId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDataQualityId(chip::EndpointId endpoint, uint16_t * dataQualityId)
+
+} // namespace MeterTypeId
+
+namespace DataQualityId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dataQualityId)
 {
     return emberAfReadServerAttribute(endpoint, MeterIdentification::Id, DataQualityId::Id, (uint8_t *) dataQualityId,
                                       sizeof(*dataQualityId));
 }
-EmberAfStatus SetDataQualityId(chip::EndpointId endpoint, uint16_t dataQualityId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dataQualityId)
 {
     return emberAfWriteServerAttribute(endpoint, MeterIdentification::Id, DataQualityId::Id, (uint8_t *) &dataQualityId,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace DataQualityId
+
 } // namespace Attributes
 } // namespace MeterIdentification
 
 namespace ApplianceStatistics {
 namespace Attributes {
-EmberAfStatus GetLogMaxSize(chip::EndpointId endpoint, uint32_t * logMaxSize)
+
+namespace LogMaxSize {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * logMaxSize)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceStatistics::Id, LogMaxSize::Id, (uint8_t *) logMaxSize,
                                       sizeof(*logMaxSize));
 }
-EmberAfStatus SetLogMaxSize(chip::EndpointId endpoint, uint32_t logMaxSize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t logMaxSize)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceStatistics::Id, LogMaxSize::Id, (uint8_t *) &logMaxSize,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLogQueueMaxSize(chip::EndpointId endpoint, uint8_t * logQueueMaxSize)
+
+} // namespace LogMaxSize
+
+namespace LogQueueMaxSize {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * logQueueMaxSize)
 {
     return emberAfReadServerAttribute(endpoint, ApplianceStatistics::Id, LogQueueMaxSize::Id, (uint8_t *) logQueueMaxSize,
                                       sizeof(*logQueueMaxSize));
 }
-EmberAfStatus SetLogQueueMaxSize(chip::EndpointId endpoint, uint8_t logQueueMaxSize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t logQueueMaxSize)
 {
     return emberAfWriteServerAttribute(endpoint, ApplianceStatistics::Id, LogQueueMaxSize::Id, (uint8_t *) &logQueueMaxSize,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace LogQueueMaxSize
+
 } // namespace Attributes
 } // namespace ApplianceStatistics
 
 namespace ElectricalMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasurementType(chip::EndpointId endpoint, uint32_t * measurementType)
+
+namespace MeasurementType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * measurementType)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasurementType::Id, (uint8_t *) measurementType,
                                       sizeof(*measurementType));
 }
-EmberAfStatus SetMeasurementType(chip::EndpointId endpoint, uint32_t measurementType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t measurementType)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasurementType::Id, (uint8_t *) &measurementType,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcVoltage(chip::EndpointId endpoint, int16_t * dcVoltage)
+
+} // namespace MeasurementType
+
+namespace DcVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltage::Id, (uint8_t *) dcVoltage,
                                       sizeof(*dcVoltage));
 }
-EmberAfStatus SetDcVoltage(chip::EndpointId endpoint, int16_t dcVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltage::Id, (uint8_t *) &dcVoltage,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcVoltageMin(chip::EndpointId endpoint, int16_t * dcVoltageMin)
+
+} // namespace DcVoltage
+
+namespace DcVoltageMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMin::Id, (uint8_t *) dcVoltageMin,
                                       sizeof(*dcVoltageMin));
 }
-EmberAfStatus SetDcVoltageMin(chip::EndpointId endpoint, int16_t dcVoltageMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMin::Id, (uint8_t *) &dcVoltageMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcVoltageMax(chip::EndpointId endpoint, int16_t * dcVoltageMax)
+
+} // namespace DcVoltageMin
+
+namespace DcVoltageMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMax::Id, (uint8_t *) dcVoltageMax,
                                       sizeof(*dcVoltageMax));
 }
-EmberAfStatus SetDcVoltageMax(chip::EndpointId endpoint, int16_t dcVoltageMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMax::Id, (uint8_t *) &dcVoltageMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcCurrent(chip::EndpointId endpoint, int16_t * dcCurrent)
+
+} // namespace DcVoltageMax
+
+namespace DcCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrent::Id, (uint8_t *) dcCurrent,
                                       sizeof(*dcCurrent));
 }
-EmberAfStatus SetDcCurrent(chip::EndpointId endpoint, int16_t dcCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrent::Id, (uint8_t *) &dcCurrent,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcCurrentMin(chip::EndpointId endpoint, int16_t * dcCurrentMin)
+
+} // namespace DcCurrent
+
+namespace DcCurrentMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMin::Id, (uint8_t *) dcCurrentMin,
                                       sizeof(*dcCurrentMin));
 }
-EmberAfStatus SetDcCurrentMin(chip::EndpointId endpoint, int16_t dcCurrentMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMin::Id, (uint8_t *) &dcCurrentMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcCurrentMax(chip::EndpointId endpoint, int16_t * dcCurrentMax)
+
+} // namespace DcCurrentMin
+
+namespace DcCurrentMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMax::Id, (uint8_t *) dcCurrentMax,
                                       sizeof(*dcCurrentMax));
 }
-EmberAfStatus SetDcCurrentMax(chip::EndpointId endpoint, int16_t dcCurrentMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMax::Id, (uint8_t *) &dcCurrentMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcPower(chip::EndpointId endpoint, int16_t * dcPower)
+
+} // namespace DcCurrentMax
+
+namespace DcPower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPower::Id, (uint8_t *) dcPower, sizeof(*dcPower));
 }
-EmberAfStatus SetDcPower(chip::EndpointId endpoint, int16_t dcPower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPower::Id, (uint8_t *) &dcPower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcPowerMin(chip::EndpointId endpoint, int16_t * dcPowerMin)
+
+} // namespace DcPower
+
+namespace DcPowerMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMin::Id, (uint8_t *) dcPowerMin,
                                       sizeof(*dcPowerMin));
 }
-EmberAfStatus SetDcPowerMin(chip::EndpointId endpoint, int16_t dcPowerMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMin::Id, (uint8_t *) &dcPowerMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcPowerMax(chip::EndpointId endpoint, int16_t * dcPowerMax)
+
+} // namespace DcPowerMin
+
+namespace DcPowerMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMax::Id, (uint8_t *) dcPowerMax,
                                       sizeof(*dcPowerMax));
 }
-EmberAfStatus SetDcPowerMax(chip::EndpointId endpoint, int16_t dcPowerMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMax::Id, (uint8_t *) &dcPowerMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcVoltageMultiplier(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier)
+
+} // namespace DcPowerMax
+
+namespace DcVoltageMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMultiplier::Id, (uint8_t *) dcVoltageMultiplier,
                                       sizeof(*dcVoltageMultiplier));
 }
-EmberAfStatus SetDcVoltageMultiplier(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageMultiplier::Id,
                                        (uint8_t *) &dcVoltageMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcVoltageDivisor(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor)
+
+} // namespace DcVoltageMultiplier
+
+namespace DcVoltageDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageDivisor::Id, (uint8_t *) dcVoltageDivisor,
                                       sizeof(*dcVoltageDivisor));
 }
-EmberAfStatus SetDcVoltageDivisor(chip::EndpointId endpoint, uint16_t dcVoltageDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcVoltageDivisor::Id, (uint8_t *) &dcVoltageDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcCurrentMultiplier(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier)
+
+} // namespace DcVoltageDivisor
+
+namespace DcCurrentMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMultiplier::Id, (uint8_t *) dcCurrentMultiplier,
                                       sizeof(*dcCurrentMultiplier));
 }
-EmberAfStatus SetDcCurrentMultiplier(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentMultiplier::Id,
                                        (uint8_t *) &dcCurrentMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcCurrentDivisor(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor)
+
+} // namespace DcCurrentMultiplier
+
+namespace DcCurrentDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentDivisor::Id, (uint8_t *) dcCurrentDivisor,
                                       sizeof(*dcCurrentDivisor));
 }
-EmberAfStatus SetDcCurrentDivisor(chip::EndpointId endpoint, uint16_t dcCurrentDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcCurrentDivisor::Id, (uint8_t *) &dcCurrentDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcPowerMultiplier(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier)
+
+} // namespace DcCurrentDivisor
+
+namespace DcPowerMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMultiplier::Id, (uint8_t *) dcPowerMultiplier,
                                       sizeof(*dcPowerMultiplier));
 }
-EmberAfStatus SetDcPowerMultiplier(chip::EndpointId endpoint, uint16_t dcPowerMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerMultiplier::Id, (uint8_t *) &dcPowerMultiplier,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetDcPowerDivisor(chip::EndpointId endpoint, uint16_t * dcPowerDivisor)
+
+} // namespace DcPowerMultiplier
+
+namespace DcPowerDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerDivisor::Id, (uint8_t *) dcPowerDivisor,
                                       sizeof(*dcPowerDivisor));
 }
-EmberAfStatus SetDcPowerDivisor(chip::EndpointId endpoint, uint16_t dcPowerDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, DcPowerDivisor::Id, (uint8_t *) &dcPowerDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcFrequency(chip::EndpointId endpoint, uint16_t * acFrequency)
+
+} // namespace DcPowerDivisor
+
+namespace AcFrequency {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequency)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequency::Id, (uint8_t *) acFrequency,
                                       sizeof(*acFrequency));
 }
-EmberAfStatus SetAcFrequency(chip::EndpointId endpoint, uint16_t acFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequency)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequency::Id, (uint8_t *) &acFrequency,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcFrequencyMin(chip::EndpointId endpoint, uint16_t * acFrequencyMin)
+
+} // namespace AcFrequency
+
+namespace AcFrequencyMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMin::Id, (uint8_t *) acFrequencyMin,
                                       sizeof(*acFrequencyMin));
 }
-EmberAfStatus SetAcFrequencyMin(chip::EndpointId endpoint, uint16_t acFrequencyMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMin::Id, (uint8_t *) &acFrequencyMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcFrequencyMax(chip::EndpointId endpoint, uint16_t * acFrequencyMax)
+
+} // namespace AcFrequencyMin
+
+namespace AcFrequencyMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMax::Id, (uint8_t *) acFrequencyMax,
                                       sizeof(*acFrequencyMax));
 }
-EmberAfStatus SetAcFrequencyMax(chip::EndpointId endpoint, uint16_t acFrequencyMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMax::Id, (uint8_t *) &acFrequencyMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetNeutralCurrent(chip::EndpointId endpoint, uint16_t * neutralCurrent)
+
+} // namespace AcFrequencyMax
+
+namespace NeutralCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * neutralCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, NeutralCurrent::Id, (uint8_t *) neutralCurrent,
                                       sizeof(*neutralCurrent));
 }
-EmberAfStatus SetNeutralCurrent(chip::EndpointId endpoint, uint16_t neutralCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t neutralCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, NeutralCurrent::Id, (uint8_t *) &neutralCurrent,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTotalActivePower(chip::EndpointId endpoint, int32_t * totalActivePower)
+
+} // namespace NeutralCurrent
+
+namespace TotalActivePower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalActivePower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, TotalActivePower::Id, (uint8_t *) totalActivePower,
                                       sizeof(*totalActivePower));
 }
-EmberAfStatus SetTotalActivePower(chip::EndpointId endpoint, int32_t totalActivePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalActivePower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, TotalActivePower::Id, (uint8_t *) &totalActivePower,
                                        ZCL_INT32S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTotalReactivePower(chip::EndpointId endpoint, int32_t * totalReactivePower)
+
+} // namespace TotalActivePower
+
+namespace TotalReactivePower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalReactivePower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, TotalReactivePower::Id, (uint8_t *) totalReactivePower,
                                       sizeof(*totalReactivePower));
 }
-EmberAfStatus SetTotalReactivePower(chip::EndpointId endpoint, int32_t totalReactivePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalReactivePower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, TotalReactivePower::Id, (uint8_t *) &totalReactivePower,
                                        ZCL_INT32S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetTotalApparentPower(chip::EndpointId endpoint, uint32_t * totalApparentPower)
+
+} // namespace TotalReactivePower
+
+namespace TotalApparentPower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalApparentPower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, TotalApparentPower::Id, (uint8_t *) totalApparentPower,
                                       sizeof(*totalApparentPower));
 }
-EmberAfStatus SetTotalApparentPower(chip::EndpointId endpoint, uint32_t totalApparentPower)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalApparentPower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, TotalApparentPower::Id, (uint8_t *) &totalApparentPower,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasured1stHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent)
+
+} // namespace TotalApparentPower
+
+namespace Measured1stHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured1stHarmonicCurrent::Id,
                                       (uint8_t *) measured1stHarmonicCurrent, sizeof(*measured1stHarmonicCurrent));
 }
-EmberAfStatus SetMeasured1stHarmonicCurrent(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured1stHarmonicCurrent::Id,
                                        (uint8_t *) &measured1stHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasured3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent)
+
+} // namespace Measured1stHarmonicCurrent
+
+namespace Measured3rdHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured3rdHarmonicCurrent::Id,
                                       (uint8_t *) measured3rdHarmonicCurrent, sizeof(*measured3rdHarmonicCurrent));
 }
-EmberAfStatus SetMeasured3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured3rdHarmonicCurrent::Id,
                                        (uint8_t *) &measured3rdHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasured5thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent)
+
+} // namespace Measured3rdHarmonicCurrent
+
+namespace Measured5thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured5thHarmonicCurrent::Id,
                                       (uint8_t *) measured5thHarmonicCurrent, sizeof(*measured5thHarmonicCurrent));
 }
-EmberAfStatus SetMeasured5thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured5thHarmonicCurrent::Id,
                                        (uint8_t *) &measured5thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasured7thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent)
+
+} // namespace Measured5thHarmonicCurrent
+
+namespace Measured7thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured7thHarmonicCurrent::Id,
                                       (uint8_t *) measured7thHarmonicCurrent, sizeof(*measured7thHarmonicCurrent));
 }
-EmberAfStatus SetMeasured7thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured7thHarmonicCurrent::Id,
                                        (uint8_t *) &measured7thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasured9thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent)
+
+} // namespace Measured7thHarmonicCurrent
+
+namespace Measured9thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured9thHarmonicCurrent::Id,
                                       (uint8_t *) measured9thHarmonicCurrent, sizeof(*measured9thHarmonicCurrent));
 }
-EmberAfStatus SetMeasured9thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured9thHarmonicCurrent::Id,
                                        (uint8_t *) &measured9thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasured11thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent)
+
+} // namespace Measured9thHarmonicCurrent
+
+namespace Measured11thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, Measured11thHarmonicCurrent::Id,
                                       (uint8_t *) measured11thHarmonicCurrent, sizeof(*measured11thHarmonicCurrent));
 }
-EmberAfStatus SetMeasured11thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, Measured11thHarmonicCurrent::Id,
                                        (uint8_t *) &measured11thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasuredPhase1stHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent)
+
+} // namespace Measured11thHarmonicCurrent
+
+namespace MeasuredPhase1stHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase1stHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase1stHarmonicCurrent, sizeof(*measuredPhase1stHarmonicCurrent));
 }
-EmberAfStatus SetMeasuredPhase1stHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase1stHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase1stHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasuredPhase3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent)
+
+} // namespace MeasuredPhase1stHarmonicCurrent
+
+namespace MeasuredPhase3rdHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase3rdHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase3rdHarmonicCurrent, sizeof(*measuredPhase3rdHarmonicCurrent));
 }
-EmberAfStatus SetMeasuredPhase3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase3rdHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase3rdHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasuredPhase5thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent)
+
+} // namespace MeasuredPhase3rdHarmonicCurrent
+
+namespace MeasuredPhase5thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase5thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase5thHarmonicCurrent, sizeof(*measuredPhase5thHarmonicCurrent));
 }
-EmberAfStatus SetMeasuredPhase5thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase5thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase5thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasuredPhase7thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent)
+
+} // namespace MeasuredPhase5thHarmonicCurrent
+
+namespace MeasuredPhase7thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase7thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase7thHarmonicCurrent, sizeof(*measuredPhase7thHarmonicCurrent));
 }
-EmberAfStatus SetMeasuredPhase7thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase7thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase7thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasuredPhase9thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent)
+
+} // namespace MeasuredPhase7thHarmonicCurrent
+
+namespace MeasuredPhase9thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase9thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase9thHarmonicCurrent, sizeof(*measuredPhase9thHarmonicCurrent));
 }
-EmberAfStatus SetMeasuredPhase9thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase9thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase9thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMeasuredPhase11thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent)
+
+} // namespace MeasuredPhase9thHarmonicCurrent
+
+namespace MeasuredPhase11thHarmonicCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase11thHarmonicCurrent::Id,
                                       (uint8_t *) measuredPhase11thHarmonicCurrent, sizeof(*measuredPhase11thHarmonicCurrent));
 }
-EmberAfStatus SetMeasuredPhase11thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, MeasuredPhase11thHarmonicCurrent::Id,
                                        (uint8_t *) &measuredPhase11thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcFrequencyMultiplier(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier)
+
+} // namespace MeasuredPhase11thHarmonicCurrent
+
+namespace AcFrequencyMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMultiplier::Id,
                                       (uint8_t *) acFrequencyMultiplier, sizeof(*acFrequencyMultiplier));
 }
-EmberAfStatus SetAcFrequencyMultiplier(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyMultiplier::Id,
                                        (uint8_t *) &acFrequencyMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcFrequencyDivisor(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor)
+
+} // namespace AcFrequencyMultiplier
+
+namespace AcFrequencyDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyDivisor::Id, (uint8_t *) acFrequencyDivisor,
                                       sizeof(*acFrequencyDivisor));
 }
-EmberAfStatus SetAcFrequencyDivisor(chip::EndpointId endpoint, uint16_t acFrequencyDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcFrequencyDivisor::Id, (uint8_t *) &acFrequencyDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerMultiplier(chip::EndpointId endpoint, uint32_t * powerMultiplier)
+
+} // namespace AcFrequencyDivisor
+
+namespace PowerMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerMultiplier::Id, (uint8_t *) powerMultiplier,
                                       sizeof(*powerMultiplier));
 }
-EmberAfStatus SetPowerMultiplier(chip::EndpointId endpoint, uint32_t powerMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerMultiplier::Id, (uint8_t *) &powerMultiplier,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerDivisor(chip::EndpointId endpoint, uint32_t * powerDivisor)
+
+} // namespace PowerMultiplier
+
+namespace PowerDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerDivisor::Id, (uint8_t *) powerDivisor,
                                       sizeof(*powerDivisor));
 }
-EmberAfStatus SetPowerDivisor(chip::EndpointId endpoint, uint32_t powerDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerDivisor::Id, (uint8_t *) &powerDivisor,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier)
+
+} // namespace PowerDivisor
+
+namespace HarmonicCurrentMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, HarmonicCurrentMultiplier::Id,
                                       (uint8_t *) harmonicCurrentMultiplier, sizeof(*harmonicCurrentMultiplier));
 }
-EmberAfStatus SetHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, HarmonicCurrentMultiplier::Id,
                                        (uint8_t *) &harmonicCurrentMultiplier, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPhaseHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier)
+
+} // namespace HarmonicCurrentMultiplier
+
+namespace PhaseHarmonicCurrentMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PhaseHarmonicCurrentMultiplier::Id,
                                       (uint8_t *) phaseHarmonicCurrentMultiplier, sizeof(*phaseHarmonicCurrentMultiplier));
 }
-EmberAfStatus SetPhaseHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PhaseHarmonicCurrentMultiplier::Id,
                                        (uint8_t *) &phaseHarmonicCurrentMultiplier, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstantaneousVoltage(chip::EndpointId endpoint, int16_t * instantaneousVoltage)
+
+} // namespace PhaseHarmonicCurrentMultiplier
+
+namespace InstantaneousVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousVoltage::Id,
                                       (uint8_t *) instantaneousVoltage, sizeof(*instantaneousVoltage));
 }
-EmberAfStatus SetInstantaneousVoltage(chip::EndpointId endpoint, int16_t instantaneousVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousVoltage::Id,
                                        (uint8_t *) &instantaneousVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstantaneousLineCurrent(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent)
+
+} // namespace InstantaneousVoltage
+
+namespace InstantaneousLineCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousLineCurrent::Id,
                                       (uint8_t *) instantaneousLineCurrent, sizeof(*instantaneousLineCurrent));
 }
-EmberAfStatus SetInstantaneousLineCurrent(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousLineCurrent::Id,
                                        (uint8_t *) &instantaneousLineCurrent, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstantaneousActiveCurrent(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent)
+
+} // namespace InstantaneousLineCurrent
+
+namespace InstantaneousActiveCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousActiveCurrent::Id,
                                       (uint8_t *) instantaneousActiveCurrent, sizeof(*instantaneousActiveCurrent));
 }
-EmberAfStatus SetInstantaneousActiveCurrent(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousActiveCurrent::Id,
                                        (uint8_t *) &instantaneousActiveCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstantaneousReactiveCurrent(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent)
+
+} // namespace InstantaneousActiveCurrent
+
+namespace InstantaneousReactiveCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousReactiveCurrent::Id,
                                       (uint8_t *) instantaneousReactiveCurrent, sizeof(*instantaneousReactiveCurrent));
 }
-EmberAfStatus SetInstantaneousReactiveCurrent(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousReactiveCurrent::Id,
                                        (uint8_t *) &instantaneousReactiveCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetInstantaneousPower(chip::EndpointId endpoint, int16_t * instantaneousPower)
+
+} // namespace InstantaneousReactiveCurrent
+
+namespace InstantaneousPower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousPower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousPower::Id, (uint8_t *) instantaneousPower,
                                       sizeof(*instantaneousPower));
 }
-EmberAfStatus SetInstantaneousPower(chip::EndpointId endpoint, int16_t instantaneousPower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousPower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, InstantaneousPower::Id, (uint8_t *) &instantaneousPower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltage(chip::EndpointId endpoint, uint16_t * rmsVoltage)
+
+} // namespace InstantaneousPower
+
+namespace RmsVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltage::Id, (uint8_t *) rmsVoltage,
                                       sizeof(*rmsVoltage));
 }
-EmberAfStatus SetRmsVoltage(chip::EndpointId endpoint, uint16_t rmsVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltage::Id, (uint8_t *) &rmsVoltage,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageMin(chip::EndpointId endpoint, uint16_t * rmsVoltageMin)
+
+} // namespace RmsVoltage
+
+namespace RmsVoltageMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMin::Id, (uint8_t *) rmsVoltageMin,
                                       sizeof(*rmsVoltageMin));
 }
-EmberAfStatus SetRmsVoltageMin(chip::EndpointId endpoint, uint16_t rmsVoltageMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMin::Id, (uint8_t *) &rmsVoltageMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageMax(chip::EndpointId endpoint, uint16_t * rmsVoltageMax)
+
+} // namespace RmsVoltageMin
+
+namespace RmsVoltageMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMax::Id, (uint8_t *) rmsVoltageMax,
                                       sizeof(*rmsVoltageMax));
 }
-EmberAfStatus SetRmsVoltageMax(chip::EndpointId endpoint, uint16_t rmsVoltageMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMax::Id, (uint8_t *) &rmsVoltageMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrent(chip::EndpointId endpoint, uint16_t * rmsCurrent)
+
+} // namespace RmsVoltageMax
+
+namespace RmsCurrent {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrent)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrent::Id, (uint8_t *) rmsCurrent,
                                       sizeof(*rmsCurrent));
 }
-EmberAfStatus SetRmsCurrent(chip::EndpointId endpoint, uint16_t rmsCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrent)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrent::Id, (uint8_t *) &rmsCurrent,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentMin(chip::EndpointId endpoint, uint16_t * rmsCurrentMin)
+
+} // namespace RmsCurrent
+
+namespace RmsCurrentMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMin::Id, (uint8_t *) rmsCurrentMin,
                                       sizeof(*rmsCurrentMin));
 }
-EmberAfStatus SetRmsCurrentMin(chip::EndpointId endpoint, uint16_t rmsCurrentMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMin::Id, (uint8_t *) &rmsCurrentMin,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentMax(chip::EndpointId endpoint, uint16_t * rmsCurrentMax)
+
+} // namespace RmsCurrentMin
+
+namespace RmsCurrentMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMax::Id, (uint8_t *) rmsCurrentMax,
                                       sizeof(*rmsCurrentMax));
 }
-EmberAfStatus SetRmsCurrentMax(chip::EndpointId endpoint, uint16_t rmsCurrentMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMax::Id, (uint8_t *) &rmsCurrentMax,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePower(chip::EndpointId endpoint, int16_t * activePower)
+
+} // namespace RmsCurrentMax
+
+namespace ActivePower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePower::Id, (uint8_t *) activePower,
                                       sizeof(*activePower));
 }
-EmberAfStatus SetActivePower(chip::EndpointId endpoint, int16_t activePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePower::Id, (uint8_t *) &activePower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerMin(chip::EndpointId endpoint, int16_t * activePowerMin)
+
+} // namespace ActivePower
+
+namespace ActivePowerMin {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMin)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMin::Id, (uint8_t *) activePowerMin,
                                       sizeof(*activePowerMin));
 }
-EmberAfStatus SetActivePowerMin(chip::EndpointId endpoint, int16_t activePowerMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMin)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMin::Id, (uint8_t *) &activePowerMin,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerMax(chip::EndpointId endpoint, int16_t * activePowerMax)
+
+} // namespace ActivePowerMin
+
+namespace ActivePowerMax {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMax)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMax::Id, (uint8_t *) activePowerMax,
                                       sizeof(*activePowerMax));
 }
-EmberAfStatus SetActivePowerMax(chip::EndpointId endpoint, int16_t activePowerMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMax)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMax::Id, (uint8_t *) &activePowerMax,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReactivePower(chip::EndpointId endpoint, int16_t * reactivePower)
+
+} // namespace ActivePowerMax
+
+namespace ReactivePower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePower::Id, (uint8_t *) reactivePower,
                                       sizeof(*reactivePower));
 }
-EmberAfStatus SetReactivePower(chip::EndpointId endpoint, int16_t reactivePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePower::Id, (uint8_t *) &reactivePower,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetApparentPower(chip::EndpointId endpoint, uint16_t * apparentPower)
+
+} // namespace ReactivePower
+
+namespace ApparentPower {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPower)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPower::Id, (uint8_t *) apparentPower,
                                       sizeof(*apparentPower));
 }
-EmberAfStatus SetApparentPower(chip::EndpointId endpoint, uint16_t apparentPower)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPower)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPower::Id, (uint8_t *) &apparentPower,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerFactor(chip::EndpointId endpoint, int8_t * powerFactor)
+
+} // namespace ApparentPower
+
+namespace PowerFactor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactor::Id, (uint8_t *) powerFactor,
                                       sizeof(*powerFactor));
 }
-EmberAfStatus SetPowerFactor(chip::EndpointId endpoint, int8_t powerFactor)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactor::Id, (uint8_t *) &powerFactor,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsVoltageMeasurementPeriod(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriod)
+
+} // namespace PowerFactor
+
+namespace AverageRmsVoltageMeasurementPeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriod)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriod::Id,
                                       (uint8_t *) averageRmsVoltageMeasurementPeriod, sizeof(*averageRmsVoltageMeasurementPeriod));
 }
-EmberAfStatus SetAverageRmsVoltageMeasurementPeriod(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriod::Id,
                                        (uint8_t *) &averageRmsVoltageMeasurementPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsUnderVoltageCounter(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter)
+
+} // namespace AverageRmsVoltageMeasurementPeriod
+
+namespace AverageRmsUnderVoltageCounter {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounter::Id,
                                       (uint8_t *) averageRmsUnderVoltageCounter, sizeof(*averageRmsUnderVoltageCounter));
 }
-EmberAfStatus SetAverageRmsUnderVoltageCounter(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounter::Id,
                                        (uint8_t *) &averageRmsUnderVoltageCounter, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeOverVoltagePeriod(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod)
+
+} // namespace AverageRmsUnderVoltageCounter
+
+namespace RmsExtremeOverVoltagePeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriod::Id,
                                       (uint8_t *) rmsExtremeOverVoltagePeriod, sizeof(*rmsExtremeOverVoltagePeriod));
 }
-EmberAfStatus SetRmsExtremeOverVoltagePeriod(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriod::Id,
                                        (uint8_t *) &rmsExtremeOverVoltagePeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeUnderVoltagePeriod(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod)
+
+} // namespace RmsExtremeOverVoltagePeriod
+
+namespace RmsExtremeUnderVoltagePeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriod::Id,
                                       (uint8_t *) rmsExtremeUnderVoltagePeriod, sizeof(*rmsExtremeUnderVoltagePeriod));
 }
-EmberAfStatus SetRmsExtremeUnderVoltagePeriod(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriod::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltagePeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSagPeriod(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod)
+
+} // namespace RmsExtremeUnderVoltagePeriod
+
+namespace RmsVoltageSagPeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriod::Id, (uint8_t *) rmsVoltageSagPeriod,
                                       sizeof(*rmsVoltageSagPeriod));
 }
-EmberAfStatus SetRmsVoltageSagPeriod(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriod::Id,
                                        (uint8_t *) &rmsVoltageSagPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSwellPeriod(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod)
+
+} // namespace RmsVoltageSagPeriod
+
+namespace RmsVoltageSwellPeriod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriod::Id,
                                       (uint8_t *) rmsVoltageSwellPeriod, sizeof(*rmsVoltageSwellPeriod));
 }
-EmberAfStatus SetRmsVoltageSwellPeriod(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriod::Id,
                                        (uint8_t *) &rmsVoltageSwellPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcVoltageMultiplier(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier)
+
+} // namespace RmsVoltageSwellPeriod
+
+namespace AcVoltageMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageMultiplier::Id, (uint8_t *) acVoltageMultiplier,
                                       sizeof(*acVoltageMultiplier));
 }
-EmberAfStatus SetAcVoltageMultiplier(chip::EndpointId endpoint, uint16_t acVoltageMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageMultiplier::Id,
                                        (uint8_t *) &acVoltageMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcVoltageDivisor(chip::EndpointId endpoint, uint16_t * acVoltageDivisor)
+
+} // namespace AcVoltageMultiplier
+
+namespace AcVoltageDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageDivisor::Id, (uint8_t *) acVoltageDivisor,
                                       sizeof(*acVoltageDivisor));
 }
-EmberAfStatus SetAcVoltageDivisor(chip::EndpointId endpoint, uint16_t acVoltageDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageDivisor::Id, (uint8_t *) &acVoltageDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCurrentMultiplier(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier)
+
+} // namespace AcVoltageDivisor
+
+namespace AcCurrentMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentMultiplier::Id, (uint8_t *) acCurrentMultiplier,
                                       sizeof(*acCurrentMultiplier));
 }
-EmberAfStatus SetAcCurrentMultiplier(chip::EndpointId endpoint, uint16_t acCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentMultiplier::Id,
                                        (uint8_t *) &acCurrentMultiplier, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCurrentDivisor(chip::EndpointId endpoint, uint16_t * acCurrentDivisor)
+
+} // namespace AcCurrentMultiplier
+
+namespace AcCurrentDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentDivisor::Id, (uint8_t *) acCurrentDivisor,
                                       sizeof(*acCurrentDivisor));
 }
-EmberAfStatus SetAcCurrentDivisor(chip::EndpointId endpoint, uint16_t acCurrentDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentDivisor::Id, (uint8_t *) &acCurrentDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcPowerMultiplier(chip::EndpointId endpoint, uint16_t * acPowerMultiplier)
+
+} // namespace AcCurrentDivisor
+
+namespace AcPowerMultiplier {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerMultiplier)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerMultiplier::Id, (uint8_t *) acPowerMultiplier,
                                       sizeof(*acPowerMultiplier));
 }
-EmberAfStatus SetAcPowerMultiplier(chip::EndpointId endpoint, uint16_t acPowerMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerMultiplier)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerMultiplier::Id, (uint8_t *) &acPowerMultiplier,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcPowerDivisor(chip::EndpointId endpoint, uint16_t * acPowerDivisor)
+
+} // namespace AcPowerMultiplier
+
+namespace AcPowerDivisor {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerDivisor)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerDivisor::Id, (uint8_t *) acPowerDivisor,
                                       sizeof(*acPowerDivisor));
 }
-EmberAfStatus SetAcPowerDivisor(chip::EndpointId endpoint, uint16_t acPowerDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerDivisor)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcPowerDivisor::Id, (uint8_t *) &acPowerDivisor,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetOverloadAlarmsMask(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask)
+
+} // namespace AcPowerDivisor
+
+namespace OverloadAlarmsMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, OverloadAlarmsMask::Id, (uint8_t *) overloadAlarmsMask,
                                       sizeof(*overloadAlarmsMask));
 }
-EmberAfStatus SetOverloadAlarmsMask(chip::EndpointId endpoint, uint8_t overloadAlarmsMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t overloadAlarmsMask)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, OverloadAlarmsMask::Id, (uint8_t *) &overloadAlarmsMask,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetVoltageOverload(chip::EndpointId endpoint, int16_t * voltageOverload)
+
+} // namespace OverloadAlarmsMask
+
+namespace VoltageOverload {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * voltageOverload)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, VoltageOverload::Id, (uint8_t *) voltageOverload,
                                       sizeof(*voltageOverload));
 }
-EmberAfStatus SetVoltageOverload(chip::EndpointId endpoint, int16_t voltageOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t voltageOverload)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, VoltageOverload::Id, (uint8_t *) &voltageOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCurrentOverload(chip::EndpointId endpoint, int16_t * currentOverload)
+
+} // namespace VoltageOverload
+
+namespace CurrentOverload {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentOverload)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, CurrentOverload::Id, (uint8_t *) currentOverload,
                                       sizeof(*currentOverload));
 }
-EmberAfStatus SetCurrentOverload(chip::EndpointId endpoint, int16_t currentOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentOverload)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, CurrentOverload::Id, (uint8_t *) &currentOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcOverloadAlarmsMask(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask)
+
+} // namespace CurrentOverload
+
+namespace AcOverloadAlarmsMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcOverloadAlarmsMask::Id,
                                       (uint8_t *) acOverloadAlarmsMask, sizeof(*acOverloadAlarmsMask));
 }
-EmberAfStatus SetAcOverloadAlarmsMask(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcOverloadAlarmsMask::Id,
                                        (uint8_t *) &acOverloadAlarmsMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcVoltageOverload(chip::EndpointId endpoint, int16_t * acVoltageOverload)
+
+} // namespace AcOverloadAlarmsMask
+
+namespace AcVoltageOverload {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acVoltageOverload)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageOverload::Id, (uint8_t *) acVoltageOverload,
                                       sizeof(*acVoltageOverload));
 }
-EmberAfStatus SetAcVoltageOverload(chip::EndpointId endpoint, int16_t acVoltageOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acVoltageOverload)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcVoltageOverload::Id, (uint8_t *) &acVoltageOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcCurrentOverload(chip::EndpointId endpoint, int16_t * acCurrentOverload)
+
+} // namespace AcVoltageOverload
+
+namespace AcCurrentOverload {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCurrentOverload)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentOverload::Id, (uint8_t *) acCurrentOverload,
                                       sizeof(*acCurrentOverload));
 }
-EmberAfStatus SetAcCurrentOverload(chip::EndpointId endpoint, int16_t acCurrentOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCurrentOverload)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcCurrentOverload::Id, (uint8_t *) &acCurrentOverload,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcActivePowerOverload(chip::EndpointId endpoint, int16_t * acActivePowerOverload)
+
+} // namespace AcCurrentOverload
+
+namespace AcActivePowerOverload {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acActivePowerOverload)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcActivePowerOverload::Id,
                                       (uint8_t *) acActivePowerOverload, sizeof(*acActivePowerOverload));
 }
-EmberAfStatus SetAcActivePowerOverload(chip::EndpointId endpoint, int16_t acActivePowerOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acActivePowerOverload)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcActivePowerOverload::Id,
                                        (uint8_t *) &acActivePowerOverload, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAcReactivePowerOverload(chip::EndpointId endpoint, int16_t * acReactivePowerOverload)
+
+} // namespace AcActivePowerOverload
+
+namespace AcReactivePowerOverload {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acReactivePowerOverload)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AcReactivePowerOverload::Id,
                                       (uint8_t *) acReactivePowerOverload, sizeof(*acReactivePowerOverload));
 }
-EmberAfStatus SetAcReactivePowerOverload(chip::EndpointId endpoint, int16_t acReactivePowerOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acReactivePowerOverload)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AcReactivePowerOverload::Id,
                                        (uint8_t *) &acReactivePowerOverload, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsOverVoltage(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage)
+
+} // namespace AcReactivePowerOverload
+
+namespace AverageRmsOverVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltage::Id,
                                       (uint8_t *) averageRmsOverVoltage, sizeof(*averageRmsOverVoltage));
 }
-EmberAfStatus SetAverageRmsOverVoltage(chip::EndpointId endpoint, int16_t averageRmsOverVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsOverVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltage::Id,
                                        (uint8_t *) &averageRmsOverVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsUnderVoltage(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage)
+
+} // namespace AverageRmsOverVoltage
+
+namespace AverageRmsUnderVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltage::Id,
                                       (uint8_t *) averageRmsUnderVoltage, sizeof(*averageRmsUnderVoltage));
 }
-EmberAfStatus SetAverageRmsUnderVoltage(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltage::Id,
                                        (uint8_t *) &averageRmsUnderVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeOverVoltage(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage)
+
+} // namespace AverageRmsUnderVoltage
+
+namespace RmsExtremeOverVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltage::Id,
                                       (uint8_t *) rmsExtremeOverVoltage, sizeof(*rmsExtremeOverVoltage));
 }
-EmberAfStatus SetRmsExtremeOverVoltage(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltage::Id,
                                        (uint8_t *) &rmsExtremeOverVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeUnderVoltage(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage)
+
+} // namespace RmsExtremeOverVoltage
+
+namespace RmsExtremeUnderVoltage {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltage::Id,
                                       (uint8_t *) rmsExtremeUnderVoltage, sizeof(*rmsExtremeUnderVoltage));
 }
-EmberAfStatus SetRmsExtremeUnderVoltage(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltage::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltage, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSag(chip::EndpointId endpoint, int16_t * rmsVoltageSag)
+
+} // namespace RmsExtremeUnderVoltage
+
+namespace RmsVoltageSag {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSag)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSag::Id, (uint8_t *) rmsVoltageSag,
                                       sizeof(*rmsVoltageSag));
 }
-EmberAfStatus SetRmsVoltageSag(chip::EndpointId endpoint, int16_t rmsVoltageSag)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSag)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSag::Id, (uint8_t *) &rmsVoltageSag,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSwell(chip::EndpointId endpoint, int16_t * rmsVoltageSwell)
+
+} // namespace RmsVoltageSag
+
+namespace RmsVoltageSwell {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSwell)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwell::Id, (uint8_t *) rmsVoltageSwell,
                                       sizeof(*rmsVoltageSwell));
 }
-EmberAfStatus SetRmsVoltageSwell(chip::EndpointId endpoint, int16_t rmsVoltageSwell)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSwell)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwell::Id, (uint8_t *) &rmsVoltageSwell,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLineCurrentPhaseB(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB)
+
+} // namespace RmsVoltageSwell
+
+namespace LineCurrentPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseB::Id, (uint8_t *) lineCurrentPhaseB,
                                       sizeof(*lineCurrentPhaseB));
 }
-EmberAfStatus SetLineCurrentPhaseB(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseB::Id, (uint8_t *) &lineCurrentPhaseB,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActiveCurrentPhaseB(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB)
+
+} // namespace LineCurrentPhaseB
+
+namespace ActiveCurrentPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseB::Id, (uint8_t *) activeCurrentPhaseB,
                                       sizeof(*activeCurrentPhaseB));
 }
-EmberAfStatus SetActiveCurrentPhaseB(chip::EndpointId endpoint, int16_t activeCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseB::Id,
                                        (uint8_t *) &activeCurrentPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReactiveCurrentPhaseB(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB)
+
+} // namespace ActiveCurrentPhaseB
+
+namespace ReactiveCurrentPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseB::Id,
                                       (uint8_t *) reactiveCurrentPhaseB, sizeof(*reactiveCurrentPhaseB));
 }
-EmberAfStatus SetReactiveCurrentPhaseB(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseB::Id,
                                        (uint8_t *) &reactiveCurrentPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltagePhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB)
+
+} // namespace ReactiveCurrentPhaseB
+
+namespace RmsVoltagePhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseB::Id, (uint8_t *) rmsVoltagePhaseB,
                                       sizeof(*rmsVoltagePhaseB));
 }
-EmberAfStatus SetRmsVoltagePhaseB(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseB::Id, (uint8_t *) &rmsVoltagePhaseB,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageMinPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB)
+
+} // namespace RmsVoltagePhaseB
+
+namespace RmsVoltageMinPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseB::Id, (uint8_t *) rmsVoltageMinPhaseB,
                                       sizeof(*rmsVoltageMinPhaseB));
 }
-EmberAfStatus SetRmsVoltageMinPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseB::Id,
                                        (uint8_t *) &rmsVoltageMinPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageMaxPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB)
+
+} // namespace RmsVoltageMinPhaseB
+
+namespace RmsVoltageMaxPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseB::Id, (uint8_t *) rmsVoltageMaxPhaseB,
                                       sizeof(*rmsVoltageMaxPhaseB));
 }
-EmberAfStatus SetRmsVoltageMaxPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseB::Id,
                                        (uint8_t *) &rmsVoltageMaxPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB)
+
+} // namespace RmsVoltageMaxPhaseB
+
+namespace RmsCurrentPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseB::Id, (uint8_t *) rmsCurrentPhaseB,
                                       sizeof(*rmsCurrentPhaseB));
 }
-EmberAfStatus SetRmsCurrentPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseB::Id, (uint8_t *) &rmsCurrentPhaseB,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentMinPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB)
+
+} // namespace RmsCurrentPhaseB
+
+namespace RmsCurrentMinPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseB::Id, (uint8_t *) rmsCurrentMinPhaseB,
                                       sizeof(*rmsCurrentMinPhaseB));
 }
-EmberAfStatus SetRmsCurrentMinPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseB::Id,
                                        (uint8_t *) &rmsCurrentMinPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentMaxPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB)
+
+} // namespace RmsCurrentMinPhaseB
+
+namespace RmsCurrentMaxPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseB::Id, (uint8_t *) rmsCurrentMaxPhaseB,
                                       sizeof(*rmsCurrentMaxPhaseB));
 }
-EmberAfStatus SetRmsCurrentMaxPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseB::Id,
                                        (uint8_t *) &rmsCurrentMaxPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerPhaseB(chip::EndpointId endpoint, int16_t * activePowerPhaseB)
+
+} // namespace RmsCurrentMaxPhaseB
+
+namespace ActivePowerPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseB::Id, (uint8_t *) activePowerPhaseB,
                                       sizeof(*activePowerPhaseB));
 }
-EmberAfStatus SetActivePowerPhaseB(chip::EndpointId endpoint, int16_t activePowerPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseB::Id, (uint8_t *) &activePowerPhaseB,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerMinPhaseB(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB)
+
+} // namespace ActivePowerPhaseB
+
+namespace ActivePowerMinPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseB::Id,
                                       (uint8_t *) activePowerMinPhaseB, sizeof(*activePowerMinPhaseB));
 }
-EmberAfStatus SetActivePowerMinPhaseB(chip::EndpointId endpoint, int16_t activePowerMinPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseB::Id,
                                        (uint8_t *) &activePowerMinPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerMaxPhaseB(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB)
+
+} // namespace ActivePowerMinPhaseB
+
+namespace ActivePowerMaxPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseB::Id,
                                       (uint8_t *) activePowerMaxPhaseB, sizeof(*activePowerMaxPhaseB));
 }
-EmberAfStatus SetActivePowerMaxPhaseB(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseB::Id,
                                        (uint8_t *) &activePowerMaxPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReactivePowerPhaseB(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB)
+
+} // namespace ActivePowerMaxPhaseB
+
+namespace ReactivePowerPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseB::Id, (uint8_t *) reactivePowerPhaseB,
                                       sizeof(*reactivePowerPhaseB));
 }
-EmberAfStatus SetReactivePowerPhaseB(chip::EndpointId endpoint, int16_t reactivePowerPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseB::Id,
                                        (uint8_t *) &reactivePowerPhaseB, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetApparentPowerPhaseB(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB)
+
+} // namespace ReactivePowerPhaseB
+
+namespace ApparentPowerPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseB::Id, (uint8_t *) apparentPowerPhaseB,
                                       sizeof(*apparentPowerPhaseB));
 }
-EmberAfStatus SetApparentPowerPhaseB(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseB::Id,
                                        (uint8_t *) &apparentPowerPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerFactorPhaseB(chip::EndpointId endpoint, int8_t * powerFactorPhaseB)
+
+} // namespace ApparentPowerPhaseB
+
+namespace PowerFactorPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseB::Id, (uint8_t *) powerFactorPhaseB,
                                       sizeof(*powerFactorPhaseB));
 }
-EmberAfStatus SetPowerFactorPhaseB(chip::EndpointId endpoint, int8_t powerFactorPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseB::Id, (uint8_t *) &powerFactorPhaseB,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsVoltageMeasurementPeriodPhaseB(chip::EndpointId endpoint,
-                                                          uint16_t * averageRmsVoltageMeasurementPeriodPhaseB)
+
+} // namespace PowerFactorPhaseB
+
+namespace AverageRmsVoltageMeasurementPeriodPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseB::Id,
                                       (uint8_t *) averageRmsVoltageMeasurementPeriodPhaseB,
                                       sizeof(*averageRmsVoltageMeasurementPeriodPhaseB));
 }
-EmberAfStatus SetAverageRmsVoltageMeasurementPeriodPhaseB(chip::EndpointId endpoint,
-                                                          uint16_t averageRmsVoltageMeasurementPeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseB::Id,
                                        (uint8_t *) &averageRmsVoltageMeasurementPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsOverVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseB)
+
+} // namespace AverageRmsVoltageMeasurementPeriodPhaseB
+
+namespace AverageRmsOverVoltageCounterPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseB::Id,
                                       (uint8_t *) averageRmsOverVoltageCounterPhaseB, sizeof(*averageRmsOverVoltageCounterPhaseB));
 }
-EmberAfStatus SetAverageRmsOverVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseB::Id,
                                        (uint8_t *) &averageRmsOverVoltageCounterPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsUnderVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseB)
+
+} // namespace AverageRmsOverVoltageCounterPhaseB
+
+namespace AverageRmsUnderVoltageCounterPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseB::Id,
                                       (uint8_t *) averageRmsUnderVoltageCounterPhaseB,
                                       sizeof(*averageRmsUnderVoltageCounterPhaseB));
 }
-EmberAfStatus SetAverageRmsUnderVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseB::Id,
                                        (uint8_t *) &averageRmsUnderVoltageCounterPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeOverVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseB)
+
+} // namespace AverageRmsUnderVoltageCounterPhaseB
+
+namespace RmsExtremeOverVoltagePeriodPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseB::Id,
                                       (uint8_t *) rmsExtremeOverVoltagePeriodPhaseB, sizeof(*rmsExtremeOverVoltagePeriodPhaseB));
 }
-EmberAfStatus SetRmsExtremeOverVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseB::Id,
                                        (uint8_t *) &rmsExtremeOverVoltagePeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeUnderVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseB)
+
+} // namespace RmsExtremeOverVoltagePeriodPhaseB
+
+namespace RmsExtremeUnderVoltagePeriodPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseB::Id,
                                       (uint8_t *) rmsExtremeUnderVoltagePeriodPhaseB, sizeof(*rmsExtremeUnderVoltagePeriodPhaseB));
 }
-EmberAfStatus SetRmsExtremeUnderVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseB::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltagePeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSagPeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB)
+
+} // namespace RmsExtremeUnderVoltagePeriodPhaseB
+
+namespace RmsVoltageSagPeriodPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseB::Id,
                                       (uint8_t *) rmsVoltageSagPeriodPhaseB, sizeof(*rmsVoltageSagPeriodPhaseB));
 }
-EmberAfStatus SetRmsVoltageSagPeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseB::Id,
                                        (uint8_t *) &rmsVoltageSagPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSwellPeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB)
+
+} // namespace RmsVoltageSagPeriodPhaseB
+
+namespace RmsVoltageSwellPeriodPhaseB {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseB::Id,
                                       (uint8_t *) rmsVoltageSwellPeriodPhaseB, sizeof(*rmsVoltageSwellPeriodPhaseB));
 }
-EmberAfStatus SetRmsVoltageSwellPeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseB::Id,
                                        (uint8_t *) &rmsVoltageSwellPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLineCurrentPhaseC(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC)
+
+} // namespace RmsVoltageSwellPeriodPhaseB
+
+namespace LineCurrentPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseC::Id, (uint8_t *) lineCurrentPhaseC,
                                       sizeof(*lineCurrentPhaseC));
 }
-EmberAfStatus SetLineCurrentPhaseC(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, LineCurrentPhaseC::Id, (uint8_t *) &lineCurrentPhaseC,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActiveCurrentPhaseC(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC)
+
+} // namespace LineCurrentPhaseC
+
+namespace ActiveCurrentPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseC::Id, (uint8_t *) activeCurrentPhaseC,
                                       sizeof(*activeCurrentPhaseC));
 }
-EmberAfStatus SetActiveCurrentPhaseC(chip::EndpointId endpoint, int16_t activeCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActiveCurrentPhaseC::Id,
                                        (uint8_t *) &activeCurrentPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReactiveCurrentPhaseC(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC)
+
+} // namespace ActiveCurrentPhaseC
+
+namespace ReactiveCurrentPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseC::Id,
                                       (uint8_t *) reactiveCurrentPhaseC, sizeof(*reactiveCurrentPhaseC));
 }
-EmberAfStatus SetReactiveCurrentPhaseC(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactiveCurrentPhaseC::Id,
                                        (uint8_t *) &reactiveCurrentPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltagePhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC)
+
+} // namespace ReactiveCurrentPhaseC
+
+namespace RmsVoltagePhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseC::Id, (uint8_t *) rmsVoltagePhaseC,
                                       sizeof(*rmsVoltagePhaseC));
 }
-EmberAfStatus SetRmsVoltagePhaseC(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltagePhaseC::Id, (uint8_t *) &rmsVoltagePhaseC,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageMinPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC)
+
+} // namespace RmsVoltagePhaseC
+
+namespace RmsVoltageMinPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseC::Id, (uint8_t *) rmsVoltageMinPhaseC,
                                       sizeof(*rmsVoltageMinPhaseC));
 }
-EmberAfStatus SetRmsVoltageMinPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMinPhaseC::Id,
                                        (uint8_t *) &rmsVoltageMinPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageMaxPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC)
+
+} // namespace RmsVoltageMinPhaseC
+
+namespace RmsVoltageMaxPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseC::Id, (uint8_t *) rmsVoltageMaxPhaseC,
                                       sizeof(*rmsVoltageMaxPhaseC));
 }
-EmberAfStatus SetRmsVoltageMaxPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageMaxPhaseC::Id,
                                        (uint8_t *) &rmsVoltageMaxPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC)
+
+} // namespace RmsVoltageMaxPhaseC
+
+namespace RmsCurrentPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseC::Id, (uint8_t *) rmsCurrentPhaseC,
                                       sizeof(*rmsCurrentPhaseC));
 }
-EmberAfStatus SetRmsCurrentPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentPhaseC::Id, (uint8_t *) &rmsCurrentPhaseC,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentMinPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC)
+
+} // namespace RmsCurrentPhaseC
+
+namespace RmsCurrentMinPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseC::Id, (uint8_t *) rmsCurrentMinPhaseC,
                                       sizeof(*rmsCurrentMinPhaseC));
 }
-EmberAfStatus SetRmsCurrentMinPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMinPhaseC::Id,
                                        (uint8_t *) &rmsCurrentMinPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsCurrentMaxPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC)
+
+} // namespace RmsCurrentMinPhaseC
+
+namespace RmsCurrentMaxPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseC::Id, (uint8_t *) rmsCurrentMaxPhaseC,
                                       sizeof(*rmsCurrentMaxPhaseC));
 }
-EmberAfStatus SetRmsCurrentMaxPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsCurrentMaxPhaseC::Id,
                                        (uint8_t *) &rmsCurrentMaxPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerPhaseC(chip::EndpointId endpoint, int16_t * activePowerPhaseC)
+
+} // namespace RmsCurrentMaxPhaseC
+
+namespace ActivePowerPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseC::Id, (uint8_t *) activePowerPhaseC,
                                       sizeof(*activePowerPhaseC));
 }
-EmberAfStatus SetActivePowerPhaseC(chip::EndpointId endpoint, int16_t activePowerPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerPhaseC::Id, (uint8_t *) &activePowerPhaseC,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerMinPhaseC(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC)
+
+} // namespace ActivePowerPhaseC
+
+namespace ActivePowerMinPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseC::Id,
                                       (uint8_t *) activePowerMinPhaseC, sizeof(*activePowerMinPhaseC));
 }
-EmberAfStatus SetActivePowerMinPhaseC(chip::EndpointId endpoint, int16_t activePowerMinPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMinPhaseC::Id,
                                        (uint8_t *) &activePowerMinPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActivePowerMaxPhaseC(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC)
+
+} // namespace ActivePowerMinPhaseC
+
+namespace ActivePowerMaxPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseC::Id,
                                       (uint8_t *) activePowerMaxPhaseC, sizeof(*activePowerMaxPhaseC));
 }
-EmberAfStatus SetActivePowerMaxPhaseC(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ActivePowerMaxPhaseC::Id,
                                        (uint8_t *) &activePowerMaxPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReactivePowerPhaseC(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC)
+
+} // namespace ActivePowerMaxPhaseC
+
+namespace ReactivePowerPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseC::Id, (uint8_t *) reactivePowerPhaseC,
                                       sizeof(*reactivePowerPhaseC));
 }
-EmberAfStatus SetReactivePowerPhaseC(chip::EndpointId endpoint, int16_t reactivePowerPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ReactivePowerPhaseC::Id,
                                        (uint8_t *) &reactivePowerPhaseC, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetApparentPowerPhaseC(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC)
+
+} // namespace ReactivePowerPhaseC
+
+namespace ApparentPowerPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseC::Id, (uint8_t *) apparentPowerPhaseC,
                                       sizeof(*apparentPowerPhaseC));
 }
-EmberAfStatus SetApparentPowerPhaseC(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, ApparentPowerPhaseC::Id,
                                        (uint8_t *) &apparentPowerPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPowerFactorPhaseC(chip::EndpointId endpoint, int8_t * powerFactorPhaseC)
+
+} // namespace ApparentPowerPhaseC
+
+namespace PowerFactorPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseC::Id, (uint8_t *) powerFactorPhaseC,
                                       sizeof(*powerFactorPhaseC));
 }
-EmberAfStatus SetPowerFactorPhaseC(chip::EndpointId endpoint, int8_t powerFactorPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, PowerFactorPhaseC::Id, (uint8_t *) &powerFactorPhaseC,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsVoltageMeasurementPeriodPhaseC(chip::EndpointId endpoint,
-                                                          uint16_t * averageRmsVoltageMeasurementPeriodPhaseC)
+
+} // namespace PowerFactorPhaseC
+
+namespace AverageRmsVoltageMeasurementPeriodPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseC::Id,
                                       (uint8_t *) averageRmsVoltageMeasurementPeriodPhaseC,
                                       sizeof(*averageRmsVoltageMeasurementPeriodPhaseC));
 }
-EmberAfStatus SetAverageRmsVoltageMeasurementPeriodPhaseC(chip::EndpointId endpoint,
-                                                          uint16_t averageRmsVoltageMeasurementPeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsVoltageMeasurementPeriodPhaseC::Id,
                                        (uint8_t *) &averageRmsVoltageMeasurementPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsOverVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseC)
+
+} // namespace AverageRmsVoltageMeasurementPeriodPhaseC
+
+namespace AverageRmsOverVoltageCounterPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseC::Id,
                                       (uint8_t *) averageRmsOverVoltageCounterPhaseC, sizeof(*averageRmsOverVoltageCounterPhaseC));
 }
-EmberAfStatus SetAverageRmsOverVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsOverVoltageCounterPhaseC::Id,
                                        (uint8_t *) &averageRmsOverVoltageCounterPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetAverageRmsUnderVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseC)
+
+} // namespace AverageRmsOverVoltageCounterPhaseC
+
+namespace AverageRmsUnderVoltageCounterPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseC::Id,
                                       (uint8_t *) averageRmsUnderVoltageCounterPhaseC,
                                       sizeof(*averageRmsUnderVoltageCounterPhaseC));
 }
-EmberAfStatus SetAverageRmsUnderVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, AverageRmsUnderVoltageCounterPhaseC::Id,
                                        (uint8_t *) &averageRmsUnderVoltageCounterPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeOverVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseC)
+
+} // namespace AverageRmsUnderVoltageCounterPhaseC
+
+namespace RmsExtremeOverVoltagePeriodPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseC::Id,
                                       (uint8_t *) rmsExtremeOverVoltagePeriodPhaseC, sizeof(*rmsExtremeOverVoltagePeriodPhaseC));
 }
-EmberAfStatus SetRmsExtremeOverVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeOverVoltagePeriodPhaseC::Id,
                                        (uint8_t *) &rmsExtremeOverVoltagePeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsExtremeUnderVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseC)
+
+} // namespace RmsExtremeOverVoltagePeriodPhaseC
+
+namespace RmsExtremeUnderVoltagePeriodPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseC::Id,
                                       (uint8_t *) rmsExtremeUnderVoltagePeriodPhaseC, sizeof(*rmsExtremeUnderVoltagePeriodPhaseC));
 }
-EmberAfStatus SetRmsExtremeUnderVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsExtremeUnderVoltagePeriodPhaseC::Id,
                                        (uint8_t *) &rmsExtremeUnderVoltagePeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSagPeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC)
+
+} // namespace RmsExtremeUnderVoltagePeriodPhaseC
+
+namespace RmsVoltageSagPeriodPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseC::Id,
                                       (uint8_t *) rmsVoltageSagPeriodPhaseC, sizeof(*rmsVoltageSagPeriodPhaseC));
 }
-EmberAfStatus SetRmsVoltageSagPeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSagPeriodPhaseC::Id,
                                        (uint8_t *) &rmsVoltageSagPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRmsVoltageSwellPeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC)
+
+} // namespace RmsVoltageSagPeriodPhaseC
+
+namespace RmsVoltageSwellPeriodPhaseC {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC)
 {
     return emberAfReadServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseC::Id,
                                       (uint8_t *) rmsVoltageSwellPeriodPhaseC, sizeof(*rmsVoltageSwellPeriodPhaseC));
 }
-EmberAfStatus SetRmsVoltageSwellPeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC)
 {
     return emberAfWriteServerAttribute(endpoint, ElectricalMeasurement::Id, RmsVoltageSwellPeriodPhaseC::Id,
                                        (uint8_t *) &rmsVoltageSwellPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace RmsVoltageSwellPeriodPhaseC
+
 } // namespace Attributes
 } // namespace ElectricalMeasurement
 
 namespace GroupKeyManagement {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace GroupKeyManagement
 
 namespace SampleMfgSpecificCluster {
 namespace Attributes {
-EmberAfStatus GetEmberSampleAttribute(chip::EndpointId endpoint, uint8_t * emberSampleAttribute)
+
+namespace EmberSampleAttribute {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute)
 {
     return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute::Id,
                                       (uint8_t *) emberSampleAttribute, sizeof(*emberSampleAttribute));
 }
-EmberAfStatus SetEmberSampleAttribute(chip::EndpointId endpoint, uint8_t emberSampleAttribute)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute)
 {
     return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute::Id,
                                        (uint8_t *) &emberSampleAttribute, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEmberSampleAttribute2(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2)
+
+} // namespace EmberSampleAttribute
+
+namespace EmberSampleAttribute2 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2)
 {
     return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute2::Id,
                                       (uint8_t *) emberSampleAttribute2, sizeof(*emberSampleAttribute2));
 }
-EmberAfStatus SetEmberSampleAttribute2(chip::EndpointId endpoint, uint8_t emberSampleAttribute2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute2)
 {
     return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster::Id, EmberSampleAttribute2::Id,
                                        (uint8_t *) &emberSampleAttribute2, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
+
+} // namespace EmberSampleAttribute2
+
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster
 
 namespace SampleMfgSpecificCluster2 {
 namespace Attributes {
-EmberAfStatus GetEmberSampleAttribute3(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3)
+
+namespace EmberSampleAttribute3 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3)
 {
     return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute3::Id,
                                       (uint8_t *) emberSampleAttribute3, sizeof(*emberSampleAttribute3));
 }
-EmberAfStatus SetEmberSampleAttribute3(chip::EndpointId endpoint, uint16_t emberSampleAttribute3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute3)
 {
     return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute3::Id,
                                        (uint8_t *) &emberSampleAttribute3, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEmberSampleAttribute4(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4)
+
+} // namespace EmberSampleAttribute3
+
+namespace EmberSampleAttribute4 {
+
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4)
 {
     return emberAfReadServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute4::Id,
                                       (uint8_t *) emberSampleAttribute4, sizeof(*emberSampleAttribute4));
 }
-EmberAfStatus SetEmberSampleAttribute4(chip::EndpointId endpoint, uint16_t emberSampleAttribute4)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute4)
 {
     return emberAfWriteServerAttribute(endpoint, SampleMfgSpecificCluster2::Id, EmberSampleAttribute4::Id,
                                        (uint8_t *) &emberSampleAttribute4, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
+
+} // namespace EmberSampleAttribute4
+
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster2
 

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -33,2225 +33,4631 @@ namespace Clusters {
 
 namespace PowerConfiguration {
 namespace Attributes {
-EmberAfStatus GetMainsVoltage(chip::EndpointId endpoint, uint16_t * mainsVoltage); // int16u
-EmberAfStatus SetMainsVoltage(chip::EndpointId endpoint, uint16_t mainsVoltage);
-EmberAfStatus GetMainsFrequency(chip::EndpointId endpoint, uint8_t * mainsFrequency); // int8u
-EmberAfStatus SetMainsFrequency(chip::EndpointId endpoint, uint8_t mainsFrequency);
-EmberAfStatus GetMainsAlarmMask(chip::EndpointId endpoint, uint8_t * mainsAlarmMask); // bitmap8
-EmberAfStatus SetMainsAlarmMask(chip::EndpointId endpoint, uint8_t mainsAlarmMask);
-EmberAfStatus GetMainsVoltageMinThreshold(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold); // int16u
-EmberAfStatus SetMainsVoltageMinThreshold(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold);
-EmberAfStatus GetMainsVoltageMaxThreshold(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold); // int16u
-EmberAfStatus SetMainsVoltageMaxThreshold(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold);
-EmberAfStatus GetMainsVoltageDwellTrip(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip); // int16u
-EmberAfStatus SetMainsVoltageDwellTrip(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip);
-EmberAfStatus GetBatteryVoltage(chip::EndpointId endpoint, uint8_t * batteryVoltage); // int8u
-EmberAfStatus SetBatteryVoltage(chip::EndpointId endpoint, uint8_t batteryVoltage);
-EmberAfStatus GetBatteryPercentageRemaining(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining); // int8u
-EmberAfStatus SetBatteryPercentageRemaining(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining);
-EmberAfStatus GetBatterySize(chip::EndpointId endpoint, uint8_t * batterySize); // enum8
-EmberAfStatus SetBatterySize(chip::EndpointId endpoint, uint8_t batterySize);
-EmberAfStatus GetBatteryAhrRating(chip::EndpointId endpoint, uint16_t * batteryAhrRating); // int16u
-EmberAfStatus SetBatteryAhrRating(chip::EndpointId endpoint, uint16_t batteryAhrRating);
-EmberAfStatus GetBatteryQuantity(chip::EndpointId endpoint, uint8_t * batteryQuantity); // int8u
-EmberAfStatus SetBatteryQuantity(chip::EndpointId endpoint, uint8_t batteryQuantity);
-EmberAfStatus GetBatteryRatedVoltage(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage); // int8u
-EmberAfStatus SetBatteryRatedVoltage(chip::EndpointId endpoint, uint8_t batteryRatedVoltage);
-EmberAfStatus GetBatteryAlarmMask(chip::EndpointId endpoint, uint8_t * batteryAlarmMask); // bitmap8
-EmberAfStatus SetBatteryAlarmMask(chip::EndpointId endpoint, uint8_t batteryAlarmMask);
-EmberAfStatus GetBatteryVoltageMinThreshold(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold); // int8u
-EmberAfStatus SetBatteryVoltageMinThreshold(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold);
-EmberAfStatus GetBatteryVoltageThreshold1(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1); // int8u
-EmberAfStatus SetBatteryVoltageThreshold1(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1);
-EmberAfStatus GetBatteryVoltageThreshold2(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2); // int8u
-EmberAfStatus SetBatteryVoltageThreshold2(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2);
-EmberAfStatus GetBatteryVoltageThreshold3(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3); // int8u
-EmberAfStatus SetBatteryVoltageThreshold3(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3);
-EmberAfStatus GetBatteryPercentageMinThreshold(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold); // int8u
-EmberAfStatus SetBatteryPercentageMinThreshold(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold);
-EmberAfStatus GetBatteryPercentageThreshold1(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1); // int8u
-EmberAfStatus SetBatteryPercentageThreshold1(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1);
-EmberAfStatus GetBatteryPercentageThreshold2(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2); // int8u
-EmberAfStatus SetBatteryPercentageThreshold2(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2);
-EmberAfStatus GetBatteryPercentageThreshold3(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3); // int8u
-EmberAfStatus SetBatteryPercentageThreshold3(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3);
-EmberAfStatus GetBatteryAlarmState(chip::EndpointId endpoint, uint32_t * batteryAlarmState); // bitmap32
-EmberAfStatus SetBatteryAlarmState(chip::EndpointId endpoint, uint32_t batteryAlarmState);
-EmberAfStatus GetBattery2Voltage(chip::EndpointId endpoint, uint8_t * battery2Voltage); // int8u
-EmberAfStatus SetBattery2Voltage(chip::EndpointId endpoint, uint8_t battery2Voltage);
-EmberAfStatus GetBattery2PercentageRemaining(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining); // int8u
-EmberAfStatus SetBattery2PercentageRemaining(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining);
-EmberAfStatus GetBattery2Size(chip::EndpointId endpoint, uint8_t * battery2Size); // enum8
-EmberAfStatus SetBattery2Size(chip::EndpointId endpoint, uint8_t battery2Size);
-EmberAfStatus GetBattery2AhrRating(chip::EndpointId endpoint, uint16_t * battery2AhrRating); // int16u
-EmberAfStatus SetBattery2AhrRating(chip::EndpointId endpoint, uint16_t battery2AhrRating);
-EmberAfStatus GetBattery2Quantity(chip::EndpointId endpoint, uint8_t * battery2Quantity); // int8u
-EmberAfStatus SetBattery2Quantity(chip::EndpointId endpoint, uint8_t battery2Quantity);
-EmberAfStatus GetBattery2RatedVoltage(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage); // int8u
-EmberAfStatus SetBattery2RatedVoltage(chip::EndpointId endpoint, uint8_t battery2RatedVoltage);
-EmberAfStatus GetBattery2AlarmMask(chip::EndpointId endpoint, uint8_t * battery2AlarmMask); // bitmap8
-EmberAfStatus SetBattery2AlarmMask(chip::EndpointId endpoint, uint8_t battery2AlarmMask);
-EmberAfStatus GetBattery2VoltageMinThreshold(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold); // int8u
-EmberAfStatus SetBattery2VoltageMinThreshold(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold);
-EmberAfStatus GetBattery2VoltageThreshold1(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1); // int8u
-EmberAfStatus SetBattery2VoltageThreshold1(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1);
-EmberAfStatus GetBattery2VoltageThreshold2(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2); // int8u
-EmberAfStatus SetBattery2VoltageThreshold2(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2);
-EmberAfStatus GetBattery2VoltageThreshold3(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3); // int8u
-EmberAfStatus SetBattery2VoltageThreshold3(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3);
-EmberAfStatus GetBattery2PercentageMinThreshold(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold); // int8u
-EmberAfStatus SetBattery2PercentageMinThreshold(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold);
-EmberAfStatus GetBattery2PercentageThreshold1(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1); // int8u
-EmberAfStatus SetBattery2PercentageThreshold1(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1);
-EmberAfStatus GetBattery2PercentageThreshold2(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2); // int8u
-EmberAfStatus SetBattery2PercentageThreshold2(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2);
-EmberAfStatus GetBattery2PercentageThreshold3(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3); // int8u
-EmberAfStatus SetBattery2PercentageThreshold3(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3);
-EmberAfStatus GetBattery2AlarmState(chip::EndpointId endpoint, uint32_t * battery2AlarmState); // bitmap32
-EmberAfStatus SetBattery2AlarmState(chip::EndpointId endpoint, uint32_t battery2AlarmState);
-EmberAfStatus GetBattery3Voltage(chip::EndpointId endpoint, uint8_t * battery3Voltage); // int8u
-EmberAfStatus SetBattery3Voltage(chip::EndpointId endpoint, uint8_t battery3Voltage);
-EmberAfStatus GetBattery3PercentageRemaining(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining); // int8u
-EmberAfStatus SetBattery3PercentageRemaining(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining);
-EmberAfStatus GetBattery3Size(chip::EndpointId endpoint, uint8_t * battery3Size); // enum8
-EmberAfStatus SetBattery3Size(chip::EndpointId endpoint, uint8_t battery3Size);
-EmberAfStatus GetBattery3AhrRating(chip::EndpointId endpoint, uint16_t * battery3AhrRating); // int16u
-EmberAfStatus SetBattery3AhrRating(chip::EndpointId endpoint, uint16_t battery3AhrRating);
-EmberAfStatus GetBattery3Quantity(chip::EndpointId endpoint, uint8_t * battery3Quantity); // int8u
-EmberAfStatus SetBattery3Quantity(chip::EndpointId endpoint, uint8_t battery3Quantity);
-EmberAfStatus GetBattery3RatedVoltage(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage); // int8u
-EmberAfStatus SetBattery3RatedVoltage(chip::EndpointId endpoint, uint8_t battery3RatedVoltage);
-EmberAfStatus GetBattery3AlarmMask(chip::EndpointId endpoint, uint8_t * battery3AlarmMask); // bitmap8
-EmberAfStatus SetBattery3AlarmMask(chip::EndpointId endpoint, uint8_t battery3AlarmMask);
-EmberAfStatus GetBattery3VoltageMinThreshold(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold); // int8u
-EmberAfStatus SetBattery3VoltageMinThreshold(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold);
-EmberAfStatus GetBattery3VoltageThreshold1(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1); // int8u
-EmberAfStatus SetBattery3VoltageThreshold1(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1);
-EmberAfStatus GetBattery3VoltageThreshold2(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2); // int8u
-EmberAfStatus SetBattery3VoltageThreshold2(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2);
-EmberAfStatus GetBattery3VoltageThreshold3(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3); // int8u
-EmberAfStatus SetBattery3VoltageThreshold3(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3);
-EmberAfStatus GetBattery3PercentageMinThreshold(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold); // int8u
-EmberAfStatus SetBattery3PercentageMinThreshold(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold);
-EmberAfStatus GetBattery3PercentageThreshold1(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1); // int8u
-EmberAfStatus SetBattery3PercentageThreshold1(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1);
-EmberAfStatus GetBattery3PercentageThreshold2(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2); // int8u
-EmberAfStatus SetBattery3PercentageThreshold2(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2);
-EmberAfStatus GetBattery3PercentageThreshold3(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3); // int8u
-EmberAfStatus SetBattery3PercentageThreshold3(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3);
-EmberAfStatus GetBattery3AlarmState(chip::EndpointId endpoint, uint32_t * battery3AlarmState); // bitmap32
-EmberAfStatus SetBattery3AlarmState(chip::EndpointId endpoint, uint32_t battery3AlarmState);
+
+namespace MainsVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltage); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltage);
+} // namespace MainsVoltage
+
+namespace MainsFrequency {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsFrequency); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsFrequency);
+} // namespace MainsFrequency
+
+namespace MainsAlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsAlarmMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsAlarmMask);
+} // namespace MainsAlarmMask
+
+namespace MainsVoltageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold);
+} // namespace MainsVoltageMinThreshold
+
+namespace MainsVoltageMaxThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold);
+} // namespace MainsVoltageMaxThreshold
+
+namespace MainsVoltageDwellTrip {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip);
+} // namespace MainsVoltageDwellTrip
+
+namespace BatteryVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltage);
+} // namespace BatteryVoltage
+
+namespace BatteryPercentageRemaining {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining);
+} // namespace BatteryPercentageRemaining
+
+namespace BatterySize {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batterySize); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batterySize);
+} // namespace BatterySize
+
+namespace BatteryAhrRating {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * batteryAhrRating); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t batteryAhrRating);
+} // namespace BatteryAhrRating
+
+namespace BatteryQuantity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity);
+} // namespace BatteryQuantity
+
+namespace BatteryRatedVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryRatedVoltage);
+} // namespace BatteryRatedVoltage
+
+namespace BatteryAlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryAlarmMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryAlarmMask);
+} // namespace BatteryAlarmMask
+
+namespace BatteryVoltageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold);
+} // namespace BatteryVoltageMinThreshold
+
+namespace BatteryVoltageThreshold1 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1);
+} // namespace BatteryVoltageThreshold1
+
+namespace BatteryVoltageThreshold2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2);
+} // namespace BatteryVoltageThreshold2
+
+namespace BatteryVoltageThreshold3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3);
+} // namespace BatteryVoltageThreshold3
+
+namespace BatteryPercentageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold);
+} // namespace BatteryPercentageMinThreshold
+
+namespace BatteryPercentageThreshold1 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1);
+} // namespace BatteryPercentageThreshold1
+
+namespace BatteryPercentageThreshold2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2);
+} // namespace BatteryPercentageThreshold2
+
+namespace BatteryPercentageThreshold3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3);
+} // namespace BatteryPercentageThreshold3
+
+namespace BatteryAlarmState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryAlarmState); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryAlarmState);
+} // namespace BatteryAlarmState
+
+namespace Battery2Voltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Voltage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Voltage);
+} // namespace Battery2Voltage
+
+namespace Battery2PercentageRemaining {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining);
+} // namespace Battery2PercentageRemaining
+
+namespace Battery2Size {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Size); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Size);
+} // namespace Battery2Size
+
+namespace Battery2AhrRating {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery2AhrRating); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery2AhrRating);
+} // namespace Battery2AhrRating
+
+namespace Battery2Quantity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Quantity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Quantity);
+} // namespace Battery2Quantity
+
+namespace Battery2RatedVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2RatedVoltage);
+} // namespace Battery2RatedVoltage
+
+namespace Battery2AlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2AlarmMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2AlarmMask);
+} // namespace Battery2AlarmMask
+
+namespace Battery2VoltageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold);
+} // namespace Battery2VoltageMinThreshold
+
+namespace Battery2VoltageThreshold1 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1);
+} // namespace Battery2VoltageThreshold1
+
+namespace Battery2VoltageThreshold2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2);
+} // namespace Battery2VoltageThreshold2
+
+namespace Battery2VoltageThreshold3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3);
+} // namespace Battery2VoltageThreshold3
+
+namespace Battery2PercentageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold);
+} // namespace Battery2PercentageMinThreshold
+
+namespace Battery2PercentageThreshold1 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1);
+} // namespace Battery2PercentageThreshold1
+
+namespace Battery2PercentageThreshold2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2);
+} // namespace Battery2PercentageThreshold2
+
+namespace Battery2PercentageThreshold3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3);
+} // namespace Battery2PercentageThreshold3
+
+namespace Battery2AlarmState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery2AlarmState); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery2AlarmState);
+} // namespace Battery2AlarmState
+
+namespace Battery3Voltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Voltage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Voltage);
+} // namespace Battery3Voltage
+
+namespace Battery3PercentageRemaining {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining);
+} // namespace Battery3PercentageRemaining
+
+namespace Battery3Size {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Size); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Size);
+} // namespace Battery3Size
+
+namespace Battery3AhrRating {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery3AhrRating); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery3AhrRating);
+} // namespace Battery3AhrRating
+
+namespace Battery3Quantity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Quantity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Quantity);
+} // namespace Battery3Quantity
+
+namespace Battery3RatedVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3RatedVoltage);
+} // namespace Battery3RatedVoltage
+
+namespace Battery3AlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3AlarmMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3AlarmMask);
+} // namespace Battery3AlarmMask
+
+namespace Battery3VoltageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold);
+} // namespace Battery3VoltageMinThreshold
+
+namespace Battery3VoltageThreshold1 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1);
+} // namespace Battery3VoltageThreshold1
+
+namespace Battery3VoltageThreshold2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2);
+} // namespace Battery3VoltageThreshold2
+
+namespace Battery3VoltageThreshold3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3);
+} // namespace Battery3VoltageThreshold3
+
+namespace Battery3PercentageMinThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold);
+} // namespace Battery3PercentageMinThreshold
+
+namespace Battery3PercentageThreshold1 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1);
+} // namespace Battery3PercentageThreshold1
+
+namespace Battery3PercentageThreshold2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2);
+} // namespace Battery3PercentageThreshold2
+
+namespace Battery3PercentageThreshold3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3);
+} // namespace Battery3PercentageThreshold3
+
+namespace Battery3AlarmState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery3AlarmState); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery3AlarmState);
+} // namespace Battery3AlarmState
+
 } // namespace Attributes
 } // namespace PowerConfiguration
 
 namespace DeviceTemperatureConfiguration {
 namespace Attributes {
-EmberAfStatus GetCurrentTemperature(chip::EndpointId endpoint, int16_t * currentTemperature); // int16s
-EmberAfStatus SetCurrentTemperature(chip::EndpointId endpoint, int16_t currentTemperature);
-EmberAfStatus GetMinTempExperienced(chip::EndpointId endpoint, int16_t * minTempExperienced); // int16s
-EmberAfStatus SetMinTempExperienced(chip::EndpointId endpoint, int16_t minTempExperienced);
-EmberAfStatus GetMaxTempExperienced(chip::EndpointId endpoint, int16_t * maxTempExperienced); // int16s
-EmberAfStatus SetMaxTempExperienced(chip::EndpointId endpoint, int16_t maxTempExperienced);
-EmberAfStatus GetOverTempTotalDwell(chip::EndpointId endpoint, uint16_t * overTempTotalDwell); // int16u
-EmberAfStatus SetOverTempTotalDwell(chip::EndpointId endpoint, uint16_t overTempTotalDwell);
-EmberAfStatus GetDeviceTempAlarmMask(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask); // bitmap8
-EmberAfStatus SetDeviceTempAlarmMask(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask);
-EmberAfStatus GetLowTempThreshold(chip::EndpointId endpoint, int16_t * lowTempThreshold); // int16s
-EmberAfStatus SetLowTempThreshold(chip::EndpointId endpoint, int16_t lowTempThreshold);
-EmberAfStatus GetHighTempThreshold(chip::EndpointId endpoint, int16_t * highTempThreshold); // int16s
-EmberAfStatus SetHighTempThreshold(chip::EndpointId endpoint, int16_t highTempThreshold);
+
+namespace CurrentTemperature {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentTemperature); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentTemperature);
+} // namespace CurrentTemperature
+
+namespace MinTempExperienced {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minTempExperienced); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minTempExperienced);
+} // namespace MinTempExperienced
+
+namespace MaxTempExperienced {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxTempExperienced); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxTempExperienced);
+} // namespace MaxTempExperienced
+
+namespace OverTempTotalDwell {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * overTempTotalDwell); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t overTempTotalDwell);
+} // namespace OverTempTotalDwell
+
+namespace DeviceTempAlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask);
+} // namespace DeviceTempAlarmMask
+
+namespace LowTempThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * lowTempThreshold); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t lowTempThreshold);
+} // namespace LowTempThreshold
+
+namespace HighTempThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * highTempThreshold); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t highTempThreshold);
+} // namespace HighTempThreshold
+
 } // namespace Attributes
 } // namespace DeviceTemperatureConfiguration
 
 namespace Identify {
 namespace Attributes {
-EmberAfStatus GetIdentifyTime(chip::EndpointId endpoint, uint16_t * identifyTime); // int16u
-EmberAfStatus SetIdentifyTime(chip::EndpointId endpoint, uint16_t identifyTime);
-EmberAfStatus GetIdentifyType(chip::EndpointId endpoint, uint8_t * identifyType); // enum8
-EmberAfStatus SetIdentifyType(chip::EndpointId endpoint, uint8_t identifyType);
+
+namespace IdentifyTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * identifyTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t identifyTime);
+} // namespace IdentifyTime
+
+namespace IdentifyType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * identifyType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t identifyType);
+} // namespace IdentifyType
+
 } // namespace Attributes
 } // namespace Identify
 
 namespace Groups {
 namespace Attributes {
-EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
-EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport);
+
+namespace NameSupport {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport);
+} // namespace NameSupport
+
 } // namespace Attributes
 } // namespace Groups
 
 namespace Scenes {
 namespace Attributes {
-EmberAfStatus GetSceneCount(chip::EndpointId endpoint, uint8_t * sceneCount); // int8u
-EmberAfStatus SetSceneCount(chip::EndpointId endpoint, uint8_t sceneCount);
-EmberAfStatus GetCurrentScene(chip::EndpointId endpoint, uint8_t * currentScene); // int8u
-EmberAfStatus SetCurrentScene(chip::EndpointId endpoint, uint8_t currentScene);
-EmberAfStatus GetCurrentGroup(chip::EndpointId endpoint, uint16_t * currentGroup); // int16u
-EmberAfStatus SetCurrentGroup(chip::EndpointId endpoint, uint16_t currentGroup);
-EmberAfStatus GetSceneValid(chip::EndpointId endpoint, bool * sceneValid); // boolean
-EmberAfStatus SetSceneValid(chip::EndpointId endpoint, bool sceneValid);
-EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
-EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport);
+
+namespace SceneCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sceneCount); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sceneCount);
+} // namespace SceneCount
+
+namespace CurrentScene {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentScene); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentScene);
+} // namespace CurrentScene
+
+namespace CurrentGroup {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentGroup); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentGroup);
+} // namespace CurrentGroup
+
+namespace SceneValid {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * sceneValid); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool sceneValid);
+} // namespace SceneValid
+
+namespace NameSupport {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport);
+} // namespace NameSupport
+
 } // namespace Attributes
 } // namespace Scenes
 
 namespace OnOff {
 namespace Attributes {
-EmberAfStatus GetOnOff(chip::EndpointId endpoint, bool * onOff); // boolean
-EmberAfStatus SetOnOff(chip::EndpointId endpoint, bool onOff);
-EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint,
-                                                        uint16_t * sampleMfgSpecificAttribute0x00000x1002); // int16u
-EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002);
-EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1049(chip::EndpointId endpoint,
-                                                        uint8_t * sampleMfgSpecificAttribute0x00000x1049); // int8u
-EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1049(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049);
-EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoint,
-                                                        uint8_t * sampleMfgSpecificAttribute0x00010x1002); // int8u
-EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002);
-EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint,
-                                                        uint16_t * sampleMfgSpecificAttribute0x00010x1040); // int16u
-EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040);
-EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, bool * globalSceneControl); // boolean
-EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, bool globalSceneControl);
-EmberAfStatus GetOnTime(chip::EndpointId endpoint, uint16_t * onTime); // int16u
-EmberAfStatus SetOnTime(chip::EndpointId endpoint, uint16_t onTime);
-EmberAfStatus GetOffWaitTime(chip::EndpointId endpoint, uint16_t * offWaitTime); // int16u
-EmberAfStatus SetOffWaitTime(chip::EndpointId endpoint, uint16_t offWaitTime);
-EmberAfStatus GetStartUpOnOff(chip::EndpointId endpoint, uint8_t * startUpOnOff); // enum8
-EmberAfStatus SetStartUpOnOff(chip::EndpointId endpoint, uint8_t startUpOnOff);
+
+namespace OnOff {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * onOff); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool onOff);
+} // namespace OnOff
+
+namespace SampleMfgSpecificAttribute0x00000x1002 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00000x1002); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002);
+} // namespace SampleMfgSpecificAttribute0x00000x1002
+
+namespace SampleMfgSpecificAttribute0x00000x1049 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00000x1049); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049);
+} // namespace SampleMfgSpecificAttribute0x00000x1049
+
+namespace SampleMfgSpecificAttribute0x00010x1002 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00010x1002); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002);
+} // namespace SampleMfgSpecificAttribute0x00010x1002
+
+namespace SampleMfgSpecificAttribute0x00010x1040 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00010x1040); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040);
+} // namespace SampleMfgSpecificAttribute0x00010x1040
+
+namespace GlobalSceneControl {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * globalSceneControl); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool globalSceneControl);
+} // namespace GlobalSceneControl
+
+namespace OnTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTime);
+} // namespace OnTime
+
+namespace OffWaitTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offWaitTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offWaitTime);
+} // namespace OffWaitTime
+
+namespace StartUpOnOff {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpOnOff); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpOnOff);
+} // namespace StartUpOnOff
+
 } // namespace Attributes
 } // namespace OnOff
 
 namespace OnOffSwitchConfiguration {
 namespace Attributes {
-EmberAfStatus GetSwitchType(chip::EndpointId endpoint, uint8_t * switchType); // enum8
-EmberAfStatus SetSwitchType(chip::EndpointId endpoint, uint8_t switchType);
-EmberAfStatus GetSwitchActions(chip::EndpointId endpoint, uint8_t * switchActions); // enum8
-EmberAfStatus SetSwitchActions(chip::EndpointId endpoint, uint8_t switchActions);
+
+namespace SwitchType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchType);
+} // namespace SwitchType
+
+namespace SwitchActions {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchActions); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchActions);
+} // namespace SwitchActions
+
 } // namespace Attributes
 } // namespace OnOffSwitchConfiguration
 
 namespace LevelControl {
 namespace Attributes {
-EmberAfStatus GetCurrentLevel(chip::EndpointId endpoint, uint8_t * currentLevel); // int8u
-EmberAfStatus SetCurrentLevel(chip::EndpointId endpoint, uint8_t currentLevel);
-EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
-EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime);
-EmberAfStatus GetOptions(chip::EndpointId endpoint, uint8_t * options); // bitmap8
-EmberAfStatus SetOptions(chip::EndpointId endpoint, uint8_t options);
-EmberAfStatus GetOnOffTransitionTime(chip::EndpointId endpoint, uint16_t * onOffTransitionTime); // int16u
-EmberAfStatus SetOnOffTransitionTime(chip::EndpointId endpoint, uint16_t onOffTransitionTime);
-EmberAfStatus GetOnLevel(chip::EndpointId endpoint, uint8_t * onLevel); // int8u
-EmberAfStatus SetOnLevel(chip::EndpointId endpoint, uint8_t onLevel);
-EmberAfStatus GetOnTransitionTime(chip::EndpointId endpoint, uint16_t * onTransitionTime); // int16u
-EmberAfStatus SetOnTransitionTime(chip::EndpointId endpoint, uint16_t onTransitionTime);
-EmberAfStatus GetOffTransitionTime(chip::EndpointId endpoint, uint16_t * offTransitionTime); // int16u
-EmberAfStatus SetOffTransitionTime(chip::EndpointId endpoint, uint16_t offTransitionTime);
-EmberAfStatus GetDefaultMoveRate(chip::EndpointId endpoint, uint8_t * defaultMoveRate); // int8u
-EmberAfStatus SetDefaultMoveRate(chip::EndpointId endpoint, uint8_t defaultMoveRate);
-EmberAfStatus GetStartUpCurrentLevel(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel); // int8u
-EmberAfStatus SetStartUpCurrentLevel(chip::EndpointId endpoint, uint8_t startUpCurrentLevel);
+
+namespace CurrentLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentLevel);
+} // namespace CurrentLevel
+
+namespace RemainingTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime);
+} // namespace RemainingTime
+
+namespace Options {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * options); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t options);
+} // namespace Options
+
+namespace OnOffTransitionTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onOffTransitionTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onOffTransitionTime);
+} // namespace OnOffTransitionTime
+
+namespace OnLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * onLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t onLevel);
+} // namespace OnLevel
+
+namespace OnTransitionTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTransitionTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTransitionTime);
+} // namespace OnTransitionTime
+
+namespace OffTransitionTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offTransitionTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offTransitionTime);
+} // namespace OffTransitionTime
+
+namespace DefaultMoveRate {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * defaultMoveRate); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t defaultMoveRate);
+} // namespace DefaultMoveRate
+
+namespace StartUpCurrentLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpCurrentLevel);
+} // namespace StartUpCurrentLevel
+
 } // namespace Attributes
 } // namespace LevelControl
 
 namespace Alarms {
 namespace Attributes {
-EmberAfStatus GetAlarmCount(chip::EndpointId endpoint, uint16_t * alarmCount); // int16u
-EmberAfStatus SetAlarmCount(chip::EndpointId endpoint, uint16_t alarmCount);
+
+namespace AlarmCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmCount);
+} // namespace AlarmCount
+
 } // namespace Attributes
 } // namespace Alarms
 
 namespace Time {
 namespace Attributes {
-EmberAfStatus GetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** time); // utc
-EmberAfStatus SetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * time);
-EmberAfStatus GetTimeStatus(chip::EndpointId endpoint, uint8_t * timeStatus); // bitmap8
-EmberAfStatus SetTimeStatus(chip::EndpointId endpoint, uint8_t timeStatus);
-EmberAfStatus GetTimeZone(chip::EndpointId endpoint, int32_t * timeZone); // int32s
-EmberAfStatus SetTimeZone(chip::EndpointId endpoint, int32_t timeZone);
-EmberAfStatus GetDstStart(chip::EndpointId endpoint, uint32_t * dstStart); // int32u
-EmberAfStatus SetDstStart(chip::EndpointId endpoint, uint32_t dstStart);
-EmberAfStatus GetDstEnd(chip::EndpointId endpoint, uint32_t * dstEnd); // int32u
-EmberAfStatus SetDstEnd(chip::EndpointId endpoint, uint32_t dstEnd);
-EmberAfStatus GetDstShift(chip::EndpointId endpoint, int32_t * dstShift); // int32s
-EmberAfStatus SetDstShift(chip::EndpointId endpoint, int32_t dstShift);
-EmberAfStatus GetStandardTime(chip::EndpointId endpoint, uint32_t * standardTime); // int32u
-EmberAfStatus SetStandardTime(chip::EndpointId endpoint, uint32_t standardTime);
-EmberAfStatus GetLocalTime(chip::EndpointId endpoint, uint32_t * localTime); // int32u
-EmberAfStatus SetLocalTime(chip::EndpointId endpoint, uint32_t localTime);
-EmberAfStatus GetLastSetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** lastSetTime); // utc
-EmberAfStatus SetLastSetTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * lastSetTime);
-EmberAfStatus GetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** validUntilTime); // utc
-EmberAfStatus SetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * validUntilTime);
+
+namespace Time {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** time); // utc
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * time);
+} // namespace Time
+
+namespace TimeStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * timeStatus); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t timeStatus);
+} // namespace TimeStatus
+
+namespace TimeZone {
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * timeZone); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t timeZone);
+} // namespace TimeZone
+
+namespace DstStart {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstStart); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstStart);
+} // namespace DstStart
+
+namespace DstEnd {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstEnd); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstEnd);
+} // namespace DstEnd
+
+namespace DstShift {
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * dstShift); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t dstShift);
+} // namespace DstShift
+
+namespace StandardTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * standardTime); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t standardTime);
+} // namespace StandardTime
+
+namespace LocalTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * localTime); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t localTime);
+} // namespace LocalTime
+
+namespace LastSetTime {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** lastSetTime); // utc
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * lastSetTime);
+} // namespace LastSetTime
+
+namespace ValidUntilTime {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** validUntilTime); // utc
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * validUntilTime);
+} // namespace ValidUntilTime
+
 } // namespace Attributes
 } // namespace Time
 
 namespace BinaryInputBasic {
 namespace Attributes {
-EmberAfStatus GetOutOfService(chip::EndpointId endpoint, bool * outOfService); // boolean
-EmberAfStatus SetOutOfService(chip::EndpointId endpoint, bool outOfService);
-EmberAfStatus GetPolarity(chip::EndpointId endpoint, uint8_t * polarity); // enum8
-EmberAfStatus SetPolarity(chip::EndpointId endpoint, uint8_t polarity);
-EmberAfStatus GetPresentValue(chip::EndpointId endpoint, bool * presentValue); // boolean
-EmberAfStatus SetPresentValue(chip::EndpointId endpoint, bool presentValue);
-EmberAfStatus GetReliability(chip::EndpointId endpoint, uint8_t * reliability); // enum8
-EmberAfStatus SetReliability(chip::EndpointId endpoint, uint8_t reliability);
-EmberAfStatus GetStatusFlags(chip::EndpointId endpoint, uint8_t * statusFlags); // bitmap8
-EmberAfStatus SetStatusFlags(chip::EndpointId endpoint, uint8_t statusFlags);
-EmberAfStatus GetApplicationType(chip::EndpointId endpoint, uint32_t * applicationType); // int32u
-EmberAfStatus SetApplicationType(chip::EndpointId endpoint, uint32_t applicationType);
+
+namespace OutOfService {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * outOfService); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool outOfService);
+} // namespace OutOfService
+
+namespace Polarity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * polarity); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t polarity);
+} // namespace Polarity
+
+namespace PresentValue {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * presentValue); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool presentValue);
+} // namespace PresentValue
+
+namespace Reliability {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * reliability); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t reliability);
+} // namespace Reliability
+
+namespace StatusFlags {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * statusFlags); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t statusFlags);
+} // namespace StatusFlags
+
+namespace ApplicationType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * applicationType); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t applicationType);
+} // namespace ApplicationType
+
 } // namespace Attributes
 } // namespace BinaryInputBasic
 
 namespace PowerProfile {
 namespace Attributes {
-EmberAfStatus GetTotalProfileNum(chip::EndpointId endpoint, uint8_t * totalProfileNum); // int8u
-EmberAfStatus SetTotalProfileNum(chip::EndpointId endpoint, uint8_t totalProfileNum);
-EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, bool * multipleScheduling); // boolean
-EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, bool multipleScheduling);
-EmberAfStatus GetEnergyFormatting(chip::EndpointId endpoint, uint8_t * energyFormatting); // bitmap8
-EmberAfStatus SetEnergyFormatting(chip::EndpointId endpoint, uint8_t energyFormatting);
-EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, bool * energyRemote); // boolean
-EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, bool energyRemote);
-EmberAfStatus GetScheduleMode(chip::EndpointId endpoint, uint8_t * scheduleMode); // bitmap8
-EmberAfStatus SetScheduleMode(chip::EndpointId endpoint, uint8_t scheduleMode);
+
+namespace TotalProfileNum {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * totalProfileNum); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t totalProfileNum);
+} // namespace TotalProfileNum
+
+namespace MultipleScheduling {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * multipleScheduling); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool multipleScheduling);
+} // namespace MultipleScheduling
+
+namespace EnergyFormatting {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * energyFormatting); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t energyFormatting);
+} // namespace EnergyFormatting
+
+namespace EnergyRemote {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * energyRemote); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool energyRemote);
+} // namespace EnergyRemote
+
+namespace ScheduleMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleMode); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleMode);
+} // namespace ScheduleMode
+
 } // namespace Attributes
 } // namespace PowerProfile
 
 namespace ApplianceControl {
 namespace Attributes {
-EmberAfStatus GetStartTime(chip::EndpointId endpoint, uint16_t * startTime); // int16u
-EmberAfStatus SetStartTime(chip::EndpointId endpoint, uint16_t startTime);
-EmberAfStatus GetFinishTime(chip::EndpointId endpoint, uint16_t * finishTime); // int16u
-EmberAfStatus SetFinishTime(chip::EndpointId endpoint, uint16_t finishTime);
-EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
-EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime);
+
+namespace StartTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startTime);
+} // namespace StartTime
+
+namespace FinishTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * finishTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t finishTime);
+} // namespace FinishTime
+
+namespace RemainingTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime);
+} // namespace RemainingTime
+
 } // namespace Attributes
 } // namespace ApplianceControl
 
 namespace Descriptor {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace Descriptor
 
 namespace PollControl {
 namespace Attributes {
-EmberAfStatus GetCheckInInterval(chip::EndpointId endpoint, uint32_t * checkInInterval); // int32u
-EmberAfStatus SetCheckInInterval(chip::EndpointId endpoint, uint32_t checkInInterval);
-EmberAfStatus GetLongPollInterval(chip::EndpointId endpoint, uint32_t * longPollInterval); // int32u
-EmberAfStatus SetLongPollInterval(chip::EndpointId endpoint, uint32_t longPollInterval);
-EmberAfStatus GetShortPollInterval(chip::EndpointId endpoint, uint16_t * shortPollInterval); // int16u
-EmberAfStatus SetShortPollInterval(chip::EndpointId endpoint, uint16_t shortPollInterval);
-EmberAfStatus GetFastPollTimeout(chip::EndpointId endpoint, uint16_t * fastPollTimeout); // int16u
-EmberAfStatus SetFastPollTimeout(chip::EndpointId endpoint, uint16_t fastPollTimeout);
-EmberAfStatus GetCheckInIntervalMin(chip::EndpointId endpoint, uint32_t * checkInIntervalMin); // int32u
-EmberAfStatus SetCheckInIntervalMin(chip::EndpointId endpoint, uint32_t checkInIntervalMin);
-EmberAfStatus GetLongPollIntervalMin(chip::EndpointId endpoint, uint32_t * longPollIntervalMin); // int32u
-EmberAfStatus SetLongPollIntervalMin(chip::EndpointId endpoint, uint32_t longPollIntervalMin);
-EmberAfStatus GetFastPollTimeoutMax(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax); // int16u
-EmberAfStatus SetFastPollTimeoutMax(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax);
+
+namespace CheckInInterval {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInInterval); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInInterval);
+} // namespace CheckInInterval
+
+namespace LongPollInterval {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollInterval); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollInterval);
+} // namespace LongPollInterval
+
+namespace ShortPollInterval {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * shortPollInterval); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t shortPollInterval);
+} // namespace ShortPollInterval
+
+namespace FastPollTimeout {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeout); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeout);
+} // namespace FastPollTimeout
+
+namespace CheckInIntervalMin {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInIntervalMin); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInIntervalMin);
+} // namespace CheckInIntervalMin
+
+namespace LongPollIntervalMin {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollIntervalMin); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollIntervalMin);
+} // namespace LongPollIntervalMin
+
+namespace FastPollTimeoutMax {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax);
+} // namespace FastPollTimeoutMax
+
 } // namespace Attributes
 } // namespace PollControl
 
 namespace Basic {
 namespace Attributes {
-EmberAfStatus GetInteractionModelVersion(chip::EndpointId endpoint, uint16_t * interactionModelVersion); // int16u
-EmberAfStatus SetInteractionModelVersion(chip::EndpointId endpoint, uint16_t interactionModelVersion);
-EmberAfStatus GetVendorID(chip::EndpointId endpoint, uint16_t * vendorID); // int16u
-EmberAfStatus SetVendorID(chip::EndpointId endpoint, uint16_t vendorID);
-EmberAfStatus GetProductID(chip::EndpointId endpoint, uint16_t * productID); // int16u
-EmberAfStatus SetProductID(chip::EndpointId endpoint, uint16_t productID);
-EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareVersion); // int16u
-EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion);
-EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
-EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion);
-EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, bool * localConfigDisabled); // boolean
-EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, bool localConfigDisabled);
-EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable); // boolean
-EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable);
+
+namespace InteractionModelVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * interactionModelVersion); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t interactionModelVersion);
+} // namespace InteractionModelVersion
+
+namespace VendorID {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID);
+} // namespace VendorID
+
+namespace ProductID {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productID); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productID);
+} // namespace ProductID
+
+namespace HardwareVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion);
+} // namespace HardwareVersion
+
+namespace SoftwareVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion);
+} // namespace SoftwareVersion
+
+namespace LocalConfigDisabled {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * localConfigDisabled); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool localConfigDisabled);
+} // namespace LocalConfigDisabled
+
+namespace Reachable {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool reachable);
+} // namespace Reachable
+
 } // namespace Attributes
 } // namespace Basic
 
 namespace OtaSoftwareUpdateRequestor {
 namespace Attributes {
-EmberAfStatus GetUpdatePossible(chip::EndpointId endpoint, bool * updatePossible); // boolean
-EmberAfStatus SetUpdatePossible(chip::EndpointId endpoint, bool updatePossible);
+
+namespace UpdatePossible {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * updatePossible); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool updatePossible);
+} // namespace UpdatePossible
+
 } // namespace Attributes
 } // namespace OtaSoftwareUpdateRequestor
 
 namespace PowerSource {
 namespace Attributes {
-EmberAfStatus GetStatus(chip::EndpointId endpoint, uint8_t * status); // enum8
-EmberAfStatus SetStatus(chip::EndpointId endpoint, uint8_t status);
-EmberAfStatus GetOrder(chip::EndpointId endpoint, uint8_t * order); // int8u
-EmberAfStatus SetOrder(chip::EndpointId endpoint, uint8_t order);
-EmberAfStatus GetWiredAssessedInputVoltage(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage); // int32u
-EmberAfStatus SetWiredAssessedInputVoltage(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage);
-EmberAfStatus GetWiredAssessedInputFrequency(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency); // int16u
-EmberAfStatus SetWiredAssessedInputFrequency(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency);
-EmberAfStatus GetWiredCurrentType(chip::EndpointId endpoint, uint8_t * wiredCurrentType); // enum8
-EmberAfStatus SetWiredCurrentType(chip::EndpointId endpoint, uint8_t wiredCurrentType);
-EmberAfStatus GetWiredAssessedCurrent(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent); // int32u
-EmberAfStatus SetWiredAssessedCurrent(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent);
-EmberAfStatus GetWiredNominalVoltage(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage); // int32u
-EmberAfStatus SetWiredNominalVoltage(chip::EndpointId endpoint, uint32_t wiredNominalVoltage);
-EmberAfStatus GetWiredMaximumCurrent(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent); // int32u
-EmberAfStatus SetWiredMaximumCurrent(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent);
-EmberAfStatus GetWiredPresent(chip::EndpointId endpoint, bool * wiredPresent); // boolean
-EmberAfStatus SetWiredPresent(chip::EndpointId endpoint, bool wiredPresent);
-EmberAfStatus GetBatteryVoltage(chip::EndpointId endpoint, uint32_t * batteryVoltage); // int32u
-EmberAfStatus SetBatteryVoltage(chip::EndpointId endpoint, uint32_t batteryVoltage);
-EmberAfStatus GetBatteryPercentRemaining(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining); // int8u
-EmberAfStatus SetBatteryPercentRemaining(chip::EndpointId endpoint, uint8_t batteryPercentRemaining);
-EmberAfStatus GetBatteryTimeRemaining(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining); // int32u
-EmberAfStatus SetBatteryTimeRemaining(chip::EndpointId endpoint, uint32_t batteryTimeRemaining);
-EmberAfStatus GetBatteryChargeLevel(chip::EndpointId endpoint, uint8_t * batteryChargeLevel); // enum8
-EmberAfStatus SetBatteryChargeLevel(chip::EndpointId endpoint, uint8_t batteryChargeLevel);
-EmberAfStatus GetBatteryReplacementNeeded(chip::EndpointId endpoint, bool * batteryReplacementNeeded); // boolean
-EmberAfStatus SetBatteryReplacementNeeded(chip::EndpointId endpoint, bool batteryReplacementNeeded);
-EmberAfStatus GetBatteryReplaceability(chip::EndpointId endpoint, uint8_t * batteryReplaceability); // enum8
-EmberAfStatus SetBatteryReplaceability(chip::EndpointId endpoint, uint8_t batteryReplaceability);
-EmberAfStatus GetBatteryPresent(chip::EndpointId endpoint, bool * batteryPresent); // boolean
-EmberAfStatus SetBatteryPresent(chip::EndpointId endpoint, bool batteryPresent);
-EmberAfStatus GetBatteryCommonDesignation(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation); // int32u
-EmberAfStatus SetBatteryCommonDesignation(chip::EndpointId endpoint, uint32_t batteryCommonDesignation);
-EmberAfStatus GetBatteryApprovedChemistry(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry); // int32u
-EmberAfStatus SetBatteryApprovedChemistry(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry);
-EmberAfStatus GetBatteryCapacity(chip::EndpointId endpoint, uint32_t * batteryCapacity); // int32u
-EmberAfStatus SetBatteryCapacity(chip::EndpointId endpoint, uint32_t batteryCapacity);
-EmberAfStatus GetBatteryQuantity(chip::EndpointId endpoint, uint8_t * batteryQuantity); // int8u
-EmberAfStatus SetBatteryQuantity(chip::EndpointId endpoint, uint8_t batteryQuantity);
-EmberAfStatus GetBatteryChargeState(chip::EndpointId endpoint, uint8_t * batteryChargeState); // enum8
-EmberAfStatus SetBatteryChargeState(chip::EndpointId endpoint, uint8_t batteryChargeState);
-EmberAfStatus GetBatteryTimeToFullCharge(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge); // int32u
-EmberAfStatus SetBatteryTimeToFullCharge(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge);
-EmberAfStatus GetBatteryFunctionalWhileCharging(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging); // boolean
-EmberAfStatus SetBatteryFunctionalWhileCharging(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging);
-EmberAfStatus GetBatteryChargingCurrent(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent); // int32u
-EmberAfStatus SetBatteryChargingCurrent(chip::EndpointId endpoint, uint32_t batteryChargingCurrent);
+
+namespace Status {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status);
+} // namespace Status
+
+namespace Order {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * order); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t order);
+} // namespace Order
+
+namespace WiredAssessedInputVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage);
+} // namespace WiredAssessedInputVoltage
+
+namespace WiredAssessedInputFrequency {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency);
+} // namespace WiredAssessedInputFrequency
+
+namespace WiredCurrentType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiredCurrentType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiredCurrentType);
+} // namespace WiredCurrentType
+
+namespace WiredAssessedCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent);
+} // namespace WiredAssessedCurrent
+
+namespace WiredNominalVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredNominalVoltage);
+} // namespace WiredNominalVoltage
+
+namespace WiredMaximumCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent);
+} // namespace WiredMaximumCurrent
+
+namespace WiredPresent {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * wiredPresent); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool wiredPresent);
+} // namespace WiredPresent
+
+namespace BatteryVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryVoltage); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryVoltage);
+} // namespace BatteryVoltage
+
+namespace BatteryPercentRemaining {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentRemaining);
+} // namespace BatteryPercentRemaining
+
+namespace BatteryTimeRemaining {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeRemaining);
+} // namespace BatteryTimeRemaining
+
+namespace BatteryChargeLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeLevel); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeLevel);
+} // namespace BatteryChargeLevel
+
+namespace BatteryReplacementNeeded {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryReplacementNeeded); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool batteryReplacementNeeded);
+} // namespace BatteryReplacementNeeded
+
+namespace BatteryReplaceability {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryReplaceability); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryReplaceability);
+} // namespace BatteryReplaceability
+
+namespace BatteryPresent {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryPresent); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool batteryPresent);
+} // namespace BatteryPresent
+
+namespace BatteryCommonDesignation {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCommonDesignation);
+} // namespace BatteryCommonDesignation
+
+namespace BatteryApprovedChemistry {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry);
+} // namespace BatteryApprovedChemistry
+
+namespace BatteryCapacity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCapacity); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCapacity);
+} // namespace BatteryCapacity
+
+namespace BatteryQuantity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity);
+} // namespace BatteryQuantity
+
+namespace BatteryChargeState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeState); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeState);
+} // namespace BatteryChargeState
+
+namespace BatteryTimeToFullCharge {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge);
+} // namespace BatteryTimeToFullCharge
+
+namespace BatteryFunctionalWhileCharging {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging);
+} // namespace BatteryFunctionalWhileCharging
+
+namespace BatteryChargingCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryChargingCurrent);
+} // namespace BatteryChargingCurrent
+
 } // namespace Attributes
 } // namespace PowerSource
 
 namespace GeneralCommissioning {
 namespace Attributes {
-EmberAfStatus GetBreadcrumb(chip::EndpointId endpoint, uint64_t * breadcrumb); // int64u
-EmberAfStatus SetBreadcrumb(chip::EndpointId endpoint, uint64_t breadcrumb);
+
+namespace Breadcrumb {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * breadcrumb); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t breadcrumb);
+} // namespace Breadcrumb
+
 } // namespace Attributes
 } // namespace GeneralCommissioning
 
 namespace GeneralDiagnostics {
 namespace Attributes {
-EmberAfStatus GetRebootCount(chip::EndpointId endpoint, uint16_t * rebootCount); // int16u
-EmberAfStatus SetRebootCount(chip::EndpointId endpoint, uint16_t rebootCount);
-EmberAfStatus GetUpTime(chip::EndpointId endpoint, uint64_t * upTime); // int64u
-EmberAfStatus SetUpTime(chip::EndpointId endpoint, uint64_t upTime);
-EmberAfStatus GetTotalOperationalHours(chip::EndpointId endpoint, uint32_t * totalOperationalHours); // int32u
-EmberAfStatus SetTotalOperationalHours(chip::EndpointId endpoint, uint32_t totalOperationalHours);
-EmberAfStatus GetBootReasons(chip::EndpointId endpoint, uint8_t * bootReasons); // enum8
-EmberAfStatus SetBootReasons(chip::EndpointId endpoint, uint8_t bootReasons);
+
+namespace RebootCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rebootCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rebootCount);
+} // namespace RebootCount
+
+namespace UpTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * upTime); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t upTime);
+} // namespace UpTime
+
+namespace TotalOperationalHours {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalOperationalHours); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalOperationalHours);
+} // namespace TotalOperationalHours
+
+namespace BootReasons {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bootReasons); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bootReasons);
+} // namespace BootReasons
+
 } // namespace Attributes
 } // namespace GeneralDiagnostics
 
 namespace SoftwareDiagnostics {
 namespace Attributes {
-EmberAfStatus GetCurrentHeapFree(chip::EndpointId endpoint, uint64_t * currentHeapFree); // int64u
-EmberAfStatus SetCurrentHeapFree(chip::EndpointId endpoint, uint64_t currentHeapFree);
-EmberAfStatus GetCurrentHeapUsed(chip::EndpointId endpoint, uint64_t * currentHeapUsed); // int64u
-EmberAfStatus SetCurrentHeapUsed(chip::EndpointId endpoint, uint64_t currentHeapUsed);
-EmberAfStatus GetCurrentHeapHighWatermark(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark); // int64u
-EmberAfStatus SetCurrentHeapHighWatermark(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark);
+
+namespace CurrentHeapFree {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapFree); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapFree);
+} // namespace CurrentHeapFree
+
+namespace CurrentHeapUsed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapUsed); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapUsed);
+} // namespace CurrentHeapUsed
+
+namespace CurrentHeapHighWatermark {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark);
+} // namespace CurrentHeapHighWatermark
+
 } // namespace Attributes
 } // namespace SoftwareDiagnostics
 
 namespace ThreadNetworkDiagnostics {
 namespace Attributes {
-EmberAfStatus GetChannel(chip::EndpointId endpoint, uint8_t * channel); // int8u
-EmberAfStatus SetChannel(chip::EndpointId endpoint, uint8_t channel);
-EmberAfStatus GetRoutingRole(chip::EndpointId endpoint, uint8_t * routingRole); // enum8
-EmberAfStatus SetRoutingRole(chip::EndpointId endpoint, uint8_t routingRole);
-EmberAfStatus GetPanId(chip::EndpointId endpoint, uint16_t * panId); // int16u
-EmberAfStatus SetPanId(chip::EndpointId endpoint, uint16_t panId);
-EmberAfStatus GetExtendedPanId(chip::EndpointId endpoint, uint64_t * extendedPanId); // int64u
-EmberAfStatus SetExtendedPanId(chip::EndpointId endpoint, uint64_t extendedPanId);
-EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
-EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount);
-EmberAfStatus GetPartitionId(chip::EndpointId endpoint, uint32_t * partitionId); // int32u
-EmberAfStatus SetPartitionId(chip::EndpointId endpoint, uint32_t partitionId);
-EmberAfStatus GetWeighting(chip::EndpointId endpoint, uint8_t * weighting); // int8u
-EmberAfStatus SetWeighting(chip::EndpointId endpoint, uint8_t weighting);
-EmberAfStatus GetDataVersion(chip::EndpointId endpoint, uint8_t * dataVersion); // int8u
-EmberAfStatus SetDataVersion(chip::EndpointId endpoint, uint8_t dataVersion);
-EmberAfStatus GetStableDataVersion(chip::EndpointId endpoint, uint8_t * stableDataVersion); // int8u
-EmberAfStatus SetStableDataVersion(chip::EndpointId endpoint, uint8_t stableDataVersion);
-EmberAfStatus GetLeaderRouterId(chip::EndpointId endpoint, uint8_t * leaderRouterId); // int8u
-EmberAfStatus SetLeaderRouterId(chip::EndpointId endpoint, uint8_t leaderRouterId);
-EmberAfStatus GetDetachedRoleCount(chip::EndpointId endpoint, uint16_t * detachedRoleCount); // int16u
-EmberAfStatus SetDetachedRoleCount(chip::EndpointId endpoint, uint16_t detachedRoleCount);
-EmberAfStatus GetChildRoleCount(chip::EndpointId endpoint, uint16_t * childRoleCount); // int16u
-EmberAfStatus SetChildRoleCount(chip::EndpointId endpoint, uint16_t childRoleCount);
-EmberAfStatus GetRouterRoleCount(chip::EndpointId endpoint, uint16_t * routerRoleCount); // int16u
-EmberAfStatus SetRouterRoleCount(chip::EndpointId endpoint, uint16_t routerRoleCount);
-EmberAfStatus GetLeaderRoleCount(chip::EndpointId endpoint, uint16_t * leaderRoleCount); // int16u
-EmberAfStatus SetLeaderRoleCount(chip::EndpointId endpoint, uint16_t leaderRoleCount);
-EmberAfStatus GetAttachAttemptCount(chip::EndpointId endpoint, uint16_t * attachAttemptCount); // int16u
-EmberAfStatus SetAttachAttemptCount(chip::EndpointId endpoint, uint16_t attachAttemptCount);
-EmberAfStatus GetPartitionIdChangeCount(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount); // int16u
-EmberAfStatus SetPartitionIdChangeCount(chip::EndpointId endpoint, uint16_t partitionIdChangeCount);
-EmberAfStatus GetBetterPartitionAttachAttemptCount(chip::EndpointId endpoint,
-                                                   uint16_t * betterPartitionAttachAttemptCount); // int16u
-EmberAfStatus SetBetterPartitionAttachAttemptCount(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount);
-EmberAfStatus GetParentChangeCount(chip::EndpointId endpoint, uint16_t * parentChangeCount); // int16u
-EmberAfStatus SetParentChangeCount(chip::EndpointId endpoint, uint16_t parentChangeCount);
-EmberAfStatus GetTxTotalCount(chip::EndpointId endpoint, uint32_t * txTotalCount); // int32u
-EmberAfStatus SetTxTotalCount(chip::EndpointId endpoint, uint32_t txTotalCount);
-EmberAfStatus GetTxUnicastCount(chip::EndpointId endpoint, uint32_t * txUnicastCount); // int32u
-EmberAfStatus SetTxUnicastCount(chip::EndpointId endpoint, uint32_t txUnicastCount);
-EmberAfStatus GetTxBroadcastCount(chip::EndpointId endpoint, uint32_t * txBroadcastCount); // int32u
-EmberAfStatus SetTxBroadcastCount(chip::EndpointId endpoint, uint32_t txBroadcastCount);
-EmberAfStatus GetTxAckRequestedCount(chip::EndpointId endpoint, uint32_t * txAckRequestedCount); // int32u
-EmberAfStatus SetTxAckRequestedCount(chip::EndpointId endpoint, uint32_t txAckRequestedCount);
-EmberAfStatus GetTxAckedCount(chip::EndpointId endpoint, uint32_t * txAckedCount); // int32u
-EmberAfStatus SetTxAckedCount(chip::EndpointId endpoint, uint32_t txAckedCount);
-EmberAfStatus GetTxNoAckRequestedCount(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount); // int32u
-EmberAfStatus SetTxNoAckRequestedCount(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount);
-EmberAfStatus GetTxDataCount(chip::EndpointId endpoint, uint32_t * txDataCount); // int32u
-EmberAfStatus SetTxDataCount(chip::EndpointId endpoint, uint32_t txDataCount);
-EmberAfStatus GetTxDataPollCount(chip::EndpointId endpoint, uint32_t * txDataPollCount); // int32u
-EmberAfStatus SetTxDataPollCount(chip::EndpointId endpoint, uint32_t txDataPollCount);
-EmberAfStatus GetTxBeaconCount(chip::EndpointId endpoint, uint32_t * txBeaconCount); // int32u
-EmberAfStatus SetTxBeaconCount(chip::EndpointId endpoint, uint32_t txBeaconCount);
-EmberAfStatus GetTxBeaconRequestCount(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount); // int32u
-EmberAfStatus SetTxBeaconRequestCount(chip::EndpointId endpoint, uint32_t txBeaconRequestCount);
-EmberAfStatus GetTxOtherCount(chip::EndpointId endpoint, uint32_t * txOtherCount); // int32u
-EmberAfStatus SetTxOtherCount(chip::EndpointId endpoint, uint32_t txOtherCount);
-EmberAfStatus GetTxRetryCount(chip::EndpointId endpoint, uint32_t * txRetryCount); // int32u
-EmberAfStatus SetTxRetryCount(chip::EndpointId endpoint, uint32_t txRetryCount);
-EmberAfStatus GetTxDirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount); // int32u
-EmberAfStatus SetTxDirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount);
-EmberAfStatus GetTxIndirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount); // int32u
-EmberAfStatus SetTxIndirectMaxRetryExpiryCount(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount);
-EmberAfStatus GetTxErrCcaCount(chip::EndpointId endpoint, uint32_t * txErrCcaCount); // int32u
-EmberAfStatus SetTxErrCcaCount(chip::EndpointId endpoint, uint32_t txErrCcaCount);
-EmberAfStatus GetTxErrAbortCount(chip::EndpointId endpoint, uint32_t * txErrAbortCount); // int32u
-EmberAfStatus SetTxErrAbortCount(chip::EndpointId endpoint, uint32_t txErrAbortCount);
-EmberAfStatus GetTxErrBusyChannelCount(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount); // int32u
-EmberAfStatus SetTxErrBusyChannelCount(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount);
-EmberAfStatus GetRxTotalCount(chip::EndpointId endpoint, uint32_t * rxTotalCount); // int32u
-EmberAfStatus SetRxTotalCount(chip::EndpointId endpoint, uint32_t rxTotalCount);
-EmberAfStatus GetRxUnicastCount(chip::EndpointId endpoint, uint32_t * rxUnicastCount); // int32u
-EmberAfStatus SetRxUnicastCount(chip::EndpointId endpoint, uint32_t rxUnicastCount);
-EmberAfStatus GetRxBroadcastCount(chip::EndpointId endpoint, uint32_t * rxBroadcastCount); // int32u
-EmberAfStatus SetRxBroadcastCount(chip::EndpointId endpoint, uint32_t rxBroadcastCount);
-EmberAfStatus GetRxDataCount(chip::EndpointId endpoint, uint32_t * rxDataCount); // int32u
-EmberAfStatus SetRxDataCount(chip::EndpointId endpoint, uint32_t rxDataCount);
-EmberAfStatus GetRxDataPollCount(chip::EndpointId endpoint, uint32_t * rxDataPollCount); // int32u
-EmberAfStatus SetRxDataPollCount(chip::EndpointId endpoint, uint32_t rxDataPollCount);
-EmberAfStatus GetRxBeaconCount(chip::EndpointId endpoint, uint32_t * rxBeaconCount); // int32u
-EmberAfStatus SetRxBeaconCount(chip::EndpointId endpoint, uint32_t rxBeaconCount);
-EmberAfStatus GetRxBeaconRequestCount(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount); // int32u
-EmberAfStatus SetRxBeaconRequestCount(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount);
-EmberAfStatus GetRxOtherCount(chip::EndpointId endpoint, uint32_t * rxOtherCount); // int32u
-EmberAfStatus SetRxOtherCount(chip::EndpointId endpoint, uint32_t rxOtherCount);
-EmberAfStatus GetRxAddressFilteredCount(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount); // int32u
-EmberAfStatus SetRxAddressFilteredCount(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount);
-EmberAfStatus GetRxDestAddrFilteredCount(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount); // int32u
-EmberAfStatus SetRxDestAddrFilteredCount(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount);
-EmberAfStatus GetRxDuplicatedCount(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount); // int32u
-EmberAfStatus SetRxDuplicatedCount(chip::EndpointId endpoint, uint32_t rxDuplicatedCount);
-EmberAfStatus GetRxErrNoFrameCount(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount); // int32u
-EmberAfStatus SetRxErrNoFrameCount(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount);
-EmberAfStatus GetRxErrUnknownNeighborCount(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount); // int32u
-EmberAfStatus SetRxErrUnknownNeighborCount(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount);
-EmberAfStatus GetRxErrInvalidSrcAddrCount(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount); // int32u
-EmberAfStatus SetRxErrInvalidSrcAddrCount(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount);
-EmberAfStatus GetRxErrSecCount(chip::EndpointId endpoint, uint32_t * rxErrSecCount); // int32u
-EmberAfStatus SetRxErrSecCount(chip::EndpointId endpoint, uint32_t rxErrSecCount);
-EmberAfStatus GetRxErrFcsCount(chip::EndpointId endpoint, uint32_t * rxErrFcsCount); // int32u
-EmberAfStatus SetRxErrFcsCount(chip::EndpointId endpoint, uint32_t rxErrFcsCount);
-EmberAfStatus GetRxErrOtherCount(chip::EndpointId endpoint, uint32_t * rxErrOtherCount); // int32u
-EmberAfStatus SetRxErrOtherCount(chip::EndpointId endpoint, uint32_t rxErrOtherCount);
-EmberAfStatus GetActiveTimestamp(chip::EndpointId endpoint, uint64_t * activeTimestamp); // int64u
-EmberAfStatus SetActiveTimestamp(chip::EndpointId endpoint, uint64_t activeTimestamp);
-EmberAfStatus GetPendingTimestamp(chip::EndpointId endpoint, uint64_t * pendingTimestamp); // int64u
-EmberAfStatus SetPendingTimestamp(chip::EndpointId endpoint, uint64_t pendingTimestamp);
-EmberAfStatus GetDelay(chip::EndpointId endpoint, uint32_t * delay); // int32u
-EmberAfStatus SetDelay(chip::EndpointId endpoint, uint32_t delay);
+
+namespace Channel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * channel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t channel);
+} // namespace Channel
+
+namespace RoutingRole {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * routingRole); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t routingRole);
+} // namespace RoutingRole
+
+namespace PanId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * panId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t panId);
+} // namespace PanId
+
+namespace ExtendedPanId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * extendedPanId); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t extendedPanId);
+} // namespace ExtendedPanId
+
+namespace OverrunCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount);
+} // namespace OverrunCount
+
+namespace PartitionId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * partitionId); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t partitionId);
+} // namespace PartitionId
+
+namespace Weighting {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * weighting); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t weighting);
+} // namespace Weighting
+
+namespace DataVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dataVersion); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dataVersion);
+} // namespace DataVersion
+
+namespace StableDataVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * stableDataVersion); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t stableDataVersion);
+} // namespace StableDataVersion
+
+namespace LeaderRouterId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * leaderRouterId); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t leaderRouterId);
+} // namespace LeaderRouterId
+
+namespace DetachedRoleCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * detachedRoleCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t detachedRoleCount);
+} // namespace DetachedRoleCount
+
+namespace ChildRoleCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * childRoleCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t childRoleCount);
+} // namespace ChildRoleCount
+
+namespace RouterRoleCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * routerRoleCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t routerRoleCount);
+} // namespace RouterRoleCount
+
+namespace LeaderRoleCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * leaderRoleCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t leaderRoleCount);
+} // namespace LeaderRoleCount
+
+namespace AttachAttemptCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * attachAttemptCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t attachAttemptCount);
+} // namespace AttachAttemptCount
+
+namespace PartitionIdChangeCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t partitionIdChangeCount);
+} // namespace PartitionIdChangeCount
+
+namespace BetterPartitionAttachAttemptCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * betterPartitionAttachAttemptCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount);
+} // namespace BetterPartitionAttachAttemptCount
+
+namespace ParentChangeCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * parentChangeCount); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t parentChangeCount);
+} // namespace ParentChangeCount
+
+namespace TxTotalCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txTotalCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txTotalCount);
+} // namespace TxTotalCount
+
+namespace TxUnicastCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txUnicastCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txUnicastCount);
+} // namespace TxUnicastCount
+
+namespace TxBroadcastCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBroadcastCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBroadcastCount);
+} // namespace TxBroadcastCount
+
+namespace TxAckRequestedCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckRequestedCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckRequestedCount);
+} // namespace TxAckRequestedCount
+
+namespace TxAckedCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckedCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckedCount);
+} // namespace TxAckedCount
+
+namespace TxNoAckRequestedCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount);
+} // namespace TxNoAckRequestedCount
+
+namespace TxDataCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataCount);
+} // namespace TxDataCount
+
+namespace TxDataPollCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataPollCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataPollCount);
+} // namespace TxDataPollCount
+
+namespace TxBeaconCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconCount);
+} // namespace TxBeaconCount
+
+namespace TxBeaconRequestCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconRequestCount);
+} // namespace TxBeaconRequestCount
+
+namespace TxOtherCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txOtherCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txOtherCount);
+} // namespace TxOtherCount
+
+namespace TxRetryCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txRetryCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txRetryCount);
+} // namespace TxRetryCount
+
+namespace TxDirectMaxRetryExpiryCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount);
+} // namespace TxDirectMaxRetryExpiryCount
+
+namespace TxIndirectMaxRetryExpiryCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount);
+} // namespace TxIndirectMaxRetryExpiryCount
+
+namespace TxErrCcaCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrCcaCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrCcaCount);
+} // namespace TxErrCcaCount
+
+namespace TxErrAbortCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrAbortCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrAbortCount);
+} // namespace TxErrAbortCount
+
+namespace TxErrBusyChannelCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount);
+} // namespace TxErrBusyChannelCount
+
+namespace RxTotalCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxTotalCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxTotalCount);
+} // namespace RxTotalCount
+
+namespace RxUnicastCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxUnicastCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxUnicastCount);
+} // namespace RxUnicastCount
+
+namespace RxBroadcastCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBroadcastCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBroadcastCount);
+} // namespace RxBroadcastCount
+
+namespace RxDataCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataCount);
+} // namespace RxDataCount
+
+namespace RxDataPollCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataPollCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataPollCount);
+} // namespace RxDataPollCount
+
+namespace RxBeaconCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconCount);
+} // namespace RxBeaconCount
+
+namespace RxBeaconRequestCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount);
+} // namespace RxBeaconRequestCount
+
+namespace RxOtherCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxOtherCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxOtherCount);
+} // namespace RxOtherCount
+
+namespace RxAddressFilteredCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount);
+} // namespace RxAddressFilteredCount
+
+namespace RxDestAddrFilteredCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount);
+} // namespace RxDestAddrFilteredCount
+
+namespace RxDuplicatedCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDuplicatedCount);
+} // namespace RxDuplicatedCount
+
+namespace RxErrNoFrameCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount);
+} // namespace RxErrNoFrameCount
+
+namespace RxErrUnknownNeighborCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount);
+} // namespace RxErrUnknownNeighborCount
+
+namespace RxErrInvalidSrcAddrCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount);
+} // namespace RxErrInvalidSrcAddrCount
+
+namespace RxErrSecCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrSecCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrSecCount);
+} // namespace RxErrSecCount
+
+namespace RxErrFcsCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrFcsCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrFcsCount);
+} // namespace RxErrFcsCount
+
+namespace RxErrOtherCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrOtherCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrOtherCount);
+} // namespace RxErrOtherCount
+
+namespace ActiveTimestamp {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * activeTimestamp); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t activeTimestamp);
+} // namespace ActiveTimestamp
+
+namespace PendingTimestamp {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * pendingTimestamp); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t pendingTimestamp);
+} // namespace PendingTimestamp
+
+namespace Delay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * delay); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t delay);
+} // namespace Delay
+
 } // namespace Attributes
 } // namespace ThreadNetworkDiagnostics
 
 namespace WiFiNetworkDiagnostics {
 namespace Attributes {
-EmberAfStatus GetSecurityType(chip::EndpointId endpoint, uint8_t * securityType); // enum8
-EmberAfStatus SetSecurityType(chip::EndpointId endpoint, uint8_t securityType);
-EmberAfStatus GetWiFiVersion(chip::EndpointId endpoint, uint8_t * wiFiVersion); // enum8
-EmberAfStatus SetWiFiVersion(chip::EndpointId endpoint, uint8_t wiFiVersion);
-EmberAfStatus GetChannelNumber(chip::EndpointId endpoint, uint16_t * channelNumber); // int16u
-EmberAfStatus SetChannelNumber(chip::EndpointId endpoint, uint16_t channelNumber);
-EmberAfStatus GetRssi(chip::EndpointId endpoint, int8_t * rssi); // int8s
-EmberAfStatus SetRssi(chip::EndpointId endpoint, int8_t rssi);
-EmberAfStatus GetBeaconLostCount(chip::EndpointId endpoint, uint32_t * beaconLostCount); // int32u
-EmberAfStatus SetBeaconLostCount(chip::EndpointId endpoint, uint32_t beaconLostCount);
-EmberAfStatus GetBeaconRxCount(chip::EndpointId endpoint, uint32_t * beaconRxCount); // int32u
-EmberAfStatus SetBeaconRxCount(chip::EndpointId endpoint, uint32_t beaconRxCount);
-EmberAfStatus GetPacketMulticastRxCount(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount); // int32u
-EmberAfStatus SetPacketMulticastRxCount(chip::EndpointId endpoint, uint32_t packetMulticastRxCount);
-EmberAfStatus GetPacketMulticastTxCount(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount); // int32u
-EmberAfStatus SetPacketMulticastTxCount(chip::EndpointId endpoint, uint32_t packetMulticastTxCount);
-EmberAfStatus GetPacketUnicastRxCount(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount); // int32u
-EmberAfStatus SetPacketUnicastRxCount(chip::EndpointId endpoint, uint32_t packetUnicastRxCount);
-EmberAfStatus GetPacketUnicastTxCount(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount); // int32u
-EmberAfStatus SetPacketUnicastTxCount(chip::EndpointId endpoint, uint32_t packetUnicastTxCount);
-EmberAfStatus GetCurrentMaxRate(chip::EndpointId endpoint, uint64_t * currentMaxRate); // int64u
-EmberAfStatus SetCurrentMaxRate(chip::EndpointId endpoint, uint64_t currentMaxRate);
-EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
-EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount);
+
+namespace SecurityType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * securityType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t securityType);
+} // namespace SecurityType
+
+namespace WiFiVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiFiVersion); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiFiVersion);
+} // namespace WiFiVersion
+
+namespace ChannelNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * channelNumber); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t channelNumber);
+} // namespace ChannelNumber
+
+namespace Rssi {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * rssi); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t rssi);
+} // namespace Rssi
+
+namespace BeaconLostCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconLostCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconLostCount);
+} // namespace BeaconLostCount
+
+namespace BeaconRxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconRxCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconRxCount);
+} // namespace BeaconRxCount
+
+namespace PacketMulticastRxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastRxCount);
+} // namespace PacketMulticastRxCount
+
+namespace PacketMulticastTxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastTxCount);
+} // namespace PacketMulticastTxCount
+
+namespace PacketUnicastRxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastRxCount);
+} // namespace PacketUnicastRxCount
+
+namespace PacketUnicastTxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastTxCount);
+} // namespace PacketUnicastTxCount
+
+namespace CurrentMaxRate {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentMaxRate); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentMaxRate);
+} // namespace CurrentMaxRate
+
+namespace OverrunCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount);
+} // namespace OverrunCount
+
 } // namespace Attributes
 } // namespace WiFiNetworkDiagnostics
 
 namespace EthernetNetworkDiagnostics {
 namespace Attributes {
-EmberAfStatus GetPHYRate(chip::EndpointId endpoint, uint8_t * pHYRate); // enum8
-EmberAfStatus SetPHYRate(chip::EndpointId endpoint, uint8_t pHYRate);
-EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, bool * fullDuplex); // boolean
-EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, bool fullDuplex);
-EmberAfStatus GetPacketRxCount(chip::EndpointId endpoint, uint64_t * packetRxCount); // int64u
-EmberAfStatus SetPacketRxCount(chip::EndpointId endpoint, uint64_t packetRxCount);
-EmberAfStatus GetPacketTxCount(chip::EndpointId endpoint, uint64_t * packetTxCount); // int64u
-EmberAfStatus SetPacketTxCount(chip::EndpointId endpoint, uint64_t packetTxCount);
-EmberAfStatus GetTxErrCount(chip::EndpointId endpoint, uint64_t * txErrCount); // int64u
-EmberAfStatus SetTxErrCount(chip::EndpointId endpoint, uint64_t txErrCount);
-EmberAfStatus GetCollisionCount(chip::EndpointId endpoint, uint64_t * collisionCount); // int64u
-EmberAfStatus SetCollisionCount(chip::EndpointId endpoint, uint64_t collisionCount);
-EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
-EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount);
-EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, bool * carrierDetect); // boolean
-EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, bool carrierDetect);
-EmberAfStatus GetTimeSinceReset(chip::EndpointId endpoint, uint64_t * timeSinceReset); // int64u
-EmberAfStatus SetTimeSinceReset(chip::EndpointId endpoint, uint64_t timeSinceReset);
+
+namespace PHYRate {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pHYRate); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pHYRate);
+} // namespace PHYRate
+
+namespace FullDuplex {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * fullDuplex); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool fullDuplex);
+} // namespace FullDuplex
+
+namespace PacketRxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetRxCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetRxCount);
+} // namespace PacketRxCount
+
+namespace PacketTxCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetTxCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetTxCount);
+} // namespace PacketTxCount
+
+namespace TxErrCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * txErrCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t txErrCount);
+} // namespace TxErrCount
+
+namespace CollisionCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * collisionCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t collisionCount);
+} // namespace CollisionCount
+
+namespace OverrunCount {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount);
+} // namespace OverrunCount
+
+namespace CarrierDetect {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * carrierDetect); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool carrierDetect);
+} // namespace CarrierDetect
+
+namespace TimeSinceReset {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * timeSinceReset); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t timeSinceReset);
+} // namespace TimeSinceReset
+
 } // namespace Attributes
 } // namespace EthernetNetworkDiagnostics
 
 namespace BridgedDeviceBasic {
 namespace Attributes {
-EmberAfStatus GetVendorID(chip::EndpointId endpoint, uint16_t * vendorID); // int16u
-EmberAfStatus SetVendorID(chip::EndpointId endpoint, uint16_t vendorID);
-EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareVersion); // int16u
-EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion);
-EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
-EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion);
-EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable); // boolean
-EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable);
+
+namespace VendorID {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID);
+} // namespace VendorID
+
+namespace HardwareVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion);
+} // namespace HardwareVersion
+
+namespace SoftwareVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion);
+} // namespace SoftwareVersion
+
+namespace Reachable {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool reachable);
+} // namespace Reachable
+
 } // namespace Attributes
 } // namespace BridgedDeviceBasic
 
 namespace Switch {
 namespace Attributes {
-EmberAfStatus GetNumberOfPositions(chip::EndpointId endpoint, uint8_t * numberOfPositions); // int8u
-EmberAfStatus SetNumberOfPositions(chip::EndpointId endpoint, uint8_t numberOfPositions);
-EmberAfStatus GetCurrentPosition(chip::EndpointId endpoint, uint8_t * currentPosition); // int8u
-EmberAfStatus SetCurrentPosition(chip::EndpointId endpoint, uint8_t currentPosition);
-EmberAfStatus GetMultiPressMax(chip::EndpointId endpoint, uint8_t * multiPressMax); // int8u
-EmberAfStatus SetMultiPressMax(chip::EndpointId endpoint, uint8_t multiPressMax);
+
+namespace NumberOfPositions {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPositions); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPositions);
+} // namespace NumberOfPositions
+
+namespace CurrentPosition {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPosition); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPosition);
+} // namespace CurrentPosition
+
+namespace MultiPressMax {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * multiPressMax); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t multiPressMax);
+} // namespace MultiPressMax
+
 } // namespace Attributes
 } // namespace Switch
 
 namespace OperationalCredentials {
 namespace Attributes {
-EmberAfStatus GetSupportedFabrics(chip::EndpointId endpoint, uint8_t * supportedFabrics); // int8u
-EmberAfStatus SetSupportedFabrics(chip::EndpointId endpoint, uint8_t supportedFabrics);
-EmberAfStatus GetCommissionedFabrics(chip::EndpointId endpoint, uint8_t * commissionedFabrics); // int8u
-EmberAfStatus SetCommissionedFabrics(chip::EndpointId endpoint, uint8_t commissionedFabrics);
+
+namespace SupportedFabrics {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * supportedFabrics); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t supportedFabrics);
+} // namespace SupportedFabrics
+
+namespace CommissionedFabrics {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * commissionedFabrics); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t commissionedFabrics);
+} // namespace CommissionedFabrics
+
 } // namespace Attributes
 } // namespace OperationalCredentials
 
 namespace FixedLabel {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace FixedLabel
 
 namespace ShadeConfiguration {
 namespace Attributes {
-EmberAfStatus GetPhysicalClosedLimit(chip::EndpointId endpoint, uint16_t * physicalClosedLimit); // int16u
-EmberAfStatus SetPhysicalClosedLimit(chip::EndpointId endpoint, uint16_t physicalClosedLimit);
-EmberAfStatus GetMotorStepSize(chip::EndpointId endpoint, uint8_t * motorStepSize); // int8u
-EmberAfStatus SetMotorStepSize(chip::EndpointId endpoint, uint8_t motorStepSize);
-EmberAfStatus GetStatus(chip::EndpointId endpoint, uint8_t * status); // bitmap8
-EmberAfStatus SetStatus(chip::EndpointId endpoint, uint8_t status);
-EmberAfStatus GetClosedLimit(chip::EndpointId endpoint, uint16_t * closedLimit); // int16u
-EmberAfStatus SetClosedLimit(chip::EndpointId endpoint, uint16_t closedLimit);
-EmberAfStatus GetMode(chip::EndpointId endpoint, uint8_t * mode); // enum8
-EmberAfStatus SetMode(chip::EndpointId endpoint, uint8_t mode);
+
+namespace PhysicalClosedLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimit); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimit);
+} // namespace PhysicalClosedLimit
+
+namespace MotorStepSize {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * motorStepSize); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t motorStepSize);
+} // namespace MotorStepSize
+
+namespace Status {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status);
+} // namespace Status
+
+namespace ClosedLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * closedLimit); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t closedLimit);
+} // namespace ClosedLimit
+
+namespace Mode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode);
+} // namespace Mode
+
 } // namespace Attributes
 } // namespace ShadeConfiguration
 
 namespace DoorLock {
 namespace Attributes {
-EmberAfStatus GetLockState(chip::EndpointId endpoint, uint8_t * lockState); // enum8
-EmberAfStatus SetLockState(chip::EndpointId endpoint, uint8_t lockState);
-EmberAfStatus GetLockType(chip::EndpointId endpoint, uint8_t * lockType); // enum8
-EmberAfStatus SetLockType(chip::EndpointId endpoint, uint8_t lockType);
-EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, bool * actuatorEnabled); // boolean
-EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, bool actuatorEnabled);
-EmberAfStatus GetDoorState(chip::EndpointId endpoint, uint8_t * doorState); // enum8
-EmberAfStatus SetDoorState(chip::EndpointId endpoint, uint8_t doorState);
-EmberAfStatus GetDoorOpenEvents(chip::EndpointId endpoint, uint32_t * doorOpenEvents); // int32u
-EmberAfStatus SetDoorOpenEvents(chip::EndpointId endpoint, uint32_t doorOpenEvents);
-EmberAfStatus GetDoorClosedEvents(chip::EndpointId endpoint, uint32_t * doorClosedEvents); // int32u
-EmberAfStatus SetDoorClosedEvents(chip::EndpointId endpoint, uint32_t doorClosedEvents);
-EmberAfStatus GetOpenPeriod(chip::EndpointId endpoint, uint16_t * openPeriod); // int16u
-EmberAfStatus SetOpenPeriod(chip::EndpointId endpoint, uint16_t openPeriod);
-EmberAfStatus GetNumLockRecordsSupported(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported); // int16u
-EmberAfStatus SetNumLockRecordsSupported(chip::EndpointId endpoint, uint16_t numLockRecordsSupported);
-EmberAfStatus GetNumTotalUsersSupported(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported); // int16u
-EmberAfStatus SetNumTotalUsersSupported(chip::EndpointId endpoint, uint16_t numTotalUsersSupported);
-EmberAfStatus GetNumPinUsersSupported(chip::EndpointId endpoint, uint16_t * numPinUsersSupported); // int16u
-EmberAfStatus SetNumPinUsersSupported(chip::EndpointId endpoint, uint16_t numPinUsersSupported);
-EmberAfStatus GetNumRfidUsersSupported(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported); // int16u
-EmberAfStatus SetNumRfidUsersSupported(chip::EndpointId endpoint, uint16_t numRfidUsersSupported);
-EmberAfStatus GetNumWeekdaySchedulesSupportedPerUser(chip::EndpointId endpoint,
-                                                     uint8_t * numWeekdaySchedulesSupportedPerUser); // int8u
-EmberAfStatus SetNumWeekdaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser);
-EmberAfStatus GetNumYeardaySchedulesSupportedPerUser(chip::EndpointId endpoint,
-                                                     uint8_t * numYeardaySchedulesSupportedPerUser); // int8u
-EmberAfStatus SetNumYeardaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser);
-EmberAfStatus GetNumHolidaySchedulesSupportedPerUser(chip::EndpointId endpoint,
-                                                     uint8_t * numHolidaySchedulesSupportedPerUser); // int8u
-EmberAfStatus SetNumHolidaySchedulesSupportedPerUser(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser);
-EmberAfStatus GetMaxPinLength(chip::EndpointId endpoint, uint8_t * maxPinLength); // int8u
-EmberAfStatus SetMaxPinLength(chip::EndpointId endpoint, uint8_t maxPinLength);
-EmberAfStatus GetMinPinLength(chip::EndpointId endpoint, uint8_t * minPinLength); // int8u
-EmberAfStatus SetMinPinLength(chip::EndpointId endpoint, uint8_t minPinLength);
-EmberAfStatus GetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength); // int8u
-EmberAfStatus SetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t maxRfidCodeLength);
-EmberAfStatus GetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t * minRfidCodeLength); // int8u
-EmberAfStatus SetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t minRfidCodeLength);
-EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, bool * enableLogging); // boolean
-EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, bool enableLogging);
-EmberAfStatus GetLedSettings(chip::EndpointId endpoint, uint8_t * ledSettings); // int8u
-EmberAfStatus SetLedSettings(chip::EndpointId endpoint, uint8_t ledSettings);
-EmberAfStatus GetAutoRelockTime(chip::EndpointId endpoint, uint32_t * autoRelockTime); // int32u
-EmberAfStatus SetAutoRelockTime(chip::EndpointId endpoint, uint32_t autoRelockTime);
-EmberAfStatus GetSoundVolume(chip::EndpointId endpoint, uint8_t * soundVolume); // int8u
-EmberAfStatus SetSoundVolume(chip::EndpointId endpoint, uint8_t soundVolume);
-EmberAfStatus GetOperatingMode(chip::EndpointId endpoint, uint8_t * operatingMode); // enum8
-EmberAfStatus SetOperatingMode(chip::EndpointId endpoint, uint8_t operatingMode);
-EmberAfStatus GetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t * supportedOperatingModes); // bitmap16
-EmberAfStatus SetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t supportedOperatingModes);
-EmberAfStatus GetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister); // bitmap16
-EmberAfStatus SetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister);
-EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, bool * enableLocalProgramming); // boolean
-EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, bool enableLocalProgramming);
-EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, bool * enableOneTouchLocking); // boolean
-EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, bool enableOneTouchLocking);
-EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, bool * enableInsideStatusLed); // boolean
-EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, bool enableInsideStatusLed);
-EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, bool * enablePrivacyModeButton); // boolean
-EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, bool enablePrivacyModeButton);
-EmberAfStatus GetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit); // int8u
-EmberAfStatus SetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit);
-EmberAfStatus GetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime); // int8u
-EmberAfStatus SetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime);
-EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, bool * sendPinOverTheAir); // boolean
-EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, bool sendPinOverTheAir);
-EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, bool * requirePinForRfOperation); // boolean
-EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, bool requirePinForRfOperation);
-EmberAfStatus GetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel); // enum8
-EmberAfStatus SetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel);
-EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
-EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint16_t alarmMask);
-EmberAfStatus GetKeypadOperationEventMask(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask); // bitmap16
-EmberAfStatus SetKeypadOperationEventMask(chip::EndpointId endpoint, uint16_t keypadOperationEventMask);
-EmberAfStatus GetRfOperationEventMask(chip::EndpointId endpoint, uint16_t * rfOperationEventMask); // bitmap16
-EmberAfStatus SetRfOperationEventMask(chip::EndpointId endpoint, uint16_t rfOperationEventMask);
-EmberAfStatus GetManualOperationEventMask(chip::EndpointId endpoint, uint16_t * manualOperationEventMask); // bitmap16
-EmberAfStatus SetManualOperationEventMask(chip::EndpointId endpoint, uint16_t manualOperationEventMask);
-EmberAfStatus GetRfidOperationEventMask(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask); // bitmap16
-EmberAfStatus SetRfidOperationEventMask(chip::EndpointId endpoint, uint16_t rfidOperationEventMask);
-EmberAfStatus GetKeypadProgrammingEventMask(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask); // bitmap16
-EmberAfStatus SetKeypadProgrammingEventMask(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask);
-EmberAfStatus GetRfProgrammingEventMask(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask); // bitmap16
-EmberAfStatus SetRfProgrammingEventMask(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask);
-EmberAfStatus GetRfidProgrammingEventMask(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask); // bitmap16
-EmberAfStatus SetRfidProgrammingEventMask(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask);
+
+namespace LockState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockState); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockState);
+} // namespace LockState
+
+namespace LockType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockType);
+} // namespace LockType
+
+namespace ActuatorEnabled {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * actuatorEnabled); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool actuatorEnabled);
+} // namespace ActuatorEnabled
+
+namespace DoorState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * doorState); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t doorState);
+} // namespace DoorState
+
+namespace DoorOpenEvents {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorOpenEvents); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorOpenEvents);
+} // namespace DoorOpenEvents
+
+namespace DoorClosedEvents {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorClosedEvents); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorClosedEvents);
+} // namespace DoorClosedEvents
+
+namespace OpenPeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * openPeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t openPeriod);
+} // namespace OpenPeriod
+
+namespace NumLockRecordsSupported {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numLockRecordsSupported);
+} // namespace NumLockRecordsSupported
+
+namespace NumTotalUsersSupported {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numTotalUsersSupported);
+} // namespace NumTotalUsersSupported
+
+namespace NumPinUsersSupported {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numPinUsersSupported); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numPinUsersSupported);
+} // namespace NumPinUsersSupported
+
+namespace NumRfidUsersSupported {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numRfidUsersSupported);
+} // namespace NumRfidUsersSupported
+
+namespace NumWeekdaySchedulesSupportedPerUser {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numWeekdaySchedulesSupportedPerUser); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser);
+} // namespace NumWeekdaySchedulesSupportedPerUser
+
+namespace NumYeardaySchedulesSupportedPerUser {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numYeardaySchedulesSupportedPerUser); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser);
+} // namespace NumYeardaySchedulesSupportedPerUser
+
+namespace NumHolidaySchedulesSupportedPerUser {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numHolidaySchedulesSupportedPerUser); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser);
+} // namespace NumHolidaySchedulesSupportedPerUser
+
+namespace MaxPinLength {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxPinLength); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxPinLength);
+} // namespace MaxPinLength
+
+namespace MinPinLength {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minPinLength); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minPinLength);
+} // namespace MinPinLength
+
+namespace MaxRfidCodeLength {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxRfidCodeLength);
+} // namespace MaxRfidCodeLength
+
+namespace MinRfidCodeLength {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minRfidCodeLength); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minRfidCodeLength);
+} // namespace MinRfidCodeLength
+
+namespace EnableLogging {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLogging); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableLogging);
+} // namespace EnableLogging
+
+namespace LedSettings {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ledSettings); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ledSettings);
+} // namespace LedSettings
+
+namespace AutoRelockTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * autoRelockTime); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t autoRelockTime);
+} // namespace AutoRelockTime
+
+namespace SoundVolume {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * soundVolume); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t soundVolume);
+} // namespace SoundVolume
+
+namespace OperatingMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operatingMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operatingMode);
+} // namespace OperatingMode
+
+namespace SupportedOperatingModes {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * supportedOperatingModes); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t supportedOperatingModes);
+} // namespace SupportedOperatingModes
+
+namespace DefaultConfigurationRegister {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister);
+} // namespace DefaultConfigurationRegister
+
+namespace EnableLocalProgramming {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLocalProgramming); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableLocalProgramming);
+} // namespace EnableLocalProgramming
+
+namespace EnableOneTouchLocking {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableOneTouchLocking); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableOneTouchLocking);
+} // namespace EnableOneTouchLocking
+
+namespace EnableInsideStatusLed {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enableInsideStatusLed); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool enableInsideStatusLed);
+} // namespace EnableInsideStatusLed
+
+namespace EnablePrivacyModeButton {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * enablePrivacyModeButton); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool enablePrivacyModeButton);
+} // namespace EnablePrivacyModeButton
+
+namespace WrongCodeEntryLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit);
+} // namespace WrongCodeEntryLimit
+
+namespace UserCodeTemporaryDisableTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime);
+} // namespace UserCodeTemporaryDisableTime
+
+namespace SendPinOverTheAir {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * sendPinOverTheAir); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool sendPinOverTheAir);
+} // namespace SendPinOverTheAir
+
+namespace RequirePinForRfOperation {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * requirePinForRfOperation); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool requirePinForRfOperation);
+} // namespace RequirePinForRfOperation
+
+namespace ZigbeeSecurityLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel);
+} // namespace ZigbeeSecurityLevel
+
+namespace AlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask);
+} // namespace AlarmMask
+
+namespace KeypadOperationEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadOperationEventMask);
+} // namespace KeypadOperationEventMask
+
+namespace RfOperationEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfOperationEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfOperationEventMask);
+} // namespace RfOperationEventMask
+
+namespace ManualOperationEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * manualOperationEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t manualOperationEventMask);
+} // namespace ManualOperationEventMask
+
+namespace RfidOperationEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidOperationEventMask);
+} // namespace RfidOperationEventMask
+
+namespace KeypadProgrammingEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask);
+} // namespace KeypadProgrammingEventMask
+
+namespace RfProgrammingEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask);
+} // namespace RfProgrammingEventMask
+
+namespace RfidProgrammingEventMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask);
+} // namespace RfidProgrammingEventMask
+
 } // namespace Attributes
 } // namespace DoorLock
 
 namespace WindowCovering {
 namespace Attributes {
-EmberAfStatus GetType(chip::EndpointId endpoint, uint8_t * type); // enum8
-EmberAfStatus SetType(chip::EndpointId endpoint, uint8_t type);
-EmberAfStatus GetPhysicalClosedLimitLift(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift); // int16u
-EmberAfStatus SetPhysicalClosedLimitLift(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift);
-EmberAfStatus GetPhysicalClosedLimitTilt(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt); // int16u
-EmberAfStatus SetPhysicalClosedLimitTilt(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt);
-EmberAfStatus GetCurrentPositionLift(chip::EndpointId endpoint, uint16_t * currentPositionLift); // int16u
-EmberAfStatus SetCurrentPositionLift(chip::EndpointId endpoint, uint16_t currentPositionLift);
-EmberAfStatus GetCurrentPositionTilt(chip::EndpointId endpoint, uint16_t * currentPositionTilt); // int16u
-EmberAfStatus SetCurrentPositionTilt(chip::EndpointId endpoint, uint16_t currentPositionTilt);
-EmberAfStatus GetNumberOfActuationsLift(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift); // int16u
-EmberAfStatus SetNumberOfActuationsLift(chip::EndpointId endpoint, uint16_t numberOfActuationsLift);
-EmberAfStatus GetNumberOfActuationsTilt(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt); // int16u
-EmberAfStatus SetNumberOfActuationsTilt(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt);
-EmberAfStatus GetConfigStatus(chip::EndpointId endpoint, uint8_t * configStatus); // bitmap8
-EmberAfStatus SetConfigStatus(chip::EndpointId endpoint, uint8_t configStatus);
-EmberAfStatus GetCurrentPositionLiftPercentage(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage); // int8u
-EmberAfStatus SetCurrentPositionLiftPercentage(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage);
-EmberAfStatus GetCurrentPositionTiltPercentage(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage); // int8u
-EmberAfStatus SetCurrentPositionTiltPercentage(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage);
-EmberAfStatus GetOperationalStatus(chip::EndpointId endpoint, uint8_t * operationalStatus); // bitmap8
-EmberAfStatus SetOperationalStatus(chip::EndpointId endpoint, uint8_t operationalStatus);
-EmberAfStatus GetTargetPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths); // int16u
-EmberAfStatus SetTargetPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths);
-EmberAfStatus GetTargetPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths); // int16u
-EmberAfStatus SetTargetPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths);
-EmberAfStatus GetEndProductType(chip::EndpointId endpoint, uint8_t * endProductType); // enum8
-EmberAfStatus SetEndProductType(chip::EndpointId endpoint, uint8_t endProductType);
-EmberAfStatus GetCurrentPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths); // int16u
-EmberAfStatus SetCurrentPositionLiftPercent100ths(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths);
-EmberAfStatus GetCurrentPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths); // int16u
-EmberAfStatus SetCurrentPositionTiltPercent100ths(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths);
-EmberAfStatus GetInstalledOpenLimitLift(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift); // int16u
-EmberAfStatus SetInstalledOpenLimitLift(chip::EndpointId endpoint, uint16_t installedOpenLimitLift);
-EmberAfStatus GetInstalledClosedLimitLift(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift); // int16u
-EmberAfStatus SetInstalledClosedLimitLift(chip::EndpointId endpoint, uint16_t installedClosedLimitLift);
-EmberAfStatus GetInstalledOpenLimitTilt(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt); // int16u
-EmberAfStatus SetInstalledOpenLimitTilt(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt);
-EmberAfStatus GetInstalledClosedLimitTilt(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt); // int16u
-EmberAfStatus SetInstalledClosedLimitTilt(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt);
-EmberAfStatus GetVelocityLift(chip::EndpointId endpoint, uint16_t * velocityLift); // int16u
-EmberAfStatus SetVelocityLift(chip::EndpointId endpoint, uint16_t velocityLift);
-EmberAfStatus GetAccelerationTimeLift(chip::EndpointId endpoint, uint16_t * accelerationTimeLift); // int16u
-EmberAfStatus SetAccelerationTimeLift(chip::EndpointId endpoint, uint16_t accelerationTimeLift);
-EmberAfStatus GetDecelerationTimeLift(chip::EndpointId endpoint, uint16_t * decelerationTimeLift); // int16u
-EmberAfStatus SetDecelerationTimeLift(chip::EndpointId endpoint, uint16_t decelerationTimeLift);
-EmberAfStatus GetMode(chip::EndpointId endpoint, uint8_t * mode); // bitmap8
-EmberAfStatus SetMode(chip::EndpointId endpoint, uint8_t mode);
-EmberAfStatus GetSafetyStatus(chip::EndpointId endpoint, uint16_t * safetyStatus); // bitmap16
-EmberAfStatus SetSafetyStatus(chip::EndpointId endpoint, uint16_t safetyStatus);
+
+namespace Type {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * type); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t type);
+} // namespace Type
+
+namespace PhysicalClosedLimitLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift);
+} // namespace PhysicalClosedLimitLift
+
+namespace PhysicalClosedLimitTilt {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt);
+} // namespace PhysicalClosedLimitTilt
+
+namespace CurrentPositionLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLift);
+} // namespace CurrentPositionLift
+
+namespace CurrentPositionTilt {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTilt); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTilt);
+} // namespace CurrentPositionTilt
+
+namespace NumberOfActuationsLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsLift);
+} // namespace NumberOfActuationsLift
+
+namespace NumberOfActuationsTilt {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt);
+} // namespace NumberOfActuationsTilt
+
+namespace ConfigStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * configStatus); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t configStatus);
+} // namespace ConfigStatus
+
+namespace CurrentPositionLiftPercentage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage);
+} // namespace CurrentPositionLiftPercentage
+
+namespace CurrentPositionTiltPercentage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage);
+} // namespace CurrentPositionTiltPercentage
+
+namespace OperationalStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationalStatus); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationalStatus);
+} // namespace OperationalStatus
+
+namespace TargetPositionLiftPercent100ths {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths);
+} // namespace TargetPositionLiftPercent100ths
+
+namespace TargetPositionTiltPercent100ths {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths);
+} // namespace TargetPositionTiltPercent100ths
+
+namespace EndProductType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * endProductType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t endProductType);
+} // namespace EndProductType
+
+namespace CurrentPositionLiftPercent100ths {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths);
+} // namespace CurrentPositionLiftPercent100ths
+
+namespace CurrentPositionTiltPercent100ths {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths);
+} // namespace CurrentPositionTiltPercent100ths
+
+namespace InstalledOpenLimitLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitLift);
+} // namespace InstalledOpenLimitLift
+
+namespace InstalledClosedLimitLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitLift);
+} // namespace InstalledClosedLimitLift
+
+namespace InstalledOpenLimitTilt {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt);
+} // namespace InstalledOpenLimitTilt
+
+namespace InstalledClosedLimitTilt {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt);
+} // namespace InstalledClosedLimitTilt
+
+namespace VelocityLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * velocityLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t velocityLift);
+} // namespace VelocityLift
+
+namespace AccelerationTimeLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * accelerationTimeLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t accelerationTimeLift);
+} // namespace AccelerationTimeLift
+
+namespace DecelerationTimeLift {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * decelerationTimeLift); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t decelerationTimeLift);
+} // namespace DecelerationTimeLift
+
+namespace Mode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode);
+} // namespace Mode
+
+namespace SafetyStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * safetyStatus); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t safetyStatus);
+} // namespace SafetyStatus
+
 } // namespace Attributes
 } // namespace WindowCovering
 
 namespace BarrierControl {
 namespace Attributes {
-EmberAfStatus GetBarrierMovingState(chip::EndpointId endpoint, uint8_t * barrierMovingState); // enum8
-EmberAfStatus SetBarrierMovingState(chip::EndpointId endpoint, uint8_t barrierMovingState);
-EmberAfStatus GetBarrierSafetyStatus(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus); // bitmap16
-EmberAfStatus SetBarrierSafetyStatus(chip::EndpointId endpoint, uint16_t barrierSafetyStatus);
-EmberAfStatus GetBarrierCapabilities(chip::EndpointId endpoint, uint8_t * barrierCapabilities); // bitmap8
-EmberAfStatus SetBarrierCapabilities(chip::EndpointId endpoint, uint8_t barrierCapabilities);
-EmberAfStatus GetBarrierOpenEvents(chip::EndpointId endpoint, uint16_t * barrierOpenEvents); // int16u
-EmberAfStatus SetBarrierOpenEvents(chip::EndpointId endpoint, uint16_t barrierOpenEvents);
-EmberAfStatus GetBarrierCloseEvents(chip::EndpointId endpoint, uint16_t * barrierCloseEvents); // int16u
-EmberAfStatus SetBarrierCloseEvents(chip::EndpointId endpoint, uint16_t barrierCloseEvents);
-EmberAfStatus GetBarrierCommandOpenEvents(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents); // int16u
-EmberAfStatus SetBarrierCommandOpenEvents(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents);
-EmberAfStatus GetBarrierCommandCloseEvents(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents); // int16u
-EmberAfStatus SetBarrierCommandCloseEvents(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents);
-EmberAfStatus GetBarrierOpenPeriod(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod); // int16u
-EmberAfStatus SetBarrierOpenPeriod(chip::EndpointId endpoint, uint16_t barrierOpenPeriod);
-EmberAfStatus GetBarrierClosePeriod(chip::EndpointId endpoint, uint16_t * barrierClosePeriod); // int16u
-EmberAfStatus SetBarrierClosePeriod(chip::EndpointId endpoint, uint16_t barrierClosePeriod);
-EmberAfStatus GetBarrierPosition(chip::EndpointId endpoint, uint8_t * barrierPosition); // int8u
-EmberAfStatus SetBarrierPosition(chip::EndpointId endpoint, uint8_t barrierPosition);
+
+namespace BarrierMovingState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierMovingState); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierMovingState);
+} // namespace BarrierMovingState
+
+namespace BarrierSafetyStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierSafetyStatus);
+} // namespace BarrierSafetyStatus
+
+namespace BarrierCapabilities {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierCapabilities); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierCapabilities);
+} // namespace BarrierCapabilities
+
+namespace BarrierOpenEvents {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenEvents); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenEvents);
+} // namespace BarrierOpenEvents
+
+namespace BarrierCloseEvents {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCloseEvents); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCloseEvents);
+} // namespace BarrierCloseEvents
+
+namespace BarrierCommandOpenEvents {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents);
+} // namespace BarrierCommandOpenEvents
+
+namespace BarrierCommandCloseEvents {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents);
+} // namespace BarrierCommandCloseEvents
+
+namespace BarrierOpenPeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenPeriod);
+} // namespace BarrierOpenPeriod
+
+namespace BarrierClosePeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierClosePeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierClosePeriod);
+} // namespace BarrierClosePeriod
+
+namespace BarrierPosition {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierPosition); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierPosition);
+} // namespace BarrierPosition
+
 } // namespace Attributes
 } // namespace BarrierControl
 
 namespace PumpConfigurationAndControl {
 namespace Attributes {
-EmberAfStatus GetMaxPressure(chip::EndpointId endpoint, int16_t * maxPressure); // int16s
-EmberAfStatus SetMaxPressure(chip::EndpointId endpoint, int16_t maxPressure);
-EmberAfStatus GetMaxSpeed(chip::EndpointId endpoint, uint16_t * maxSpeed); // int16u
-EmberAfStatus SetMaxSpeed(chip::EndpointId endpoint, uint16_t maxSpeed);
-EmberAfStatus GetMaxFlow(chip::EndpointId endpoint, uint16_t * maxFlow); // int16u
-EmberAfStatus SetMaxFlow(chip::EndpointId endpoint, uint16_t maxFlow);
-EmberAfStatus GetMinConstPressure(chip::EndpointId endpoint, int16_t * minConstPressure); // int16s
-EmberAfStatus SetMinConstPressure(chip::EndpointId endpoint, int16_t minConstPressure);
-EmberAfStatus GetMaxConstPressure(chip::EndpointId endpoint, int16_t * maxConstPressure); // int16s
-EmberAfStatus SetMaxConstPressure(chip::EndpointId endpoint, int16_t maxConstPressure);
-EmberAfStatus GetMinCompPressure(chip::EndpointId endpoint, int16_t * minCompPressure); // int16s
-EmberAfStatus SetMinCompPressure(chip::EndpointId endpoint, int16_t minCompPressure);
-EmberAfStatus GetMaxCompPressure(chip::EndpointId endpoint, int16_t * maxCompPressure); // int16s
-EmberAfStatus SetMaxCompPressure(chip::EndpointId endpoint, int16_t maxCompPressure);
-EmberAfStatus GetMinConstSpeed(chip::EndpointId endpoint, uint16_t * minConstSpeed); // int16u
-EmberAfStatus SetMinConstSpeed(chip::EndpointId endpoint, uint16_t minConstSpeed);
-EmberAfStatus GetMaxConstSpeed(chip::EndpointId endpoint, uint16_t * maxConstSpeed); // int16u
-EmberAfStatus SetMaxConstSpeed(chip::EndpointId endpoint, uint16_t maxConstSpeed);
-EmberAfStatus GetMinConstFlow(chip::EndpointId endpoint, uint16_t * minConstFlow); // int16u
-EmberAfStatus SetMinConstFlow(chip::EndpointId endpoint, uint16_t minConstFlow);
-EmberAfStatus GetMaxConstFlow(chip::EndpointId endpoint, uint16_t * maxConstFlow); // int16u
-EmberAfStatus SetMaxConstFlow(chip::EndpointId endpoint, uint16_t maxConstFlow);
-EmberAfStatus GetMinConstTemp(chip::EndpointId endpoint, int16_t * minConstTemp); // int16s
-EmberAfStatus SetMinConstTemp(chip::EndpointId endpoint, int16_t minConstTemp);
-EmberAfStatus GetMaxConstTemp(chip::EndpointId endpoint, int16_t * maxConstTemp); // int16s
-EmberAfStatus SetMaxConstTemp(chip::EndpointId endpoint, int16_t maxConstTemp);
-EmberAfStatus GetPumpStatus(chip::EndpointId endpoint, uint16_t * pumpStatus); // bitmap16
-EmberAfStatus SetPumpStatus(chip::EndpointId endpoint, uint16_t pumpStatus);
-EmberAfStatus GetEffectiveOperationMode(chip::EndpointId endpoint, uint8_t * effectiveOperationMode); // enum8
-EmberAfStatus SetEffectiveOperationMode(chip::EndpointId endpoint, uint8_t effectiveOperationMode);
-EmberAfStatus GetEffectiveControlMode(chip::EndpointId endpoint, uint8_t * effectiveControlMode); // enum8
-EmberAfStatus SetEffectiveControlMode(chip::EndpointId endpoint, uint8_t effectiveControlMode);
-EmberAfStatus GetCapacity(chip::EndpointId endpoint, int16_t * capacity); // int16s
-EmberAfStatus SetCapacity(chip::EndpointId endpoint, int16_t capacity);
-EmberAfStatus GetSpeed(chip::EndpointId endpoint, uint16_t * speed); // int16u
-EmberAfStatus SetSpeed(chip::EndpointId endpoint, uint16_t speed);
-EmberAfStatus GetLifetimeEnergyConsumed(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed); // int32u
-EmberAfStatus SetLifetimeEnergyConsumed(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed);
-EmberAfStatus GetOperationMode(chip::EndpointId endpoint, uint8_t * operationMode); // enum8
-EmberAfStatus SetOperationMode(chip::EndpointId endpoint, uint8_t operationMode);
-EmberAfStatus GetControlMode(chip::EndpointId endpoint, uint8_t * controlMode); // enum8
-EmberAfStatus SetControlMode(chip::EndpointId endpoint, uint8_t controlMode);
-EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
-EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint16_t alarmMask);
+
+namespace MaxPressure {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxPressure); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxPressure);
+} // namespace MaxPressure
+
+namespace MaxSpeed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxSpeed); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxSpeed);
+} // namespace MaxSpeed
+
+namespace MaxFlow {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxFlow); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFlow);
+} // namespace MaxFlow
+
+namespace MinConstPressure {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstPressure); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstPressure);
+} // namespace MinConstPressure
+
+namespace MaxConstPressure {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstPressure); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstPressure);
+} // namespace MaxConstPressure
+
+namespace MinCompPressure {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCompPressure); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCompPressure);
+} // namespace MinCompPressure
+
+namespace MaxCompPressure {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCompPressure); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCompPressure);
+} // namespace MaxCompPressure
+
+namespace MinConstSpeed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstSpeed); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstSpeed);
+} // namespace MinConstSpeed
+
+namespace MaxConstSpeed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstSpeed); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstSpeed);
+} // namespace MaxConstSpeed
+
+namespace MinConstFlow {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstFlow); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstFlow);
+} // namespace MinConstFlow
+
+namespace MaxConstFlow {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstFlow); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstFlow);
+} // namespace MaxConstFlow
+
+namespace MinConstTemp {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstTemp); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstTemp);
+} // namespace MinConstTemp
+
+namespace MaxConstTemp {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstTemp); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstTemp);
+} // namespace MaxConstTemp
+
+namespace PumpStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pumpStatus); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pumpStatus);
+} // namespace PumpStatus
+
+namespace EffectiveOperationMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveOperationMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveOperationMode);
+} // namespace EffectiveOperationMode
+
+namespace EffectiveControlMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveControlMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveControlMode);
+} // namespace EffectiveControlMode
+
+namespace Capacity {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * capacity); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t capacity);
+} // namespace Capacity
+
+namespace Speed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * speed); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t speed);
+} // namespace Speed
+
+namespace LifetimeEnergyConsumed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed);
+} // namespace LifetimeEnergyConsumed
+
+namespace OperationMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationMode);
+} // namespace OperationMode
+
+namespace ControlMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlMode);
+} // namespace ControlMode
+
+namespace AlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask);
+} // namespace AlarmMask
+
 } // namespace Attributes
 } // namespace PumpConfigurationAndControl
 
 namespace Thermostat {
 namespace Attributes {
-EmberAfStatus GetLocalTemperature(chip::EndpointId endpoint, int16_t * localTemperature); // int16s
-EmberAfStatus SetLocalTemperature(chip::EndpointId endpoint, int16_t localTemperature);
-EmberAfStatus GetOutdoorTemperature(chip::EndpointId endpoint, int16_t * outdoorTemperature); // int16s
-EmberAfStatus SetOutdoorTemperature(chip::EndpointId endpoint, int16_t outdoorTemperature);
-EmberAfStatus GetOccupancy(chip::EndpointId endpoint, uint8_t * occupancy); // bitmap8
-EmberAfStatus SetOccupancy(chip::EndpointId endpoint, uint8_t occupancy);
-EmberAfStatus GetAbsMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit); // int16s
-EmberAfStatus SetAbsMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit);
-EmberAfStatus GetAbsMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit); // int16s
-EmberAfStatus SetAbsMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit);
-EmberAfStatus GetAbsMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit); // int16s
-EmberAfStatus SetAbsMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit);
-EmberAfStatus GetAbsMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit); // int16s
-EmberAfStatus SetAbsMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit);
-EmberAfStatus GetPiCoolingDemand(chip::EndpointId endpoint, uint8_t * piCoolingDemand); // int8u
-EmberAfStatus SetPiCoolingDemand(chip::EndpointId endpoint, uint8_t piCoolingDemand);
-EmberAfStatus GetPiHeatingDemand(chip::EndpointId endpoint, uint8_t * piHeatingDemand); // int8u
-EmberAfStatus SetPiHeatingDemand(chip::EndpointId endpoint, uint8_t piHeatingDemand);
-EmberAfStatus GetHvacSystemTypeConfiguration(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration); // bitmap8
-EmberAfStatus SetHvacSystemTypeConfiguration(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration);
-EmberAfStatus GetLocalTemperatureCalibration(chip::EndpointId endpoint, int8_t * localTemperatureCalibration); // int8s
-EmberAfStatus SetLocalTemperatureCalibration(chip::EndpointId endpoint, int8_t localTemperatureCalibration);
-EmberAfStatus GetOccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint); // int16s
-EmberAfStatus SetOccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint);
-EmberAfStatus GetOccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint); // int16s
-EmberAfStatus SetOccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint);
-EmberAfStatus GetUnoccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint); // int16s
-EmberAfStatus SetUnoccupiedCoolingSetpoint(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint);
-EmberAfStatus GetUnoccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint); // int16s
-EmberAfStatus SetUnoccupiedHeatingSetpoint(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint);
-EmberAfStatus GetMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit); // int16s
-EmberAfStatus SetMinHeatSetpointLimit(chip::EndpointId endpoint, int16_t minHeatSetpointLimit);
-EmberAfStatus GetMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit); // int16s
-EmberAfStatus SetMaxHeatSetpointLimit(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit);
-EmberAfStatus GetMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit); // int16s
-EmberAfStatus SetMinCoolSetpointLimit(chip::EndpointId endpoint, int16_t minCoolSetpointLimit);
-EmberAfStatus GetMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit); // int16s
-EmberAfStatus SetMaxCoolSetpointLimit(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit);
-EmberAfStatus GetMinSetpointDeadBand(chip::EndpointId endpoint, int8_t * minSetpointDeadBand); // int8s
-EmberAfStatus SetMinSetpointDeadBand(chip::EndpointId endpoint, int8_t minSetpointDeadBand);
-EmberAfStatus GetRemoteSensing(chip::EndpointId endpoint, uint8_t * remoteSensing); // bitmap8
-EmberAfStatus SetRemoteSensing(chip::EndpointId endpoint, uint8_t remoteSensing);
-EmberAfStatus GetControlSequenceOfOperation(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation); // enum8
-EmberAfStatus SetControlSequenceOfOperation(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation);
-EmberAfStatus GetSystemMode(chip::EndpointId endpoint, uint8_t * systemMode); // enum8
-EmberAfStatus SetSystemMode(chip::EndpointId endpoint, uint8_t systemMode);
-EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint8_t * alarmMask); // bitmap8
-EmberAfStatus SetAlarmMask(chip::EndpointId endpoint, uint8_t alarmMask);
-EmberAfStatus GetThermostatRunningMode(chip::EndpointId endpoint, uint8_t * thermostatRunningMode); // enum8
-EmberAfStatus SetThermostatRunningMode(chip::EndpointId endpoint, uint8_t thermostatRunningMode);
-EmberAfStatus GetStartOfWeek(chip::EndpointId endpoint, uint8_t * startOfWeek); // enum8
-EmberAfStatus SetStartOfWeek(chip::EndpointId endpoint, uint8_t startOfWeek);
-EmberAfStatus GetNumberOfWeeklyTransitions(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions); // int8u
-EmberAfStatus SetNumberOfWeeklyTransitions(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions);
-EmberAfStatus GetNumberOfDailyTransitions(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions); // int8u
-EmberAfStatus SetNumberOfDailyTransitions(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions);
-EmberAfStatus GetTemperatureSetpointHold(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold); // enum8
-EmberAfStatus SetTemperatureSetpointHold(chip::EndpointId endpoint, uint8_t temperatureSetpointHold);
-EmberAfStatus GetTemperatureSetpointHoldDuration(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration); // int16u
-EmberAfStatus SetTemperatureSetpointHoldDuration(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration);
-EmberAfStatus GetThermostatProgrammingOperationMode(chip::EndpointId endpoint,
-                                                    uint8_t * thermostatProgrammingOperationMode); // bitmap8
-EmberAfStatus SetThermostatProgrammingOperationMode(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode);
-EmberAfStatus GetHvacRelayState(chip::EndpointId endpoint, uint16_t * hvacRelayState); // bitmap16
-EmberAfStatus SetHvacRelayState(chip::EndpointId endpoint, uint16_t hvacRelayState);
-EmberAfStatus GetSetpointChangeSource(chip::EndpointId endpoint, uint8_t * setpointChangeSource); // enum8
-EmberAfStatus SetSetpointChangeSource(chip::EndpointId endpoint, uint8_t setpointChangeSource);
-EmberAfStatus GetSetpointChangeAmount(chip::EndpointId endpoint, int16_t * setpointChangeAmount); // int16s
-EmberAfStatus SetSetpointChangeAmount(chip::EndpointId endpoint, int16_t setpointChangeAmount);
-EmberAfStatus GetSetpointChangeSourceTimestamp(chip::EndpointId endpoint,
-                                               /* TYPE WARNING: utc defaults to */ uint8_t ** setpointChangeSourceTimestamp); // utc
-EmberAfStatus SetSetpointChangeSourceTimestamp(chip::EndpointId endpoint,
-                                               /* TYPE WARNING: utc defaults to */ uint8_t * setpointChangeSourceTimestamp);
-EmberAfStatus GetAcType(chip::EndpointId endpoint, uint8_t * acType); // enum8
-EmberAfStatus SetAcType(chip::EndpointId endpoint, uint8_t acType);
-EmberAfStatus GetAcCapacity(chip::EndpointId endpoint, uint16_t * acCapacity); // int16u
-EmberAfStatus SetAcCapacity(chip::EndpointId endpoint, uint16_t acCapacity);
-EmberAfStatus GetAcRefrigerantType(chip::EndpointId endpoint, uint8_t * acRefrigerantType); // enum8
-EmberAfStatus SetAcRefrigerantType(chip::EndpointId endpoint, uint8_t acRefrigerantType);
-EmberAfStatus GetAcCompressor(chip::EndpointId endpoint, uint8_t * acCompressor); // enum8
-EmberAfStatus SetAcCompressor(chip::EndpointId endpoint, uint8_t acCompressor);
-EmberAfStatus GetAcErrorCode(chip::EndpointId endpoint, uint32_t * acErrorCode); // bitmap32
-EmberAfStatus SetAcErrorCode(chip::EndpointId endpoint, uint32_t acErrorCode);
-EmberAfStatus GetAcLouverPosition(chip::EndpointId endpoint, uint8_t * acLouverPosition); // enum8
-EmberAfStatus SetAcLouverPosition(chip::EndpointId endpoint, uint8_t acLouverPosition);
-EmberAfStatus GetAcCoilTemperature(chip::EndpointId endpoint, int16_t * acCoilTemperature); // int16s
-EmberAfStatus SetAcCoilTemperature(chip::EndpointId endpoint, int16_t acCoilTemperature);
-EmberAfStatus GetAcCapacityFormat(chip::EndpointId endpoint, uint8_t * acCapacityFormat); // enum8
-EmberAfStatus SetAcCapacityFormat(chip::EndpointId endpoint, uint8_t acCapacityFormat);
+
+namespace LocalTemperature {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * localTemperature); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t localTemperature);
+} // namespace LocalTemperature
+
+namespace OutdoorTemperature {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * outdoorTemperature); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t outdoorTemperature);
+} // namespace OutdoorTemperature
+
+namespace Occupancy {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy);
+} // namespace Occupancy
+
+namespace AbsMinHeatSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit);
+} // namespace AbsMinHeatSetpointLimit
+
+namespace AbsMaxHeatSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit);
+} // namespace AbsMaxHeatSetpointLimit
+
+namespace AbsMinCoolSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit);
+} // namespace AbsMinCoolSetpointLimit
+
+namespace AbsMaxCoolSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit);
+} // namespace AbsMaxCoolSetpointLimit
+
+namespace PiCoolingDemand {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piCoolingDemand); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piCoolingDemand);
+} // namespace PiCoolingDemand
+
+namespace PiHeatingDemand {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piHeatingDemand); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piHeatingDemand);
+} // namespace PiHeatingDemand
+
+namespace HvacSystemTypeConfiguration {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration);
+} // namespace HvacSystemTypeConfiguration
+
+namespace LocalTemperatureCalibration {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * localTemperatureCalibration); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t localTemperatureCalibration);
+} // namespace LocalTemperatureCalibration
+
+namespace OccupiedCoolingSetpoint {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint);
+} // namespace OccupiedCoolingSetpoint
+
+namespace OccupiedHeatingSetpoint {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint);
+} // namespace OccupiedHeatingSetpoint
+
+namespace UnoccupiedCoolingSetpoint {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint);
+} // namespace UnoccupiedCoolingSetpoint
+
+namespace UnoccupiedHeatingSetpoint {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint);
+} // namespace UnoccupiedHeatingSetpoint
+
+namespace MinHeatSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minHeatSetpointLimit);
+} // namespace MinHeatSetpointLimit
+
+namespace MaxHeatSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit);
+} // namespace MaxHeatSetpointLimit
+
+namespace MinCoolSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCoolSetpointLimit);
+} // namespace MinCoolSetpointLimit
+
+namespace MaxCoolSetpointLimit {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit);
+} // namespace MaxCoolSetpointLimit
+
+namespace MinSetpointDeadBand {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * minSetpointDeadBand); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t minSetpointDeadBand);
+} // namespace MinSetpointDeadBand
+
+namespace RemoteSensing {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * remoteSensing); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t remoteSensing);
+} // namespace RemoteSensing
+
+namespace ControlSequenceOfOperation {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation);
+} // namespace ControlSequenceOfOperation
+
+namespace SystemMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * systemMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t systemMode);
+} // namespace SystemMode
+
+namespace AlarmMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * alarmMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t alarmMask);
+} // namespace AlarmMask
+
+namespace ThermostatRunningMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatRunningMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatRunningMode);
+} // namespace ThermostatRunningMode
+
+namespace StartOfWeek {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startOfWeek); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startOfWeek);
+} // namespace StartOfWeek
+
+namespace NumberOfWeeklyTransitions {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions);
+} // namespace NumberOfWeeklyTransitions
+
+namespace NumberOfDailyTransitions {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions);
+} // namespace NumberOfDailyTransitions
+
+namespace TemperatureSetpointHold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureSetpointHold);
+} // namespace TemperatureSetpointHold
+
+namespace TemperatureSetpointHoldDuration {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration);
+} // namespace TemperatureSetpointHoldDuration
+
+namespace ThermostatProgrammingOperationMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatProgrammingOperationMode); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode);
+} // namespace ThermostatProgrammingOperationMode
+
+namespace HvacRelayState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hvacRelayState); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hvacRelayState);
+} // namespace HvacRelayState
+
+namespace SetpointChangeSource {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * setpointChangeSource); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t setpointChangeSource);
+} // namespace SetpointChangeSource
+
+namespace SetpointChangeAmount {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * setpointChangeAmount); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t setpointChangeAmount);
+} // namespace SetpointChangeAmount
+
+namespace SetpointChangeSourceTimestamp {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t ** setpointChangeSourceTimestamp); // utc
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: utc defaults to */ uint8_t * setpointChangeSourceTimestamp);
+} // namespace SetpointChangeSourceTimestamp
+
+namespace AcType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acType);
+} // namespace AcType
+
+namespace AcCapacity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCapacity); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCapacity);
+} // namespace AcCapacity
+
+namespace AcRefrigerantType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acRefrigerantType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acRefrigerantType);
+} // namespace AcRefrigerantType
+
+namespace AcCompressor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCompressor); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCompressor);
+} // namespace AcCompressor
+
+namespace AcErrorCode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * acErrorCode); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t acErrorCode);
+} // namespace AcErrorCode
+
+namespace AcLouverPosition {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acLouverPosition); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acLouverPosition);
+} // namespace AcLouverPosition
+
+namespace AcCoilTemperature {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCoilTemperature); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCoilTemperature);
+} // namespace AcCoilTemperature
+
+namespace AcCapacityFormat {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCapacityFormat); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCapacityFormat);
+} // namespace AcCapacityFormat
+
 } // namespace Attributes
 } // namespace Thermostat
 
 namespace FanControl {
 namespace Attributes {
-EmberAfStatus GetFanMode(chip::EndpointId endpoint, uint8_t * fanMode); // enum8
-EmberAfStatus SetFanMode(chip::EndpointId endpoint, uint8_t fanMode);
-EmberAfStatus GetFanModeSequence(chip::EndpointId endpoint, uint8_t * fanModeSequence); // enum8
-EmberAfStatus SetFanModeSequence(chip::EndpointId endpoint, uint8_t fanModeSequence);
+
+namespace FanMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanMode);
+} // namespace FanMode
+
+namespace FanModeSequence {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanModeSequence); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanModeSequence);
+} // namespace FanModeSequence
+
 } // namespace Attributes
 } // namespace FanControl
 
 namespace DehumidificationControl {
 namespace Attributes {
-EmberAfStatus GetRelativeHumidity(chip::EndpointId endpoint, uint8_t * relativeHumidity); // int8u
-EmberAfStatus SetRelativeHumidity(chip::EndpointId endpoint, uint8_t relativeHumidity);
-EmberAfStatus GetDehumidificationCooling(chip::EndpointId endpoint, uint8_t * dehumidificationCooling); // int8u
-EmberAfStatus SetDehumidificationCooling(chip::EndpointId endpoint, uint8_t dehumidificationCooling);
-EmberAfStatus GetRhDehumidificationSetpoint(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint); // int8u
-EmberAfStatus SetRhDehumidificationSetpoint(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint);
-EmberAfStatus GetRelativeHumidityMode(chip::EndpointId endpoint, uint8_t * relativeHumidityMode); // enum8
-EmberAfStatus SetRelativeHumidityMode(chip::EndpointId endpoint, uint8_t relativeHumidityMode);
-EmberAfStatus GetDehumidificationLockout(chip::EndpointId endpoint, uint8_t * dehumidificationLockout); // enum8
-EmberAfStatus SetDehumidificationLockout(chip::EndpointId endpoint, uint8_t dehumidificationLockout);
-EmberAfStatus GetDehumidificationHysteresis(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis); // int8u
-EmberAfStatus SetDehumidificationHysteresis(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis);
-EmberAfStatus GetDehumidificationMaxCool(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool); // int8u
-EmberAfStatus SetDehumidificationMaxCool(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool);
-EmberAfStatus GetRelativeHumidityDisplay(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay); // enum8
-EmberAfStatus SetRelativeHumidityDisplay(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay);
+
+namespace RelativeHumidity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidity);
+} // namespace RelativeHumidity
+
+namespace DehumidificationCooling {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationCooling); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationCooling);
+} // namespace DehumidificationCooling
+
+namespace RhDehumidificationSetpoint {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint);
+} // namespace RhDehumidificationSetpoint
+
+namespace RelativeHumidityMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityMode);
+} // namespace RelativeHumidityMode
+
+namespace DehumidificationLockout {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationLockout); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationLockout);
+} // namespace DehumidificationLockout
+
+namespace DehumidificationHysteresis {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis);
+} // namespace DehumidificationHysteresis
+
+namespace DehumidificationMaxCool {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool);
+} // namespace DehumidificationMaxCool
+
+namespace RelativeHumidityDisplay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay);
+} // namespace RelativeHumidityDisplay
+
 } // namespace Attributes
 } // namespace DehumidificationControl
 
 namespace ThermostatUserInterfaceConfiguration {
 namespace Attributes {
-EmberAfStatus GetTemperatureDisplayMode(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode); // enum8
-EmberAfStatus SetTemperatureDisplayMode(chip::EndpointId endpoint, uint8_t temperatureDisplayMode);
-EmberAfStatus GetKeypadLockout(chip::EndpointId endpoint, uint8_t * keypadLockout); // enum8
-EmberAfStatus SetKeypadLockout(chip::EndpointId endpoint, uint8_t keypadLockout);
-EmberAfStatus GetScheduleProgrammingVisibility(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility); // enum8
-EmberAfStatus SetScheduleProgrammingVisibility(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility);
+
+namespace TemperatureDisplayMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureDisplayMode);
+} // namespace TemperatureDisplayMode
+
+namespace KeypadLockout {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * keypadLockout); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t keypadLockout);
+} // namespace KeypadLockout
+
+namespace ScheduleProgrammingVisibility {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility);
+} // namespace ScheduleProgrammingVisibility
+
 } // namespace Attributes
 } // namespace ThermostatUserInterfaceConfiguration
 
 namespace ColorControl {
 namespace Attributes {
-EmberAfStatus GetCurrentHue(chip::EndpointId endpoint, uint8_t * currentHue); // int8u
-EmberAfStatus SetCurrentHue(chip::EndpointId endpoint, uint8_t currentHue);
-EmberAfStatus GetCurrentSaturation(chip::EndpointId endpoint, uint8_t * currentSaturation); // int8u
-EmberAfStatus SetCurrentSaturation(chip::EndpointId endpoint, uint8_t currentSaturation);
-EmberAfStatus GetRemainingTime(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
-EmberAfStatus SetRemainingTime(chip::EndpointId endpoint, uint16_t remainingTime);
-EmberAfStatus GetCurrentX(chip::EndpointId endpoint, uint16_t * currentX); // int16u
-EmberAfStatus SetCurrentX(chip::EndpointId endpoint, uint16_t currentX);
-EmberAfStatus GetCurrentY(chip::EndpointId endpoint, uint16_t * currentY); // int16u
-EmberAfStatus SetCurrentY(chip::EndpointId endpoint, uint16_t currentY);
-EmberAfStatus GetDriftCompensation(chip::EndpointId endpoint, uint8_t * driftCompensation); // enum8
-EmberAfStatus SetDriftCompensation(chip::EndpointId endpoint, uint8_t driftCompensation);
-EmberAfStatus GetColorTemperature(chip::EndpointId endpoint, uint16_t * colorTemperature); // int16u
-EmberAfStatus SetColorTemperature(chip::EndpointId endpoint, uint16_t colorTemperature);
-EmberAfStatus GetColorMode(chip::EndpointId endpoint, uint8_t * colorMode); // enum8
-EmberAfStatus SetColorMode(chip::EndpointId endpoint, uint8_t colorMode);
-EmberAfStatus GetColorControlOptions(chip::EndpointId endpoint, uint8_t * colorControlOptions); // bitmap8
-EmberAfStatus SetColorControlOptions(chip::EndpointId endpoint, uint8_t colorControlOptions);
-EmberAfStatus GetNumberOfPrimaries(chip::EndpointId endpoint, uint8_t * numberOfPrimaries); // int8u
-EmberAfStatus SetNumberOfPrimaries(chip::EndpointId endpoint, uint8_t numberOfPrimaries);
-EmberAfStatus GetPrimary1X(chip::EndpointId endpoint, uint16_t * primary1X); // int16u
-EmberAfStatus SetPrimary1X(chip::EndpointId endpoint, uint16_t primary1X);
-EmberAfStatus GetPrimary1Y(chip::EndpointId endpoint, uint16_t * primary1Y); // int16u
-EmberAfStatus SetPrimary1Y(chip::EndpointId endpoint, uint16_t primary1Y);
-EmberAfStatus GetPrimary1Intensity(chip::EndpointId endpoint, uint8_t * primary1Intensity); // int8u
-EmberAfStatus SetPrimary1Intensity(chip::EndpointId endpoint, uint8_t primary1Intensity);
-EmberAfStatus GetPrimary2X(chip::EndpointId endpoint, uint16_t * primary2X); // int16u
-EmberAfStatus SetPrimary2X(chip::EndpointId endpoint, uint16_t primary2X);
-EmberAfStatus GetPrimary2Y(chip::EndpointId endpoint, uint16_t * primary2Y); // int16u
-EmberAfStatus SetPrimary2Y(chip::EndpointId endpoint, uint16_t primary2Y);
-EmberAfStatus GetPrimary2Intensity(chip::EndpointId endpoint, uint8_t * primary2Intensity); // int8u
-EmberAfStatus SetPrimary2Intensity(chip::EndpointId endpoint, uint8_t primary2Intensity);
-EmberAfStatus GetPrimary3X(chip::EndpointId endpoint, uint16_t * primary3X); // int16u
-EmberAfStatus SetPrimary3X(chip::EndpointId endpoint, uint16_t primary3X);
-EmberAfStatus GetPrimary3Y(chip::EndpointId endpoint, uint16_t * primary3Y); // int16u
-EmberAfStatus SetPrimary3Y(chip::EndpointId endpoint, uint16_t primary3Y);
-EmberAfStatus GetPrimary3Intensity(chip::EndpointId endpoint, uint8_t * primary3Intensity); // int8u
-EmberAfStatus SetPrimary3Intensity(chip::EndpointId endpoint, uint8_t primary3Intensity);
-EmberAfStatus GetPrimary4X(chip::EndpointId endpoint, uint16_t * primary4X); // int16u
-EmberAfStatus SetPrimary4X(chip::EndpointId endpoint, uint16_t primary4X);
-EmberAfStatus GetPrimary4Y(chip::EndpointId endpoint, uint16_t * primary4Y); // int16u
-EmberAfStatus SetPrimary4Y(chip::EndpointId endpoint, uint16_t primary4Y);
-EmberAfStatus GetPrimary4Intensity(chip::EndpointId endpoint, uint8_t * primary4Intensity); // int8u
-EmberAfStatus SetPrimary4Intensity(chip::EndpointId endpoint, uint8_t primary4Intensity);
-EmberAfStatus GetPrimary5X(chip::EndpointId endpoint, uint16_t * primary5X); // int16u
-EmberAfStatus SetPrimary5X(chip::EndpointId endpoint, uint16_t primary5X);
-EmberAfStatus GetPrimary5Y(chip::EndpointId endpoint, uint16_t * primary5Y); // int16u
-EmberAfStatus SetPrimary5Y(chip::EndpointId endpoint, uint16_t primary5Y);
-EmberAfStatus GetPrimary5Intensity(chip::EndpointId endpoint, uint8_t * primary5Intensity); // int8u
-EmberAfStatus SetPrimary5Intensity(chip::EndpointId endpoint, uint8_t primary5Intensity);
-EmberAfStatus GetPrimary6X(chip::EndpointId endpoint, uint16_t * primary6X); // int16u
-EmberAfStatus SetPrimary6X(chip::EndpointId endpoint, uint16_t primary6X);
-EmberAfStatus GetPrimary6Y(chip::EndpointId endpoint, uint16_t * primary6Y); // int16u
-EmberAfStatus SetPrimary6Y(chip::EndpointId endpoint, uint16_t primary6Y);
-EmberAfStatus GetPrimary6Intensity(chip::EndpointId endpoint, uint8_t * primary6Intensity); // int8u
-EmberAfStatus SetPrimary6Intensity(chip::EndpointId endpoint, uint8_t primary6Intensity);
-EmberAfStatus GetWhitePointX(chip::EndpointId endpoint, uint16_t * whitePointX); // int16u
-EmberAfStatus SetWhitePointX(chip::EndpointId endpoint, uint16_t whitePointX);
-EmberAfStatus GetWhitePointY(chip::EndpointId endpoint, uint16_t * whitePointY); // int16u
-EmberAfStatus SetWhitePointY(chip::EndpointId endpoint, uint16_t whitePointY);
-EmberAfStatus GetColorPointRX(chip::EndpointId endpoint, uint16_t * colorPointRX); // int16u
-EmberAfStatus SetColorPointRX(chip::EndpointId endpoint, uint16_t colorPointRX);
-EmberAfStatus GetColorPointRY(chip::EndpointId endpoint, uint16_t * colorPointRY); // int16u
-EmberAfStatus SetColorPointRY(chip::EndpointId endpoint, uint16_t colorPointRY);
-EmberAfStatus GetColorPointRIntensity(chip::EndpointId endpoint, uint8_t * colorPointRIntensity); // int8u
-EmberAfStatus SetColorPointRIntensity(chip::EndpointId endpoint, uint8_t colorPointRIntensity);
-EmberAfStatus GetColorPointGX(chip::EndpointId endpoint, uint16_t * colorPointGX); // int16u
-EmberAfStatus SetColorPointGX(chip::EndpointId endpoint, uint16_t colorPointGX);
-EmberAfStatus GetColorPointGY(chip::EndpointId endpoint, uint16_t * colorPointGY); // int16u
-EmberAfStatus SetColorPointGY(chip::EndpointId endpoint, uint16_t colorPointGY);
-EmberAfStatus GetColorPointGIntensity(chip::EndpointId endpoint, uint8_t * colorPointGIntensity); // int8u
-EmberAfStatus SetColorPointGIntensity(chip::EndpointId endpoint, uint8_t colorPointGIntensity);
-EmberAfStatus GetColorPointBX(chip::EndpointId endpoint, uint16_t * colorPointBX); // int16u
-EmberAfStatus SetColorPointBX(chip::EndpointId endpoint, uint16_t colorPointBX);
-EmberAfStatus GetColorPointBY(chip::EndpointId endpoint, uint16_t * colorPointBY); // int16u
-EmberAfStatus SetColorPointBY(chip::EndpointId endpoint, uint16_t colorPointBY);
-EmberAfStatus GetColorPointBIntensity(chip::EndpointId endpoint, uint8_t * colorPointBIntensity); // int8u
-EmberAfStatus SetColorPointBIntensity(chip::EndpointId endpoint, uint8_t colorPointBIntensity);
-EmberAfStatus GetEnhancedCurrentHue(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue); // int16u
-EmberAfStatus SetEnhancedCurrentHue(chip::EndpointId endpoint, uint16_t enhancedCurrentHue);
-EmberAfStatus GetEnhancedColorMode(chip::EndpointId endpoint, uint8_t * enhancedColorMode); // enum8
-EmberAfStatus SetEnhancedColorMode(chip::EndpointId endpoint, uint8_t enhancedColorMode);
-EmberAfStatus GetColorLoopActive(chip::EndpointId endpoint, uint8_t * colorLoopActive); // int8u
-EmberAfStatus SetColorLoopActive(chip::EndpointId endpoint, uint8_t colorLoopActive);
-EmberAfStatus GetColorLoopDirection(chip::EndpointId endpoint, uint8_t * colorLoopDirection); // int8u
-EmberAfStatus SetColorLoopDirection(chip::EndpointId endpoint, uint8_t colorLoopDirection);
-EmberAfStatus GetColorLoopTime(chip::EndpointId endpoint, uint16_t * colorLoopTime); // int16u
-EmberAfStatus SetColorLoopTime(chip::EndpointId endpoint, uint16_t colorLoopTime);
-EmberAfStatus GetColorLoopStartEnhancedHue(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue); // int16u
-EmberAfStatus SetColorLoopStartEnhancedHue(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue);
-EmberAfStatus GetColorLoopStoredEnhancedHue(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue); // int16u
-EmberAfStatus SetColorLoopStoredEnhancedHue(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue);
-EmberAfStatus GetColorCapabilities(chip::EndpointId endpoint, uint16_t * colorCapabilities); // bitmap16
-EmberAfStatus SetColorCapabilities(chip::EndpointId endpoint, uint16_t colorCapabilities);
-EmberAfStatus GetColorTempPhysicalMin(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin); // int16u
-EmberAfStatus SetColorTempPhysicalMin(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin);
-EmberAfStatus GetColorTempPhysicalMax(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax); // int16u
-EmberAfStatus SetColorTempPhysicalMax(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax);
-EmberAfStatus GetCoupleColorTempToLevelMinMireds(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds); // int16u
-EmberAfStatus SetCoupleColorTempToLevelMinMireds(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds);
-EmberAfStatus GetStartUpColorTemperatureMireds(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds); // int16u
-EmberAfStatus SetStartUpColorTemperatureMireds(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds);
+
+namespace CurrentHue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentHue); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentHue);
+} // namespace CurrentHue
+
+namespace CurrentSaturation {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentSaturation); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentSaturation);
+} // namespace CurrentSaturation
+
+namespace RemainingTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime);
+} // namespace RemainingTime
+
+namespace CurrentX {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentX); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentX);
+} // namespace CurrentX
+
+namespace CurrentY {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentY); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentY);
+} // namespace CurrentY
+
+namespace DriftCompensation {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * driftCompensation); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t driftCompensation);
+} // namespace DriftCompensation
+
+namespace ColorTemperature {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTemperature); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTemperature);
+} // namespace ColorTemperature
+
+namespace ColorMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorMode);
+} // namespace ColorMode
+
+namespace ColorControlOptions {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorControlOptions); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorControlOptions);
+} // namespace ColorControlOptions
+
+namespace NumberOfPrimaries {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPrimaries); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPrimaries);
+} // namespace NumberOfPrimaries
+
+namespace Primary1X {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1X); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1X);
+} // namespace Primary1X
+
+namespace Primary1Y {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1Y); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1Y);
+} // namespace Primary1Y
+
+namespace Primary1Intensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary1Intensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary1Intensity);
+} // namespace Primary1Intensity
+
+namespace Primary2X {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2X); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2X);
+} // namespace Primary2X
+
+namespace Primary2Y {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2Y); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2Y);
+} // namespace Primary2Y
+
+namespace Primary2Intensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary2Intensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary2Intensity);
+} // namespace Primary2Intensity
+
+namespace Primary3X {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3X); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3X);
+} // namespace Primary3X
+
+namespace Primary3Y {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3Y); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3Y);
+} // namespace Primary3Y
+
+namespace Primary3Intensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary3Intensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary3Intensity);
+} // namespace Primary3Intensity
+
+namespace Primary4X {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4X); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4X);
+} // namespace Primary4X
+
+namespace Primary4Y {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4Y); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4Y);
+} // namespace Primary4Y
+
+namespace Primary4Intensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary4Intensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary4Intensity);
+} // namespace Primary4Intensity
+
+namespace Primary5X {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5X); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5X);
+} // namespace Primary5X
+
+namespace Primary5Y {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5Y); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5Y);
+} // namespace Primary5Y
+
+namespace Primary5Intensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary5Intensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary5Intensity);
+} // namespace Primary5Intensity
+
+namespace Primary6X {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6X); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6X);
+} // namespace Primary6X
+
+namespace Primary6Y {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6Y); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6Y);
+} // namespace Primary6Y
+
+namespace Primary6Intensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary6Intensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary6Intensity);
+} // namespace Primary6Intensity
+
+namespace WhitePointX {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointX); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointX);
+} // namespace WhitePointX
+
+namespace WhitePointY {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointY); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointY);
+} // namespace WhitePointY
+
+namespace ColorPointRX {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRX); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRX);
+} // namespace ColorPointRX
+
+namespace ColorPointRY {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRY); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRY);
+} // namespace ColorPointRY
+
+namespace ColorPointRIntensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointRIntensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointRIntensity);
+} // namespace ColorPointRIntensity
+
+namespace ColorPointGX {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGX); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGX);
+} // namespace ColorPointGX
+
+namespace ColorPointGY {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGY); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGY);
+} // namespace ColorPointGY
+
+namespace ColorPointGIntensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointGIntensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointGIntensity);
+} // namespace ColorPointGIntensity
+
+namespace ColorPointBX {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBX); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBX);
+} // namespace ColorPointBX
+
+namespace ColorPointBY {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBY); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBY);
+} // namespace ColorPointBY
+
+namespace ColorPointBIntensity {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointBIntensity); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointBIntensity);
+} // namespace ColorPointBIntensity
+
+namespace EnhancedCurrentHue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enhancedCurrentHue);
+} // namespace EnhancedCurrentHue
+
+namespace EnhancedColorMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enhancedColorMode); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enhancedColorMode);
+} // namespace EnhancedColorMode
+
+namespace ColorLoopActive {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopActive); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopActive);
+} // namespace ColorLoopActive
+
+namespace ColorLoopDirection {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopDirection); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopDirection);
+} // namespace ColorLoopDirection
+
+namespace ColorLoopTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopTime);
+} // namespace ColorLoopTime
+
+namespace ColorLoopStartEnhancedHue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue);
+} // namespace ColorLoopStartEnhancedHue
+
+namespace ColorLoopStoredEnhancedHue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue);
+} // namespace ColorLoopStoredEnhancedHue
+
+namespace ColorCapabilities {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorCapabilities); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorCapabilities);
+} // namespace ColorCapabilities
+
+namespace ColorTempPhysicalMin {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin);
+} // namespace ColorTempPhysicalMin
+
+namespace ColorTempPhysicalMax {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax);
+} // namespace ColorTempPhysicalMax
+
+namespace CoupleColorTempToLevelMinMireds {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds);
+} // namespace CoupleColorTempToLevelMinMireds
+
+namespace StartUpColorTemperatureMireds {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds);
+} // namespace StartUpColorTemperatureMireds
+
 } // namespace Attributes
 } // namespace ColorControl
 
 namespace BallastConfiguration {
 namespace Attributes {
-EmberAfStatus GetPhysicalMinLevel(chip::EndpointId endpoint, uint8_t * physicalMinLevel); // int8u
-EmberAfStatus SetPhysicalMinLevel(chip::EndpointId endpoint, uint8_t physicalMinLevel);
-EmberAfStatus GetPhysicalMaxLevel(chip::EndpointId endpoint, uint8_t * physicalMaxLevel); // int8u
-EmberAfStatus SetPhysicalMaxLevel(chip::EndpointId endpoint, uint8_t physicalMaxLevel);
-EmberAfStatus GetBallastStatus(chip::EndpointId endpoint, uint8_t * ballastStatus); // bitmap8
-EmberAfStatus SetBallastStatus(chip::EndpointId endpoint, uint8_t ballastStatus);
-EmberAfStatus GetMinLevel(chip::EndpointId endpoint, uint8_t * minLevel); // int8u
-EmberAfStatus SetMinLevel(chip::EndpointId endpoint, uint8_t minLevel);
-EmberAfStatus GetMaxLevel(chip::EndpointId endpoint, uint8_t * maxLevel); // int8u
-EmberAfStatus SetMaxLevel(chip::EndpointId endpoint, uint8_t maxLevel);
-EmberAfStatus GetPowerOnLevel(chip::EndpointId endpoint, uint8_t * powerOnLevel); // int8u
-EmberAfStatus SetPowerOnLevel(chip::EndpointId endpoint, uint8_t powerOnLevel);
-EmberAfStatus GetPowerOnFadeTime(chip::EndpointId endpoint, uint16_t * powerOnFadeTime); // int16u
-EmberAfStatus SetPowerOnFadeTime(chip::EndpointId endpoint, uint16_t powerOnFadeTime);
-EmberAfStatus GetIntrinsicBallastFactor(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor); // int8u
-EmberAfStatus SetIntrinsicBallastFactor(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor);
-EmberAfStatus GetBallastFactorAdjustment(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment); // int8u
-EmberAfStatus SetBallastFactorAdjustment(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment);
-EmberAfStatus GetLampQuality(chip::EndpointId endpoint, uint8_t * lampQuality); // int8u
-EmberAfStatus SetLampQuality(chip::EndpointId endpoint, uint8_t lampQuality);
-EmberAfStatus GetLampAlarmMode(chip::EndpointId endpoint, uint8_t * lampAlarmMode); // bitmap8
-EmberAfStatus SetLampAlarmMode(chip::EndpointId endpoint, uint8_t lampAlarmMode);
+
+namespace PhysicalMinLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMinLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMinLevel);
+} // namespace PhysicalMinLevel
+
+namespace PhysicalMaxLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMaxLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMaxLevel);
+} // namespace PhysicalMaxLevel
+
+namespace BallastStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastStatus); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastStatus);
+} // namespace BallastStatus
+
+namespace MinLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel);
+} // namespace MinLevel
+
+namespace MaxLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel);
+} // namespace MaxLevel
+
+namespace PowerOnLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * powerOnLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t powerOnLevel);
+} // namespace PowerOnLevel
+
+namespace PowerOnFadeTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * powerOnFadeTime); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t powerOnFadeTime);
+} // namespace PowerOnFadeTime
+
+namespace IntrinsicBallastFactor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor);
+} // namespace IntrinsicBallastFactor
+
+namespace BallastFactorAdjustment {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment);
+} // namespace BallastFactorAdjustment
+
+namespace LampQuality {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampQuality); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampQuality);
+} // namespace LampQuality
+
+namespace LampAlarmMode {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampAlarmMode); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampAlarmMode);
+} // namespace LampAlarmMode
+
 } // namespace Attributes
 } // namespace BallastConfiguration
 
 namespace IlluminanceMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue); // int16u
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, uint16_t measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue); // int16u
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, uint16_t minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue); // int16u
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance);
-EmberAfStatus GetLightSensorType(chip::EndpointId endpoint, uint8_t * lightSensorType); // enum8
-EmberAfStatus SetLightSensorType(chip::EndpointId endpoint, uint8_t lightSensorType);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+} // namespace Tolerance
+
+namespace LightSensorType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lightSensorType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lightSensorType);
+} // namespace LightSensorType
+
 } // namespace Attributes
 } // namespace IlluminanceMeasurement
 
 namespace IlluminanceLevelSensing {
 namespace Attributes {
-EmberAfStatus GetLevelStatus(chip::EndpointId endpoint, uint8_t * levelStatus); // enum8
-EmberAfStatus SetLevelStatus(chip::EndpointId endpoint, uint8_t levelStatus);
-EmberAfStatus GetLightSensorType(chip::EndpointId endpoint, uint8_t * lightSensorType); // enum8
-EmberAfStatus SetLightSensorType(chip::EndpointId endpoint, uint8_t lightSensorType);
-EmberAfStatus GetIlluminanceLevelTarget(chip::EndpointId endpoint, uint16_t * illuminanceLevelTarget); // int16u
-EmberAfStatus SetIlluminanceLevelTarget(chip::EndpointId endpoint, uint16_t illuminanceLevelTarget);
+
+namespace LevelStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * levelStatus); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t levelStatus);
+} // namespace LevelStatus
+
+namespace LightSensorType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lightSensorType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lightSensorType);
+} // namespace LightSensorType
+
+namespace IlluminanceLevelTarget {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * illuminanceLevelTarget); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t illuminanceLevelTarget);
+} // namespace IlluminanceLevelTarget
+
 } // namespace Attributes
 } // namespace IlluminanceLevelSensing
 
 namespace TemperatureMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TemperatureMeasurement
 
 namespace PressureMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance);
-EmberAfStatus GetScaledValue(chip::EndpointId endpoint, int16_t * scaledValue); // int16s
-EmberAfStatus SetScaledValue(chip::EndpointId endpoint, int16_t scaledValue);
-EmberAfStatus GetMinScaledValue(chip::EndpointId endpoint, int16_t * minScaledValue); // int16s
-EmberAfStatus SetMinScaledValue(chip::EndpointId endpoint, int16_t minScaledValue);
-EmberAfStatus GetMaxScaledValue(chip::EndpointId endpoint, int16_t * maxScaledValue); // int16s
-EmberAfStatus SetMaxScaledValue(chip::EndpointId endpoint, int16_t maxScaledValue);
-EmberAfStatus GetScaledTolerance(chip::EndpointId endpoint, uint16_t * scaledTolerance); // int16u
-EmberAfStatus SetScaledTolerance(chip::EndpointId endpoint, uint16_t scaledTolerance);
-EmberAfStatus GetScale(chip::EndpointId endpoint, int8_t * scale); // int8s
-EmberAfStatus SetScale(chip::EndpointId endpoint, int8_t scale);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+} // namespace Tolerance
+
+namespace ScaledValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * scaledValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t scaledValue);
+} // namespace ScaledValue
+
+namespace MinScaledValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minScaledValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minScaledValue);
+} // namespace MinScaledValue
+
+namespace MaxScaledValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxScaledValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxScaledValue);
+} // namespace MaxScaledValue
+
+namespace ScaledTolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * scaledTolerance); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t scaledTolerance);
+} // namespace ScaledTolerance
+
+namespace Scale {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * scale); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t scale);
+} // namespace Scale
+
 } // namespace Attributes
 } // namespace PressureMeasurement
 
 namespace FlowMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, int16_t measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, int16_t minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, int16_t maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace FlowMeasurement
 
 namespace RelativeHumidityMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue); // int16u
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, uint16_t measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue); // int16u
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, uint16_t minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue); // int16u
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, uint16_t tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace RelativeHumidityMeasurement
 
 namespace OccupancySensing {
 namespace Attributes {
-EmberAfStatus GetOccupancy(chip::EndpointId endpoint, uint8_t * occupancy); // bitmap8
-EmberAfStatus SetOccupancy(chip::EndpointId endpoint, uint8_t occupancy);
-EmberAfStatus GetOccupancySensorType(chip::EndpointId endpoint, uint8_t * occupancySensorType); // enum8
-EmberAfStatus SetOccupancySensorType(chip::EndpointId endpoint, uint8_t occupancySensorType);
-EmberAfStatus GetOccupancySensorTypeBitmap(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap); // bitmap8
-EmberAfStatus SetOccupancySensorTypeBitmap(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap);
-EmberAfStatus GetPirOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay); // int16u
-EmberAfStatus SetPirOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay);
-EmberAfStatus GetPirUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay); // int16u
-EmberAfStatus SetPirUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay);
-EmberAfStatus GetPirUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold); // int8u
-EmberAfStatus SetPirUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold);
-EmberAfStatus GetUltrasonicOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
-                                                     uint16_t * ultrasonicOccupiedToUnoccupiedDelay); // int16u
-EmberAfStatus SetUltrasonicOccupiedToUnoccupiedDelay(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay);
-EmberAfStatus GetUltrasonicUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
-                                                     uint16_t * ultrasonicUnoccupiedToOccupiedDelay); // int16u
-EmberAfStatus SetUltrasonicUnoccupiedToOccupiedDelay(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay);
-EmberAfStatus GetUltrasonicUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                         uint8_t * ultrasonicUnoccupiedToOccupiedThreshold); // int8u
-EmberAfStatus SetUltrasonicUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                         uint8_t ultrasonicUnoccupiedToOccupiedThreshold);
-EmberAfStatus GetPhysicalContactOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t * physicalContactOccupiedToUnoccupiedDelay); // int16u
-EmberAfStatus SetPhysicalContactOccupiedToUnoccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t physicalContactOccupiedToUnoccupiedDelay);
-EmberAfStatus GetPhysicalContactUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t * physicalContactUnoccupiedToOccupiedDelay); // int16u
-EmberAfStatus SetPhysicalContactUnoccupiedToOccupiedDelay(chip::EndpointId endpoint,
-                                                          uint16_t physicalContactUnoccupiedToOccupiedDelay);
-EmberAfStatus GetPhysicalContactUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                              uint8_t * physicalContactUnoccupiedToOccupiedThreshold); // int8u
-EmberAfStatus SetPhysicalContactUnoccupiedToOccupiedThreshold(chip::EndpointId endpoint,
-                                                              uint8_t physicalContactUnoccupiedToOccupiedThreshold);
+
+namespace Occupancy {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy);
+} // namespace Occupancy
+
+namespace OccupancySensorType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorType); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorType);
+} // namespace OccupancySensorType
+
+namespace OccupancySensorTypeBitmap {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap);
+} // namespace OccupancySensorTypeBitmap
+
+namespace PirOccupiedToUnoccupiedDelay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay);
+} // namespace PirOccupiedToUnoccupiedDelay
+
+namespace PirUnoccupiedToOccupiedDelay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay);
+} // namespace PirUnoccupiedToOccupiedDelay
+
+namespace PirUnoccupiedToOccupiedThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold);
+} // namespace PirUnoccupiedToOccupiedThreshold
+
+namespace UltrasonicOccupiedToUnoccupiedDelay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicOccupiedToUnoccupiedDelay); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay);
+} // namespace UltrasonicOccupiedToUnoccupiedDelay
+
+namespace UltrasonicUnoccupiedToOccupiedDelay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicUnoccupiedToOccupiedDelay); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay);
+} // namespace UltrasonicUnoccupiedToOccupiedDelay
+
+namespace UltrasonicUnoccupiedToOccupiedThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ultrasonicUnoccupiedToOccupiedThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ultrasonicUnoccupiedToOccupiedThreshold);
+} // namespace UltrasonicUnoccupiedToOccupiedThreshold
+
+namespace PhysicalContactOccupiedToUnoccupiedDelay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactOccupiedToUnoccupiedDelay); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactOccupiedToUnoccupiedDelay);
+} // namespace PhysicalContactOccupiedToUnoccupiedDelay
+
+namespace PhysicalContactUnoccupiedToOccupiedDelay {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactUnoccupiedToOccupiedDelay); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactUnoccupiedToOccupiedDelay);
+} // namespace PhysicalContactUnoccupiedToOccupiedDelay
+
+namespace PhysicalContactUnoccupiedToOccupiedThreshold {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalContactUnoccupiedToOccupiedThreshold); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalContactUnoccupiedToOccupiedThreshold);
+} // namespace PhysicalContactUnoccupiedToOccupiedThreshold
+
 } // namespace Attributes
 } // namespace OccupancySensing
 
 namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace CarbonMonoxideConcentrationMeasurement
 
 namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace CarbonDioxideConcentrationMeasurement
 
 namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace EthyleneConcentrationMeasurement
 
 namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace EthyleneOxideConcentrationMeasurement
 
 namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace HydrogenConcentrationMeasurement
 
 namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace HydrogenSulphideConcentrationMeasurement
 
 namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace NitricOxideConcentrationMeasurement
 
 namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace NitrogenDioxideConcentrationMeasurement
 
 namespace OxygenConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace OxygenConcentrationMeasurement
 
 namespace OzoneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace OzoneConcentrationMeasurement
 
 namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace SulfurDioxideConcentrationMeasurement
 
 namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace DissolvedOxygenConcentrationMeasurement
 
 namespace BromateConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace BromateConcentrationMeasurement
 
 namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChloraminesConcentrationMeasurement
 
 namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChlorineConcentrationMeasurement
 
 namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace FecalColiformAndEColiConcentrationMeasurement
 
 namespace FluorideConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace FluorideConcentrationMeasurement
 
 namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace HaloaceticAcidsConcentrationMeasurement
 
 namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TotalTrihalomethanesConcentrationMeasurement
 
 namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TotalColiformBacteriaConcentrationMeasurement
 
 namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace TurbidityConcentrationMeasurement
 
 namespace CopperConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace CopperConcentrationMeasurement
 
 namespace LeadConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace LeadConcentrationMeasurement
 
 namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ManganeseConcentrationMeasurement
 
 namespace SulfateConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace SulfateConcentrationMeasurement
 
 namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace BromodichloromethaneConcentrationMeasurement
 
 namespace BromoformConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace BromoformConcentrationMeasurement
 
 namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChlorodibromomethaneConcentrationMeasurement
 
 namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace ChloroformConcentrationMeasurement
 
 namespace SodiumConcentrationMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasuredValue(chip::EndpointId endpoint,
-                               /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus SetMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
-EmberAfStatus GetMinMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus SetMinMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
-EmberAfStatus GetMaxMeasuredValue(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus SetMaxMeasuredValue(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
-EmberAfStatus GetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus SetTolerance(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+
+namespace MeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+} // namespace MeasuredValue
+
+namespace MinMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+} // namespace MinMeasuredValue
+
+namespace MaxMeasuredValue {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+} // namespace MaxMeasuredValue
+
+namespace Tolerance {
+EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+} // namespace Tolerance
+
 } // namespace Attributes
 } // namespace SodiumConcentrationMeasurement
 
 namespace IasZone {
 namespace Attributes {
-EmberAfStatus GetZoneState(chip::EndpointId endpoint, uint8_t * zoneState); // enum8
-EmberAfStatus SetZoneState(chip::EndpointId endpoint, uint8_t zoneState);
-EmberAfStatus GetZoneType(chip::EndpointId endpoint, uint16_t * zoneType); // enum16
-EmberAfStatus SetZoneType(chip::EndpointId endpoint, uint16_t zoneType);
-EmberAfStatus GetZoneStatus(chip::EndpointId endpoint, uint16_t * zoneStatus); // bitmap16
-EmberAfStatus SetZoneStatus(chip::EndpointId endpoint, uint16_t zoneStatus);
-EmberAfStatus GetIasCieAddress(chip::EndpointId endpoint, chip::NodeId * iasCieAddress); // node_id
-EmberAfStatus SetIasCieAddress(chip::EndpointId endpoint, chip::NodeId iasCieAddress);
-EmberAfStatus GetZoneId(chip::EndpointId endpoint, uint8_t * zoneId); // int8u
-EmberAfStatus SetZoneId(chip::EndpointId endpoint, uint8_t zoneId);
-EmberAfStatus GetNumberOfZoneSensitivityLevelsSupported(chip::EndpointId endpoint,
-                                                        uint8_t * numberOfZoneSensitivityLevelsSupported); // int8u
-EmberAfStatus SetNumberOfZoneSensitivityLevelsSupported(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported);
-EmberAfStatus GetCurrentZoneSensitivityLevel(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel); // int8u
-EmberAfStatus SetCurrentZoneSensitivityLevel(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel);
+
+namespace ZoneState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneState); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneState);
+} // namespace ZoneState
+
+namespace ZoneType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneType); // enum16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneType);
+} // namespace ZoneType
+
+namespace ZoneStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneStatus); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneStatus);
+} // namespace ZoneStatus
+
+namespace IasCieAddress {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * iasCieAddress); // node_id
+EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId iasCieAddress);
+} // namespace IasCieAddress
+
+namespace ZoneId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneId); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneId);
+} // namespace ZoneId
+
+namespace NumberOfZoneSensitivityLevelsSupported {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfZoneSensitivityLevelsSupported); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported);
+} // namespace NumberOfZoneSensitivityLevelsSupported
+
+namespace CurrentZoneSensitivityLevel {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel);
+} // namespace CurrentZoneSensitivityLevel
+
 } // namespace Attributes
 } // namespace IasZone
 
 namespace IasWd {
 namespace Attributes {
-EmberAfStatus GetMaxDuration(chip::EndpointId endpoint, uint16_t * maxDuration); // int16u
-EmberAfStatus SetMaxDuration(chip::EndpointId endpoint, uint16_t maxDuration);
+
+namespace MaxDuration {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxDuration); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxDuration);
+} // namespace MaxDuration
+
 } // namespace Attributes
 } // namespace IasWd
 
 namespace WakeOnLan {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace WakeOnLan
 
 namespace TvChannel {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace TvChannel
 
 namespace TargetNavigator {
 namespace Attributes {
-EmberAfStatus GetCurrentNavigatorTarget(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget); // int8u
-EmberAfStatus SetCurrentNavigatorTarget(chip::EndpointId endpoint, uint8_t currentNavigatorTarget);
+
+namespace CurrentNavigatorTarget {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentNavigatorTarget);
+} // namespace CurrentNavigatorTarget
+
 } // namespace Attributes
 } // namespace TargetNavigator
 
 namespace MediaPlayback {
 namespace Attributes {
-EmberAfStatus GetPlaybackState(chip::EndpointId endpoint, uint8_t * playbackState); // enum8
-EmberAfStatus SetPlaybackState(chip::EndpointId endpoint, uint8_t playbackState);
-EmberAfStatus GetStartTime(chip::EndpointId endpoint, uint64_t * startTime); // int64u
-EmberAfStatus SetStartTime(chip::EndpointId endpoint, uint64_t startTime);
-EmberAfStatus GetDuration(chip::EndpointId endpoint, uint64_t * duration); // int64u
-EmberAfStatus SetDuration(chip::EndpointId endpoint, uint64_t duration);
-EmberAfStatus GetPositionUpdatedAt(chip::EndpointId endpoint, uint64_t * positionUpdatedAt); // int64u
-EmberAfStatus SetPositionUpdatedAt(chip::EndpointId endpoint, uint64_t positionUpdatedAt);
-EmberAfStatus GetPosition(chip::EndpointId endpoint, uint64_t * position); // int64u
-EmberAfStatus SetPosition(chip::EndpointId endpoint, uint64_t position);
-EmberAfStatus GetPlaybackSpeed(chip::EndpointId endpoint, uint64_t * playbackSpeed); // int64u
-EmberAfStatus SetPlaybackSpeed(chip::EndpointId endpoint, uint64_t playbackSpeed);
-EmberAfStatus GetSeekRangeEnd(chip::EndpointId endpoint, uint64_t * seekRangeEnd); // int64u
-EmberAfStatus SetSeekRangeEnd(chip::EndpointId endpoint, uint64_t seekRangeEnd);
-EmberAfStatus GetSeekRangeStart(chip::EndpointId endpoint, uint64_t * seekRangeStart); // int64u
-EmberAfStatus SetSeekRangeStart(chip::EndpointId endpoint, uint64_t seekRangeStart);
+
+namespace PlaybackState {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * playbackState); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t playbackState);
+} // namespace PlaybackState
+
+namespace StartTime {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * startTime); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t startTime);
+} // namespace StartTime
+
+namespace Duration {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * duration); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t duration);
+} // namespace Duration
+
+namespace PositionUpdatedAt {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * positionUpdatedAt); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t positionUpdatedAt);
+} // namespace PositionUpdatedAt
+
+namespace Position {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * position); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t position);
+} // namespace Position
+
+namespace PlaybackSpeed {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * playbackSpeed); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t playbackSpeed);
+} // namespace PlaybackSpeed
+
+namespace SeekRangeEnd {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeEnd); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeEnd);
+} // namespace SeekRangeEnd
+
+namespace SeekRangeStart {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeStart); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeStart);
+} // namespace SeekRangeStart
+
 } // namespace Attributes
 } // namespace MediaPlayback
 
 namespace MediaInput {
 namespace Attributes {
-EmberAfStatus GetCurrentMediaInput(chip::EndpointId endpoint, uint8_t * currentMediaInput); // int8u
-EmberAfStatus SetCurrentMediaInput(chip::EndpointId endpoint, uint8_t currentMediaInput);
+
+namespace CurrentMediaInput {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentMediaInput); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentMediaInput);
+} // namespace CurrentMediaInput
+
 } // namespace Attributes
 } // namespace MediaInput
 
 namespace ContentLauncher {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace ContentLauncher
 
 namespace AudioOutput {
 namespace Attributes {
-EmberAfStatus GetCurrentAudioOutput(chip::EndpointId endpoint, uint8_t * currentAudioOutput); // int8u
-EmberAfStatus SetCurrentAudioOutput(chip::EndpointId endpoint, uint8_t currentAudioOutput);
+
+namespace CurrentAudioOutput {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentAudioOutput); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentAudioOutput);
+} // namespace CurrentAudioOutput
+
 } // namespace Attributes
 } // namespace AudioOutput
 
 namespace ApplicationLauncher {
 namespace Attributes {
-EmberAfStatus GetCatalogVendorId(chip::EndpointId endpoint, uint8_t * catalogVendorId); // int8u
-EmberAfStatus SetCatalogVendorId(chip::EndpointId endpoint, uint8_t catalogVendorId);
-EmberAfStatus GetApplicationId(chip::EndpointId endpoint, uint8_t * applicationId); // int8u
-EmberAfStatus SetApplicationId(chip::EndpointId endpoint, uint8_t applicationId);
+
+namespace CatalogVendorId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * catalogVendorId); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t catalogVendorId);
+} // namespace CatalogVendorId
+
+namespace ApplicationId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationId); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationId);
+} // namespace ApplicationId
+
 } // namespace Attributes
 } // namespace ApplicationLauncher
 
 namespace ApplicationBasic {
 namespace Attributes {
-EmberAfStatus GetVendorId(chip::EndpointId endpoint, uint16_t * vendorId); // int16u
-EmberAfStatus SetVendorId(chip::EndpointId endpoint, uint16_t vendorId);
-EmberAfStatus GetProductId(chip::EndpointId endpoint, uint16_t * productId); // int16u
-EmberAfStatus SetProductId(chip::EndpointId endpoint, uint16_t productId);
-EmberAfStatus GetCatalogVendorId(chip::EndpointId endpoint, uint16_t * catalogVendorId); // int16u
-EmberAfStatus SetCatalogVendorId(chip::EndpointId endpoint, uint16_t catalogVendorId);
-EmberAfStatus GetApplicationStatus(chip::EndpointId endpoint, uint8_t * applicationStatus); // enum8
-EmberAfStatus SetApplicationStatus(chip::EndpointId endpoint, uint8_t applicationStatus);
+
+namespace VendorId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorId);
+} // namespace VendorId
+
+namespace ProductId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productId);
+} // namespace ProductId
+
+namespace CatalogVendorId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * catalogVendorId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t catalogVendorId);
+} // namespace CatalogVendorId
+
+namespace ApplicationStatus {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationStatus); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationStatus);
+} // namespace ApplicationStatus
+
 } // namespace Attributes
 } // namespace ApplicationBasic
 
 namespace TestCluster {
 namespace Attributes {
-EmberAfStatus GetBoolean(chip::EndpointId endpoint, bool * boolean); // boolean
-EmberAfStatus SetBoolean(chip::EndpointId endpoint, bool boolean);
-EmberAfStatus GetBitmap8(chip::EndpointId endpoint, uint8_t * bitmap8); // bitmap8
-EmberAfStatus SetBitmap8(chip::EndpointId endpoint, uint8_t bitmap8);
-EmberAfStatus GetBitmap16(chip::EndpointId endpoint, uint16_t * bitmap16); // bitmap16
-EmberAfStatus SetBitmap16(chip::EndpointId endpoint, uint16_t bitmap16);
-EmberAfStatus GetBitmap32(chip::EndpointId endpoint, uint32_t * bitmap32); // bitmap32
-EmberAfStatus SetBitmap32(chip::EndpointId endpoint, uint32_t bitmap32);
-EmberAfStatus GetBitmap64(chip::EndpointId endpoint, uint64_t * bitmap64); // bitmap64
-EmberAfStatus SetBitmap64(chip::EndpointId endpoint, uint64_t bitmap64);
-EmberAfStatus GetInt8u(chip::EndpointId endpoint, uint8_t * int8u); // int8u
-EmberAfStatus SetInt8u(chip::EndpointId endpoint, uint8_t int8u);
-EmberAfStatus GetInt16u(chip::EndpointId endpoint, uint16_t * int16u); // int16u
-EmberAfStatus SetInt16u(chip::EndpointId endpoint, uint16_t int16u);
-EmberAfStatus GetInt32u(chip::EndpointId endpoint, uint32_t * int32u); // int32u
-EmberAfStatus SetInt32u(chip::EndpointId endpoint, uint32_t int32u);
-EmberAfStatus GetInt64u(chip::EndpointId endpoint, uint64_t * int64u); // int64u
-EmberAfStatus SetInt64u(chip::EndpointId endpoint, uint64_t int64u);
-EmberAfStatus GetInt8s(chip::EndpointId endpoint, int8_t * int8s); // int8s
-EmberAfStatus SetInt8s(chip::EndpointId endpoint, int8_t int8s);
-EmberAfStatus GetInt16s(chip::EndpointId endpoint, int16_t * int16s); // int16s
-EmberAfStatus SetInt16s(chip::EndpointId endpoint, int16_t int16s);
-EmberAfStatus GetInt32s(chip::EndpointId endpoint, int32_t * int32s); // int32s
-EmberAfStatus SetInt32s(chip::EndpointId endpoint, int32_t int32s);
-EmberAfStatus GetInt64s(chip::EndpointId endpoint, int64_t * int64s); // int64s
-EmberAfStatus SetInt64s(chip::EndpointId endpoint, int64_t int64s);
-EmberAfStatus GetEnum8(chip::EndpointId endpoint, uint8_t * enum8); // enum8
-EmberAfStatus SetEnum8(chip::EndpointId endpoint, uint8_t enum8);
-EmberAfStatus GetEnum16(chip::EndpointId endpoint, uint16_t * enum16); // enum16
-EmberAfStatus SetEnum16(chip::EndpointId endpoint, uint16_t enum16);
-EmberAfStatus GetEpochUs(chip::EndpointId endpoint, uint64_t * epochUs); // epoch_us
-EmberAfStatus SetEpochUs(chip::EndpointId endpoint, uint64_t epochUs);
-EmberAfStatus GetEpochS(chip::EndpointId endpoint, uint32_t * epochS); // epoch_s
-EmberAfStatus SetEpochS(chip::EndpointId endpoint, uint32_t epochS);
-EmberAfStatus GetUnsupported(chip::EndpointId endpoint, bool * unsupported); // boolean
-EmberAfStatus SetUnsupported(chip::EndpointId endpoint, bool unsupported);
+
+namespace Boolean {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * boolean); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool boolean);
+} // namespace Boolean
+
+namespace Bitmap8 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bitmap8); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bitmap8);
+} // namespace Bitmap8
+
+namespace Bitmap16 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * bitmap16); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t bitmap16);
+} // namespace Bitmap16
+
+namespace Bitmap32 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * bitmap32); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t bitmap32);
+} // namespace Bitmap32
+
+namespace Bitmap64 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * bitmap64); // bitmap64
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t bitmap64);
+} // namespace Bitmap64
+
+namespace Int8u {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * int8u); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t int8u);
+} // namespace Int8u
+
+namespace Int16u {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * int16u); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t int16u);
+} // namespace Int16u
+
+namespace Int32u {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * int32u); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t int32u);
+} // namespace Int32u
+
+namespace Int64u {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * int64u); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t int64u);
+} // namespace Int64u
+
+namespace Int8s {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * int8s); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t int8s);
+} // namespace Int8s
+
+namespace Int16s {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * int16s); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t int16s);
+} // namespace Int16s
+
+namespace Int32s {
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * int32s); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t int32s);
+} // namespace Int32s
+
+namespace Int64s {
+EmberAfStatus Get(chip::EndpointId endpoint, int64_t * int64s); // int64s
+EmberAfStatus Set(chip::EndpointId endpoint, int64_t int64s);
+} // namespace Int64s
+
+namespace Enum8 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enum8); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enum8);
+} // namespace Enum8
+
+namespace Enum16 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enum16); // enum16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enum16);
+} // namespace Enum16
+
+namespace EpochUs {
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * epochUs); // epoch_us
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t epochUs);
+} // namespace EpochUs
+
+namespace EpochS {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * epochS); // epoch_s
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t epochS);
+} // namespace EpochS
+
+namespace Unsupported {
+EmberAfStatus Get(chip::EndpointId endpoint, bool * unsupported); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool unsupported);
+} // namespace Unsupported
+
 } // namespace Attributes
 } // namespace TestCluster
 
 namespace ApplianceIdentification {
 namespace Attributes {
-EmberAfStatus GetCompanyId(chip::EndpointId endpoint, uint16_t * companyId); // int16u
-EmberAfStatus SetCompanyId(chip::EndpointId endpoint, uint16_t companyId);
-EmberAfStatus GetBrandId(chip::EndpointId endpoint, uint16_t * brandId); // int16u
-EmberAfStatus SetBrandId(chip::EndpointId endpoint, uint16_t brandId);
-EmberAfStatus GetProductTypeId(chip::EndpointId endpoint, uint16_t * productTypeId); // int16u
-EmberAfStatus SetProductTypeId(chip::EndpointId endpoint, uint16_t productTypeId);
-EmberAfStatus GetCecedSpecificationVersion(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion); // int8u
-EmberAfStatus SetCecedSpecificationVersion(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion);
+
+namespace CompanyId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * companyId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t companyId);
+} // namespace CompanyId
+
+namespace BrandId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * brandId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t brandId);
+} // namespace BrandId
+
+namespace ProductTypeId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productTypeId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productTypeId);
+} // namespace ProductTypeId
+
+namespace CecedSpecificationVersion {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion);
+} // namespace CecedSpecificationVersion
+
 } // namespace Attributes
 } // namespace ApplianceIdentification
 
 namespace MeterIdentification {
 namespace Attributes {
-EmberAfStatus GetMeterTypeId(chip::EndpointId endpoint, uint16_t * meterTypeId); // int16u
-EmberAfStatus SetMeterTypeId(chip::EndpointId endpoint, uint16_t meterTypeId);
-EmberAfStatus GetDataQualityId(chip::EndpointId endpoint, uint16_t * dataQualityId); // int16u
-EmberAfStatus SetDataQualityId(chip::EndpointId endpoint, uint16_t dataQualityId);
+
+namespace MeterTypeId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * meterTypeId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t meterTypeId);
+} // namespace MeterTypeId
+
+namespace DataQualityId {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dataQualityId); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dataQualityId);
+} // namespace DataQualityId
+
 } // namespace Attributes
 } // namespace MeterIdentification
 
 namespace ApplianceStatistics {
 namespace Attributes {
-EmberAfStatus GetLogMaxSize(chip::EndpointId endpoint, uint32_t * logMaxSize); // int32u
-EmberAfStatus SetLogMaxSize(chip::EndpointId endpoint, uint32_t logMaxSize);
-EmberAfStatus GetLogQueueMaxSize(chip::EndpointId endpoint, uint8_t * logQueueMaxSize); // int8u
-EmberAfStatus SetLogQueueMaxSize(chip::EndpointId endpoint, uint8_t logQueueMaxSize);
+
+namespace LogMaxSize {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * logMaxSize); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t logMaxSize);
+} // namespace LogMaxSize
+
+namespace LogQueueMaxSize {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * logQueueMaxSize); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t logQueueMaxSize);
+} // namespace LogQueueMaxSize
+
 } // namespace Attributes
 } // namespace ApplianceStatistics
 
 namespace ElectricalMeasurement {
 namespace Attributes {
-EmberAfStatus GetMeasurementType(chip::EndpointId endpoint, uint32_t * measurementType); // bitmap32
-EmberAfStatus SetMeasurementType(chip::EndpointId endpoint, uint32_t measurementType);
-EmberAfStatus GetDcVoltage(chip::EndpointId endpoint, int16_t * dcVoltage); // int16s
-EmberAfStatus SetDcVoltage(chip::EndpointId endpoint, int16_t dcVoltage);
-EmberAfStatus GetDcVoltageMin(chip::EndpointId endpoint, int16_t * dcVoltageMin); // int16s
-EmberAfStatus SetDcVoltageMin(chip::EndpointId endpoint, int16_t dcVoltageMin);
-EmberAfStatus GetDcVoltageMax(chip::EndpointId endpoint, int16_t * dcVoltageMax); // int16s
-EmberAfStatus SetDcVoltageMax(chip::EndpointId endpoint, int16_t dcVoltageMax);
-EmberAfStatus GetDcCurrent(chip::EndpointId endpoint, int16_t * dcCurrent); // int16s
-EmberAfStatus SetDcCurrent(chip::EndpointId endpoint, int16_t dcCurrent);
-EmberAfStatus GetDcCurrentMin(chip::EndpointId endpoint, int16_t * dcCurrentMin); // int16s
-EmberAfStatus SetDcCurrentMin(chip::EndpointId endpoint, int16_t dcCurrentMin);
-EmberAfStatus GetDcCurrentMax(chip::EndpointId endpoint, int16_t * dcCurrentMax); // int16s
-EmberAfStatus SetDcCurrentMax(chip::EndpointId endpoint, int16_t dcCurrentMax);
-EmberAfStatus GetDcPower(chip::EndpointId endpoint, int16_t * dcPower); // int16s
-EmberAfStatus SetDcPower(chip::EndpointId endpoint, int16_t dcPower);
-EmberAfStatus GetDcPowerMin(chip::EndpointId endpoint, int16_t * dcPowerMin); // int16s
-EmberAfStatus SetDcPowerMin(chip::EndpointId endpoint, int16_t dcPowerMin);
-EmberAfStatus GetDcPowerMax(chip::EndpointId endpoint, int16_t * dcPowerMax); // int16s
-EmberAfStatus SetDcPowerMax(chip::EndpointId endpoint, int16_t dcPowerMax);
-EmberAfStatus GetDcVoltageMultiplier(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier); // int16u
-EmberAfStatus SetDcVoltageMultiplier(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier);
-EmberAfStatus GetDcVoltageDivisor(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor); // int16u
-EmberAfStatus SetDcVoltageDivisor(chip::EndpointId endpoint, uint16_t dcVoltageDivisor);
-EmberAfStatus GetDcCurrentMultiplier(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier); // int16u
-EmberAfStatus SetDcCurrentMultiplier(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier);
-EmberAfStatus GetDcCurrentDivisor(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor); // int16u
-EmberAfStatus SetDcCurrentDivisor(chip::EndpointId endpoint, uint16_t dcCurrentDivisor);
-EmberAfStatus GetDcPowerMultiplier(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier); // int16u
-EmberAfStatus SetDcPowerMultiplier(chip::EndpointId endpoint, uint16_t dcPowerMultiplier);
-EmberAfStatus GetDcPowerDivisor(chip::EndpointId endpoint, uint16_t * dcPowerDivisor); // int16u
-EmberAfStatus SetDcPowerDivisor(chip::EndpointId endpoint, uint16_t dcPowerDivisor);
-EmberAfStatus GetAcFrequency(chip::EndpointId endpoint, uint16_t * acFrequency); // int16u
-EmberAfStatus SetAcFrequency(chip::EndpointId endpoint, uint16_t acFrequency);
-EmberAfStatus GetAcFrequencyMin(chip::EndpointId endpoint, uint16_t * acFrequencyMin); // int16u
-EmberAfStatus SetAcFrequencyMin(chip::EndpointId endpoint, uint16_t acFrequencyMin);
-EmberAfStatus GetAcFrequencyMax(chip::EndpointId endpoint, uint16_t * acFrequencyMax); // int16u
-EmberAfStatus SetAcFrequencyMax(chip::EndpointId endpoint, uint16_t acFrequencyMax);
-EmberAfStatus GetNeutralCurrent(chip::EndpointId endpoint, uint16_t * neutralCurrent); // int16u
-EmberAfStatus SetNeutralCurrent(chip::EndpointId endpoint, uint16_t neutralCurrent);
-EmberAfStatus GetTotalActivePower(chip::EndpointId endpoint, int32_t * totalActivePower); // int32s
-EmberAfStatus SetTotalActivePower(chip::EndpointId endpoint, int32_t totalActivePower);
-EmberAfStatus GetTotalReactivePower(chip::EndpointId endpoint, int32_t * totalReactivePower); // int32s
-EmberAfStatus SetTotalReactivePower(chip::EndpointId endpoint, int32_t totalReactivePower);
-EmberAfStatus GetTotalApparentPower(chip::EndpointId endpoint, uint32_t * totalApparentPower); // int32u
-EmberAfStatus SetTotalApparentPower(chip::EndpointId endpoint, uint32_t totalApparentPower);
-EmberAfStatus GetMeasured1stHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent); // int16s
-EmberAfStatus SetMeasured1stHarmonicCurrent(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent);
-EmberAfStatus GetMeasured3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent); // int16s
-EmberAfStatus SetMeasured3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent);
-EmberAfStatus GetMeasured5thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasured5thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent);
-EmberAfStatus GetMeasured7thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasured7thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent);
-EmberAfStatus GetMeasured9thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasured9thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent);
-EmberAfStatus GetMeasured11thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasured11thHarmonicCurrent(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent);
-EmberAfStatus GetMeasuredPhase1stHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent); // int16s
-EmberAfStatus SetMeasuredPhase1stHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent);
-EmberAfStatus GetMeasuredPhase3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent); // int16s
-EmberAfStatus SetMeasuredPhase3rdHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent);
-EmberAfStatus GetMeasuredPhase5thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasuredPhase5thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent);
-EmberAfStatus GetMeasuredPhase7thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasuredPhase7thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent);
-EmberAfStatus GetMeasuredPhase9thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasuredPhase9thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent);
-EmberAfStatus GetMeasuredPhase11thHarmonicCurrent(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent); // int16s
-EmberAfStatus SetMeasuredPhase11thHarmonicCurrent(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent);
-EmberAfStatus GetAcFrequencyMultiplier(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier); // int16u
-EmberAfStatus SetAcFrequencyMultiplier(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier);
-EmberAfStatus GetAcFrequencyDivisor(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor); // int16u
-EmberAfStatus SetAcFrequencyDivisor(chip::EndpointId endpoint, uint16_t acFrequencyDivisor);
-EmberAfStatus GetPowerMultiplier(chip::EndpointId endpoint, uint32_t * powerMultiplier); // int32u
-EmberAfStatus SetPowerMultiplier(chip::EndpointId endpoint, uint32_t powerMultiplier);
-EmberAfStatus GetPowerDivisor(chip::EndpointId endpoint, uint32_t * powerDivisor); // int32u
-EmberAfStatus SetPowerDivisor(chip::EndpointId endpoint, uint32_t powerDivisor);
-EmberAfStatus GetHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier); // int8s
-EmberAfStatus SetHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier);
-EmberAfStatus GetPhaseHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier); // int8s
-EmberAfStatus SetPhaseHarmonicCurrentMultiplier(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier);
-EmberAfStatus GetInstantaneousVoltage(chip::EndpointId endpoint, int16_t * instantaneousVoltage); // int16s
-EmberAfStatus SetInstantaneousVoltage(chip::EndpointId endpoint, int16_t instantaneousVoltage);
-EmberAfStatus GetInstantaneousLineCurrent(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent); // int16u
-EmberAfStatus SetInstantaneousLineCurrent(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent);
-EmberAfStatus GetInstantaneousActiveCurrent(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent); // int16s
-EmberAfStatus SetInstantaneousActiveCurrent(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent);
-EmberAfStatus GetInstantaneousReactiveCurrent(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent); // int16s
-EmberAfStatus SetInstantaneousReactiveCurrent(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent);
-EmberAfStatus GetInstantaneousPower(chip::EndpointId endpoint, int16_t * instantaneousPower); // int16s
-EmberAfStatus SetInstantaneousPower(chip::EndpointId endpoint, int16_t instantaneousPower);
-EmberAfStatus GetRmsVoltage(chip::EndpointId endpoint, uint16_t * rmsVoltage); // int16u
-EmberAfStatus SetRmsVoltage(chip::EndpointId endpoint, uint16_t rmsVoltage);
-EmberAfStatus GetRmsVoltageMin(chip::EndpointId endpoint, uint16_t * rmsVoltageMin); // int16u
-EmberAfStatus SetRmsVoltageMin(chip::EndpointId endpoint, uint16_t rmsVoltageMin);
-EmberAfStatus GetRmsVoltageMax(chip::EndpointId endpoint, uint16_t * rmsVoltageMax); // int16u
-EmberAfStatus SetRmsVoltageMax(chip::EndpointId endpoint, uint16_t rmsVoltageMax);
-EmberAfStatus GetRmsCurrent(chip::EndpointId endpoint, uint16_t * rmsCurrent); // int16u
-EmberAfStatus SetRmsCurrent(chip::EndpointId endpoint, uint16_t rmsCurrent);
-EmberAfStatus GetRmsCurrentMin(chip::EndpointId endpoint, uint16_t * rmsCurrentMin); // int16u
-EmberAfStatus SetRmsCurrentMin(chip::EndpointId endpoint, uint16_t rmsCurrentMin);
-EmberAfStatus GetRmsCurrentMax(chip::EndpointId endpoint, uint16_t * rmsCurrentMax); // int16u
-EmberAfStatus SetRmsCurrentMax(chip::EndpointId endpoint, uint16_t rmsCurrentMax);
-EmberAfStatus GetActivePower(chip::EndpointId endpoint, int16_t * activePower); // int16s
-EmberAfStatus SetActivePower(chip::EndpointId endpoint, int16_t activePower);
-EmberAfStatus GetActivePowerMin(chip::EndpointId endpoint, int16_t * activePowerMin); // int16s
-EmberAfStatus SetActivePowerMin(chip::EndpointId endpoint, int16_t activePowerMin);
-EmberAfStatus GetActivePowerMax(chip::EndpointId endpoint, int16_t * activePowerMax); // int16s
-EmberAfStatus SetActivePowerMax(chip::EndpointId endpoint, int16_t activePowerMax);
-EmberAfStatus GetReactivePower(chip::EndpointId endpoint, int16_t * reactivePower); // int16s
-EmberAfStatus SetReactivePower(chip::EndpointId endpoint, int16_t reactivePower);
-EmberAfStatus GetApparentPower(chip::EndpointId endpoint, uint16_t * apparentPower); // int16u
-EmberAfStatus SetApparentPower(chip::EndpointId endpoint, uint16_t apparentPower);
-EmberAfStatus GetPowerFactor(chip::EndpointId endpoint, int8_t * powerFactor); // int8s
-EmberAfStatus SetPowerFactor(chip::EndpointId endpoint, int8_t powerFactor);
-EmberAfStatus GetAverageRmsVoltageMeasurementPeriod(chip::EndpointId endpoint,
-                                                    uint16_t * averageRmsVoltageMeasurementPeriod); // int16u
-EmberAfStatus SetAverageRmsVoltageMeasurementPeriod(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod);
-EmberAfStatus GetAverageRmsUnderVoltageCounter(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter); // int16u
-EmberAfStatus SetAverageRmsUnderVoltageCounter(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter);
-EmberAfStatus GetRmsExtremeOverVoltagePeriod(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod); // int16u
-EmberAfStatus SetRmsExtremeOverVoltagePeriod(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod);
-EmberAfStatus GetRmsExtremeUnderVoltagePeriod(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod); // int16u
-EmberAfStatus SetRmsExtremeUnderVoltagePeriod(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod);
-EmberAfStatus GetRmsVoltageSagPeriod(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod); // int16u
-EmberAfStatus SetRmsVoltageSagPeriod(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod);
-EmberAfStatus GetRmsVoltageSwellPeriod(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod); // int16u
-EmberAfStatus SetRmsVoltageSwellPeriod(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod);
-EmberAfStatus GetAcVoltageMultiplier(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier); // int16u
-EmberAfStatus SetAcVoltageMultiplier(chip::EndpointId endpoint, uint16_t acVoltageMultiplier);
-EmberAfStatus GetAcVoltageDivisor(chip::EndpointId endpoint, uint16_t * acVoltageDivisor); // int16u
-EmberAfStatus SetAcVoltageDivisor(chip::EndpointId endpoint, uint16_t acVoltageDivisor);
-EmberAfStatus GetAcCurrentMultiplier(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier); // int16u
-EmberAfStatus SetAcCurrentMultiplier(chip::EndpointId endpoint, uint16_t acCurrentMultiplier);
-EmberAfStatus GetAcCurrentDivisor(chip::EndpointId endpoint, uint16_t * acCurrentDivisor); // int16u
-EmberAfStatus SetAcCurrentDivisor(chip::EndpointId endpoint, uint16_t acCurrentDivisor);
-EmberAfStatus GetAcPowerMultiplier(chip::EndpointId endpoint, uint16_t * acPowerMultiplier); // int16u
-EmberAfStatus SetAcPowerMultiplier(chip::EndpointId endpoint, uint16_t acPowerMultiplier);
-EmberAfStatus GetAcPowerDivisor(chip::EndpointId endpoint, uint16_t * acPowerDivisor); // int16u
-EmberAfStatus SetAcPowerDivisor(chip::EndpointId endpoint, uint16_t acPowerDivisor);
-EmberAfStatus GetOverloadAlarmsMask(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask); // bitmap8
-EmberAfStatus SetOverloadAlarmsMask(chip::EndpointId endpoint, uint8_t overloadAlarmsMask);
-EmberAfStatus GetVoltageOverload(chip::EndpointId endpoint, int16_t * voltageOverload); // int16s
-EmberAfStatus SetVoltageOverload(chip::EndpointId endpoint, int16_t voltageOverload);
-EmberAfStatus GetCurrentOverload(chip::EndpointId endpoint, int16_t * currentOverload); // int16s
-EmberAfStatus SetCurrentOverload(chip::EndpointId endpoint, int16_t currentOverload);
-EmberAfStatus GetAcOverloadAlarmsMask(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask); // bitmap16
-EmberAfStatus SetAcOverloadAlarmsMask(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask);
-EmberAfStatus GetAcVoltageOverload(chip::EndpointId endpoint, int16_t * acVoltageOverload); // int16s
-EmberAfStatus SetAcVoltageOverload(chip::EndpointId endpoint, int16_t acVoltageOverload);
-EmberAfStatus GetAcCurrentOverload(chip::EndpointId endpoint, int16_t * acCurrentOverload); // int16s
-EmberAfStatus SetAcCurrentOverload(chip::EndpointId endpoint, int16_t acCurrentOverload);
-EmberAfStatus GetAcActivePowerOverload(chip::EndpointId endpoint, int16_t * acActivePowerOverload); // int16s
-EmberAfStatus SetAcActivePowerOverload(chip::EndpointId endpoint, int16_t acActivePowerOverload);
-EmberAfStatus GetAcReactivePowerOverload(chip::EndpointId endpoint, int16_t * acReactivePowerOverload); // int16s
-EmberAfStatus SetAcReactivePowerOverload(chip::EndpointId endpoint, int16_t acReactivePowerOverload);
-EmberAfStatus GetAverageRmsOverVoltage(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage); // int16s
-EmberAfStatus SetAverageRmsOverVoltage(chip::EndpointId endpoint, int16_t averageRmsOverVoltage);
-EmberAfStatus GetAverageRmsUnderVoltage(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage); // int16s
-EmberAfStatus SetAverageRmsUnderVoltage(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage);
-EmberAfStatus GetRmsExtremeOverVoltage(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage); // int16s
-EmberAfStatus SetRmsExtremeOverVoltage(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage);
-EmberAfStatus GetRmsExtremeUnderVoltage(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage); // int16s
-EmberAfStatus SetRmsExtremeUnderVoltage(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage);
-EmberAfStatus GetRmsVoltageSag(chip::EndpointId endpoint, int16_t * rmsVoltageSag); // int16s
-EmberAfStatus SetRmsVoltageSag(chip::EndpointId endpoint, int16_t rmsVoltageSag);
-EmberAfStatus GetRmsVoltageSwell(chip::EndpointId endpoint, int16_t * rmsVoltageSwell); // int16s
-EmberAfStatus SetRmsVoltageSwell(chip::EndpointId endpoint, int16_t rmsVoltageSwell);
-EmberAfStatus GetLineCurrentPhaseB(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB); // int16u
-EmberAfStatus SetLineCurrentPhaseB(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB);
-EmberAfStatus GetActiveCurrentPhaseB(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB); // int16s
-EmberAfStatus SetActiveCurrentPhaseB(chip::EndpointId endpoint, int16_t activeCurrentPhaseB);
-EmberAfStatus GetReactiveCurrentPhaseB(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB); // int16s
-EmberAfStatus SetReactiveCurrentPhaseB(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB);
-EmberAfStatus GetRmsVoltagePhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB); // int16u
-EmberAfStatus SetRmsVoltagePhaseB(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB);
-EmberAfStatus GetRmsVoltageMinPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB); // int16u
-EmberAfStatus SetRmsVoltageMinPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB);
-EmberAfStatus GetRmsVoltageMaxPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB); // int16u
-EmberAfStatus SetRmsVoltageMaxPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB);
-EmberAfStatus GetRmsCurrentPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB); // int16u
-EmberAfStatus SetRmsCurrentPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB);
-EmberAfStatus GetRmsCurrentMinPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB); // int16u
-EmberAfStatus SetRmsCurrentMinPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB);
-EmberAfStatus GetRmsCurrentMaxPhaseB(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB); // int16u
-EmberAfStatus SetRmsCurrentMaxPhaseB(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB);
-EmberAfStatus GetActivePowerPhaseB(chip::EndpointId endpoint, int16_t * activePowerPhaseB); // int16s
-EmberAfStatus SetActivePowerPhaseB(chip::EndpointId endpoint, int16_t activePowerPhaseB);
-EmberAfStatus GetActivePowerMinPhaseB(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB); // int16s
-EmberAfStatus SetActivePowerMinPhaseB(chip::EndpointId endpoint, int16_t activePowerMinPhaseB);
-EmberAfStatus GetActivePowerMaxPhaseB(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB); // int16s
-EmberAfStatus SetActivePowerMaxPhaseB(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB);
-EmberAfStatus GetReactivePowerPhaseB(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB); // int16s
-EmberAfStatus SetReactivePowerPhaseB(chip::EndpointId endpoint, int16_t reactivePowerPhaseB);
-EmberAfStatus GetApparentPowerPhaseB(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB); // int16u
-EmberAfStatus SetApparentPowerPhaseB(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB);
-EmberAfStatus GetPowerFactorPhaseB(chip::EndpointId endpoint, int8_t * powerFactorPhaseB); // int8s
-EmberAfStatus SetPowerFactorPhaseB(chip::EndpointId endpoint, int8_t powerFactorPhaseB);
-EmberAfStatus GetAverageRmsVoltageMeasurementPeriodPhaseB(chip::EndpointId endpoint,
-                                                          uint16_t * averageRmsVoltageMeasurementPeriodPhaseB); // int16u
-EmberAfStatus SetAverageRmsVoltageMeasurementPeriodPhaseB(chip::EndpointId endpoint,
-                                                          uint16_t averageRmsVoltageMeasurementPeriodPhaseB);
-EmberAfStatus GetAverageRmsOverVoltageCounterPhaseB(chip::EndpointId endpoint,
-                                                    uint16_t * averageRmsOverVoltageCounterPhaseB); // int16u
-EmberAfStatus SetAverageRmsOverVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB);
-EmberAfStatus GetAverageRmsUnderVoltageCounterPhaseB(chip::EndpointId endpoint,
-                                                     uint16_t * averageRmsUnderVoltageCounterPhaseB); // int16u
-EmberAfStatus SetAverageRmsUnderVoltageCounterPhaseB(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB);
-EmberAfStatus GetRmsExtremeOverVoltagePeriodPhaseB(chip::EndpointId endpoint,
-                                                   uint16_t * rmsExtremeOverVoltagePeriodPhaseB); // int16u
-EmberAfStatus SetRmsExtremeOverVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB);
-EmberAfStatus GetRmsExtremeUnderVoltagePeriodPhaseB(chip::EndpointId endpoint,
-                                                    uint16_t * rmsExtremeUnderVoltagePeriodPhaseB); // int16u
-EmberAfStatus SetRmsExtremeUnderVoltagePeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB);
-EmberAfStatus GetRmsVoltageSagPeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB); // int16u
-EmberAfStatus SetRmsVoltageSagPeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB);
-EmberAfStatus GetRmsVoltageSwellPeriodPhaseB(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB); // int16u
-EmberAfStatus SetRmsVoltageSwellPeriodPhaseB(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB);
-EmberAfStatus GetLineCurrentPhaseC(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC); // int16u
-EmberAfStatus SetLineCurrentPhaseC(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC);
-EmberAfStatus GetActiveCurrentPhaseC(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC); // int16s
-EmberAfStatus SetActiveCurrentPhaseC(chip::EndpointId endpoint, int16_t activeCurrentPhaseC);
-EmberAfStatus GetReactiveCurrentPhaseC(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC); // int16s
-EmberAfStatus SetReactiveCurrentPhaseC(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC);
-EmberAfStatus GetRmsVoltagePhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC); // int16u
-EmberAfStatus SetRmsVoltagePhaseC(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC);
-EmberAfStatus GetRmsVoltageMinPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC); // int16u
-EmberAfStatus SetRmsVoltageMinPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC);
-EmberAfStatus GetRmsVoltageMaxPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC); // int16u
-EmberAfStatus SetRmsVoltageMaxPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC);
-EmberAfStatus GetRmsCurrentPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC); // int16u
-EmberAfStatus SetRmsCurrentPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC);
-EmberAfStatus GetRmsCurrentMinPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC); // int16u
-EmberAfStatus SetRmsCurrentMinPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC);
-EmberAfStatus GetRmsCurrentMaxPhaseC(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC); // int16u
-EmberAfStatus SetRmsCurrentMaxPhaseC(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC);
-EmberAfStatus GetActivePowerPhaseC(chip::EndpointId endpoint, int16_t * activePowerPhaseC); // int16s
-EmberAfStatus SetActivePowerPhaseC(chip::EndpointId endpoint, int16_t activePowerPhaseC);
-EmberAfStatus GetActivePowerMinPhaseC(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC); // int16s
-EmberAfStatus SetActivePowerMinPhaseC(chip::EndpointId endpoint, int16_t activePowerMinPhaseC);
-EmberAfStatus GetActivePowerMaxPhaseC(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC); // int16s
-EmberAfStatus SetActivePowerMaxPhaseC(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC);
-EmberAfStatus GetReactivePowerPhaseC(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC); // int16s
-EmberAfStatus SetReactivePowerPhaseC(chip::EndpointId endpoint, int16_t reactivePowerPhaseC);
-EmberAfStatus GetApparentPowerPhaseC(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC); // int16u
-EmberAfStatus SetApparentPowerPhaseC(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC);
-EmberAfStatus GetPowerFactorPhaseC(chip::EndpointId endpoint, int8_t * powerFactorPhaseC); // int8s
-EmberAfStatus SetPowerFactorPhaseC(chip::EndpointId endpoint, int8_t powerFactorPhaseC);
-EmberAfStatus GetAverageRmsVoltageMeasurementPeriodPhaseC(chip::EndpointId endpoint,
-                                                          uint16_t * averageRmsVoltageMeasurementPeriodPhaseC); // int16u
-EmberAfStatus SetAverageRmsVoltageMeasurementPeriodPhaseC(chip::EndpointId endpoint,
-                                                          uint16_t averageRmsVoltageMeasurementPeriodPhaseC);
-EmberAfStatus GetAverageRmsOverVoltageCounterPhaseC(chip::EndpointId endpoint,
-                                                    uint16_t * averageRmsOverVoltageCounterPhaseC); // int16u
-EmberAfStatus SetAverageRmsOverVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC);
-EmberAfStatus GetAverageRmsUnderVoltageCounterPhaseC(chip::EndpointId endpoint,
-                                                     uint16_t * averageRmsUnderVoltageCounterPhaseC); // int16u
-EmberAfStatus SetAverageRmsUnderVoltageCounterPhaseC(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC);
-EmberAfStatus GetRmsExtremeOverVoltagePeriodPhaseC(chip::EndpointId endpoint,
-                                                   uint16_t * rmsExtremeOverVoltagePeriodPhaseC); // int16u
-EmberAfStatus SetRmsExtremeOverVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC);
-EmberAfStatus GetRmsExtremeUnderVoltagePeriodPhaseC(chip::EndpointId endpoint,
-                                                    uint16_t * rmsExtremeUnderVoltagePeriodPhaseC); // int16u
-EmberAfStatus SetRmsExtremeUnderVoltagePeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC);
-EmberAfStatus GetRmsVoltageSagPeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC); // int16u
-EmberAfStatus SetRmsVoltageSagPeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC);
-EmberAfStatus GetRmsVoltageSwellPeriodPhaseC(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC); // int16u
-EmberAfStatus SetRmsVoltageSwellPeriodPhaseC(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC);
+
+namespace MeasurementType {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * measurementType); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t measurementType);
+} // namespace MeasurementType
+
+namespace DcVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltage); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltage);
+} // namespace DcVoltage
+
+namespace DcVoltageMin {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMin); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMin);
+} // namespace DcVoltageMin
+
+namespace DcVoltageMax {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMax); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMax);
+} // namespace DcVoltageMax
+
+namespace DcCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrent);
+} // namespace DcCurrent
+
+namespace DcCurrentMin {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMin); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMin);
+} // namespace DcCurrentMin
+
+namespace DcCurrentMax {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMax); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMax);
+} // namespace DcCurrentMax
+
+namespace DcPower {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPower); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPower);
+} // namespace DcPower
+
+namespace DcPowerMin {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMin); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMin);
+} // namespace DcPowerMin
+
+namespace DcPowerMax {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMax); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMax);
+} // namespace DcPowerMax
+
+namespace DcVoltageMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier);
+} // namespace DcVoltageMultiplier
+
+namespace DcVoltageDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageDivisor);
+} // namespace DcVoltageDivisor
+
+namespace DcCurrentMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier);
+} // namespace DcCurrentMultiplier
+
+namespace DcCurrentDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentDivisor);
+} // namespace DcCurrentDivisor
+
+namespace DcPowerMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerMultiplier);
+} // namespace DcPowerMultiplier
+
+namespace DcPowerDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerDivisor);
+} // namespace DcPowerDivisor
+
+namespace AcFrequency {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequency); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequency);
+} // namespace AcFrequency
+
+namespace AcFrequencyMin {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMin); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMin);
+} // namespace AcFrequencyMin
+
+namespace AcFrequencyMax {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMax); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMax);
+} // namespace AcFrequencyMax
+
+namespace NeutralCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * neutralCurrent); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t neutralCurrent);
+} // namespace NeutralCurrent
+
+namespace TotalActivePower {
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalActivePower); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalActivePower);
+} // namespace TotalActivePower
+
+namespace TotalReactivePower {
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalReactivePower); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalReactivePower);
+} // namespace TotalReactivePower
+
+namespace TotalApparentPower {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalApparentPower); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalApparentPower);
+} // namespace TotalApparentPower
+
+namespace Measured1stHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent);
+} // namespace Measured1stHarmonicCurrent
+
+namespace Measured3rdHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent);
+} // namespace Measured3rdHarmonicCurrent
+
+namespace Measured5thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent);
+} // namespace Measured5thHarmonicCurrent
+
+namespace Measured7thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent);
+} // namespace Measured7thHarmonicCurrent
+
+namespace Measured9thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent);
+} // namespace Measured9thHarmonicCurrent
+
+namespace Measured11thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent);
+} // namespace Measured11thHarmonicCurrent
+
+namespace MeasuredPhase1stHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent);
+} // namespace MeasuredPhase1stHarmonicCurrent
+
+namespace MeasuredPhase3rdHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent);
+} // namespace MeasuredPhase3rdHarmonicCurrent
+
+namespace MeasuredPhase5thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent);
+} // namespace MeasuredPhase5thHarmonicCurrent
+
+namespace MeasuredPhase7thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent);
+} // namespace MeasuredPhase7thHarmonicCurrent
+
+namespace MeasuredPhase9thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent);
+} // namespace MeasuredPhase9thHarmonicCurrent
+
+namespace MeasuredPhase11thHarmonicCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent);
+} // namespace MeasuredPhase11thHarmonicCurrent
+
+namespace AcFrequencyMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier);
+} // namespace AcFrequencyMultiplier
+
+namespace AcFrequencyDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyDivisor);
+} // namespace AcFrequencyDivisor
+
+namespace PowerMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerMultiplier); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerMultiplier);
+} // namespace PowerMultiplier
+
+namespace PowerDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerDivisor); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerDivisor);
+} // namespace PowerDivisor
+
+namespace HarmonicCurrentMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier);
+} // namespace HarmonicCurrentMultiplier
+
+namespace PhaseHarmonicCurrentMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier);
+} // namespace PhaseHarmonicCurrentMultiplier
+
+namespace InstantaneousVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousVoltage); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousVoltage);
+} // namespace InstantaneousVoltage
+
+namespace InstantaneousLineCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent);
+} // namespace InstantaneousLineCurrent
+
+namespace InstantaneousActiveCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent);
+} // namespace InstantaneousActiveCurrent
+
+namespace InstantaneousReactiveCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent);
+} // namespace InstantaneousReactiveCurrent
+
+namespace InstantaneousPower {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousPower); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousPower);
+} // namespace InstantaneousPower
+
+namespace RmsVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltage); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltage);
+} // namespace RmsVoltage
+
+namespace RmsVoltageMin {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMin); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMin);
+} // namespace RmsVoltageMin
+
+namespace RmsVoltageMax {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMax); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMax);
+} // namespace RmsVoltageMax
+
+namespace RmsCurrent {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrent); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrent);
+} // namespace RmsCurrent
+
+namespace RmsCurrentMin {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMin); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMin);
+} // namespace RmsCurrentMin
+
+namespace RmsCurrentMax {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMax); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMax);
+} // namespace RmsCurrentMax
+
+namespace ActivePower {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePower); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePower);
+} // namespace ActivePower
+
+namespace ActivePowerMin {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMin); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMin);
+} // namespace ActivePowerMin
+
+namespace ActivePowerMax {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMax); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMax);
+} // namespace ActivePowerMax
+
+namespace ReactivePower {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePower); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePower);
+} // namespace ReactivePower
+
+namespace ApparentPower {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPower); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPower);
+} // namespace ApparentPower
+
+namespace PowerFactor {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactor); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactor);
+} // namespace PowerFactor
+
+namespace AverageRmsVoltageMeasurementPeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod);
+} // namespace AverageRmsVoltageMeasurementPeriod
+
+namespace AverageRmsUnderVoltageCounter {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter);
+} // namespace AverageRmsUnderVoltageCounter
+
+namespace RmsExtremeOverVoltagePeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod);
+} // namespace RmsExtremeOverVoltagePeriod
+
+namespace RmsExtremeUnderVoltagePeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod);
+} // namespace RmsExtremeUnderVoltagePeriod
+
+namespace RmsVoltageSagPeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod);
+} // namespace RmsVoltageSagPeriod
+
+namespace RmsVoltageSwellPeriod {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod);
+} // namespace RmsVoltageSwellPeriod
+
+namespace AcVoltageMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageMultiplier);
+} // namespace AcVoltageMultiplier
+
+namespace AcVoltageDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageDivisor);
+} // namespace AcVoltageDivisor
+
+namespace AcCurrentMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentMultiplier);
+} // namespace AcCurrentMultiplier
+
+namespace AcCurrentDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentDivisor);
+} // namespace AcCurrentDivisor
+
+namespace AcPowerMultiplier {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerMultiplier); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerMultiplier);
+} // namespace AcPowerMultiplier
+
+namespace AcPowerDivisor {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerDivisor); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerDivisor);
+} // namespace AcPowerDivisor
+
+namespace OverloadAlarmsMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t overloadAlarmsMask);
+} // namespace OverloadAlarmsMask
+
+namespace VoltageOverload {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * voltageOverload); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t voltageOverload);
+} // namespace VoltageOverload
+
+namespace CurrentOverload {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentOverload); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentOverload);
+} // namespace CurrentOverload
+
+namespace AcOverloadAlarmsMask {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask);
+} // namespace AcOverloadAlarmsMask
+
+namespace AcVoltageOverload {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acVoltageOverload); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acVoltageOverload);
+} // namespace AcVoltageOverload
+
+namespace AcCurrentOverload {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCurrentOverload); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCurrentOverload);
+} // namespace AcCurrentOverload
+
+namespace AcActivePowerOverload {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acActivePowerOverload); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acActivePowerOverload);
+} // namespace AcActivePowerOverload
+
+namespace AcReactivePowerOverload {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acReactivePowerOverload); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t acReactivePowerOverload);
+} // namespace AcReactivePowerOverload
+
+namespace AverageRmsOverVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsOverVoltage);
+} // namespace AverageRmsOverVoltage
+
+namespace AverageRmsUnderVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage);
+} // namespace AverageRmsUnderVoltage
+
+namespace RmsExtremeOverVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage);
+} // namespace RmsExtremeOverVoltage
+
+namespace RmsExtremeUnderVoltage {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage);
+} // namespace RmsExtremeUnderVoltage
+
+namespace RmsVoltageSag {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSag); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSag);
+} // namespace RmsVoltageSag
+
+namespace RmsVoltageSwell {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSwell); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSwell);
+} // namespace RmsVoltageSwell
+
+namespace LineCurrentPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB);
+} // namespace LineCurrentPhaseB
+
+namespace ActiveCurrentPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseB);
+} // namespace ActiveCurrentPhaseB
+
+namespace ReactiveCurrentPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB);
+} // namespace ReactiveCurrentPhaseB
+
+namespace RmsVoltagePhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB);
+} // namespace RmsVoltagePhaseB
+
+namespace RmsVoltageMinPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB);
+} // namespace RmsVoltageMinPhaseB
+
+namespace RmsVoltageMaxPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB);
+} // namespace RmsVoltageMaxPhaseB
+
+namespace RmsCurrentPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB);
+} // namespace RmsCurrentPhaseB
+
+namespace RmsCurrentMinPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB);
+} // namespace RmsCurrentMinPhaseB
+
+namespace RmsCurrentMaxPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB);
+} // namespace RmsCurrentMaxPhaseB
+
+namespace ActivePowerPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseB); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseB);
+} // namespace ActivePowerPhaseB
+
+namespace ActivePowerMinPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseB);
+} // namespace ActivePowerMinPhaseB
+
+namespace ActivePowerMaxPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB);
+} // namespace ActivePowerMaxPhaseB
+
+namespace ReactivePowerPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseB);
+} // namespace ReactivePowerPhaseB
+
+namespace ApparentPowerPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB);
+} // namespace ApparentPowerPhaseB
+
+namespace PowerFactorPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseB); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseB);
+} // namespace PowerFactorPhaseB
+
+namespace AverageRmsVoltageMeasurementPeriodPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseB);
+} // namespace AverageRmsVoltageMeasurementPeriodPhaseB
+
+namespace AverageRmsOverVoltageCounterPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB);
+} // namespace AverageRmsOverVoltageCounterPhaseB
+
+namespace AverageRmsUnderVoltageCounterPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB);
+} // namespace AverageRmsUnderVoltageCounterPhaseB
+
+namespace RmsExtremeOverVoltagePeriodPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB);
+} // namespace RmsExtremeOverVoltagePeriodPhaseB
+
+namespace RmsExtremeUnderVoltagePeriodPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB);
+} // namespace RmsExtremeUnderVoltagePeriodPhaseB
+
+namespace RmsVoltageSagPeriodPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB);
+} // namespace RmsVoltageSagPeriodPhaseB
+
+namespace RmsVoltageSwellPeriodPhaseB {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB);
+} // namespace RmsVoltageSwellPeriodPhaseB
+
+namespace LineCurrentPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC);
+} // namespace LineCurrentPhaseC
+
+namespace ActiveCurrentPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseC);
+} // namespace ActiveCurrentPhaseC
+
+namespace ReactiveCurrentPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC);
+} // namespace ReactiveCurrentPhaseC
+
+namespace RmsVoltagePhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC);
+} // namespace RmsVoltagePhaseC
+
+namespace RmsVoltageMinPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC);
+} // namespace RmsVoltageMinPhaseC
+
+namespace RmsVoltageMaxPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC);
+} // namespace RmsVoltageMaxPhaseC
+
+namespace RmsCurrentPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC);
+} // namespace RmsCurrentPhaseC
+
+namespace RmsCurrentMinPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC);
+} // namespace RmsCurrentMinPhaseC
+
+namespace RmsCurrentMaxPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC);
+} // namespace RmsCurrentMaxPhaseC
+
+namespace ActivePowerPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseC); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseC);
+} // namespace ActivePowerPhaseC
+
+namespace ActivePowerMinPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseC);
+} // namespace ActivePowerMinPhaseC
+
+namespace ActivePowerMaxPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC);
+} // namespace ActivePowerMaxPhaseC
+
+namespace ReactivePowerPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseC);
+} // namespace ReactivePowerPhaseC
+
+namespace ApparentPowerPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC);
+} // namespace ApparentPowerPhaseC
+
+namespace PowerFactorPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseC); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseC);
+} // namespace PowerFactorPhaseC
+
+namespace AverageRmsVoltageMeasurementPeriodPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseC);
+} // namespace AverageRmsVoltageMeasurementPeriodPhaseC
+
+namespace AverageRmsOverVoltageCounterPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC);
+} // namespace AverageRmsOverVoltageCounterPhaseC
+
+namespace AverageRmsUnderVoltageCounterPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC);
+} // namespace AverageRmsUnderVoltageCounterPhaseC
+
+namespace RmsExtremeOverVoltagePeriodPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC);
+} // namespace RmsExtremeOverVoltagePeriodPhaseC
+
+namespace RmsExtremeUnderVoltagePeriodPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC);
+} // namespace RmsExtremeUnderVoltagePeriodPhaseC
+
+namespace RmsVoltageSagPeriodPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC);
+} // namespace RmsVoltageSagPeriodPhaseC
+
+namespace RmsVoltageSwellPeriodPhaseC {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC);
+} // namespace RmsVoltageSwellPeriodPhaseC
+
 } // namespace Attributes
 } // namespace ElectricalMeasurement
 
 namespace GroupKeyManagement {
 namespace Attributes {
+
 } // namespace Attributes
 } // namespace GroupKeyManagement
 
 namespace SampleMfgSpecificCluster {
 namespace Attributes {
-EmberAfStatus GetEmberSampleAttribute(chip::EndpointId endpoint, uint8_t * emberSampleAttribute); // int8u
-EmberAfStatus SetEmberSampleAttribute(chip::EndpointId endpoint, uint8_t emberSampleAttribute);
-EmberAfStatus GetEmberSampleAttribute2(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2); // int8u
-EmberAfStatus SetEmberSampleAttribute2(chip::EndpointId endpoint, uint8_t emberSampleAttribute2);
+
+namespace EmberSampleAttribute {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute);
+} // namespace EmberSampleAttribute
+
+namespace EmberSampleAttribute2 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute2);
+} // namespace EmberSampleAttribute2
+
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster
 
 namespace SampleMfgSpecificCluster2 {
 namespace Attributes {
-EmberAfStatus GetEmberSampleAttribute3(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3); // int16u
-EmberAfStatus SetEmberSampleAttribute3(chip::EndpointId endpoint, uint16_t emberSampleAttribute3);
-EmberAfStatus GetEmberSampleAttribute4(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4); // int16u
-EmberAfStatus SetEmberSampleAttribute4(chip::EndpointId endpoint, uint16_t emberSampleAttribute4);
+
+namespace EmberSampleAttribute3 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute3);
+} // namespace EmberSampleAttribute3
+
+namespace EmberSampleAttribute4 {
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute4);
+} // namespace EmberSampleAttribute4
+
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster2
 


### PR DESCRIPTION
#### Problem
We now have per-attribute namespaces, so it makes sense to put our accessor functions in those.

#### Change overview
Accessors in per-attribute namespaces.  So `AttrName::Get` instead of `GetAttrName`.

#### Testing
No behavior changes.  Tree compiles.