### PR TITLE
Minor System::Clock cleanup

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -257,7 +257,7 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
 
     // TODO: make this configurable
 #if CHIP_PROGRESS_LOGGING
-    uint32_t delta = (static_cast<uint32_t>(System::SystemClock().GetMonotonicMicroseconds() - startUS) / 1000);
+    uint32_t delta = static_cast<uint32_t>((System::SystemClock().GetMonotonicMicroseconds() - startUS) / 1000);
     if (delta > 100)
     {
         ChipLogError(DeviceLayer, "Long dispatch time: %" PRIu32 " ms, for event type %d", delta, event->Type);

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -112,16 +112,6 @@ namespace Clock {
 using MonotonicMicroseconds = ClockBase::MonotonicMicroseconds;
 using MonotonicMilliseconds = ClockBase::MonotonicMicroseconds;
 
-// DO NOT USE - Temporary backward compatibility functions. TODO: remove.
-inline MonotonicMicroseconds GetMonotonicMicroseconds()
-{
-    return SystemClock().GetMonotonicMicroseconds();
-}
-inline MonotonicMilliseconds GetMonotonicMilliseconds()
-{
-    return SystemClock().GetMonotonicMilliseconds();
-}
-
 /**
  *  Compares two time values and returns true if the first value is earlier than the second value.
  *


### PR DESCRIPTION
#### Problem

Followups from PR #10056 Indirect access for System::Clock functions

Fixes #10146 Remove GetMonotonicMicroseconds() call
Fixes #10145 remove.
Fixes #10144 The static cast should have the / 1000 within it

#### Change overview

- Removes the global backward-compatibility wrappers for `GetMonotonic…()`.
- Correctly parenthesize the #10146 cast.

#### Testing

CI. No changes to functionality intended.
