### PR TITLE
add IpVlan topology to CHIP

### DIFF
--- a/src/test_driver/linux-cirque/topologies/three_node_with_ipv6.json
+++ b/src/test_driver/linux-cirque/topologies/three_node_with_ipv6.json
@@ -2,21 +2,21 @@
     "device0": {
         "type": "CHIP-00",
         "base_image": "connectedhomeip/chip-cirque-device-base",
-        "docker_network": "IpvLan",
+        "docker_network": "Ipv6",
         "capability": ["Interactive", "Mount"],
         "mount_pairs": [["{chip_repo}", "{chip_repo}"]]
     },
     "device1": {
         "type": "CHIP-01",
         "base_image": "connectedhomeip/chip-cirque-device-base",
-        "docker_network": "IpvLan",
+        "docker_network": "Ipv6",
         "capability": ["Interactive", "Mount"],
         "mount_pairs": [["{chip_repo}", "{chip_repo}"]]
     },
     "device2": {
         "type": "CHIP-02",
         "base_image": "connectedhomeip/chip-cirque-device-base",
-        "docker_network": "IpvLan",
+        "docker_network": "Ipv6",
         "capability": ["Interactive", "Mount"],
         "mount_pairs": [["{chip_repo}", "{chip_repo}"]]
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
*  Matter/CHIP would use IPv6 only, and need to add cirque ipv6 topology file

#### Change overview
add ipv6 topology

#### Testing
Manual run