### PR TITLE
Generate cluster objects for all clusters.

### DIFF
--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -7,9 +7,8 @@
 namespace chip {
 namespace app {
 namespace clusters {
-{{#all_user_clusters}}
-{{#if (user_cluster_has_enabled_command name side)}}
-namespace {{asCamelCased name false}} {
+{{#zcl_clusters}}
+namespace {{asUpperCamelCase name}} {
 {{#zcl_structs}}
 namespace {{asType label}} {
 CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) const{
@@ -91,8 +90,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
 {{/zcl_structs}}
 }
 
-{{/if}}
-{{/all_user_clusters}}
+{{/zcl_clusters}}
 
 } // namespace clusters
 } // namespace app

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -12,8 +12,8 @@ namespace chip {
 namespace app {
 namespace clusters {
 
-{{#all_user_clusters}}
-namespace {{asCamelCased name false}} {
+{{#zcl_clusters}}
+namespace {{asUpperCamelCase name}} {
 {{#zcl_enums}}
 // Enum for {{label}}
 enum class {{asType label}} : {{asUnderlyingZclType type}} {
@@ -60,11 +60,11 @@ namespace {{name}} {
     };
     {{/if}}
 
-}// namespace for {{name}}
+} // namespace {{name}}
 {{/zcl_structs}}
 
-}// namespace for {{name}}
-{{/all_user_clusters}}
+} // namespace {{asUpperCamelCase name}}
+{{/zcl_clusters}}
 
 } // namespace clusters
 } // namespace app

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -24,17 +24,53 @@
 namespace chip {
 namespace app {
 namespace clusters {
-namespace AccountLogin {
+namespace PowerConfiguration {
 }
 
-namespace ApplicationLauncher {
-namespace ApplicationLauncherApp {
+namespace DeviceTemperatureConfiguration {
+}
+
+namespace Identify {
+}
+
+namespace Groups {
+}
+
+namespace Scenes {
+}
+
+namespace OnOff {
+}
+
+namespace OnOffSwitchConfiguration {
+}
+
+namespace LevelControl {
+}
+
+namespace Alarms {
+}
+
+namespace Time {
+}
+
+namespace BinaryInputBasic {
+}
+
+namespace PowerProfile {
+}
+
+namespace ApplianceControl {
+}
+
+namespace Descriptor {
+namespace DeviceType {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kCatalogVendorIdFieldId), catalogVendorId));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kApplicationIdFieldId), applicationId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kTypeFieldId), type));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRevisionFieldId), revision));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -49,11 +85,11 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     {
         switch (chip::TLV::TagNumFromTag(reader.GetTag()))
         {
-        case kCatalogVendorIdFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, catalogVendorId));
+        case kTypeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, type));
             break;
-        case kApplicationIdFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, applicationId));
+        case kRevisionFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, revision));
             break;
         default:
             break;
@@ -63,8 +99,1052 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
-} // namespace ApplicationLauncherApp
-} // namespace ApplicationLauncher
+} // namespace DeviceType
+} // namespace Descriptor
+
+namespace PollControl {
+}
+
+namespace Basic {
+}
+
+namespace OtaSoftwareUpdateProvider {
+}
+
+namespace OtaSoftwareUpdateRequestor {
+}
+
+namespace PowerSource {
+}
+
+namespace GeneralCommissioning {
+namespace BasicCommissioningInfoType {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFailSafeExpiryLengthMsFieldId), failSafeExpiryLengthMs));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kFailSafeExpiryLengthMsFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, failSafeExpiryLengthMs));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace BasicCommissioningInfoType
+} // namespace GeneralCommissioning
+
+namespace NetworkCommissioning {
+namespace ThreadInterfaceScanResult {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kDiscoveryResponseFieldId), discoveryResponse));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kDiscoveryResponseFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, discoveryResponse));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace ThreadInterfaceScanResult
+namespace WiFiInterfaceScanResult {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kSecurityFieldId), security));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kSsidFieldId), ssid));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kBssidFieldId), bssid));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kChannelFieldId), channel));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFrequencyBandFieldId), frequencyBand));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kSecurityFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, security));
+            break;
+        case kSsidFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, ssid));
+            break;
+        case kBssidFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, bssid));
+            break;
+        case kChannelFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, channel));
+            break;
+        case kFrequencyBandFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, frequencyBand));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace WiFiInterfaceScanResult
+} // namespace NetworkCommissioning
+
+namespace DiagnosticLogs {
+}
+
+namespace GeneralDiagnostics {
+namespace NetworkInterfaceType {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricConnectedFieldId), fabricConnected));
+    ReturnErrorOnFailure(
+        DataModel::Encode(writer, TLV::ContextTag(kOffPremiseServicesReachableIPv4FieldId), offPremiseServicesReachableIPv4));
+    ReturnErrorOnFailure(
+        DataModel::Encode(writer, TLV::ContextTag(kOffPremiseServicesReachableIPv6FieldId), offPremiseServicesReachableIPv6));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kHardwareAddressFieldId), hardwareAddress));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kTypeFieldId), type));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+            break;
+        case kFabricConnectedFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricConnected));
+            break;
+        case kOffPremiseServicesReachableIPv4FieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, offPremiseServicesReachableIPv4));
+            break;
+        case kOffPremiseServicesReachableIPv6FieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, offPremiseServicesReachableIPv6));
+            break;
+        case kHardwareAddressFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, hardwareAddress));
+            break;
+        case kTypeFieldId:
+            uint8_t v;
+            ReturnErrorOnFailure(DataModel::Decode(reader, v));
+            type = static_cast<InterfaceType>(v);
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace NetworkInterfaceType
+} // namespace GeneralDiagnostics
+
+namespace SoftwareDiagnostics {
+namespace ThreadMetrics {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kIdFieldId), id));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kStackFreeCurrentFieldId), stackFreeCurrent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kStackFreeMinimumFieldId), stackFreeMinimum));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kStackSizeFieldId), stackSize));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, id));
+            break;
+        case kNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+            break;
+        case kStackFreeCurrentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, stackFreeCurrent));
+            break;
+        case kStackFreeMinimumFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, stackFreeMinimum));
+            break;
+        case kStackSizeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, stackSize));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace ThreadMetrics
+} // namespace SoftwareDiagnostics
+
+namespace ThreadNetworkDiagnostics {
+namespace NeighborTable {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kExtAddressFieldId), extAddress));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAgeFieldId), age));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRloc16FieldId), rloc16));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLinkFrameCounterFieldId), linkFrameCounter));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMleFrameCounterFieldId), mleFrameCounter));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLqiFieldId), lqi));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAverageRssiFieldId), averageRssi));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLastRssiFieldId), lastRssi));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFrameErrorRateFieldId), frameErrorRate));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMessageErrorRateFieldId), messageErrorRate));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRxOnWhenIdleFieldId), rxOnWhenIdle));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFullThreadDeviceFieldId), fullThreadDevice));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFullNetworkDataFieldId), fullNetworkData));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kIsChildFieldId), isChild));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kExtAddressFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, extAddress));
+            break;
+        case kAgeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, age));
+            break;
+        case kRloc16FieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, rloc16));
+            break;
+        case kLinkFrameCounterFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, linkFrameCounter));
+            break;
+        case kMleFrameCounterFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, mleFrameCounter));
+            break;
+        case kLqiFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, lqi));
+            break;
+        case kAverageRssiFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, averageRssi));
+            break;
+        case kLastRssiFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, lastRssi));
+            break;
+        case kFrameErrorRateFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, frameErrorRate));
+            break;
+        case kMessageErrorRateFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, messageErrorRate));
+            break;
+        case kRxOnWhenIdleFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, rxOnWhenIdle));
+            break;
+        case kFullThreadDeviceFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, fullThreadDevice));
+            break;
+        case kFullNetworkDataFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, fullNetworkData));
+            break;
+        case kIsChildFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, isChild));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace NeighborTable
+namespace OperationalDatasetComponents {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kActiveTimestampPresentFieldId), activeTimestampPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPendingTimestampPresentFieldId), pendingTimestampPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMasterKeyPresentFieldId), masterKeyPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNetworkNamePresentFieldId), networkNamePresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kExtendedPanIdPresentFieldId), extendedPanIdPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMeshLocalPrefixPresentFieldId), meshLocalPrefixPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kDelayPresentFieldId), delayPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPanIdPresentFieldId), panIdPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kChannelPresentFieldId), channelPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPskcPresentFieldId), pskcPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kSecurityPolicyPresentFieldId), securityPolicyPresent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kChannelMaskPresentFieldId), channelMaskPresent));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kActiveTimestampPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, activeTimestampPresent));
+            break;
+        case kPendingTimestampPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, pendingTimestampPresent));
+            break;
+        case kMasterKeyPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, masterKeyPresent));
+            break;
+        case kNetworkNamePresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, networkNamePresent));
+            break;
+        case kExtendedPanIdPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, extendedPanIdPresent));
+            break;
+        case kMeshLocalPrefixPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, meshLocalPrefixPresent));
+            break;
+        case kDelayPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, delayPresent));
+            break;
+        case kPanIdPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, panIdPresent));
+            break;
+        case kChannelPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, channelPresent));
+            break;
+        case kPskcPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, pskcPresent));
+            break;
+        case kSecurityPolicyPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, securityPolicyPresent));
+            break;
+        case kChannelMaskPresentFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, channelMaskPresent));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace OperationalDatasetComponents
+namespace RouteTable {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kExtAddressFieldId), extAddress));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRloc16FieldId), rloc16));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRouterIdFieldId), routerId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNextHopFieldId), nextHop));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPathCostFieldId), pathCost));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLQIInFieldId), lQIIn));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLQIOutFieldId), lQIOut));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAgeFieldId), age));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAllocatedFieldId), allocated));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLinkEstablishedFieldId), linkEstablished));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kExtAddressFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, extAddress));
+            break;
+        case kRloc16FieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, rloc16));
+            break;
+        case kRouterIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, routerId));
+            break;
+        case kNextHopFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, nextHop));
+            break;
+        case kPathCostFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, pathCost));
+            break;
+        case kLQIInFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, lQIIn));
+            break;
+        case kLQIOutFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, lQIOut));
+            break;
+        case kAgeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, age));
+            break;
+        case kAllocatedFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, allocated));
+            break;
+        case kLinkEstablishedFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, linkEstablished));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace RouteTable
+namespace SecurityPolicy {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRotationTimeFieldId), rotationTime));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFlagsFieldId), flags));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kRotationTimeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, rotationTime));
+            break;
+        case kFlagsFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, flags));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace SecurityPolicy
+} // namespace ThreadNetworkDiagnostics
+
+namespace WiFiNetworkDiagnostics {
+}
+
+namespace EthernetNetworkDiagnostics {
+}
+
+namespace BridgedDeviceBasic {
+}
+
+namespace Switch {
+}
+
+namespace AdministratorCommissioning {
+}
+
+namespace OperationalCredentials {
+namespace FabricDescriptor {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricIndexFieldId), fabricIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRootPublicKeyFieldId), rootPublicKey));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kVendorIdFieldId), vendorId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricIdFieldId), fabricId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNodeIdFieldId), nodeId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLabelFieldId), label));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kFabricIndexFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
+            break;
+        case kRootPublicKeyFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, rootPublicKey));
+            break;
+        case kVendorIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, vendorId));
+            break;
+        case kFabricIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricId));
+            break;
+        case kNodeIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, nodeId));
+            break;
+        case kLabelFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, label));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace FabricDescriptor
+namespace NOCStruct {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricIndexFieldId), fabricIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNocFieldId), noc));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kFabricIndexFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
+            break;
+        case kNocFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, noc));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace NOCStruct
+} // namespace OperationalCredentials
+
+namespace FixedLabel {
+namespace LabelStruct {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLabelFieldId), label));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kValueFieldId), value));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kLabelFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, label));
+            break;
+        case kValueFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, value));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace LabelStruct
+} // namespace FixedLabel
+
+namespace ShadeConfiguration {
+}
+
+namespace DoorLock {
+}
+
+namespace WindowCovering {
+}
+
+namespace BarrierControl {
+}
+
+namespace PumpConfigurationAndControl {
+}
+
+namespace Thermostat {
+}
+
+namespace FanControl {
+}
+
+namespace DehumidificationControl {
+}
+
+namespace ThermostatUserInterfaceConfiguration {
+}
+
+namespace ColorControl {
+}
+
+namespace BallastConfiguration {
+}
+
+namespace IlluminanceMeasurement {
+}
+
+namespace IlluminanceLevelSensing {
+}
+
+namespace TemperatureMeasurement {
+}
+
+namespace PressureMeasurement {
+}
+
+namespace FlowMeasurement {
+}
+
+namespace RelativeHumidityMeasurement {
+}
+
+namespace OccupancySensing {
+}
+
+namespace CarbonMonoxideConcentrationMeasurement {
+}
+
+namespace CarbonDioxideConcentrationMeasurement {
+}
+
+namespace EthyleneConcentrationMeasurement {
+}
+
+namespace EthyleneOxideConcentrationMeasurement {
+}
+
+namespace HydrogenConcentrationMeasurement {
+}
+
+namespace HydrogenSulphideConcentrationMeasurement {
+}
+
+namespace NitricOxideConcentrationMeasurement {
+}
+
+namespace NitrogenDioxideConcentrationMeasurement {
+}
+
+namespace OxygenConcentrationMeasurement {
+}
+
+namespace OzoneConcentrationMeasurement {
+}
+
+namespace SulfurDioxideConcentrationMeasurement {
+}
+
+namespace DissolvedOxygenConcentrationMeasurement {
+}
+
+namespace BromateConcentrationMeasurement {
+}
+
+namespace ChloraminesConcentrationMeasurement {
+}
+
+namespace ChlorineConcentrationMeasurement {
+}
+
+namespace FecalColiformAndEColiConcentrationMeasurement {
+}
+
+namespace FluorideConcentrationMeasurement {
+}
+
+namespace HaloaceticAcidsConcentrationMeasurement {
+}
+
+namespace TotalTrihalomethanesConcentrationMeasurement {
+}
+
+namespace TotalColiformBacteriaConcentrationMeasurement {
+}
+
+namespace TurbidityConcentrationMeasurement {
+}
+
+namespace CopperConcentrationMeasurement {
+}
+
+namespace LeadConcentrationMeasurement {
+}
+
+namespace ManganeseConcentrationMeasurement {
+}
+
+namespace SulfateConcentrationMeasurement {
+}
+
+namespace BromodichloromethaneConcentrationMeasurement {
+}
+
+namespace BromoformConcentrationMeasurement {
+}
+
+namespace ChlorodibromomethaneConcentrationMeasurement {
+}
+
+namespace ChloroformConcentrationMeasurement {
+}
+
+namespace SodiumConcentrationMeasurement {
+}
+
+namespace IasZone {
+}
+
+namespace IasAce {
+}
+
+namespace IasWd {
+}
+
+namespace WakeOnLan {
+}
+
+namespace TvChannel {
+namespace TvChannelInfo {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMajorNumberFieldId), majorNumber));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMinorNumberFieldId), minorNumber));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kCallSignFieldId), callSign));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAffiliateCallSignFieldId), affiliateCallSign));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kMajorNumberFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, majorNumber));
+            break;
+        case kMinorNumberFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, minorNumber));
+            break;
+        case kNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+            break;
+        case kCallSignFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, callSign));
+            break;
+        case kAffiliateCallSignFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, affiliateCallSign));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace TvChannelInfo
+namespace TvChannelLineupInfo {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kOperatorNameFieldId), operatorName));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLineupNameFieldId), lineupName));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPostalCodeFieldId), postalCode));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLineupInfoTypeFieldId), lineupInfoType));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kOperatorNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, operatorName));
+            break;
+        case kLineupNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, lineupName));
+            break;
+        case kPostalCodeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, postalCode));
+            break;
+        case kLineupInfoTypeFieldId:
+            uint8_t v;
+            ReturnErrorOnFailure(DataModel::Decode(reader, v));
+            lineupInfoType = static_cast<TvChannelLineupInfoType>(v);
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace TvChannelLineupInfo
+} // namespace TvChannel
+
+namespace TargetNavigator {
+namespace NavigateTargetTargetInfo {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kIdentifierFieldId), identifier));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kIdentifierFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, identifier));
+            break;
+        case kNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace NavigateTargetTargetInfo
+} // namespace TargetNavigator
+
+namespace MediaPlayback {
+namespace MediaPlaybackPosition {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kUpdatedAtFieldId), updatedAt));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPositionFieldId), position));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kUpdatedAtFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, updatedAt));
+            break;
+        case kPositionFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, position));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace MediaPlaybackPosition
+} // namespace MediaPlayback
+
+namespace MediaInput {
+namespace MediaInputInfo {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kIndexFieldId), index));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kInputTypeFieldId), inputType));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kDescriptionFieldId), description));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kIndexFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, index));
+            break;
+        case kInputTypeFieldId:
+            uint8_t v;
+            ReturnErrorOnFailure(DataModel::Decode(reader, v));
+            inputType = static_cast<MediaInputType>(v);
+            break;
+        case kNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+            break;
+        case kDescriptionFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, description));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace MediaInputInfo
+} // namespace MediaInput
+
+namespace LowPower {
+}
+
+namespace KeypadInput {
+}
 
 namespace ContentLauncher {
 namespace ContentLaunchAdditionalInfo {
@@ -316,283 +1396,15 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
 } // namespace ContentLaunchStyleInformation
 } // namespace ContentLauncher
 
