### PR TITLE
[crypto] Add support for CHIP_CONFIG_SECURITY_TEST_MODE.

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -32,7 +32,7 @@ controller.
 
 #### IP Pairing
 
-`chip-tool pairing onnetwork 0 34567890 3840 ::1 5540` will use PASE over IP to
+`chip-tool pairing onnetwork 34567890` will use PASE over IP to
 pair a device.
 
 NOTE: to run both the Node and Controller as separate processes on the same

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -32,7 +32,7 @@ controller.
 
 #### IP Pairing
 
-`chip-tool pairing onnetwork 0 20202021 3840 ::1 5540` will use PASE over IP to
+`chip-tool pairing onnetwork 0 34567890 3840 ::1 5540` will use PASE over IP to
 pair a device.
 
 NOTE: to run both the Node and Controller as separate processes on the same

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -32,8 +32,7 @@ controller.
 
 #### IP Pairing
 
-`chip-tool pairing onnetwork 34567890` will use PASE over IP to
-pair a device.
+`chip-tool pairing onnetwork 34567890` will use PASE over IP to pair a device.
 
 NOTE: to run both the Node and Controller as separate processes on the same
 Linux or Mac machine, build the all-clusters-app with BLE disabled as follows:

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1387,6 +1387,23 @@
 #endif // CHIP_CONFIG_SECURITY_TEST_MODE
 
 /**
+ *  @def CHIP_CONFIG_TEST_SHARED_SECRET_VALUE
+ *
+ *  @brief
+ *    Shared secret to use for unit tests or when CHIP_CONFIG_SECURITY_TEST_MODE is enabled.
+ *
+ *    This parameter is 32 bytes to maximize entropy passed to the CryptoContext::InitWithSecret KDF,
+ *    and can be initialized either as a raw string or array of bytes. The default test secret of
+ *    "Test secret for key derivation." results in the following encryption keys:
+ *
+ *              5E DE D2 44 E5 53 2B 3C DC 23 40 9D BA D0 52 D2
+ *              A9 E0 11 B1 73 7C 6D 4B 70 E4 C0 A2 FE 66 04 76
+ */
+#ifndef CHIP_CONFIG_TEST_SHARED_SECRET_VALUE
+#define CHIP_CONFIG_TEST_SHARED_SECRET_VALUE "Test secret for key derivation."
+#endif // CHIP_CONFIG_TEST_SHARED_SECRET_VALUE
+
+/**
  *  @def CHIP_CONFIG_ENABLE_DNS_RESOLVER
  *
  *  @brief

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -375,7 +375,7 @@ public:
     const char * GetR2ISessionInfo() const override { return "r2i"; }
 
 private:
-    const char * kTestSecret = "Test secret for key derivation";
+    const char * kTestSecret = CHIP_CONFIG_TEST_SHARED_SECRET_VALUE;
 };
 
 typedef struct PASESessionSerialized

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -86,7 +86,8 @@ CHIP_ERROR CryptoContext::InitFromSecret(const ByteSpan & secret, const ByteSpan
     (void) info;
     (void) infoLen;
 
-    ChipLogError(SecureChannel, "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation...");
+    #pragma message "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key.  Node can only communicate with other nodes built with this flag set."
+    ChipLogError(SecureChannel, "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key.  Node can only communicate with other nodes built with this flag set.");
 
     ReturnErrorOnFailure(mHKDF.HKDF_SHA256(testSecret.data(), testSecret.size(), testSalt.data(), testSalt.size(), SEKeysInfo,
                                            sizeof(SEKeysInfo), &mKeys[0][0], sizeof(mKeys)));

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -72,8 +72,31 @@ CHIP_ERROR CryptoContext::InitFromSecret(const ByteSpan & secret, const ByteSpan
         infoLen = sizeof(RSEKeysInfo);
     }
 
+#if CHIP_CONFIG_SECURITY_TEST_MODE
+
+    // If enabled, override the generated session key with a known key pair
+    // to allow man-in-the-middle session key recovery for testing purposes:
+    //      44 D4 3C 91 D2 27 F3 BA 08 24 C5 D8 7C B8 1B 33
+    //      AC C1 8F 06 C7 BC 9B E8 24 6A 67 8C B1 F8 BA 3D
+
+    const char * kTestSecret    = "Test secret for key derivation";
+    size_t secretLen            = strlen(kTestSecret);
+    const ByteSpan & testSecret = ByteSpan(reinterpret_cast<const uint8_t *>(kTestSecret), secretLen);
+    const ByteSpan & testSalt   = ByteSpan(nullptr, 0);
+    (void) info;
+    (void) infoLen;
+
+    ChipLogError(SecureChannel, "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation...");
+
+    ReturnErrorOnFailure(mHKDF.HKDF_SHA256(testSecret.data(), testSecret.size(), testSalt.data(), testSalt.size(), SEKeysInfo,
+                                           sizeof(SEKeysInfo), &mKeys[0][0], sizeof(mKeys)));
+
+#else
+
     ReturnErrorOnFailure(
         mHKDF.HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info, infoLen, &mKeys[0][0], sizeof(mKeys)));
+
+#endif
 
     mKeyAvailable = true;
     mSessionRole  = role;
@@ -81,8 +104,9 @@ CHIP_ERROR CryptoContext::InitFromSecret(const ByteSpan & secret, const ByteSpan
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CryptoContext::Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key,
-                               const ByteSpan & salt, SessionInfoType infoType, SessionRole role)
+CHIP_ERROR CryptoContext::InitFromKeyPair(const Crypto::P256Keypair & local_keypair,
+                                          const Crypto::P256PublicKey & remote_public_key, const ByteSpan & salt,
+                                          SessionInfoType infoType, SessionRole role)
 {
 
     VerifyOrReturnError(mKeyAvailable == false, CHIP_ERROR_INCORRECT_STATE);

--- a/src/transport/CryptoContext.h
+++ b/src/transport/CryptoContext.h
@@ -68,8 +68,8 @@ public:
      * @param role               Role of the new session (initiator or responder)
      * @return CHIP_ERROR        The result of key derivation
      */
