### PR TITLE
fix for malformed IPv6 Network Solicitation packet

### DIFF
--- a/third_party/lwip/repo/lwip/src/core/ipv6/nd6.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv6/nd6.c
@@ -1111,8 +1111,8 @@ nd6_send_ns(struct netif *netif, const ip6_addr_t *target_addr, u8_t flags)
   }
 
   /* Allocate a packet. */
-  p = pbuf_alloc(PBUF_IP, sizeof(struct ns_header) + ND6_LLADDR_OPTION_SIZE(netif->hwaddr_len), PBUF_RAM);
-  if ((p == NULL) || (p->len < (sizeof(struct ns_header) + ND6_LLADDR_OPTION_SIZE(netif->hwaddr_len)))) {
+  p = pbuf_alloc(PBUF_IP, sizeof(struct ns_header) + (lladdr_opt_len << 3), PBUF_RAM);
+  if ((p == NULL) || (p->len < (sizeof(struct ns_header) + (lladdr_opt_len << 3)))) {
     /* We couldn't allocate a suitable pbuf for the ns. drop it. */
     if (p != NULL) {
       pbuf_free(p);


### PR DESCRIPTION
#### Problem
This fixes the issue reported here - https://github.com/project-chip/connectedhomeip/issues/9791

The current version of lwip has a bug that creates a malformed Network Solicitation packet that can cause certain cable-modem/router models to crash (ex. https://www.motorola.com/us/mg7550/p).  It takes a power cycle to recover from the crash.

#### Change overview
A code update to fix the issue.

#### Testing
This was manually tested with the examples/lock-app/p6 application.  The problem occurs on the "Enable WiFi Network" step during the provisioning before Test Event tests are run.

`zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=str:<WIFI SSID> breadcrumb=0 timeoutMs=1000
`

The problem no longer occurs after the code update in this pull request.