-namespace DoorLock {
-}
-
-namespace GeneralCommissioning {
-namespace BasicCommissioningInfoType {
+namespace AudioOutput {
+namespace AudioOutputInfo {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFailSafeExpiryLengthMsFieldId), failSafeExpiryLengthMs));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kFailSafeExpiryLengthMsFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, failSafeExpiryLengthMs));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace BasicCommissioningInfoType
-} // namespace GeneralCommissioning
-
-namespace Groups {
-}
-
-namespace Identify {
-}
-
-namespace KeypadInput {
-}
-
-namespace MediaPlayback {
-namespace MediaPlaybackPosition {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kUpdatedAtFieldId), updatedAt));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPositionFieldId), position));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kUpdatedAtFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, updatedAt));
-            break;
-        case kPositionFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, position));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace MediaPlaybackPosition
-} // namespace MediaPlayback
-
-namespace NetworkCommissioning {
-namespace ThreadInterfaceScanResult {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kDiscoveryResponseFieldId), discoveryResponse));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kDiscoveryResponseFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, discoveryResponse));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace ThreadInterfaceScanResult
-namespace WiFiInterfaceScanResult {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kSecurityFieldId), security));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kSsidFieldId), ssid));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kBssidFieldId), bssid));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kChannelFieldId), channel));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFrequencyBandFieldId), frequencyBand));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kSecurityFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, security));
-            break;
-        case kSsidFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, ssid));
-            break;
-        case kBssidFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, bssid));
-            break;
-        case kChannelFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, channel));
-            break;
-        case kFrequencyBandFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, frequencyBand));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace WiFiInterfaceScanResult
-} // namespace NetworkCommissioning
-
-namespace OtaSoftwareUpdateProvider {
-}
-
-namespace OperationalCredentials {
-namespace FabricDescriptor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricIndexFieldId), fabricIndex));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kRootPublicKeyFieldId), rootPublicKey));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kVendorIdFieldId), vendorId));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricIdFieldId), fabricId));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNodeIdFieldId), nodeId));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLabelFieldId), label));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kFabricIndexFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
-            break;
-        case kRootPublicKeyFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, rootPublicKey));
-            break;
-        case kVendorIdFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, vendorId));
-            break;
-        case kFabricIdFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, fabricId));
-            break;
-        case kNodeIdFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, nodeId));
-            break;
-        case kLabelFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, label));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace FabricDescriptor
-namespace NOCStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kFabricIndexFieldId), fabricIndex));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNocFieldId), noc));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kFabricIndexFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
-            break;
-        case kNocFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, noc));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace NOCStruct
-} // namespace OperationalCredentials
-
-namespace Scenes {
-}
-
-namespace TvChannel {
-namespace TvChannelInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMajorNumberFieldId), majorNumber));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kMinorNumberFieldId), minorNumber));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kIndexFieldId), index));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kOutputTypeFieldId), outputType));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kCallSignFieldId), callSign));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAffiliateCallSignFieldId), affiliateCallSign));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -607,66 +1419,16 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     {
         switch (chip::TLV::TagNumFromTag(reader.GetTag()))
         {
-        case kMajorNumberFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, majorNumber));
+        case kIndexFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, index));
             break;
-        case kMinorNumberFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, minorNumber));
-            break;
-        case kNameFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, name));
-            break;
-        case kCallSignFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, callSign));
-            break;
-        case kAffiliateCallSignFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, affiliateCallSign));
-            break;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-} // namespace TvChannelInfo
-namespace TvChannelLineupInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kOperatorNameFieldId), operatorName));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLineupNameFieldId), lineupName));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kPostalCodeFieldId), postalCode));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kLineupInfoTypeFieldId), lineupInfoType));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kOperatorNameFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, operatorName));
-            break;
-        case kLineupNameFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, lineupName));
-            break;
-        case kPostalCodeFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, postalCode));
-            break;
-        case kLineupInfoTypeFieldId:
+        case kOutputTypeFieldId:
             uint8_t v;
             ReturnErrorOnFailure(DataModel::Decode(reader, v));
-            lineupInfoType = static_cast<TvChannelLineupInfoType>(v);
+            outputType = static_cast<AudioOutputType>(v);
+            break;
+        case kNameFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
             break;
         default:
             break;
@@ -676,17 +1438,17 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
-} // namespace TvChannelLineupInfo
-} // namespace TvChannel
+} // namespace AudioOutputInfo
+} // namespace AudioOutput
 
-namespace TargetNavigator {
-namespace NavigateTargetTargetInfo {
+namespace ApplicationLauncher {
+namespace ApplicationLauncherApp {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kIdentifierFieldId), identifier));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kNameFieldId), name));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kCatalogVendorIdFieldId), catalogVendorId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kApplicationIdFieldId), applicationId));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -701,11 +1463,11 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     {
         switch (chip::TLV::TagNumFromTag(reader.GetTag()))
         {
-        case kIdentifierFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, identifier));
+        case kCatalogVendorIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, catalogVendorId));
             break;
-        case kNameFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+        case kApplicationIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, applicationId));
             break;
         default:
             break;
