### PR TITLE
Normalized generation of `DecodableType` cluster objects.

### DIFF
--- a/src/app/tests/TestDataModelSerialization.cpp
+++ b/src/app/tests/TestDataModelSerialization.cpp
@@ -30,6 +30,8 @@
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
 
+namespace {
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
@@ -241,7 +243,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecNestedStruc
     // Decode
     //
     {
-        TestCluster::NestedStruct::Type t;
+        TestCluster::NestedStruct::DecodableType t;
 
         _this->SetupReader();
 
@@ -530,7 +532,7 @@ void TestDataModelSerialization::TestDataModelSerialization_OptionalFields(nlTes
     // Decode
     //
     {
-        TestCluster::SimpleStruct::Type t;
+        TestCluster::SimpleStruct::DecodableType t;
 
         _this->SetupReader();
 
@@ -602,7 +604,7 @@ void TestDataModelSerialization::TestDataModelSerialization_ExtraField(nlTestSui
     // Decode
     //
     {
-        TestCluster::SimpleStruct::Type t;
+        TestCluster::SimpleStruct::DecodableType t;
 
         _this->SetupReader();
 
@@ -673,7 +675,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidSimpleFieldTy
         // Decode
         //
         {
-            TestCluster::SimpleStruct::Type t;
+            TestCluster::SimpleStruct::DecodableType t;
 
             _this->SetupReader();
 
@@ -724,7 +726,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidSimpleFieldTy
         // Decode
         //
         {
-            TestCluster::SimpleStruct::Type t;
+            TestCluster::SimpleStruct::DecodableType t;
 
             _this->SetupReader();
 
@@ -800,6 +802,8 @@ int Finalize(void * aContext)
     chip::Platform::MemoryShutdown();
     return SUCCESS;
 }
+
+} // namespace
 
 // clang-format off
 const nlTest sTests[] =

--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -21,8 +21,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) const{
     return CHIP_NO_ERROR;
 }
 
-{{#if struct_contains_array}}
-{{else}}
+{{#unless struct_contains_array}}
 CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
     CHIP_ERROR err;
     TLV::TLVType outer;
@@ -53,7 +52,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
-{{/if}}
+{{/unless}}
 
 {{#if struct_contains_array}}
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {

--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -21,6 +21,8 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) const{
     return CHIP_NO_ERROR;
 }
 
+{{#if struct_contains_array}}
+{{else}}
 CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
     CHIP_ERROR err;
     TLV::TLVType outer;
@@ -51,11 +53,9 @@ CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
-{{#if struct_contains_array}}
-CHIP_ERROR DecodableType::Encode(TLV::TLVWriter &writer, uint64_t tag) const{
-    return CHIP_ERROR_BAD_REQUEST;
-}
+{{/if}}
 
+{{#if struct_contains_array}}
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
     CHIP_ERROR err;
     TLV::TLVType outer;

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -35,14 +35,17 @@ namespace {{name}} {
     public:
         {{#zcl_struct_items}}
         {{#if isArray}}
-        DataModel::List<{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
+        DataModel::List<{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type false}}{{/if_is_enum}}> {{asLowerCamelCase label}};
         {{else}}
-        {{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
+        {{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type false}}{{/if_is_enum}} {{asLowerCamelCase label}};
         {{/if}}
         {{/zcl_struct_items}}
 
         CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) const;
+        {{#if struct_contains_array}}
+        {{else}}
         CHIP_ERROR Decode(TLV::TLVReader &reader);
+        {{/if}}
     };
 
     {{#if struct_contains_array}}
@@ -50,14 +53,15 @@ namespace {{name}} {
     public:
         {{#zcl_struct_items checkForDoubleNestedArray="true"}}
         {{#if isArray}}
-        DataModel::DecodableList<{{#if struct_item_contains_nested_array}}{{type}}::DecodableType{{else}}{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type}}{{/if_is_enum}}{{/if}}> {{asLowerCamelCase label}};
+        DataModel::DecodableList<{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type true}}{{/if_is_enum}}> {{asLowerCamelCase label}};
         {{else}}
-        {{#if struct_item_contains_nested_array}}{{type}}::DecodableType{{else}}{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type}}{{/if_is_enum}}{{/if}} {{asLowerCamelCase label}};
+        {{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type true}}{{/if_is_enum}} {{asLowerCamelCase label}};
         {{/if}}
         {{/zcl_struct_items}}
-        CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) const;
         CHIP_ERROR Decode(TLV::TLVReader &reader);
     };
+    {{else}}
+    using DecodableType = Type;
     {{/if}}
 
 } // namespace {{name}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -35,9 +35,9 @@ namespace {{name}} {
     public:
         {{#zcl_struct_items}}
         {{#if isArray}}
-        DataModel::List<{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type false}}{{/if_is_enum}}> {{asLowerCamelCase label}};
+        DataModel::List<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToEncodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
         {{else}}
-        {{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type false}}{{/if_is_enum}} {{asLowerCamelCase label}};
+        {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToEncodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
         {{/if}}
         {{/zcl_struct_items}}
 
@@ -52,9 +52,9 @@ namespace {{name}} {
     public:
         {{#zcl_struct_items checkForDoubleNestedArray="true"}}
         {{#if isArray}}
-        DataModel::DecodableList<{{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type true}}{{/if_is_enum}}> {{asLowerCamelCase label}};
+        DataModel::DecodableList<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
         {{else}}
-        {{#if_is_enum type}}{{type}}{{else}}{{asChipZapType type true}}{{/if_is_enum}} {{asLowerCamelCase label}};
+        {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
         {{/if}}
         {{/zcl_struct_items}}
         CHIP_ERROR Decode(TLV::TLVReader &reader);

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -42,10 +42,9 @@ namespace {{name}} {
         {{/zcl_struct_items}}
 
         CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) const;
-        {{#if struct_contains_array}}
-        {{else}}
+        {{#unless struct_contains_array}}
         CHIP_ERROR Decode(TLV::TLVReader &reader);
-        {{/if}}
+        {{/unless}}
     };
 
     {{#if struct_contains_array}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -348,7 +348,7 @@ function asMEI(prefix, suffix)
   return cHelper.asHex((prefix << 16) + suffix, 8);
 }
 
-function asChipZapType(type)
+function asChipZapType(type, makeDecodable)
 {
   if (StringHelper.isOctetString(type)) {
     return 'chip::ByteSpan';
@@ -402,7 +402,11 @@ function asChipZapType(type)
       case 'uint64_t':
         return basicType;
       default:
-        return type + '::Type'
+        if (makeDecodable) {
+          return type + '::DecodableType'
+        } else {
+          return type + '::Type'
+        }
       }
     })
   }

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -348,7 +348,22 @@ function asMEI(prefix, suffix)
   return cHelper.asHex((prefix << 16) + suffix, 8);
 }
 
-function asChipZapType(type, makeDecodable)
+/*
+ * @brief
+ *
+ * This function converts a given ZAP type to a Cluster Object
+ * type used by the Matter SDK.
+ *
+ * Args:
+ *
+ * type:            ZAP type specified in the XML
+ * isDecodable:     Whether to emit an Encodable or Decodable cluster
+ *                  object type.
+ *
+ * These types can be found in src/app/data-model/.
+ *
+ */
+function zapTypeToClusterObjectType(type, isDecodable)
 {
   if (StringHelper.isOctetString(type)) {
     return 'chip::ByteSpan';
@@ -402,7 +417,7 @@ function asChipZapType(type, makeDecodable)
       case 'uint64_t':
         return basicType;
       default:
-        if (makeDecodable) {
+        if (isDecodable) {
           return type + '::DecodableType'
         } else {
           return type + '::Type'
@@ -418,17 +433,28 @@ function asChipZapType(type, makeDecodable)
   return templateUtil.templatePromise(this.global, promise)
 }
 
+function zapTypeToEncodableClusterObjectType(type)
+{
+  return zapTypeToClusterObjectType.call(this, type, false)
+}
+
+function zapTypeToDecodableClusterObjectType(type)
+{
+  return zapTypeToClusterObjectType.call(this, type, true)
+}
+
 //
 // Module exports
 //
-exports.asPrintFormat                     = asPrintFormat;
-exports.asReadType                        = asReadType;
-exports.asReadTypeLength                  = asReadTypeLength;
-exports.chip_endpoint_generated_functions = chip_endpoint_generated_functions
-exports.chip_endpoint_cluster_list        = chip_endpoint_cluster_list
-exports.asTypeLiteralSuffix               = asTypeLiteralSuffix;
-exports.asLowerCamelCase                  = asLowerCamelCase;
-exports.asUpperCamelCase                  = asUpperCamelCase;
-exports.hasSpecificAttributes             = hasSpecificAttributes;
-exports.asMEI                             = asMEI;
-exports.asChipZapType                     = asChipZapType;
+exports.asPrintFormat                       = asPrintFormat;
+exports.asReadType                          = asReadType;
+exports.asReadTypeLength                    = asReadTypeLength;
+exports.chip_endpoint_generated_functions   = chip_endpoint_generated_functions
+exports.chip_endpoint_cluster_list          = chip_endpoint_cluster_list
+exports.asTypeLiteralSuffix                 = asTypeLiteralSuffix;
+exports.asLowerCamelCase                    = asLowerCamelCase;
+exports.asUpperCamelCase                    = asUpperCamelCase;
+exports.hasSpecificAttributes               = hasSpecificAttributes;
+exports.asMEI                               = asMEI;
+exports.zapTypeToEncodableClusterObjectType = zapTypeToEncodableClusterObjectType;
+exports.zapTypeToDecodableClusterObjectType = zapTypeToDecodableClusterObjectType;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -99,6 +99,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace DeviceType
 } // namespace Descriptor
 
@@ -149,6 +150,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace BasicCommissioningInfoType
 } // namespace GeneralCommissioning
 
@@ -184,6 +186,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ThreadInterfaceScanResult
 namespace WiFiInterfaceScanResult {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -232,6 +235,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace WiFiInterfaceScanResult
 } // namespace NetworkCommissioning
 
@@ -294,6 +298,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace NetworkInterfaceType
 } // namespace GeneralDiagnostics
 
@@ -345,6 +350,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ThreadMetrics
 } // namespace SoftwareDiagnostics
 
@@ -432,6 +438,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace NeighborTable
 namespace OperationalDatasetComponents {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -508,6 +515,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace OperationalDatasetComponents
 namespace RouteTable {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -576,6 +584,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace RouteTable
 namespace SecurityPolicy {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -612,6 +621,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace SecurityPolicy
 } // namespace ThreadNetworkDiagnostics
 
@@ -682,6 +692,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace FabricDescriptor
 namespace NOCStruct {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -718,6 +729,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace NOCStruct
 } // namespace OperationalCredentials
 
@@ -757,6 +769,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace LabelStruct
 } // namespace FixedLabel
 
@@ -964,6 +977,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace TvChannelInfo
 namespace TvChannelLineupInfo {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1010,6 +1024,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace TvChannelLineupInfo
 } // namespace TvChannel
 
@@ -1049,6 +1064,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace NavigateTargetTargetInfo
 } // namespace TargetNavigator
 
@@ -1088,6 +1104,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace MediaPlaybackPosition
 } // namespace MediaPlayback
 
@@ -1137,6 +1154,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace MediaInputInfo
 } // namespace MediaInput
 
@@ -1182,6 +1200,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ContentLaunchAdditionalInfo
 namespace ContentLaunchParamater {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1193,39 +1212,6 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kExternalIDListFieldId), externalIDList));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kTypeFieldId:
-            uint8_t v;
-            ReturnErrorOnFailure(DataModel::Decode(reader, v));
-            type = static_cast<ContentLaunchParameterEnum>(v);
-            break;
-        case kValueFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, value));
-            break;
-        case kExternalIDListFieldId:
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DecodableType::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    return CHIP_ERROR_BAD_REQUEST;
 }
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
@@ -1311,6 +1297,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ContentLaunchBrandingInformation
 namespace ContentLaunchDimension {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1353,6 +1340,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ContentLaunchDimension
 namespace ContentLaunchStyleInformation {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1393,6 +1381,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ContentLaunchStyleInformation
 } // namespace ContentLauncher
 
@@ -1438,6 +1427,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace AudioOutputInfo
 } // namespace AudioOutput
 
@@ -1477,6 +1467,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace ApplicationLauncherApp
 } // namespace ApplicationLauncher
 
@@ -1536,6 +1527,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace SimpleStruct
 namespace NestedStruct {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1576,6 +1568,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace NestedStruct
 namespace NestedStructList {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1591,46 +1584,6 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kGFieldId), g));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kAFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, a));
-            break;
-        case kBFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, b));
-            break;
-        case kCFieldId:
-            ReturnErrorOnFailure(DataModel::Decode(reader, c));
-            break;
-        case kDFieldId:
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        case kEFieldId:
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        case kFFieldId:
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        case kGFieldId:
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DecodableType::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    return CHIP_ERROR_BAD_REQUEST;
 }
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
@@ -1683,31 +1636,6 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(kAFieldId), a));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err;
-    TLV::TLVType outer;
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case kAFieldId:
-            return CHIP_ERROR_NOT_IMPLEMENTED;
-        default:
-            break;
-        }
-    }
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DecodableType::Encode(TLV::TLVWriter & writer, uint64_t tag) const
-{
-    return CHIP_ERROR_BAD_REQUEST;
 }
 
 CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
@@ -1769,6 +1697,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace TestListStructOctet
 } // namespace TestCluster
 
@@ -1843,6 +1772,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace GroupKey
 namespace GroupState {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
@@ -1883,6 +1813,7 @@ CHIP_ERROR Type::Decode(TLV::TLVReader & reader)
     ReturnErrorOnFailure(reader.ExitContainer(outer));
     return CHIP_NO_ERROR;
 }
+
 } // namespace GroupState
 } // namespace GroupKeyManagement
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -991,6 +991,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace DeviceType
 
 } // namespace Descriptor
@@ -1227,6 +1229,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace BasicCommissioningInfoType
 
 namespace Commands {
@@ -1333,6 +1337,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace ThreadInterfaceScanResult
 namespace WiFiInterfaceScanResult {
 enum FieldId
@@ -1356,6 +1362,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace WiFiInterfaceScanResult
 
@@ -1660,6 +1668,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace NetworkInterfaceType
 
 } // namespace GeneralDiagnostics
@@ -1687,6 +1697,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace ThreadMetrics
 
@@ -1765,6 +1777,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace NeighborTable
 namespace OperationalDatasetComponents {
 enum FieldId
@@ -1803,6 +1817,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace OperationalDatasetComponents
 namespace RouteTable {
 enum FieldId
@@ -1837,6 +1853,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace RouteTable
 namespace SecurityPolicy {
 enum FieldId
@@ -1854,6 +1872,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace SecurityPolicy
 
@@ -2065,6 +2085,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace FabricDescriptor
 namespace NOCStruct {
 enum FieldId
@@ -2082,6 +2104,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace NOCStruct
 
@@ -2236,6 +2260,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace LabelStruct
 
@@ -3680,6 +3706,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace TvChannelInfo
 namespace TvChannelLineupInfo {
 enum FieldId
@@ -3701,6 +3729,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace TvChannelLineupInfo
 
@@ -3773,6 +3803,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace NavigateTargetTargetInfo
 
 namespace Commands {
@@ -3834,6 +3866,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace MediaPlaybackPosition
 
@@ -4099,6 +4133,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace MediaInputInfo
 
 namespace Commands {
@@ -4334,6 +4370,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace ContentLaunchAdditionalInfo
 namespace ContentLaunchParamater {
 enum FieldId
@@ -4351,7 +4389,6 @@ public:
     DataModel::List<ContentLaunchAdditionalInfo::Type> externalIDList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
 struct DecodableType
@@ -4359,8 +4396,7 @@ struct DecodableType
 public:
     ContentLaunchParameterEnum type;
     Span<const char> value;
-    DataModel::DecodableList<ContentLaunchAdditionalInfo::Type> externalIDList;
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    DataModel::DecodableList<ContentLaunchAdditionalInfo::DecodableType> externalIDList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4390,6 +4426,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace ContentLaunchBrandingInformation
 namespace ContentLaunchDimension {
 enum FieldId
@@ -4410,6 +4448,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace ContentLaunchDimension
 namespace ContentLaunchStyleInformation {
 enum FieldId
@@ -4429,6 +4469,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace ContentLaunchStyleInformation
 
@@ -4506,6 +4548,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace AudioOutputInfo
 
 namespace Commands {
@@ -4556,6 +4600,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace ApplicationLauncherApp
 
@@ -4673,6 +4719,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace SimpleStruct
 namespace NestedStruct {
 enum FieldId
@@ -4692,6 +4740,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace NestedStruct
 namespace NestedStructList {
@@ -4718,7 +4768,6 @@ public:
     DataModel::List<uint8_t> g;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
 struct DecodableType
@@ -4726,12 +4775,11 @@ struct DecodableType
 public:
     uint8_t a;
     bool b;
-    SimpleStruct::Type c;
-    DataModel::DecodableList<SimpleStruct::Type> d;
+    SimpleStruct::DecodableType c;
+    DataModel::DecodableList<SimpleStruct::DecodableType> d;
     DataModel::DecodableList<uint32_t> e;
     DataModel::DecodableList<chip::ByteSpan> f;
     DataModel::DecodableList<uint8_t> g;
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4748,14 +4796,12 @@ public:
     DataModel::List<NestedStructList::Type> a;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
 struct DecodableType
 {
 public:
     DataModel::DecodableList<NestedStructList::DecodableType> a;
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4776,6 +4822,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace TestListStructOctet
 
@@ -5257,6 +5305,8 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
+using DecodableType = Type;
+
 } // namespace GroupKey
 namespace GroupState {
 enum FieldId
@@ -5276,6 +5326,8 @@ public:
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
+
+using DecodableType = Type;
 
 } // namespace GroupState
 


### PR DESCRIPTION
Today for a struct definition in schema, a `Type` cluster object definition is minimally generated, while a `DecodableType` object definition is only generated if the struct contains a list. The presence of such embedded lists requires the use of the `DecodableType`, which in turn contains a `DataModel::DecodableList` instead of a Span-backed `DataModel::List`
to permit in-place traversal of the list.

However, this creates inconsistency since some structs only come with a single 'Type' definition while others come with both.

This PR normalizes it such that both `Type` and `DecodableType` are emitted, with the latter just an alias to 'Type' if it doesn't contain a list.

This makes it easier for developers to always rely on using the `DecodableType` for decoding data, and the `Type` type for encoding.

This also simplifies the ZAPT template files as well, and sets the stage for some future simplifications as well for supporting these objects for attributes and commands.

Bundled some other minimal fixes as well in this PR, which include omitting `Encode` on `DecodableType` definitions (since it's only meant for iterating on decode) and omitting `Decode` on 'Type' definitions if they contain a list.

#### Testing

- Updated the `TestDataModelSerialization` test to now exclusively use the `DecodableType` on the decode path, and used that to validate these changes.