### PR TITLE
Introduce a TLV::Tag for TLV tags.

### DIFF
--- a/src/lib/core/CHIPTLVTags.h
+++ b/src/lib/core/CHIPTLVTags.h
@@ -27,6 +27,8 @@
 namespace chip {
 namespace TLV {
 
+typedef uint64_t Tag;
+
 enum TLVCommonProfiles
 {
     /**
@@ -86,7 +88,7 @@ enum
  * @param[in]   tagNum          The profile-specific tag number assigned to the tag.
  * @return                      A 64-bit integer representing the tag.
  */
-inline constexpr uint64_t ProfileTag(uint32_t profileId, uint32_t tagNum)
+inline constexpr Tag ProfileTag(uint32_t profileId, uint32_t tagNum)
 {
     return ((static_cast<uint64_t>(profileId)) << kProfileIdShift) | tagNum;
 }
@@ -99,7 +101,7 @@ inline constexpr uint64_t ProfileTag(uint32_t profileId, uint32_t tagNum)
  * @param[in]   tagNum          The profile-specific tag number assigned to the tag.
  * @return                      A 64-bit integer representing the tag.
  */
-inline uint64_t ProfileTag(uint16_t vendorId, uint16_t profileNum, uint32_t tagNum)
+inline Tag ProfileTag(uint16_t vendorId, uint16_t profileNum, uint32_t tagNum)
 {
     return ((static_cast<uint64_t>(vendorId)) << kVendorIdShift) | ((static_cast<uint64_t>(profileNum)) << kProfileNumShift) |
         tagNum;
@@ -111,7 +113,7 @@ inline uint64_t ProfileTag(uint16_t vendorId, uint16_t profileNum, uint32_t tagN
  * @param[in]   tagNum          The context-specific tag number assigned to the tag.
  * @return                      A 64-bit integer representing the tag.
  */
-inline constexpr uint64_t ContextTag(uint8_t tagNum)
+inline constexpr Tag ContextTag(uint8_t tagNum)
 {
     return kSpecialTagMarker | tagNum;
 }
@@ -122,7 +124,7 @@ inline constexpr uint64_t ContextTag(uint8_t tagNum)
  * @param[in]   tagNum          The common profile tag number assigned to the tag.
  * @return                      A 64-bit integer representing the tag.
  */
-inline uint64_t CommonTag(uint32_t tagNum)
+inline Tag CommonTag(uint32_t tagNum)
 {
     return ProfileTag(kCommonProfileId, tagNum);
 }
@@ -146,7 +148,7 @@ enum
  * @param[in]   tag             The API representation of a profile-specific TLV tag.
  * @return                      The profile id.
  */
-inline uint32_t ProfileIdFromTag(uint64_t tag)
+inline uint32_t ProfileIdFromTag(Tag tag)
 {
     return static_cast<uint32_t>((tag & kProfileIdMask) >> kProfileIdShift);
 }
@@ -159,7 +161,7 @@ inline uint32_t ProfileIdFromTag(uint64_t tag)
  * @param[in]   tag             The API representation of a profile-specific TLV tag.
  * @return                      The associated profile number.
  */
-inline uint16_t ProfileNumFromTag(uint64_t tag)
+inline uint16_t ProfileNumFromTag(Tag tag)
 {
     return static_cast<uint16_t>((tag & kProfileIdMask) >> kProfileIdShift);
 }
@@ -175,7 +177,7 @@ inline uint16_t ProfileNumFromTag(uint64_t tag)
  * @param[in]   tag             The API representation of a profile-specific or context-specific TLV tag.
  * @return                      The associated tag number.
  */
-inline uint32_t TagNumFromTag(uint64_t tag)
+inline uint32_t TagNumFromTag(Tag tag)
 {
     return static_cast<uint32_t>(tag & kTagNumMask);
 }
@@ -188,7 +190,7 @@ inline uint32_t TagNumFromTag(uint64_t tag)
  * @param[in]   tag             The API representation of a profile-specific TLV tag.
  * @return                      The associated vendor id.
  */
-inline uint16_t VendorIdFromTag(uint64_t tag)
+inline uint16_t VendorIdFromTag(Tag tag)
 {
     return static_cast<uint16_t>((tag & kProfileIdMask) >> kVendorIdShift);
 }
@@ -196,7 +198,7 @@ inline uint16_t VendorIdFromTag(uint64_t tag)
 /**
  * Returns true of the supplied tag is a profile-specific tag.
  */
-inline bool IsProfileTag(uint64_t tag)
+inline bool IsProfileTag(Tag tag)
 {
     return (tag & kProfileIdMask) != kSpecialTagMarker;
 }
@@ -204,13 +206,13 @@ inline bool IsProfileTag(uint64_t tag)
 /**
  * Returns true if the supplied tag is a context-specific tag.
  */
-inline bool IsContextTag(uint64_t tag)
+inline bool IsContextTag(Tag tag)
 {
     return (tag & kProfileIdMask) == kSpecialTagMarker && TagNumFromTag(tag) < kContextTagMaxNum;
 }
 
 // TODO: move to private namespace
-inline bool IsSpecialTag(uint64_t tag)
+inline bool IsSpecialTag(Tag tag)
 {
     return (tag & kProfileIdMask) == kSpecialTagMarker;
 }


### PR DESCRIPTION
We can work on converting various code to using that instead of
raw uint64_t, and then make it a class to get some type-safety.

#### Problem
We use uint64_t for tlv tags, so it's easy to pass in an integer when a tag is meant.

#### Change overview
Introduce a named type for tags, so we can start switching to that and eventually get to type-safety.

#### Testing
No behavior changes.