### PR TITLE
Fix Android build in gn_build.sh

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -113,6 +113,10 @@ for arg; do
     user_args+=" $arg"
 done
 
+# Android prebuilt JAR setup
+python3 build/chip/java/tests/generate_jars_for_test.py
+python3 third_party/android_deps/set_up_android_deps.py
+
 # Android SDK setup
 android_sdk_args=""
 


### PR DESCRIPTION
#### Problem
After #9876 and #9996, `set_up_android_deps.py` and `generate_jars_for_test.py` are a prerequisite for Android builds. They were added to the Android build scripts, but I missed `gn_build.sh` because it uses `target_os=all`.

#### Change overview
* Invoke JAR generation scripts in `gn_build.sh`

#### Testing
`gn_build.sh` passes