@@ -715,8 +1477,14 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
-} // namespace NavigateTargetTargetInfo
-} // namespace TargetNavigator
+} // namespace ApplicationLauncherApp
+} // namespace ApplicationLauncher
+
+namespace ApplicationBasic {
+}
+
+namespace AccountLogin {
+}
 
 namespace TestCluster {
 namespace SimpleStruct {
@@ -1003,6 +1771,126 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestListStructOctet
 } // namespace TestCluster
+
+namespace Messaging {
+}
+
+namespace ApplianceIdentification {
+}
+
+namespace MeterIdentification {
+}
+
+namespace ApplianceEventsAndAlert {
+}
+
+namespace ApplianceStatistics {
+}
+
+namespace ElectricalMeasurement {
+}
+
+namespace Binding {
+}
+
+namespace GroupKeyManagement {
+namespace GroupKey {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kVendorIdFieldId), vendorId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kGroupKeyIndexFieldId), groupKeyIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kGroupKeyRootFieldId), groupKeyRoot));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kGroupKeyEpochStartTimeFieldId), groupKeyEpochStartTime));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kGroupKeySecurityPolicyFieldId), groupKeySecurityPolicy));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kVendorIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, vendorId));
+            break;
+        case kGroupKeyIndexFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, groupKeyIndex));
+            break;
+        case kGroupKeyRootFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, groupKeyRoot));
+            break;
+        case kGroupKeyEpochStartTimeFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, groupKeyEpochStartTime));
+            break;
+        case kGroupKeySecurityPolicyFieldId:
+            uint8_t v;
+            ReturnErrorOnFailure(DataModel::Decode(reader, v));
+            groupKeySecurityPolicy = static_cast<GroupKeySecurityPolicy>(v);
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace GroupKey
+namespace GroupState {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kVendorIdFieldId), vendorId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kVendorGroupIdFieldId), vendorGroupId));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kGroupKeySetIndexFieldId), groupKeySetIndex));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outer;
+    err = reader.EnterContainer(outer);
+    ReturnErrorOnFailure(err);
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kVendorIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, vendorId));
+            break;
+        case kVendorGroupIdFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, vendorGroupId));
+            break;
+        case kGroupKeySetIndexFieldId:
+            ReturnErrorOnFailure(DataModel::Decode(reader, groupKeySetIndex));
+            break;
+        default:
+            break;
+        }
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace GroupState
+} // namespace GroupKeyManagement
+
+namespace SampleMfgSpecificCluster {
+}
+
+namespace SampleMfgSpecificCluster2 {
+}
 
 } // namespace clusters
 } // namespace app

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -29,263 +29,63 @@ namespace chip {
 namespace app {
 namespace clusters {
 
-namespace AccountLogin {
+namespace PowerConfiguration {
 
-} // namespace AccountLogin
-namespace AdministratorCommissioning {
-// Enum for StatusCode
-enum class StatusCode : uint8_t
+} // namespace PowerConfiguration
+namespace DeviceTemperatureConfiguration {
+
+} // namespace DeviceTemperatureConfiguration
+namespace Identify {
+
+} // namespace Identify
+namespace Groups {
+
+} // namespace Groups
+namespace Scenes {
+
+} // namespace Scenes
+namespace OnOff {
+// Enum for OnOffDelayedAllOffEffectVariant
+enum class OnOffDelayedAllOffEffectVariant : uint8_t
 {
-    STATUS_CODE_SUCCESS       = 0x00,
-    STATUS_CODE_BUSY          = 0x01,
-    STATUS_CODE_GENERAL_ERROR = 0x02,
+    ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_FADE_TO_OFF_IN_0P8_SECONDS                                        = 0x00,
+    ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_NO_FADE                                                           = 0x01,
+    ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_50_PERCENT_DIM_DOWN_IN_0P8_SECONDS_THEN_FADE_TO_OFF_IN_12_SECONDS = 0x02,
+};
+// Enum for OnOffDyingLightEffectVariant
+enum class OnOffDyingLightEffectVariant : uint8_t
+{
+    ON_OFF_DYING_LIGHT_EFFECT_VARIANT_20_PERCENTER_DIM_UP_IN_0P5_SECONDS_THEN_FADE_TO_OFF_IN_1_SECOND = 0x00,
+};
+// Enum for OnOffEffectIdentifier
+enum class OnOffEffectIdentifier : uint8_t
+{
+    ON_OFF_EFFECT_IDENTIFIER_DELAYED_ALL_OFF = 0x00,
+    ON_OFF_EFFECT_IDENTIFIER_DYING_LIGHT     = 0x01,
 };
 
-} // namespace AdministratorCommissioning
-namespace ApplicationBasic {
-// Enum for ApplicationBasicStatus
-enum class ApplicationBasicStatus : uint8_t
-{
-    APPLICATION_BASIC_STATUS_STOPPED                  = 0x00,
-    APPLICATION_BASIC_STATUS_ACTIVE_VISIBLE_FOCUS     = 0x01,
-    APPLICATION_BASIC_STATUS_ACTIVE_HIDDEN            = 0x02,
-    APPLICATION_BASIC_STATUS_ACTIVE_VISIBLE_NOT_FOCUS = 0x03,
-};
+} // namespace OnOff
+namespace OnOffSwitchConfiguration {
 
-} // namespace ApplicationBasic
-namespace ApplicationLauncher {
-// Enum for ApplicationLauncherStatus
-enum class ApplicationLauncherStatus : uint8_t
-{
-    APPLICATION_LAUNCHER_STATUS_SUCCESS           = 0x00,
-    APPLICATION_LAUNCHER_STATUS_APP_NOT_AVAILABLE = 0x01,
-    APPLICATION_LAUNCHER_STATUS_SYSTEM_BUSY       = 0x02,
-};
+} // namespace OnOffSwitchConfiguration
+namespace LevelControl {
 
-namespace ApplicationLauncherApp {
-enum FieldId
-{
-    kCatalogVendorIdFieldId = 0,
-    kApplicationIdFieldId   = 1,
-};
+} // namespace LevelControl
+namespace Alarms {
 
-struct Type
-{
-public:
-    uint16_t catalogVendorId;
-    Span<const char> applicationId;
+} // namespace Alarms
+namespace Time {
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ApplicationLauncherApp
-
-} // namespace ApplicationLauncher
-namespace AudioOutput {
-// Enum for AudioOutputType
-enum class AudioOutputType : uint8_t
-{
-    AUDIO_OUTPUT_TYPE_HDMI      = 0x00,
-    AUDIO_OUTPUT_TYPE_BT        = 0x01,
-    AUDIO_OUTPUT_TYPE_OPTICAL   = 0x02,
-    AUDIO_OUTPUT_TYPE_HEADPHONE = 0x03,
-    AUDIO_OUTPUT_TYPE_INTERNAL  = 0x04,
-    AUDIO_OUTPUT_TYPE_OTHER     = 0x05,
-};
-
-namespace AudioOutputInfo {
-enum FieldId
-{
-    kIndexFieldId      = 0,
-    kOutputTypeFieldId = 1,
-    kNameFieldId       = 2,
-};
-
-struct Type
-{
-public:
-    uint8_t index;
-    AudioOutputType outputType;
-    chip::ByteSpan name;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace AudioOutputInfo
-
-} // namespace AudioOutput
-namespace BarrierControl {
-
-} // namespace BarrierControl
-namespace Basic {
-
-} // namespace Basic
+} // namespace Time
 namespace BinaryInputBasic {
 
 } // namespace BinaryInputBasic
-namespace Binding {
+namespace PowerProfile {
 
-} // namespace Binding
-namespace BridgedDeviceBasic {
+} // namespace PowerProfile
+namespace ApplianceControl {
 
-} // namespace BridgedDeviceBasic
-namespace ColorControl {
-
-} // namespace ColorControl
-namespace ContentLauncher {
-// Enum for ContentLaunchMetricType
-enum class ContentLaunchMetricType : uint8_t
-{
-    CONTENT_LAUNCH_METRIC_TYPE_PIXELS     = 0x00,
-    CONTENT_LAUNCH_METRIC_TYPE_PERCENTAGE = 0x01,
-};
-// Enum for ContentLaunchParameterEnum
-enum class ContentLaunchParameterEnum : uint8_t
-{
-    CONTENT_LAUNCH_PARAMETER_ENUM_ACTOR       = 0x00,
-    CONTENT_LAUNCH_PARAMETER_ENUM_CHANNEL     = 0x01,
-    CONTENT_LAUNCH_PARAMETER_ENUM_CHARACTER   = 0x02,
-    CONTENT_LAUNCH_PARAMETER_ENUM_EVENT       = 0x03,
-    CONTENT_LAUNCH_PARAMETER_ENUM_FRANCHISE   = 0x04,
-    CONTENT_LAUNCH_PARAMETER_ENUM_GENRE       = 0x05,
-    CONTENT_LAUNCH_PARAMETER_ENUM_LEAGUE      = 0x06,
-    CONTENT_LAUNCH_PARAMETER_ENUM_POPULARITY  = 0x07,
-    CONTENT_LAUNCH_PARAMETER_ENUM_SPORT       = 0x08,
-    CONTENT_LAUNCH_PARAMETER_ENUM_SPORTS_TEAM = 0x09,
-    CONTENT_LAUNCH_PARAMETER_ENUM_VIDEO       = 0x0A,
-};
-// Enum for ContentLaunchStatus
-enum class ContentLaunchStatus : uint8_t
-{
-    CONTENT_LAUNCH_STATUS_SUCCESS           = 0x00,
-    CONTENT_LAUNCH_STATUS_URL_NOT_AVAILABLE = 0x01,
-    CONTENT_LAUNCH_STATUS_AUTH_FAILED       = 0x02,
-};
-// Enum for ContentLaunchStreamingType
-enum class ContentLaunchStreamingType : uint8_t
-{
-    CONTENT_LAUNCH_STREAMING_TYPE_DASH = 0x00,
-    CONTENT_LAUNCH_STREAMING_TYPE_HLS  = 0x01,
-};
-
-namespace ContentLaunchAdditionalInfo {
-enum FieldId
-{
-    kNameFieldId  = 0,
-    kValueFieldId = 1,
-};
-
-struct Type
-{
-public:
-    Span<const char> name;
-    Span<const char> value;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ContentLaunchAdditionalInfo
-namespace ContentLaunchParamater {
-enum FieldId
-{
-    kTypeFieldId           = 0,
-    kValueFieldId          = 1,
-    kExternalIDListFieldId = 2,
-};
-
-struct Type
-{
-public:
-    ContentLaunchParameterEnum type;
-    Span<const char> value;
-    DataModel::List<ContentLaunchAdditionalInfo::Type> externalIDList;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-struct DecodableType
-{
-public:
-    ContentLaunchParameterEnum type;
-    Span<const char> value;
-    DataModel::DecodableList<ContentLaunchAdditionalInfo::Type> externalIDList;
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ContentLaunchParamater
-namespace ContentLaunchBrandingInformation {
-enum FieldId
-{
-    kProviderNameFieldId = 0,
-    kBackgroundFieldId   = 1,
-    kLogoFieldId         = 2,
-    kProgressBarFieldId  = 3,
-    kSplashFieldId       = 4,
-    kWaterMarkFieldId    = 5,
-};
-
-struct Type
-{
-public:
-    Span<const char> providerName;
-    uint8_t background;
-    uint8_t logo;
-    uint8_t progressBar;
-    uint8_t splash;
-    uint8_t waterMark;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ContentLaunchBrandingInformation
-namespace ContentLaunchDimension {
-enum FieldId
-{
-    kWidthFieldId  = 0,
-    kHeightFieldId = 1,
-    kMetricFieldId = 2,
-};
-
-struct Type
-{
-public:
-    Span<const char> width;
-    Span<const char> height;
-    ContentLaunchMetricType metric;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ContentLaunchDimension
-namespace ContentLaunchStyleInformation {
-enum FieldId
-{
-    kImageUrlFieldId = 0,
-    kColorFieldId    = 1,
-    kSizeFieldId     = 2,
-};
-
-struct Type
-{
-public:
-    Span<const char> imageUrl;
-    Span<const char> color;
-    uint8_t size;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ContentLaunchStyleInformation
-
-} // namespace ContentLauncher
+} // namespace ApplianceControl
 namespace Descriptor {
 
 namespace DeviceType {
@@ -308,79 +108,50 @@ public:
 } // namespace DeviceType
 
 } // namespace Descriptor
-namespace DiagnosticLogs {
-// Enum for LogsIntent
-enum class LogsIntent : uint8_t
-{
-    LOGS_INTENT_END_USER_SUPPORT = 0x00,
-    LOGS_INTENT_NETWORK_DIAG     = 0x01,
-    LOGS_INTENT_CRASH_LOGS       = 0x02,
-};
-// Enum for LogsStatus
-enum class LogsStatus : uint8_t
-{
-    LOGS_STATUS_SUCCESS   = 0x00,
-    LOGS_STATUS_EXHAUSTED = 0x01,
-    LOGS_STATUS_NO_LOGS   = 0x02,
-    LOGS_STATUS_BUSY      = 0x03,
-    LOGS_STATUS_DENIED    = 0x04,
-};
-// Enum for LogsTransferProtocol
-enum class LogsTransferProtocol : uint8_t
-{
-    LOGS_TRANSFER_PROTOCOL_RESPONSE_PAYLOAD = 0x00,
-    LOGS_TRANSFER_PROTOCOL_BDX              = 0x01,
-};
+namespace PollControl {
 
-} // namespace DiagnosticLogs
-namespace DoorLock {
+} // namespace PollControl
+namespace Basic {
 
-} // namespace DoorLock
-namespace ElectricalMeasurement {
-
-} // namespace ElectricalMeasurement
-namespace EthernetNetworkDiagnostics {
-// Enum for PHYRateType
-enum class PHYRateType : uint8_t
+} // namespace Basic
+namespace OtaSoftwareUpdateProvider {
+// Enum for OTAApplyUpdateAction
+enum class OTAApplyUpdateAction : uint8_t
 {
-    PHY_RATE_TYPE_10_M   = 0x00,
-    PHY_RATE_TYPE_100_M  = 0x01,
-    PHY_RATE_TYPE_1000_M = 0x02,
-    PHY_RATE_TYPE_2__5_G = 0x03,
-    PHY_RATE_TYPE_5_G    = 0x04,
-    PHY_RATE_TYPE_10_G   = 0x05,
-    PHY_RATE_TYPE_40_G   = 0x06,
-    PHY_RATE_TYPE_100_G  = 0x07,
-    PHY_RATE_TYPE_200_G  = 0x08,
-    PHY_RATE_TYPE_400_G  = 0x09,
+    OTA_APPLY_UPDATE_ACTION_PROCEED           = 0x00,
+    OTA_APPLY_UPDATE_ACTION_AWAIT_NEXT_ACTION = 0x01,
+    OTA_APPLY_UPDATE_ACTION_DISCONTINUE       = 0x02,
+};
+// Enum for OTADownloadProtocol
+enum class OTADownloadProtocol : uint8_t
+{
+    OTA_DOWNLOAD_PROTOCOL_BDX_SYNCHRONOUS  = 0x00,
+    OTA_DOWNLOAD_PROTOCOL_BDX_ASYNCHRONOUS = 0x01,
+    OTA_DOWNLOAD_PROTOCOL_HTTPS            = 0x02,
+    OTA_DOWNLOAD_PROTOCOL_VENDOR_SPECIFIC  = 0x03,
+};
+// Enum for OTAQueryStatus
+enum class OTAQueryStatus : uint8_t
+{
+    OTA_QUERY_STATUS_UPDATE_AVAILABLE = 0x00,
+    OTA_QUERY_STATUS_BUSY             = 0x01,
+    OTA_QUERY_STATUS_NOT_AVAILABLE    = 0x02,
 };
 
-} // namespace EthernetNetworkDiagnostics
-namespace FixedLabel {
-
-namespace LabelStruct {
-enum FieldId
+} // namespace OtaSoftwareUpdateProvider
+namespace OtaSoftwareUpdateRequestor {
+// Enum for OTAAnnouncementReason
+enum class OTAAnnouncementReason : uint8_t
 {
-    kLabelFieldId = 0,
-    kValueFieldId = 1,
+    OTA_ANNOUNCEMENT_REASON_SIMPLE_ANNOUNCEMENT     = 0x00,
+    OTA_ANNOUNCEMENT_REASON_UPDATE_AVAILABLE        = 0x01,
+    OTA_ANNOUNCEMENT_REASON_URGENT_UPDATE_AVAILABLE = 0x02,
 };
 
-struct Type
-{
-public:
-    chip::ByteSpan label;
-    chip::ByteSpan value;
+} // namespace OtaSoftwareUpdateRequestor
+namespace PowerSource {
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace LabelStruct
-
-} // namespace FixedLabel
-namespace FlowMeasurement {
-
-} // namespace FlowMeasurement
+} // namespace PowerSource
 namespace GeneralCommissioning {
 // Enum for GeneralCommissioningError
 enum class GeneralCommissioningError : uint8_t
@@ -415,6 +186,99 @@ public:
 } // namespace BasicCommissioningInfoType
 
 } // namespace GeneralCommissioning
+namespace NetworkCommissioning {
+// Enum for NetworkCommissioningError
+enum class NetworkCommissioningError : uint8_t
+{
+    NETWORK_COMMISSIONING_ERROR_SUCCESS                  = 0x00,
+    NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE             = 0x01,
+    NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED          = 0x02,
+    NETWORK_COMMISSIONING_ERROR_NETWORK_ID_NOT_FOUND     = 0x03,
+    NETWORK_COMMISSIONING_ERROR_DUPLICATE_NETWORK_ID     = 0x04,
+    NETWORK_COMMISSIONING_ERROR_NETWORK_NOT_FOUND        = 0x05,
+    NETWORK_COMMISSIONING_ERROR_REGULATORY_ERROR         = 0x06,
+    NETWORK_COMMISSIONING_ERROR_AUTH_FAILURE             = 0x07,
+    NETWORK_COMMISSIONING_ERROR_UNSUPPORTED_SECURITY     = 0x08,
+    NETWORK_COMMISSIONING_ERROR_OTHER_CONNECTION_FAILURE = 0x09,
+    NETWORK_COMMISSIONING_ERROR_IPV6_FAILED              = 0x0A,
+    NETWORK_COMMISSIONING_ERROR_IP_BIND_FAILED           = 0x0B,
+    NETWORK_COMMISSIONING_ERROR_LABEL9                   = 0x0C,
+    NETWORK_COMMISSIONING_ERROR_LABEL10                  = 0x0D,
+    NETWORK_COMMISSIONING_ERROR_LABEL11                  = 0x0E,
+    NETWORK_COMMISSIONING_ERROR_LABEL12                  = 0x0F,
+    NETWORK_COMMISSIONING_ERROR_LABEL13                  = 0x10,
+    NETWORK_COMMISSIONING_ERROR_LABEL14                  = 0x11,
+    NETWORK_COMMISSIONING_ERROR_LABEL15                  = 0x12,
+    NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR            = 0x13,
+};
+
+namespace ThreadInterfaceScanResult {
+enum FieldId
+{
+    kDiscoveryResponseFieldId = 0,
+};
+
+struct Type
+{
+public:
+    chip::ByteSpan discoveryResponse;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ThreadInterfaceScanResult
+namespace WiFiInterfaceScanResult {
+enum FieldId
+{
+    kSecurityFieldId      = 0,
+    kSsidFieldId          = 1,
+    kBssidFieldId         = 2,
+    kChannelFieldId       = 3,
+    kFrequencyBandFieldId = 4,
+};
+
+struct Type
+{
+public:
+    uint8_t security;
+    chip::ByteSpan ssid;
+    chip::ByteSpan bssid;
+    uint8_t channel;
+    uint32_t frequencyBand;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace WiFiInterfaceScanResult
+
+} // namespace NetworkCommissioning
+namespace DiagnosticLogs {
+// Enum for LogsIntent
+enum class LogsIntent : uint8_t
+{
+    LOGS_INTENT_END_USER_SUPPORT = 0x00,
+    LOGS_INTENT_NETWORK_DIAG     = 0x01,
+    LOGS_INTENT_CRASH_LOGS       = 0x02,
+};
+// Enum for LogsStatus
+enum class LogsStatus : uint8_t
+{
+    LOGS_STATUS_SUCCESS   = 0x00,
+    LOGS_STATUS_EXHAUSTED = 0x01,
+    LOGS_STATUS_NO_LOGS   = 0x02,
+    LOGS_STATUS_BUSY      = 0x03,
+    LOGS_STATUS_DENIED    = 0x04,
+};
+// Enum for LogsTransferProtocol
+enum class LogsTransferProtocol : uint8_t
+{
+    LOGS_TRANSFER_PROTOCOL_RESPONSE_PAYLOAD = 0x00,
+    LOGS_TRANSFER_PROTOCOL_BDX              = 0x01,
+};
+
+} // namespace DiagnosticLogs
 namespace GeneralDiagnostics {
 // Enum for BootReasonType
 enum class BootReasonType : uint8_t
@@ -499,479 +363,6 @@ public:
 } // namespace NetworkInterfaceType
 
 } // namespace GeneralDiagnostics
-namespace GroupKeyManagement {
-// Enum for GroupKeySecurityPolicy
-enum class GroupKeySecurityPolicy : uint8_t
-{
-    GROUP_KEY_SECURITY_POLICY_STANDARD    = 0x00,
-    GROUP_KEY_SECURITY_POLICY_LOW_LATENCY = 0x01,
-};
-
-namespace GroupKey {
-enum FieldId
-{
-    kVendorIdFieldId               = 0,
-    kGroupKeyIndexFieldId          = 1,
-    kGroupKeyRootFieldId           = 2,
-    kGroupKeyEpochStartTimeFieldId = 3,
-    kGroupKeySecurityPolicyFieldId = 4,
-};
-
-struct Type
-{
-public:
-    uint16_t vendorId;
-    uint16_t groupKeyIndex;
-    chip::ByteSpan groupKeyRoot;
-    uint64_t groupKeyEpochStartTime;
-    GroupKeySecurityPolicy groupKeySecurityPolicy;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace GroupKey
-namespace GroupState {
-enum FieldId
-{
-    kVendorIdFieldId         = 0,
-    kVendorGroupIdFieldId    = 1,
-    kGroupKeySetIndexFieldId = 2,
-};
-
-struct Type
-{
-public:
-    uint16_t vendorId;
-    uint16_t vendorGroupId;
-    uint16_t groupKeySetIndex;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace GroupState
-
-} // namespace GroupKeyManagement
-namespace Groups {
-
-} // namespace Groups
-namespace Identify {
-
-} // namespace Identify
-namespace KeypadInput {
-// Enum for KeypadInputCecKeyCode
-enum class KeypadInputCecKeyCode : uint8_t
-{
-    KEYPAD_INPUT_CEC_KEY_CODE_SELECT                       = 0x00,
-    KEYPAD_INPUT_CEC_KEY_CODE_UP                           = 0x01,
-    KEYPAD_INPUT_CEC_KEY_CODE_DOWN                         = 0x02,
-    KEYPAD_INPUT_CEC_KEY_CODE_LEFT                         = 0x03,
-    KEYPAD_INPUT_CEC_KEY_CODE_RIGHT                        = 0x04,
-    KEYPAD_INPUT_CEC_KEY_CODE_RIGHT_UP                     = 0x05,
-    KEYPAD_INPUT_CEC_KEY_CODE_RIGHT_DOWN                   = 0x06,
-    KEYPAD_INPUT_CEC_KEY_CODE_LEFT_UP                      = 0x07,
-    KEYPAD_INPUT_CEC_KEY_CODE_LEFT_DOWN                    = 0x08,
-    KEYPAD_INPUT_CEC_KEY_CODE_ROOT_MENU                    = 0x09,
-    KEYPAD_INPUT_CEC_KEY_CODE_SETUP_MENU                   = 0x0A,
-    KEYPAD_INPUT_CEC_KEY_CODE_CONTENTS_MENU                = 0x0B,
-    KEYPAD_INPUT_CEC_KEY_CODE_FAVORITE_MENU                = 0x0C,
-    KEYPAD_INPUT_CEC_KEY_CODE_EXIT                         = 0x0D,
-    KEYPAD_INPUT_CEC_KEY_CODE_MEDIA_TOP_MENU               = 0x10,
-    KEYPAD_INPUT_CEC_KEY_CODE_MEDIA_CONTEXT_SENSITIVE_MENU = 0x11,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER_ENTRY_MODE            = 0x1D,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER11                     = 0x1E,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER12                     = 0x1F,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER0_OR_NUMBER10          = 0x20,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS1                     = 0x21,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS2                     = 0x22,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS3                     = 0x23,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS4                     = 0x24,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS5                     = 0x25,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS6                     = 0x26,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS7                     = 0x27,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS8                     = 0x28,
-    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS9                     = 0x29,
-    KEYPAD_INPUT_CEC_KEY_CODE_DOT                          = 0x2A,
-    KEYPAD_INPUT_CEC_KEY_CODE_ENTER                        = 0x2B,
-    KEYPAD_INPUT_CEC_KEY_CODE_CLEAR                        = 0x2C,
-    KEYPAD_INPUT_CEC_KEY_CODE_NEXT_FAVORITE                = 0x2F,
-    KEYPAD_INPUT_CEC_KEY_CODE_CHANNEL_UP                   = 0x30,
-    KEYPAD_INPUT_CEC_KEY_CODE_CHANNEL_DOWN                 = 0x31,
-    KEYPAD_INPUT_CEC_KEY_CODE_PREVIOUS_CHANNEL             = 0x32,
-    KEYPAD_INPUT_CEC_KEY_CODE_SOUND_SELECT                 = 0x33,
-    KEYPAD_INPUT_CEC_KEY_CODE_INPUT_SELECT                 = 0x34,
-    KEYPAD_INPUT_CEC_KEY_CODE_DISPLAY_INFORMATION          = 0x35,
-    KEYPAD_INPUT_CEC_KEY_CODE_HELP                         = 0x36,
-    KEYPAD_INPUT_CEC_KEY_CODE_PAGE_UP                      = 0x37,
-    KEYPAD_INPUT_CEC_KEY_CODE_PAGE_DOWN                    = 0x38,
-    KEYPAD_INPUT_CEC_KEY_CODE_POWER                        = 0x40,
-    KEYPAD_INPUT_CEC_KEY_CODE_VOLUME_UP                    = 0x41,
-    KEYPAD_INPUT_CEC_KEY_CODE_VOLUME_DOWN                  = 0x42,
-    KEYPAD_INPUT_CEC_KEY_CODE_MUTE                         = 0x43,
-    KEYPAD_INPUT_CEC_KEY_CODE_PLAY                         = 0x44,
-    KEYPAD_INPUT_CEC_KEY_CODE_STOP                         = 0x45,
-    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE                        = 0x46,
-    KEYPAD_INPUT_CEC_KEY_CODE_RECORD                       = 0x47,
-    KEYPAD_INPUT_CEC_KEY_CODE_REWIND                       = 0x48,
-    KEYPAD_INPUT_CEC_KEY_CODE_FAST_FORWARD                 = 0x49,
-    KEYPAD_INPUT_CEC_KEY_CODE_EJECT                        = 0x4A,
-    KEYPAD_INPUT_CEC_KEY_CODE_FORWARD                      = 0x4B,
-    KEYPAD_INPUT_CEC_KEY_CODE_BACKWARD                     = 0x4C,
-    KEYPAD_INPUT_CEC_KEY_CODE_STOP_RECORD                  = 0x4D,
-    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE_RECORD                 = 0x4E,
-    KEYPAD_INPUT_CEC_KEY_CODE_RESERVED                     = 0x4F,
-    KEYPAD_INPUT_CEC_KEY_CODE_ANGLE                        = 0x50,
-    KEYPAD_INPUT_CEC_KEY_CODE_SUB_PICTURE                  = 0x51,
-    KEYPAD_INPUT_CEC_KEY_CODE_VIDEO_ON_DEMAND              = 0x52,
-    KEYPAD_INPUT_CEC_KEY_CODE_ELECTRONIC_PROGRAM_GUIDE     = 0x53,
-    KEYPAD_INPUT_CEC_KEY_CODE_TIMER_PROGRAMMING            = 0x54,
-    KEYPAD_INPUT_CEC_KEY_CODE_INITIAL_CONFIGURATION        = 0x55,
-    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_BROADCAST_TYPE        = 0x56,
-    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_SOUND_PRESENTATION    = 0x57,
-    KEYPAD_INPUT_CEC_KEY_CODE_PLAY_FUNCTION                = 0x60,
-    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE_PLAY_FUNCTION          = 0x61,
-    KEYPAD_INPUT_CEC_KEY_CODE_RECORD_FUNCTION              = 0x62,
-    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE_RECORD_FUNCTION        = 0x63,
-    KEYPAD_INPUT_CEC_KEY_CODE_STOP_FUNCTION                = 0x64,
-    KEYPAD_INPUT_CEC_KEY_CODE_MUTE_FUNCTION                = 0x65,
-    KEYPAD_INPUT_CEC_KEY_CODE_RESTORE_VOLUME_FUNCTION      = 0x66,
-    KEYPAD_INPUT_CEC_KEY_CODE_TUNE_FUNCTION                = 0x67,
-    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_MEDIA_FUNCTION        = 0x68,
-    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_AV_INPUT_FUNCTION     = 0x69,
-    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_AUDIO_INPUT_FUNCTION  = 0x6A,
-    KEYPAD_INPUT_CEC_KEY_CODE_POWER_TOGGLE_FUNCTION        = 0x6B,
-    KEYPAD_INPUT_CEC_KEY_CODE_POWER_OFF_FUNCTION           = 0x6C,
-    KEYPAD_INPUT_CEC_KEY_CODE_POWER_ON_FUNCTION            = 0x6D,
-    KEYPAD_INPUT_CEC_KEY_CODE_F1_BLUE                      = 0x71,
-    KEYPAD_INPUT_CEC_KEY_CODE_F2_RED                       = 0x72,
-    KEYPAD_INPUT_CEC_KEY_CODE_F3_GREEN                     = 0x73,
-    KEYPAD_INPUT_CEC_KEY_CODE_F4_YELLOW                    = 0x74,
-    KEYPAD_INPUT_CEC_KEY_CODE_F5                           = 0x75,
-    KEYPAD_INPUT_CEC_KEY_CODE_DATA                         = 0x76,
-};
-// Enum for KeypadInputStatus
-enum class KeypadInputStatus : uint8_t
-{
-    KEYPAD_INPUT_STATUS_SUCCESS                      = 0x00,
-    KEYPAD_INPUT_STATUS_UNSUPPORTED_KEY              = 0x01,
-    KEYPAD_INPUT_STATUS_INVALID_KEY_IN_CURRENT_STATE = 0x02,
-};
-
-} // namespace KeypadInput
-namespace LevelControl {
-
-} // namespace LevelControl
-namespace LowPower {
-
-} // namespace LowPower
-namespace MediaInput {
-// Enum for MediaInputType
-enum class MediaInputType : uint8_t
-{
-    MEDIA_INPUT_TYPE_INTERNAL  = 0x00,
-    MEDIA_INPUT_TYPE_AUX       = 0x01,
-    MEDIA_INPUT_TYPE_COAX      = 0x02,
-    MEDIA_INPUT_TYPE_COMPOSITE = 0x03,
-    MEDIA_INPUT_TYPE_HDMI      = 0x04,
-    MEDIA_INPUT_TYPE_INPUT     = 0x05,
-    MEDIA_INPUT_TYPE_LINE      = 0x06,
-    MEDIA_INPUT_TYPE_OPTICAL   = 0x07,
-    MEDIA_INPUT_TYPE_VIDEO     = 0x08,
-    MEDIA_INPUT_TYPE_SCART     = 0x09,
-    MEDIA_INPUT_TYPE_USB       = 0x0A,
-    MEDIA_INPUT_TYPE_OTHER     = 0x0B,
-};
-
-namespace MediaInputInfo {
-enum FieldId
-{
-    kIndexFieldId       = 0,
-    kInputTypeFieldId   = 1,
-    kNameFieldId        = 2,
-    kDescriptionFieldId = 3,
-};
-
-struct Type
-{
-public:
-    uint8_t index;
-    MediaInputType inputType;
-    chip::ByteSpan name;
-    chip::ByteSpan description;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace MediaInputInfo
-
-} // namespace MediaInput
-namespace MediaPlayback {
-// Enum for MediaPlaybackState
-enum class MediaPlaybackState : uint8_t
-{
-    MEDIA_PLAYBACK_STATE_PLAYING     = 0x00,
-    MEDIA_PLAYBACK_STATE_PAUSED      = 0x01,
-    MEDIA_PLAYBACK_STATE_NOT_PLAYING = 0x02,
-    MEDIA_PLAYBACK_STATE_BUFFERING   = 0x03,
-};
-// Enum for MediaPlaybackStatus
-enum class MediaPlaybackStatus : uint8_t
-{
-    MEDIA_PLAYBACK_STATUS_SUCCESS                   = 0x00,
-    MEDIA_PLAYBACK_STATUS_INVALID_STATE_FOR_COMMAND = 0x01,
-    MEDIA_PLAYBACK_STATUS_NOT_ALLOWED               = 0x02,
-    MEDIA_PLAYBACK_STATUS_NOT_ACTIVE                = 0x03,
-    MEDIA_PLAYBACK_STATUS_SPEED_OUT_OF_RANGE        = 0x04,
-    MEDIA_PLAYBACK_STATUS_SEEK_OUT_OF_RANGE         = 0x05,
-};
-
-namespace MediaPlaybackPosition {
-enum FieldId
-{
-    kUpdatedAtFieldId = 0,
-    kPositionFieldId  = 1,
-};
-
-struct Type
-{
-public:
-    uint64_t updatedAt;
-    uint64_t position;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace MediaPlaybackPosition
-
-} // namespace MediaPlayback
-namespace NetworkCommissioning {
-// Enum for NetworkCommissioningError
-enum class NetworkCommissioningError : uint8_t
-{
-    NETWORK_COMMISSIONING_ERROR_SUCCESS                  = 0x00,
-    NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE             = 0x01,
-    NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED          = 0x02,
-    NETWORK_COMMISSIONING_ERROR_NETWORK_ID_NOT_FOUND     = 0x03,
-    NETWORK_COMMISSIONING_ERROR_DUPLICATE_NETWORK_ID     = 0x04,
-    NETWORK_COMMISSIONING_ERROR_NETWORK_NOT_FOUND        = 0x05,
-    NETWORK_COMMISSIONING_ERROR_REGULATORY_ERROR         = 0x06,
-    NETWORK_COMMISSIONING_ERROR_AUTH_FAILURE             = 0x07,
-    NETWORK_COMMISSIONING_ERROR_UNSUPPORTED_SECURITY     = 0x08,
-    NETWORK_COMMISSIONING_ERROR_OTHER_CONNECTION_FAILURE = 0x09,
-    NETWORK_COMMISSIONING_ERROR_IPV6_FAILED              = 0x0A,
-    NETWORK_COMMISSIONING_ERROR_IP_BIND_FAILED           = 0x0B,
-    NETWORK_COMMISSIONING_ERROR_LABEL9                   = 0x0C,
-    NETWORK_COMMISSIONING_ERROR_LABEL10                  = 0x0D,
-    NETWORK_COMMISSIONING_ERROR_LABEL11                  = 0x0E,
-    NETWORK_COMMISSIONING_ERROR_LABEL12                  = 0x0F,
-    NETWORK_COMMISSIONING_ERROR_LABEL13                  = 0x10,
-    NETWORK_COMMISSIONING_ERROR_LABEL14                  = 0x11,
-    NETWORK_COMMISSIONING_ERROR_LABEL15                  = 0x12,
-    NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR            = 0x13,
-};
-
-namespace ThreadInterfaceScanResult {
-enum FieldId
-{
-    kDiscoveryResponseFieldId = 0,
-};
-
-struct Type
-{
-public:
-    chip::ByteSpan discoveryResponse;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace ThreadInterfaceScanResult
-namespace WiFiInterfaceScanResult {
-enum FieldId
-{
-    kSecurityFieldId      = 0,
-    kSsidFieldId          = 1,
-    kBssidFieldId         = 2,
-    kChannelFieldId       = 3,
-    kFrequencyBandFieldId = 4,
-};
-
-struct Type
-{
-public:
-    uint8_t security;
-    chip::ByteSpan ssid;
-    chip::ByteSpan bssid;
-    uint8_t channel;
-    uint32_t frequencyBand;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace WiFiInterfaceScanResult
-
-} // namespace NetworkCommissioning
-namespace OtaSoftwareUpdateProvider {
-// Enum for OTAApplyUpdateAction
-enum class OTAApplyUpdateAction : uint8_t
-{
-    OTA_APPLY_UPDATE_ACTION_PROCEED           = 0x00,
-    OTA_APPLY_UPDATE_ACTION_AWAIT_NEXT_ACTION = 0x01,
-    OTA_APPLY_UPDATE_ACTION_DISCONTINUE       = 0x02,
-};
-// Enum for OTADownloadProtocol
-enum class OTADownloadProtocol : uint8_t
-{
-    OTA_DOWNLOAD_PROTOCOL_BDX_SYNCHRONOUS  = 0x00,
-    OTA_DOWNLOAD_PROTOCOL_BDX_ASYNCHRONOUS = 0x01,
-    OTA_DOWNLOAD_PROTOCOL_HTTPS            = 0x02,
-    OTA_DOWNLOAD_PROTOCOL_VENDOR_SPECIFIC  = 0x03,
-};
-// Enum for OTAQueryStatus
-enum class OTAQueryStatus : uint8_t
-{
-    OTA_QUERY_STATUS_UPDATE_AVAILABLE = 0x00,
-    OTA_QUERY_STATUS_BUSY             = 0x01,
-    OTA_QUERY_STATUS_NOT_AVAILABLE    = 0x02,
-};
-
-} // namespace OtaSoftwareUpdateProvider
-namespace OtaSoftwareUpdateRequestor {
-// Enum for OTAAnnouncementReason
-enum class OTAAnnouncementReason : uint8_t
-{
-    OTA_ANNOUNCEMENT_REASON_SIMPLE_ANNOUNCEMENT     = 0x00,
-    OTA_ANNOUNCEMENT_REASON_UPDATE_AVAILABLE        = 0x01,
-    OTA_ANNOUNCEMENT_REASON_URGENT_UPDATE_AVAILABLE = 0x02,
-};
-
-} // namespace OtaSoftwareUpdateRequestor
-namespace OccupancySensing {
-
-} // namespace OccupancySensing
-namespace OnOff {
-// Enum for OnOffDelayedAllOffEffectVariant
-enum class OnOffDelayedAllOffEffectVariant : uint8_t
-{
-    ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_FADE_TO_OFF_IN_0P8_SECONDS                                        = 0x00,
-    ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_NO_FADE                                                           = 0x01,
-    ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_50_PERCENT_DIM_DOWN_IN_0P8_SECONDS_THEN_FADE_TO_OFF_IN_12_SECONDS = 0x02,
-};
-// Enum for OnOffDyingLightEffectVariant
-enum class OnOffDyingLightEffectVariant : uint8_t
-{
-    ON_OFF_DYING_LIGHT_EFFECT_VARIANT_20_PERCENTER_DIM_UP_IN_0P5_SECONDS_THEN_FADE_TO_OFF_IN_1_SECOND = 0x00,
-};
-// Enum for OnOffEffectIdentifier
-enum class OnOffEffectIdentifier : uint8_t
-{
-    ON_OFF_EFFECT_IDENTIFIER_DELAYED_ALL_OFF = 0x00,
-    ON_OFF_EFFECT_IDENTIFIER_DYING_LIGHT     = 0x01,
-};
-
-} // namespace OnOff
-namespace OnOffSwitchConfiguration {
-
-} // namespace OnOffSwitchConfiguration
-namespace OperationalCredentials {
-// Enum for NodeOperationalCertStatus
-enum class NodeOperationalCertStatus : uint8_t
-{
-    NODE_OPERATIONAL_CERT_STATUS_SUCCESS                = 0x00,
-    NODE_OPERATIONAL_CERT_STATUS_INVALID_PUBLIC_KEY     = 0x01,
-    NODE_OPERATIONAL_CERT_STATUS_INVALID_NODE_OP_ID     = 0x02,
-    NODE_OPERATIONAL_CERT_STATUS_INVALID_NOC            = 0x03,
-    NODE_OPERATIONAL_CERT_STATUS_MISSING_CSR            = 0x04,
-    NODE_OPERATIONAL_CERT_STATUS_TABLE_FULL             = 0x05,
-    NODE_OPERATIONAL_CERT_STATUS_INSUFFICIENT_PRIVILEGE = 0x08,
-    NODE_OPERATIONAL_CERT_STATUS_FABRIC_CONFLICT        = 0x09,
-    NODE_OPERATIONAL_CERT_STATUS_LABEL_CONFLICT         = 0x0A,
-    NODE_OPERATIONAL_CERT_STATUS_INVALID_FABRIC_INDEX   = 0x0B,
-};
-
-namespace FabricDescriptor {
-enum FieldId
-{
-    kFabricIndexFieldId   = 0,
-    kRootPublicKeyFieldId = 1,
-    kVendorIdFieldId      = 2,
-    kFabricIdFieldId      = 3,
-    kNodeIdFieldId        = 4,
-    kLabelFieldId         = 5,
-};
-
-struct Type
-{
-public:
-    uint8_t fabricIndex;
-    chip::ByteSpan rootPublicKey;
-    uint16_t vendorId;
-    uint64_t fabricId;
-    uint64_t nodeId;
-    chip::ByteSpan label;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace FabricDescriptor
-namespace NOCStruct {
-enum FieldId
-{
-    kFabricIndexFieldId = 0,
-    kNocFieldId         = 1,
-};
-
-struct Type
-{
-public:
-    uint8_t fabricIndex;
-    chip::ByteSpan noc;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace NOCStruct
-
-} // namespace OperationalCredentials
-namespace PowerSource {
-
-} // namespace PowerSource
-namespace PressureMeasurement {
-
-} // namespace PressureMeasurement
-namespace PumpConfigurationAndControl {
-// Enum for PumpControlMode
-enum class PumpControlMode : uint8_t
-{
-    PUMP_CONTROL_MODE_CONSTANT_SPEED        = 0x00,
-    PUMP_CONTROL_MODE_CONSTANT_PRESSURE     = 0x01,
-    PUMP_CONTROL_MODE_PROPORTIONAL_PRESSURE = 0x02,
-    PUMP_CONTROL_MODE_CONSTANT_FLOW         = 0x03,
-    PUMP_CONTROL_MODE_CONSTANT_TEMPERATURE  = 0x05,
-    PUMP_CONTROL_MODE_AUTOMATIC             = 0x07,
-};
-// Enum for PumpOperationMode
-enum class PumpOperationMode : uint8_t
-{
-    PUMP_OPERATION_MODE_NORMAL  = 0x00,
-    PUMP_OPERATION_MODE_MINIMUM = 0x01,
-    PUMP_OPERATION_MODE_MAXIMUM = 0x02,
-    PUMP_OPERATION_MODE_LOCAL   = 0x03,
-};
-
-} // namespace PumpConfigurationAndControl
-namespace RelativeHumidityMeasurement {
-
-} // namespace RelativeHumidityMeasurement
-namespace Scenes {
-
-} // namespace Scenes
 namespace SoftwareDiagnostics {
 
 namespace ThreadMetrics {
@@ -1000,248 +391,6 @@ public:
 } // namespace ThreadMetrics
 
 } // namespace SoftwareDiagnostics
-namespace Switch {
-
-} // namespace Switch
-namespace TvChannel {
-// Enum for TvChannelErrorType
-enum class TvChannelErrorType : uint8_t
-{
-    TV_CHANNEL_ERROR_TYPE_MULTIPLE_MATCHES = 0x00,
-    TV_CHANNEL_ERROR_TYPE_NO_MATCHES       = 0x01,
-};
-// Enum for TvChannelLineupInfoType
-enum class TvChannelLineupInfoType : uint8_t
-{
-    TV_CHANNEL_LINEUP_INFO_TYPE_MSO = 0x00,
-};
-
-namespace TvChannelInfo {
-enum FieldId
-{
-    kMajorNumberFieldId       = 0,
-    kMinorNumberFieldId       = 1,
-    kNameFieldId              = 2,
-    kCallSignFieldId          = 3,
-    kAffiliateCallSignFieldId = 4,
-};
-
-struct Type
-{
-public:
-    uint16_t majorNumber;
-    uint16_t minorNumber;
-    chip::ByteSpan name;
-    chip::ByteSpan callSign;
-    chip::ByteSpan affiliateCallSign;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace TvChannelInfo
-namespace TvChannelLineupInfo {
-enum FieldId
-{
-    kOperatorNameFieldId   = 0,
-    kLineupNameFieldId     = 1,
-    kPostalCodeFieldId     = 2,
-    kLineupInfoTypeFieldId = 3,
-};
-
-struct Type
-{
-public:
-    Span<const char> operatorName;
-    Span<const char> lineupName;
-    Span<const char> postalCode;
-    TvChannelLineupInfoType lineupInfoType;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace TvChannelLineupInfo
-
-} // namespace TvChannel
-namespace TargetNavigator {
-// Enum for NavigateTargetStatus
-enum class NavigateTargetStatus : uint8_t
-{
-    NAVIGATE_TARGET_STATUS_SUCCESS           = 0x00,
-    NAVIGATE_TARGET_STATUS_APP_NOT_AVAILABLE = 0x01,
-    NAVIGATE_TARGET_STATUS_SYSTEM_BUSY       = 0x02,
-};
-
-namespace NavigateTargetTargetInfo {
-enum FieldId
-{
-    kIdentifierFieldId = 0,
-    kNameFieldId       = 1,
-};
-
-struct Type
-{
-public:
-    uint8_t identifier;
-    chip::ByteSpan name;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace NavigateTargetTargetInfo
-
-} // namespace TargetNavigator
-namespace TemperatureMeasurement {
-
-} // namespace TemperatureMeasurement
-namespace TestCluster {
-// Enum for SimpleEnum
-enum class SimpleEnum : uint8_t
-{
-    SIMPLE_ENUM_UNSPECIFIED = 0x00,
-    SIMPLE_ENUM_VALUE_A     = 0x01,
-    SIMPLE_ENUM_VALUE_B     = 0x02,
-    SIMPLE_ENUM_VALUE_C     = 0x03,
-};
-
-namespace SimpleStruct {
-enum FieldId
-{
-    kAFieldId = 0,
-    kBFieldId = 1,
-    kCFieldId = 2,
-    kDFieldId = 3,
-    kEFieldId = 4,
-};
-
-struct Type
-{
-public:
-    uint8_t a;
-    bool b;
-    SimpleEnum c;
-    chip::ByteSpan d;
-    Span<const char> e;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace SimpleStruct
-namespace NestedStruct {
-enum FieldId
-{
-    kAFieldId = 0,
-    kBFieldId = 1,
-    kCFieldId = 2,
-};
-
-struct Type
-{
-public:
-    uint8_t a;
-    bool b;
-    SimpleStruct::Type c;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace NestedStruct
-namespace NestedStructList {
-enum FieldId
-{
-    kAFieldId = 0,
-    kBFieldId = 1,
-    kCFieldId = 2,
-    kDFieldId = 3,
-    kEFieldId = 4,
-    kFFieldId = 5,
-    kGFieldId = 6,
-};
-
-struct Type
-{
-public:
-    uint8_t a;
-    bool b;
-    SimpleStruct::Type c;
-    DataModel::List<SimpleStruct::Type> d;
-    DataModel::List<uint32_t> e;
-    DataModel::List<chip::ByteSpan> f;
-    DataModel::List<uint8_t> g;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-struct DecodableType
-{
-public:
-    uint8_t a;
-    bool b;
-    SimpleStruct::Type c;
-    DataModel::DecodableList<SimpleStruct::Type> d;
-    DataModel::DecodableList<uint32_t> e;
-    DataModel::DecodableList<chip::ByteSpan> f;
-    DataModel::DecodableList<uint8_t> g;
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace NestedStructList
-namespace DoubleNestedStructList {
-enum FieldId
-{
-    kAFieldId = 0,
-};
-
-struct Type
-{
-public:
-    DataModel::List<NestedStructList::Type> a;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-struct DecodableType
-{
-public:
-    DataModel::DecodableList<NestedStructList::DecodableType> a;
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace DoubleNestedStructList
-namespace TestListStructOctet {
-enum FieldId
-{
-    kFabricIndexFieldId     = 0,
-    kOperationalCertFieldId = 1,
-};
-
-struct Type
-{
-public:
-    uint64_t fabricIndex;
-    chip::ByteSpan operationalCert;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-
-} // namespace TestListStructOctet
-
-} // namespace TestCluster
-namespace Thermostat {
-
-} // namespace Thermostat
-namespace ThermostatUserInterfaceConfiguration {
-
-} // namespace ThermostatUserInterfaceConfiguration
 namespace ThreadNetworkDiagnostics {
 // Enum for NetworkFault
 enum class NetworkFault : uint8_t
@@ -1397,9 +546,6 @@ public:
 } // namespace SecurityPolicy
 
 } // namespace ThreadNetworkDiagnostics
-namespace WakeOnLan {
-
-} // namespace WakeOnLan
 namespace WiFiNetworkDiagnostics {
 // Enum for SecurityType
 enum class SecurityType : uint8_t
@@ -1423,6 +569,129 @@ enum class WiFiVersionType : uint8_t
 };
 
 } // namespace WiFiNetworkDiagnostics
+namespace EthernetNetworkDiagnostics {
+// Enum for PHYRateType
+enum class PHYRateType : uint8_t
+{
+    PHY_RATE_TYPE_10_M   = 0x00,
+    PHY_RATE_TYPE_100_M  = 0x01,
+    PHY_RATE_TYPE_1000_M = 0x02,
+    PHY_RATE_TYPE_2__5_G = 0x03,
+    PHY_RATE_TYPE_5_G    = 0x04,
+    PHY_RATE_TYPE_10_G   = 0x05,
+    PHY_RATE_TYPE_40_G   = 0x06,
+    PHY_RATE_TYPE_100_G  = 0x07,
+    PHY_RATE_TYPE_200_G  = 0x08,
+    PHY_RATE_TYPE_400_G  = 0x09,
+};
+
+} // namespace EthernetNetworkDiagnostics
+namespace BridgedDeviceBasic {
+
+} // namespace BridgedDeviceBasic
+namespace Switch {
+
+} // namespace Switch
+namespace AdministratorCommissioning {
+// Enum for StatusCode
+enum class StatusCode : uint8_t
+{
+    STATUS_CODE_SUCCESS       = 0x00,
+    STATUS_CODE_BUSY          = 0x01,
+    STATUS_CODE_GENERAL_ERROR = 0x02,
+};
+
+} // namespace AdministratorCommissioning
+namespace OperationalCredentials {
+// Enum for NodeOperationalCertStatus
+enum class NodeOperationalCertStatus : uint8_t
+{
+    NODE_OPERATIONAL_CERT_STATUS_SUCCESS                = 0x00,
+    NODE_OPERATIONAL_CERT_STATUS_INVALID_PUBLIC_KEY     = 0x01,
+    NODE_OPERATIONAL_CERT_STATUS_INVALID_NODE_OP_ID     = 0x02,
+    NODE_OPERATIONAL_CERT_STATUS_INVALID_NOC            = 0x03,
+    NODE_OPERATIONAL_CERT_STATUS_MISSING_CSR            = 0x04,
+    NODE_OPERATIONAL_CERT_STATUS_TABLE_FULL             = 0x05,
+    NODE_OPERATIONAL_CERT_STATUS_INSUFFICIENT_PRIVILEGE = 0x08,
+    NODE_OPERATIONAL_CERT_STATUS_FABRIC_CONFLICT        = 0x09,
+    NODE_OPERATIONAL_CERT_STATUS_LABEL_CONFLICT         = 0x0A,
+    NODE_OPERATIONAL_CERT_STATUS_INVALID_FABRIC_INDEX   = 0x0B,
+};
+
+namespace FabricDescriptor {
+enum FieldId
+{
+    kFabricIndexFieldId   = 0,
+    kRootPublicKeyFieldId = 1,
+    kVendorIdFieldId      = 2,
+    kFabricIdFieldId      = 3,
+    kNodeIdFieldId        = 4,
+    kLabelFieldId         = 5,
+};
+
+struct Type
+{
+public:
+    uint8_t fabricIndex;
+    chip::ByteSpan rootPublicKey;
+    uint16_t vendorId;
+    uint64_t fabricId;
+    uint64_t nodeId;
+    chip::ByteSpan label;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace FabricDescriptor
+namespace NOCStruct {
+enum FieldId
+{
+    kFabricIndexFieldId = 0,
+    kNocFieldId         = 1,
+};
+
+struct Type
+{
+public:
+    uint8_t fabricIndex;
+    chip::ByteSpan noc;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace NOCStruct
+
+} // namespace OperationalCredentials
+namespace FixedLabel {
+
+namespace LabelStruct {
+enum FieldId
+{
+    kLabelFieldId = 0,
+    kValueFieldId = 1,
+};
+
+struct Type
+{
+public:
+    chip::ByteSpan label;
+    chip::ByteSpan value;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace LabelStruct
+
+} // namespace FixedLabel
+namespace ShadeConfiguration {
+
+} // namespace ShadeConfiguration
+namespace DoorLock {
+
+} // namespace DoorLock
 namespace WindowCovering {
 // Enum for WcEndProductType
 enum class WcEndProductType : uint8_t
@@ -1470,6 +739,1009 @@ enum class WcType : uint8_t
 };
 
 } // namespace WindowCovering
+namespace BarrierControl {
+
+} // namespace BarrierControl
+namespace PumpConfigurationAndControl {
+// Enum for PumpControlMode
+enum class PumpControlMode : uint8_t
+{
+    PUMP_CONTROL_MODE_CONSTANT_SPEED        = 0x00,
+    PUMP_CONTROL_MODE_CONSTANT_PRESSURE     = 0x01,
+    PUMP_CONTROL_MODE_PROPORTIONAL_PRESSURE = 0x02,
+    PUMP_CONTROL_MODE_CONSTANT_FLOW         = 0x03,
+    PUMP_CONTROL_MODE_CONSTANT_TEMPERATURE  = 0x05,
+    PUMP_CONTROL_MODE_AUTOMATIC             = 0x07,
+};
+// Enum for PumpOperationMode
+enum class PumpOperationMode : uint8_t
+{
+    PUMP_OPERATION_MODE_NORMAL  = 0x00,
+    PUMP_OPERATION_MODE_MINIMUM = 0x01,
+    PUMP_OPERATION_MODE_MAXIMUM = 0x02,
+    PUMP_OPERATION_MODE_LOCAL   = 0x03,
+};
+
+} // namespace PumpConfigurationAndControl
+namespace Thermostat {
+
+} // namespace Thermostat
+namespace FanControl {
+
+} // namespace FanControl
+namespace DehumidificationControl {
+
+} // namespace DehumidificationControl
+namespace ThermostatUserInterfaceConfiguration {
+
+} // namespace ThermostatUserInterfaceConfiguration
+namespace ColorControl {
+
+} // namespace ColorControl
+namespace BallastConfiguration {
+
+} // namespace BallastConfiguration
+namespace IlluminanceMeasurement {
+
+} // namespace IlluminanceMeasurement
+namespace IlluminanceLevelSensing {
+
+} // namespace IlluminanceLevelSensing
+namespace TemperatureMeasurement {
+
+} // namespace TemperatureMeasurement
+namespace PressureMeasurement {
+
+} // namespace PressureMeasurement
+namespace FlowMeasurement {
+
+} // namespace FlowMeasurement
+namespace RelativeHumidityMeasurement {
+
+} // namespace RelativeHumidityMeasurement
+namespace OccupancySensing {
+
+} // namespace OccupancySensing
+namespace CarbonMonoxideConcentrationMeasurement {
+
+} // namespace CarbonMonoxideConcentrationMeasurement
+namespace CarbonDioxideConcentrationMeasurement {
+
+} // namespace CarbonDioxideConcentrationMeasurement
+namespace EthyleneConcentrationMeasurement {
+
+} // namespace EthyleneConcentrationMeasurement
+namespace EthyleneOxideConcentrationMeasurement {
+
+} // namespace EthyleneOxideConcentrationMeasurement
+namespace HydrogenConcentrationMeasurement {
+
+} // namespace HydrogenConcentrationMeasurement
+namespace HydrogenSulphideConcentrationMeasurement {
+
+} // namespace HydrogenSulphideConcentrationMeasurement
+namespace NitricOxideConcentrationMeasurement {
+
+} // namespace NitricOxideConcentrationMeasurement
+namespace NitrogenDioxideConcentrationMeasurement {
+
+} // namespace NitrogenDioxideConcentrationMeasurement
+namespace OxygenConcentrationMeasurement {
+
+} // namespace OxygenConcentrationMeasurement
+namespace OzoneConcentrationMeasurement {
+
+} // namespace OzoneConcentrationMeasurement
+namespace SulfurDioxideConcentrationMeasurement {
+
+} // namespace SulfurDioxideConcentrationMeasurement
+namespace DissolvedOxygenConcentrationMeasurement {
+
+} // namespace DissolvedOxygenConcentrationMeasurement
+namespace BromateConcentrationMeasurement {
+
+} // namespace BromateConcentrationMeasurement
+namespace ChloraminesConcentrationMeasurement {
+
+} // namespace ChloraminesConcentrationMeasurement
+namespace ChlorineConcentrationMeasurement {
+
+} // namespace ChlorineConcentrationMeasurement
+namespace FecalColiformAndEColiConcentrationMeasurement {
+
+} // namespace FecalColiformAndEColiConcentrationMeasurement
+namespace FluorideConcentrationMeasurement {
+
+} // namespace FluorideConcentrationMeasurement
+namespace HaloaceticAcidsConcentrationMeasurement {
+
+} // namespace HaloaceticAcidsConcentrationMeasurement
+namespace TotalTrihalomethanesConcentrationMeasurement {
+
+} // namespace TotalTrihalomethanesConcentrationMeasurement
+namespace TotalColiformBacteriaConcentrationMeasurement {
+
+} // namespace TotalColiformBacteriaConcentrationMeasurement
+namespace TurbidityConcentrationMeasurement {
+
+} // namespace TurbidityConcentrationMeasurement
+namespace CopperConcentrationMeasurement {
+
+} // namespace CopperConcentrationMeasurement
+namespace LeadConcentrationMeasurement {
+
+} // namespace LeadConcentrationMeasurement
+namespace ManganeseConcentrationMeasurement {
+
+} // namespace ManganeseConcentrationMeasurement
+namespace SulfateConcentrationMeasurement {
+
+} // namespace SulfateConcentrationMeasurement
+namespace BromodichloromethaneConcentrationMeasurement {
+
+} // namespace BromodichloromethaneConcentrationMeasurement
+namespace BromoformConcentrationMeasurement {
+
+} // namespace BromoformConcentrationMeasurement
+namespace ChlorodibromomethaneConcentrationMeasurement {
+
+} // namespace ChlorodibromomethaneConcentrationMeasurement
+namespace ChloroformConcentrationMeasurement {
+
+} // namespace ChloroformConcentrationMeasurement
+namespace SodiumConcentrationMeasurement {
+
+} // namespace SodiumConcentrationMeasurement
+namespace IasZone {
+
+} // namespace IasZone
+namespace IasAce {
+
+} // namespace IasAce
+namespace IasWd {
+
+} // namespace IasWd
+namespace WakeOnLan {
+
+} // namespace WakeOnLan
+namespace TvChannel {
+// Enum for TvChannelErrorType
+enum class TvChannelErrorType : uint8_t
+{
+    TV_CHANNEL_ERROR_TYPE_MULTIPLE_MATCHES = 0x00,
+    TV_CHANNEL_ERROR_TYPE_NO_MATCHES       = 0x01,
+};
+// Enum for TvChannelLineupInfoType
+enum class TvChannelLineupInfoType : uint8_t
+{
+    TV_CHANNEL_LINEUP_INFO_TYPE_MSO = 0x00,
+};
+
+namespace TvChannelInfo {
+enum FieldId
+{
+    kMajorNumberFieldId       = 0,
+    kMinorNumberFieldId       = 1,
+    kNameFieldId              = 2,
+    kCallSignFieldId          = 3,
+    kAffiliateCallSignFieldId = 4,
+};
+
+struct Type
+{
+public:
+    uint16_t majorNumber;
+    uint16_t minorNumber;
+    chip::ByteSpan name;
+    chip::ByteSpan callSign;
+    chip::ByteSpan affiliateCallSign;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace TvChannelInfo
+namespace TvChannelLineupInfo {
+enum FieldId
+{
+    kOperatorNameFieldId   = 0,
+    kLineupNameFieldId     = 1,
+    kPostalCodeFieldId     = 2,
+    kLineupInfoTypeFieldId = 3,
+};
+
+struct Type
+{
+public:
+    Span<const char> operatorName;
+    Span<const char> lineupName;
+    Span<const char> postalCode;
+    TvChannelLineupInfoType lineupInfoType;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace TvChannelLineupInfo
+
+} // namespace TvChannel
+namespace TargetNavigator {
+// Enum for NavigateTargetStatus
+enum class NavigateTargetStatus : uint8_t
+{
+    NAVIGATE_TARGET_STATUS_SUCCESS           = 0x00,
+    NAVIGATE_TARGET_STATUS_APP_NOT_AVAILABLE = 0x01,
+    NAVIGATE_TARGET_STATUS_SYSTEM_BUSY       = 0x02,
+};
+
+namespace NavigateTargetTargetInfo {
+enum FieldId
+{
+    kIdentifierFieldId = 0,
+    kNameFieldId       = 1,
+};
+
+struct Type
+{
+public:
+    uint8_t identifier;
+    chip::ByteSpan name;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace NavigateTargetTargetInfo
+
+} // namespace TargetNavigator
+namespace MediaPlayback {
+// Enum for MediaPlaybackState
+enum class MediaPlaybackState : uint8_t
+{
+    MEDIA_PLAYBACK_STATE_PLAYING     = 0x00,
+    MEDIA_PLAYBACK_STATE_PAUSED      = 0x01,
+    MEDIA_PLAYBACK_STATE_NOT_PLAYING = 0x02,
+    MEDIA_PLAYBACK_STATE_BUFFERING   = 0x03,
+};
+// Enum for MediaPlaybackStatus
+enum class MediaPlaybackStatus : uint8_t
+{
+    MEDIA_PLAYBACK_STATUS_SUCCESS                   = 0x00,
+    MEDIA_PLAYBACK_STATUS_INVALID_STATE_FOR_COMMAND = 0x01,
+    MEDIA_PLAYBACK_STATUS_NOT_ALLOWED               = 0x02,
+    MEDIA_PLAYBACK_STATUS_NOT_ACTIVE                = 0x03,
+    MEDIA_PLAYBACK_STATUS_SPEED_OUT_OF_RANGE        = 0x04,
+    MEDIA_PLAYBACK_STATUS_SEEK_OUT_OF_RANGE         = 0x05,
+};
+
+namespace MediaPlaybackPosition {
+enum FieldId
+{
+    kUpdatedAtFieldId = 0,
+    kPositionFieldId  = 1,
+};
+
+struct Type
+{
+public:
+    uint64_t updatedAt;
+    uint64_t position;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace MediaPlaybackPosition
+
+} // namespace MediaPlayback
+namespace MediaInput {
+// Enum for MediaInputType
+enum class MediaInputType : uint8_t
+{
+    MEDIA_INPUT_TYPE_INTERNAL  = 0x00,
+    MEDIA_INPUT_TYPE_AUX       = 0x01,
+    MEDIA_INPUT_TYPE_COAX      = 0x02,
+    MEDIA_INPUT_TYPE_COMPOSITE = 0x03,
+    MEDIA_INPUT_TYPE_HDMI      = 0x04,
+    MEDIA_INPUT_TYPE_INPUT     = 0x05,
+    MEDIA_INPUT_TYPE_LINE      = 0x06,
+    MEDIA_INPUT_TYPE_OPTICAL   = 0x07,
+    MEDIA_INPUT_TYPE_VIDEO     = 0x08,
+    MEDIA_INPUT_TYPE_SCART     = 0x09,
+    MEDIA_INPUT_TYPE_USB       = 0x0A,
+    MEDIA_INPUT_TYPE_OTHER     = 0x0B,
+};
+
+namespace MediaInputInfo {
+enum FieldId
+{
+    kIndexFieldId       = 0,
+    kInputTypeFieldId   = 1,
+    kNameFieldId        = 2,
+    kDescriptionFieldId = 3,
+};
+
+struct Type
+{
+public:
+    uint8_t index;
+    MediaInputType inputType;
+    chip::ByteSpan name;
+    chip::ByteSpan description;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace MediaInputInfo
+
+} // namespace MediaInput
+namespace LowPower {
+
+} // namespace LowPower
+namespace KeypadInput {
+// Enum for KeypadInputCecKeyCode
+enum class KeypadInputCecKeyCode : uint8_t
+{
+    KEYPAD_INPUT_CEC_KEY_CODE_SELECT                       = 0x00,
+    KEYPAD_INPUT_CEC_KEY_CODE_UP                           = 0x01,
+    KEYPAD_INPUT_CEC_KEY_CODE_DOWN                         = 0x02,
+    KEYPAD_INPUT_CEC_KEY_CODE_LEFT                         = 0x03,
+    KEYPAD_INPUT_CEC_KEY_CODE_RIGHT                        = 0x04,
+    KEYPAD_INPUT_CEC_KEY_CODE_RIGHT_UP                     = 0x05,
+    KEYPAD_INPUT_CEC_KEY_CODE_RIGHT_DOWN                   = 0x06,
+    KEYPAD_INPUT_CEC_KEY_CODE_LEFT_UP                      = 0x07,
+    KEYPAD_INPUT_CEC_KEY_CODE_LEFT_DOWN                    = 0x08,
+    KEYPAD_INPUT_CEC_KEY_CODE_ROOT_MENU                    = 0x09,
+    KEYPAD_INPUT_CEC_KEY_CODE_SETUP_MENU                   = 0x0A,
+    KEYPAD_INPUT_CEC_KEY_CODE_CONTENTS_MENU                = 0x0B,
+    KEYPAD_INPUT_CEC_KEY_CODE_FAVORITE_MENU                = 0x0C,
+    KEYPAD_INPUT_CEC_KEY_CODE_EXIT                         = 0x0D,
+    KEYPAD_INPUT_CEC_KEY_CODE_MEDIA_TOP_MENU               = 0x10,
+    KEYPAD_INPUT_CEC_KEY_CODE_MEDIA_CONTEXT_SENSITIVE_MENU = 0x11,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER_ENTRY_MODE            = 0x1D,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER11                     = 0x1E,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER12                     = 0x1F,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBER0_OR_NUMBER10          = 0x20,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS1                     = 0x21,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS2                     = 0x22,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS3                     = 0x23,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS4                     = 0x24,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS5                     = 0x25,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS6                     = 0x26,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS7                     = 0x27,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS8                     = 0x28,
+    KEYPAD_INPUT_CEC_KEY_CODE_NUMBERS9                     = 0x29,
+    KEYPAD_INPUT_CEC_KEY_CODE_DOT                          = 0x2A,
+    KEYPAD_INPUT_CEC_KEY_CODE_ENTER                        = 0x2B,
+    KEYPAD_INPUT_CEC_KEY_CODE_CLEAR                        = 0x2C,
+    KEYPAD_INPUT_CEC_KEY_CODE_NEXT_FAVORITE                = 0x2F,
+    KEYPAD_INPUT_CEC_KEY_CODE_CHANNEL_UP                   = 0x30,
+    KEYPAD_INPUT_CEC_KEY_CODE_CHANNEL_DOWN                 = 0x31,
+    KEYPAD_INPUT_CEC_KEY_CODE_PREVIOUS_CHANNEL             = 0x32,
+    KEYPAD_INPUT_CEC_KEY_CODE_SOUND_SELECT                 = 0x33,
+    KEYPAD_INPUT_CEC_KEY_CODE_INPUT_SELECT                 = 0x34,
+    KEYPAD_INPUT_CEC_KEY_CODE_DISPLAY_INFORMATION          = 0x35,
+    KEYPAD_INPUT_CEC_KEY_CODE_HELP                         = 0x36,
+    KEYPAD_INPUT_CEC_KEY_CODE_PAGE_UP                      = 0x37,
+    KEYPAD_INPUT_CEC_KEY_CODE_PAGE_DOWN                    = 0x38,
+    KEYPAD_INPUT_CEC_KEY_CODE_POWER                        = 0x40,
+    KEYPAD_INPUT_CEC_KEY_CODE_VOLUME_UP                    = 0x41,
+    KEYPAD_INPUT_CEC_KEY_CODE_VOLUME_DOWN                  = 0x42,
+    KEYPAD_INPUT_CEC_KEY_CODE_MUTE                         = 0x43,
+    KEYPAD_INPUT_CEC_KEY_CODE_PLAY                         = 0x44,
+    KEYPAD_INPUT_CEC_KEY_CODE_STOP                         = 0x45,
+    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE                        = 0x46,
+    KEYPAD_INPUT_CEC_KEY_CODE_RECORD                       = 0x47,
+    KEYPAD_INPUT_CEC_KEY_CODE_REWIND                       = 0x48,
+    KEYPAD_INPUT_CEC_KEY_CODE_FAST_FORWARD                 = 0x49,
+    KEYPAD_INPUT_CEC_KEY_CODE_EJECT                        = 0x4A,
+    KEYPAD_INPUT_CEC_KEY_CODE_FORWARD                      = 0x4B,
+    KEYPAD_INPUT_CEC_KEY_CODE_BACKWARD                     = 0x4C,
+    KEYPAD_INPUT_CEC_KEY_CODE_STOP_RECORD                  = 0x4D,
+    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE_RECORD                 = 0x4E,
+    KEYPAD_INPUT_CEC_KEY_CODE_RESERVED                     = 0x4F,
+    KEYPAD_INPUT_CEC_KEY_CODE_ANGLE                        = 0x50,
+    KEYPAD_INPUT_CEC_KEY_CODE_SUB_PICTURE                  = 0x51,
+    KEYPAD_INPUT_CEC_KEY_CODE_VIDEO_ON_DEMAND              = 0x52,
+    KEYPAD_INPUT_CEC_KEY_CODE_ELECTRONIC_PROGRAM_GUIDE     = 0x53,
+    KEYPAD_INPUT_CEC_KEY_CODE_TIMER_PROGRAMMING            = 0x54,
+    KEYPAD_INPUT_CEC_KEY_CODE_INITIAL_CONFIGURATION        = 0x55,
+    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_BROADCAST_TYPE        = 0x56,
+    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_SOUND_PRESENTATION    = 0x57,
+    KEYPAD_INPUT_CEC_KEY_CODE_PLAY_FUNCTION                = 0x60,
+    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE_PLAY_FUNCTION          = 0x61,
+    KEYPAD_INPUT_CEC_KEY_CODE_RECORD_FUNCTION              = 0x62,
+    KEYPAD_INPUT_CEC_KEY_CODE_PAUSE_RECORD_FUNCTION        = 0x63,
+    KEYPAD_INPUT_CEC_KEY_CODE_STOP_FUNCTION                = 0x64,
+    KEYPAD_INPUT_CEC_KEY_CODE_MUTE_FUNCTION                = 0x65,
+    KEYPAD_INPUT_CEC_KEY_CODE_RESTORE_VOLUME_FUNCTION      = 0x66,
+    KEYPAD_INPUT_CEC_KEY_CODE_TUNE_FUNCTION                = 0x67,
+    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_MEDIA_FUNCTION        = 0x68,
+    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_AV_INPUT_FUNCTION     = 0x69,
+    KEYPAD_INPUT_CEC_KEY_CODE_SELECT_AUDIO_INPUT_FUNCTION  = 0x6A,
+    KEYPAD_INPUT_CEC_KEY_CODE_POWER_TOGGLE_FUNCTION        = 0x6B,
+    KEYPAD_INPUT_CEC_KEY_CODE_POWER_OFF_FUNCTION           = 0x6C,
+    KEYPAD_INPUT_CEC_KEY_CODE_POWER_ON_FUNCTION            = 0x6D,
+    KEYPAD_INPUT_CEC_KEY_CODE_F1_BLUE                      = 0x71,
+    KEYPAD_INPUT_CEC_KEY_CODE_F2_RED                       = 0x72,
+    KEYPAD_INPUT_CEC_KEY_CODE_F3_GREEN                     = 0x73,
+    KEYPAD_INPUT_CEC_KEY_CODE_F4_YELLOW                    = 0x74,
+    KEYPAD_INPUT_CEC_KEY_CODE_F5                           = 0x75,
+    KEYPAD_INPUT_CEC_KEY_CODE_DATA                         = 0x76,
+};
+// Enum for KeypadInputStatus
+enum class KeypadInputStatus : uint8_t
+{
+    KEYPAD_INPUT_STATUS_SUCCESS                      = 0x00,
+    KEYPAD_INPUT_STATUS_UNSUPPORTED_KEY              = 0x01,
+    KEYPAD_INPUT_STATUS_INVALID_KEY_IN_CURRENT_STATE = 0x02,
+};
+
+} // namespace KeypadInput
+namespace ContentLauncher {
+// Enum for ContentLaunchMetricType
+enum class ContentLaunchMetricType : uint8_t
+{
+    CONTENT_LAUNCH_METRIC_TYPE_PIXELS     = 0x00,
+    CONTENT_LAUNCH_METRIC_TYPE_PERCENTAGE = 0x01,
+};
+// Enum for ContentLaunchParameterEnum
+enum class ContentLaunchParameterEnum : uint8_t
+{
+    CONTENT_LAUNCH_PARAMETER_ENUM_ACTOR       = 0x00,
+    CONTENT_LAUNCH_PARAMETER_ENUM_CHANNEL     = 0x01,
+    CONTENT_LAUNCH_PARAMETER_ENUM_CHARACTER   = 0x02,
+    CONTENT_LAUNCH_PARAMETER_ENUM_EVENT       = 0x03,
+    CONTENT_LAUNCH_PARAMETER_ENUM_FRANCHISE   = 0x04,
+    CONTENT_LAUNCH_PARAMETER_ENUM_GENRE       = 0x05,
+    CONTENT_LAUNCH_PARAMETER_ENUM_LEAGUE      = 0x06,
+    CONTENT_LAUNCH_PARAMETER_ENUM_POPULARITY  = 0x07,
+    CONTENT_LAUNCH_PARAMETER_ENUM_SPORT       = 0x08,
+    CONTENT_LAUNCH_PARAMETER_ENUM_SPORTS_TEAM = 0x09,
+    CONTENT_LAUNCH_PARAMETER_ENUM_VIDEO       = 0x0A,
+};
+// Enum for ContentLaunchStatus
+enum class ContentLaunchStatus : uint8_t
+{
+    CONTENT_LAUNCH_STATUS_SUCCESS           = 0x00,
+    CONTENT_LAUNCH_STATUS_URL_NOT_AVAILABLE = 0x01,
+    CONTENT_LAUNCH_STATUS_AUTH_FAILED       = 0x02,
+};
+// Enum for ContentLaunchStreamingType
+enum class ContentLaunchStreamingType : uint8_t
+{
+    CONTENT_LAUNCH_STREAMING_TYPE_DASH = 0x00,
+    CONTENT_LAUNCH_STREAMING_TYPE_HLS  = 0x01,
+};
+
+namespace ContentLaunchAdditionalInfo {
+enum FieldId
+{
+    kNameFieldId  = 0,
+    kValueFieldId = 1,
+};
+
+struct Type
+{
+public:
+    Span<const char> name;
+    Span<const char> value;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ContentLaunchAdditionalInfo
+namespace ContentLaunchParamater {
+enum FieldId
+{
+    kTypeFieldId           = 0,
+    kValueFieldId          = 1,
+    kExternalIDListFieldId = 2,
+};
+
+struct Type
+{
+public:
+    ContentLaunchParameterEnum type;
+    Span<const char> value;
+    DataModel::List<ContentLaunchAdditionalInfo::Type> externalIDList;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+struct DecodableType
+{
+public:
+    ContentLaunchParameterEnum type;
+    Span<const char> value;
+    DataModel::DecodableList<ContentLaunchAdditionalInfo::Type> externalIDList;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ContentLaunchParamater
+namespace ContentLaunchBrandingInformation {
+enum FieldId
+{
+    kProviderNameFieldId = 0,
+    kBackgroundFieldId   = 1,
+    kLogoFieldId         = 2,
+    kProgressBarFieldId  = 3,
+    kSplashFieldId       = 4,
+    kWaterMarkFieldId    = 5,
+};
+
+struct Type
+{
+public:
+    Span<const char> providerName;
+    uint8_t background;
+    uint8_t logo;
+    uint8_t progressBar;
+    uint8_t splash;
+    uint8_t waterMark;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ContentLaunchBrandingInformation
+namespace ContentLaunchDimension {
+enum FieldId
+{
+    kWidthFieldId  = 0,
+    kHeightFieldId = 1,
+    kMetricFieldId = 2,
+};
+
+struct Type
+{
+public:
+    Span<const char> width;
+    Span<const char> height;
+    ContentLaunchMetricType metric;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ContentLaunchDimension
+namespace ContentLaunchStyleInformation {
+enum FieldId
+{
+    kImageUrlFieldId = 0,
+    kColorFieldId    = 1,
+    kSizeFieldId     = 2,
+};
+
+struct Type
+{
+public:
+    Span<const char> imageUrl;
+    Span<const char> color;
+    uint8_t size;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ContentLaunchStyleInformation
+
+} // namespace ContentLauncher
+namespace AudioOutput {
+// Enum for AudioOutputType
+enum class AudioOutputType : uint8_t
+{
+    AUDIO_OUTPUT_TYPE_HDMI      = 0x00,
+    AUDIO_OUTPUT_TYPE_BT        = 0x01,
+    AUDIO_OUTPUT_TYPE_OPTICAL   = 0x02,
+    AUDIO_OUTPUT_TYPE_HEADPHONE = 0x03,
+    AUDIO_OUTPUT_TYPE_INTERNAL  = 0x04,
+    AUDIO_OUTPUT_TYPE_OTHER     = 0x05,
+};
+
+namespace AudioOutputInfo {
+enum FieldId
+{
+    kIndexFieldId      = 0,
+    kOutputTypeFieldId = 1,
+    kNameFieldId       = 2,
+};
+
+struct Type
+{
+public:
+    uint8_t index;
+    AudioOutputType outputType;
+    chip::ByteSpan name;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace AudioOutputInfo
+
+} // namespace AudioOutput
+namespace ApplicationLauncher {
+// Enum for ApplicationLauncherStatus
+enum class ApplicationLauncherStatus : uint8_t
+{
+    APPLICATION_LAUNCHER_STATUS_SUCCESS           = 0x00,
+    APPLICATION_LAUNCHER_STATUS_APP_NOT_AVAILABLE = 0x01,
+    APPLICATION_LAUNCHER_STATUS_SYSTEM_BUSY       = 0x02,
+};
+
+namespace ApplicationLauncherApp {
+enum FieldId
+{
+    kCatalogVendorIdFieldId = 0,
+    kApplicationIdFieldId   = 1,
+};
+
+struct Type
+{
+public:
+    uint16_t catalogVendorId;
+    Span<const char> applicationId;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace ApplicationLauncherApp
+
+} // namespace ApplicationLauncher
+namespace ApplicationBasic {
+// Enum for ApplicationBasicStatus
+enum class ApplicationBasicStatus : uint8_t
+{
+    APPLICATION_BASIC_STATUS_STOPPED                  = 0x00,
+    APPLICATION_BASIC_STATUS_ACTIVE_VISIBLE_FOCUS     = 0x01,
+    APPLICATION_BASIC_STATUS_ACTIVE_HIDDEN            = 0x02,
+    APPLICATION_BASIC_STATUS_ACTIVE_VISIBLE_NOT_FOCUS = 0x03,
+};
+
+} // namespace ApplicationBasic
+namespace AccountLogin {
+
+} // namespace AccountLogin
+namespace TestCluster {
+// Enum for SimpleEnum
+enum class SimpleEnum : uint8_t
+{
+    SIMPLE_ENUM_UNSPECIFIED = 0x00,
+    SIMPLE_ENUM_VALUE_A     = 0x01,
+    SIMPLE_ENUM_VALUE_B     = 0x02,
+    SIMPLE_ENUM_VALUE_C     = 0x03,
+};
+
+namespace SimpleStruct {
+enum FieldId
+{
+    kAFieldId = 0,
+    kBFieldId = 1,
+    kCFieldId = 2,
+    kDFieldId = 3,
+    kEFieldId = 4,
+};
+
+struct Type
+{
+public:
+    uint8_t a;
+    bool b;
+    SimpleEnum c;
+    chip::ByteSpan d;
+    Span<const char> e;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace SimpleStruct
+namespace NestedStruct {
+enum FieldId
+{
+    kAFieldId = 0,
+    kBFieldId = 1,
+    kCFieldId = 2,
+};
+
+struct Type
+{
+public:
+    uint8_t a;
+    bool b;
+    SimpleStruct::Type c;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace NestedStruct
+namespace NestedStructList {
+enum FieldId
+{
+    kAFieldId = 0,
+    kBFieldId = 1,
+    kCFieldId = 2,
+    kDFieldId = 3,
+    kEFieldId = 4,
+    kFFieldId = 5,
+    kGFieldId = 6,
+};
+
+struct Type
+{
+public:
+    uint8_t a;
+    bool b;
+    SimpleStruct::Type c;
+    DataModel::List<SimpleStruct::Type> d;
+    DataModel::List<uint32_t> e;
+    DataModel::List<chip::ByteSpan> f;
+    DataModel::List<uint8_t> g;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+struct DecodableType
+{
+public:
+    uint8_t a;
+    bool b;
+    SimpleStruct::Type c;
+    DataModel::DecodableList<SimpleStruct::Type> d;
+    DataModel::DecodableList<uint32_t> e;
+    DataModel::DecodableList<chip::ByteSpan> f;
+    DataModel::DecodableList<uint8_t> g;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace NestedStructList
+namespace DoubleNestedStructList {
+enum FieldId
+{
+    kAFieldId = 0,
+};
+
+struct Type
+{
+public:
+    DataModel::List<NestedStructList::Type> a;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+struct DecodableType
+{
+public:
+    DataModel::DecodableList<NestedStructList::DecodableType> a;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace DoubleNestedStructList
+namespace TestListStructOctet {
+enum FieldId
+{
+    kFabricIndexFieldId     = 0,
+    kOperationalCertFieldId = 1,
+};
+
+struct Type
+{
+public:
+    uint64_t fabricIndex;
+    chip::ByteSpan operationalCert;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace TestListStructOctet
+
+} // namespace TestCluster
+namespace Messaging {
+// Enum for EventId
+enum class EventId : uint8_t
+{
+    EVENT_ID_METER_COVER_REMOVED                   = 0x00,
+    EVENT_ID_METER_COVER_CLOSED                    = 0x01,
+    EVENT_ID_STRONG_MAGNETIC_FIELD                 = 0x02,
+    EVENT_ID_NO_STRONG_MAGNETIC_FIELD              = 0x03,
+    EVENT_ID_BATTERY_FAILURE                       = 0x04,
+    EVENT_ID_LOW_BATTERY                           = 0x05,
+    EVENT_ID_PROGRAM_MEMORY_ERROR                  = 0x06,
+    EVENT_ID_RAM_ERROR                             = 0x07,
+    EVENT_ID_NV_MEMORY_ERROR                       = 0x08,
+    EVENT_ID_MEASUREMENT_SYSTEM_ERROR              = 0x09,
+    EVENT_ID_WATCHDOG_ERROR                        = 0x0A,
+    EVENT_ID_SUPPLY_DISCONNECT_FAILURE             = 0x0B,
+    EVENT_ID_SUPPLY_CONNECT_FAILURE                = 0x0C,
+    EVENT_ID_MEASURMENT_SOFTWARE_CHANGED           = 0x0D,
+    EVENT_ID_DST_ENABLED                           = 0x0E,
+    EVENT_ID_DST_DISABLED                          = 0x0F,
+    EVENT_ID_CLOCK_ADJ_BACKWARD                    = 0x10,
+    EVENT_ID_CLOCK_ADJ_FORWARD                     = 0x11,
+    EVENT_ID_CLOCK_INVALID                         = 0x12,
+    EVENT_ID_COMMS_ERROR_HAN                       = 0x13,
+    EVENT_ID_COMMS_OK_HAN                          = 0x14,
+    EVENT_ID_FRAUD_ATTEMPT                         = 0x15,
+    EVENT_ID_POWER_LOSS                            = 0x16,
+    EVENT_ID_INCORRECT_PROTOCOL                    = 0x17,
+    EVENT_ID_UNUSUAL_HAN_TRAFFIC                   = 0x18,
+    EVENT_ID_UNEXPECTED_CLOCK_CHANGE               = 0x19,
+    EVENT_ID_COMMS_USING_UNAUTHENTICATED_COMPONENT = 0x1A,
+    EVENT_ID_ERROR_REG_CLEAR                       = 0x1B,
+    EVENT_ID_ALARM_REG_CLEAR                       = 0x1C,
+    EVENT_ID_UNEXPECTED_HW_RESET                   = 0x1D,
+    EVENT_ID_UNEXPECTED_PROGRAM_EXECUTION          = 0x1E,
+    EVENT_ID_EVENT_LOG_CLEARED                     = 0x1F,
+    EVENT_ID_MANUAL_DISCONNECT                     = 0x20,
+    EVENT_ID_MANUAL_CONNECT                        = 0x21,
+    EVENT_ID_REMOTE_DISCONNECTION                  = 0x22,
+    EVENT_ID_LOCAL_DISCONNECTION                   = 0x23,
+    EVENT_ID_LIMIT_THRESHOLD_EXCEEDED              = 0x24,
+    EVENT_ID_LIMIT_THRESHOLD_OK                    = 0x25,
+    EVENT_ID_LIMIT_THRESHOLD_CHANGED               = 0x26,
+    EVENT_ID_MAXIMUM_DEMAND_EXCEEDED               = 0x27,
+    EVENT_ID_PROFILE_CLEARED                       = 0x28,
+    EVENT_ID_FIRMWARE_READY_FOR_ACTIVATION         = 0x29,
+    EVENT_ID_FIRMWARE_ACTIVATED                    = 0x2A,
+    EVENT_ID_PATCH_FAILURE                         = 0x2B,
+    EVENT_ID_TOU_TARIFF_ACTIVATION                 = 0x2C,
+    EVENT_ID_8X8_TARIFFACTIVATED                   = 0x2D,
+    EVENT_ID_SINGLE_TARIFF_RATE_ACTIVATED          = 0x2E,
+    EVENT_ID_ASYNCHRONOUS_BILLING_OCCURRED         = 0x2F,
+    EVENT_ID_SYNCHRONOUS_BILLING_OCCURRED          = 0x30,
+    EVENT_ID_INCORRECT_POLARITY                    = 0x80,
+    EVENT_ID_CURRENT_NO_VOLTAGE                    = 0x81,
+    EVENT_ID_UNDER_VOLTAGE                         = 0x82,
+    EVENT_ID_OVER_VOLTAGE                          = 0x83,
+    EVENT_ID_NORMAL_VOLTAGE                        = 0x84,
+    EVENT_ID_PF_BELOW_THRESHOLD                    = 0x85,
+    EVENT_ID_PF_ABOVE_THRESHOLD                    = 0x86,
+    EVENT_ID_TERMINAL_COVER_REMOVED                = 0x87,
+    EVENT_ID_TERMINAL_COVER_CLOSED                 = 0x88,
+    EVENT_ID_REVERSE_FLOW                          = 0xA0,
+    EVENT_ID_TILT_TAMPER                           = 0xA1,
+    EVENT_ID_BATTERY_COVER_REMOVED                 = 0xA2,
+    EVENT_ID_BATTERY_COVER_CLOSED                  = 0xA3,
+    EVENT_ID_EXCESS_FLOW                           = 0xA4,
+    EVENT_ID_CREDIT_OK                             = 0xC0,
+    EVENT_ID_LOW_CREDIT                            = 0xC1,
+    EVENT_ID_EMERGENCY_CREDIT_IN_USE               = 0xC0,
+    EVENT_ID_EMERGENCY_CREDIT_EXHAUSTED            = 0xC1,
+    EVENT_ID_ZERO_CREDIT_EC_NOT_SELECTED           = 0xC2,
+    EVENT_ID_SUPPLY_ON                             = 0xC3,
+    EVENT_ID_SUPPLY_OFF_AARMED                     = 0xC4,
+    EVENT_ID_SUPPLY_OFF                            = 0xC5,
+    EVENT_ID_DISCOUNT_APPLIED                      = 0xC6,
+    EVENT_ID_MANUFACTURER_SPECIFIC_A               = 0xE0,
+    EVENT_ID_MANUFACTURER_SPECIFIC_B               = 0xE1,
+    EVENT_ID_MANUFACTURER_SPECIFIC_C               = 0xE2,
+    EVENT_ID_MANUFACTURER_SPECIFIC_D               = 0xE3,
+    EVENT_ID_MANUFACTURER_SPECIFIC_E               = 0xE4,
+    EVENT_ID_MANUFACTURER_SPECIFIC_F               = 0xE5,
+    EVENT_ID_MANUFACTURER_SPECIFIC_G               = 0xE6,
+    EVENT_ID_MANUFACTURER_SPECIFIC_H               = 0xE7,
+    EVENT_ID_MANUFACTURER_SPECIFIC_I               = 0xE8,
+};
+// Enum for MessagingControlConfirmation
+enum class MessagingControlConfirmation : uint8_t
+{
+    MESSAGING_CONTROL_CONFIRMATION_NOT_REQUIRED = 0x00,
+    MESSAGING_CONTROL_CONFIRMATION_REQUIRED     = 0x80,
+};
+// Enum for MessagingControlEnhancedConfirmation
+enum class MessagingControlEnhancedConfirmation : uint8_t
+{
+    MESSAGING_CONTROL_ENHANCED_CONFIRMATION_NOT_REQUIRED = 0x00,
+    MESSAGING_CONTROL_ENHANCED_CONFIRMATION_REQUIRED     = 0x20,
+};
+// Enum for MessagingControlImportance
+enum class MessagingControlImportance : uint8_t
+{
+    MESSAGING_CONTROL_IMPORTANCE_LOW      = 0x00,
+    MESSAGING_CONTROL_IMPORTANCE_MEDIUM   = 0x04,
+    MESSAGING_CONTROL_IMPORTANCE_HIGH     = 0x08,
+    MESSAGING_CONTROL_IMPORTANCE_CRITICAL = 0x0C,
+};
+// Enum for MessagingControlTransmission
+enum class MessagingControlTransmission : uint8_t
+{
+    MESSAGING_CONTROL_TRANSMISSION_NORMAL               = 0x00,
+    MESSAGING_CONTROL_TRANSMISSION_NORMAL_AND_ANONYMOUS = 0x01,
+    MESSAGING_CONTROL_TRANSMISSION_ANONYMOUS            = 0x02,
+    MESSAGING_CONTROL_TRANSMISSION_RESERVED             = 0x03,
+};
+
+} // namespace Messaging
+namespace ApplianceIdentification {
+
+} // namespace ApplianceIdentification
+namespace MeterIdentification {
+
+} // namespace MeterIdentification
+namespace ApplianceEventsAndAlert {
+
+} // namespace ApplianceEventsAndAlert
+namespace ApplianceStatistics {
+
+} // namespace ApplianceStatistics
+namespace ElectricalMeasurement {
+
+} // namespace ElectricalMeasurement
+namespace Binding {
+
+} // namespace Binding
+namespace GroupKeyManagement {
+// Enum for GroupKeySecurityPolicy
+enum class GroupKeySecurityPolicy : uint8_t
+{
+    GROUP_KEY_SECURITY_POLICY_STANDARD    = 0x00,
+    GROUP_KEY_SECURITY_POLICY_LOW_LATENCY = 0x01,
+};
+
+namespace GroupKey {
+enum FieldId
+{
+    kVendorIdFieldId               = 0,
+    kGroupKeyIndexFieldId          = 1,
+    kGroupKeyRootFieldId           = 2,
+    kGroupKeyEpochStartTimeFieldId = 3,
+    kGroupKeySecurityPolicyFieldId = 4,
+};
+
+struct Type
+{
+public:
+    uint16_t vendorId;
+    uint16_t groupKeyIndex;
+    chip::ByteSpan groupKeyRoot;
+    uint64_t groupKeyEpochStartTime;
+    GroupKeySecurityPolicy groupKeySecurityPolicy;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace GroupKey
+namespace GroupState {
+enum FieldId
+{
+    kVendorIdFieldId         = 0,
+    kVendorGroupIdFieldId    = 1,
+    kGroupKeySetIndexFieldId = 2,
+};
+
+struct Type
+{
+public:
+    uint16_t vendorId;
+    uint16_t vendorGroupId;
+    uint16_t groupKeySetIndex;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+
+} // namespace GroupState
+
+} // namespace GroupKeyManagement
+namespace SampleMfgSpecificCluster {
+
+} // namespace SampleMfgSpecificCluster
+namespace SampleMfgSpecificCluster2 {
+
+} // namespace SampleMfgSpecificCluster2
 
 } // namespace clusters
 } // namespace app


### PR DESCRIPTION
We're only generating them for the ones enabled in controller-clusters.zap.

#### Problem
Not generating cluster objects for some clusters; makes other things that try to use the cluster objects in signatures not compile.

#### Change overview
Generate them for all clusters.

#### Testing
Tree compiles.