-    CHIP_ERROR Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key,
-                    const ByteSpan & salt, SessionInfoType infoType, SessionRole role);
+    CHIP_ERROR InitFromKeyPair(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key,
+                               const ByteSpan & salt, SessionInfoType infoType, SessionRole role);
 
     /**
      * @brief

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -46,29 +46,29 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 
     // Test all combinations of invalid parameters
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), ByteSpan(nullptr, 10),
-                                CryptoContext::SessionInfoType::kSessionEstablishment,
-                                CryptoContext::SessionRole::kInitiator) == CHIP_ERROR_INVALID_ARGUMENT);
+                   channel.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan(nullptr, 10),
+                                           CryptoContext::SessionInfoType::kSessionEstablishment,
+                                           CryptoContext::SessionRole::kInitiator) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test the channel is successfully created with valid parameters
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), ByteSpan(nullptr, 0),
-                                CryptoContext::SessionInfoType::kSessionEstablishment,
-                                CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
+                   channel.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan(nullptr, 0),
+                                           CryptoContext::SessionInfoType::kSessionEstablishment,
+                                           CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
 
     // Test the channel cannot be reinitialized
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), ByteSpan(nullptr, 0),
-                                CryptoContext::SessionInfoType::kSessionEstablishment,
-                                CryptoContext::SessionRole::kInitiator) == CHIP_ERROR_INCORRECT_STATE);
+                   channel.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan(nullptr, 0),
+                                           CryptoContext::SessionInfoType::kSessionEstablishment,
+                                           CryptoContext::SessionRole::kInitiator) == CHIP_ERROR_INCORRECT_STATE);
 
     // Test the channel can be initialized with valid salt
     const char * salt = "Test Salt";
     CryptoContext channel2;
     NL_TEST_ASSERT(inSuite,
-                   channel2.Init(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
-                                 CryptoContext::SessionInfoType::kSessionEstablishment,
-                                 CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
+                   channel2.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
+                                            CryptoContext::SessionInfoType::kSessionEstablishment,
+                                            CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
 }
 
 void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
@@ -92,9 +92,9 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
 
     const char * salt = "Test Salt";
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
-                                CryptoContext::SessionInfoType::kSessionEstablishment,
-                                CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
+                   channel.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
+                                           CryptoContext::SessionInfoType::kSessionEstablishment,
+                                           CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
 
     // Test initialized channel, but invalid arguments
     NL_TEST_ASSERT(inSuite, channel.Encrypt(nullptr, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);
@@ -123,9 +123,9 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   channel.Init(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
-                                CryptoContext::SessionInfoType::kSessionEstablishment,
-                                CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
+                   channel.InitFromKeyPair(keypair, keypair2.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
+                                           CryptoContext::SessionInfoType::kSessionEstablishment,
+                                           CryptoContext::SessionRole::kInitiator) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, channel.Encrypt(plain_text, sizeof(plain_text), encrypted, packetHeader, mac) == CHIP_NO_ERROR);
 
     CryptoContext channel2;
@@ -135,9 +135,9 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
                    channel2.Decrypt(encrypted, sizeof(plain_text), output, packetHeader, mac) ==
                        CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     NL_TEST_ASSERT(inSuite,
-                   channel2.Init(keypair2, keypair.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
-                                 CryptoContext::SessionInfoType::kSessionEstablishment,
-                                 CryptoContext::SessionRole::kResponder) == CHIP_NO_ERROR);
+                   channel2.InitFromKeyPair(keypair2, keypair.Pubkey(), ByteSpan((const uint8_t *) salt, sizeof(salt)),
+                                            CryptoContext::SessionInfoType::kSessionEstablishment,
+                                            CryptoContext::SessionRole::kResponder) == CHIP_NO_ERROR);
 
     // Channel initialized, but invalid arguments to decrypt
     NL_TEST_ASSERT(inSuite, channel2.Decrypt(nullptr, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION

#### Problem
The `CHIP_CONFIG_SECURITY_TEST_MODE` feature flag doesn't actually work currently.
The purpose of the flag is to build a test image which resolves all sessions to a fixed test key so packets can be dissected and verified during development.

#### Change overview
Implement `CHIP_CONFIG_SECURITY_TEST_MODE` in `CryptoContext::InitFromSecret()`.

Also renamed CryptoContext::Init() to CryptoContext::InitFromKeyPair() for clarity.

#### Testing
Manually tested against sniffer.