### PR TITLE
[btp] align code to the specification

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -130,7 +130,7 @@ class BluetoothManager : BleCallback {
         wrappedCallback.onServicesDiscovered(gatt, status)
 
         Log.i("$TAG|onServicesDiscovered", "Services Discovered")
-        gatt?.requestMtu(131);
+        gatt?.requestMtu(247);
       }
 
       override fun onMtuChanged(gatt: BluetoothGatt?, mtu: Int, status: Int) {

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1112,18 +1112,13 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBufferHandle && 
                      CHIP_BLE_TRANSPORT_PROTOCOL_MIN_SUPPORTED_VERSION, CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION);
         mState = kState_Aborting;
     }
-    else if ((resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V1) ||
-             (resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V2))
+    else
     {
         // Set Rx and Tx fragment sizes to the same value
         mBtpEngine.SetRxFragmentSize(resp.mFragmentSize);
         mBtpEngine.SetTxFragmentSize(resp.mFragmentSize);
     }
-    else // resp.SelectedProtocolVersion >= kBleTransportProtocolVersion_V3
-    {
-        // This is the peripheral, so set Rx fragment size, and leave Tx at default
-        mBtpEngine.SetRxFragmentSize(resp.mFragmentSize);
-    }
+
     ChipLogProgress(Ble, "using BTP fragment sizes rx %d / tx %d.", mBtpEngine.GetRxFragmentSize(), mBtpEngine.GetTxFragmentSize());
 
     ReturnErrorOnFailure(resp.Encode(responseBuf));
@@ -1158,17 +1153,9 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandle &&
     // Set fragment size as minimum of (reported ATT MTU, BTP characteristic size)
     resp.mFragmentSize = chip::min(resp.mFragmentSize, BtpEngine::sMaxFragmentSize);
 
-    if ((resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V1) ||
-        (resp.mSelectedProtocolVersion == kBleTransportProtocolVersion_V2))
-    {
-        mBtpEngine.SetRxFragmentSize(resp.mFragmentSize);
-        mBtpEngine.SetTxFragmentSize(resp.mFragmentSize);
-    }
-    else // resp.SelectedProtocolVersion >= kBleTransportProtocolVersion_V3
-    {
-        // This is the central, so set Tx fragement size, and leave Rx at default.
-        mBtpEngine.SetTxFragmentSize(resp.mFragmentSize);
-    }
+    mBtpEngine.SetRxFragmentSize(resp.mFragmentSize);
+    mBtpEngine.SetTxFragmentSize(resp.mFragmentSize);
+
     ChipLogProgress(Ble, "using BTP fragment sizes rx %d / tx %d.", mBtpEngine.GetRxFragmentSize(), mBtpEngine.GetTxFragmentSize());
 
     // Select local and remote max receive window size based on local resources available for both incoming indications

--- a/src/ble/BleConfig.h
+++ b/src/ble/BleConfig.h
@@ -165,7 +165,7 @@
  *
  */
 #ifndef BLE_MAX_RECEIVE_WINDOW_SIZE
-#define BLE_MAX_RECEIVE_WINDOW_SIZE                            3
+#define BLE_MAX_RECEIVE_WINDOW_SIZE 6
 #endif
 
 #if (BLE_MAX_RECEIVE_WINDOW_SIZE < 3)
@@ -180,7 +180,7 @@
  *
  */
 #ifndef BLE_CONFIG_ERROR_MIN
-#define BLE_CONFIG_ERROR_MIN                               6000
+#define BLE_CONFIG_ERROR_MIN 6000
 #endif // BLE_CONFIG_ERROR_MIN
 
 /**
@@ -191,7 +191,7 @@
  *
  */
 #ifndef BLE_CONFIG_ERROR_MAX
-#define BLE_CONFIG_ERROR_MAX                               6999
+#define BLE_CONFIG_ERROR_MAX 6999
 #endif // BLE_CONFIG_ERROR_MAX
 
 /**
@@ -203,7 +203,7 @@
  *
  */
 #ifndef BLE_CONFIG_ERROR
-#define BLE_CONFIG_ERROR(e)                               (BLE_CONFIG_ERROR_MIN + (e))
+#define BLE_CONFIG_ERROR(e) (BLE_CONFIG_ERROR_MIN + (e))
 #endif // BLE_CONFIG_ERROR
 
 // clang-format on

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -67,8 +67,8 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 // Magic values expected in first 2 bytes of valid BLE transport capabilities request or response:
-#define CAPABILITIES_MSG_CHECK_BYTE_1 'n'
-#define CAPABILITIES_MSG_CHECK_BYTE_2 'l'
+#define CAPABILITIES_MSG_CHECK_BYTE_1 0b01100101
+#define CAPABILITIES_MSG_CHECK_BYTE_2 0b01101100
 
 namespace chip {
 namespace Ble {

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -77,8 +77,8 @@ namespace Ble {
  */
 #define NUM_SUPPORTED_PROTOCOL_VERSIONS 8
 /// Version(s) of the CHIP BLE Transport Protocol that this stack supports.
-#define CHIP_BLE_TRANSPORT_PROTOCOL_MIN_SUPPORTED_VERSION kBleTransportProtocolVersion_V2
-#define CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION kBleTransportProtocolVersion_V3
+#define CHIP_BLE_TRANSPORT_PROTOCOL_MIN_SUPPORTED_VERSION kBleTransportProtocolVersion_V4
+#define CHIP_BLE_TRANSPORT_PROTOCOL_MAX_SUPPORTED_VERSION kBleTransportProtocolVersion_V4
 
 /// Forward declarations.
 class BleLayer;
@@ -88,9 +88,7 @@ class BLEEndPoint;
 typedef enum
 {
     kBleTransportProtocolVersion_None = 0,
-    kBleTransportProtocolVersion_V1   = 1, // Prototype BTP version without ACKs or flow-control.
-    kBleTransportProtocolVersion_V2   = 2, // First BTP version with ACKs and flow-control.
-    kBleTransportProtocolVersion_V3   = 3  // First BTP version with asymetric fragement sizes.
+    kBleTransportProtocolVersion_V4   = 4 // BTP as defined by CHIP v1.0
 } BleTransportProtocolVersion;
 
 constexpr size_t kCapabilitiesRequestMagicnumLength          = 2;

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -74,7 +74,7 @@ static void PrintBufDebug(const System::PacketBufferHandle & buf)
 }
 
 const uint16_t BtpEngine::sDefaultFragmentSize = 20;  // 23-byte minimum ATT_MTU - 3 bytes for ATT operation header
-const uint16_t BtpEngine::sMaxFragmentSize     = 128; // Size of write and indication characteristics
+const uint16_t BtpEngine::sMaxFragmentSize     = 244; // Maximum size of BTP segment
 
 CHIP_ERROR BtpEngine::Init(void * an_app_state, bool expect_first_ack)
 {


### PR DESCRIPTION
#### Problem

- BTP fragment size is limited to 128 (244 in the spec - which works best with ATT_MTU >= 247)
- BTP in version 4 is not supported (required by the spec)
- The maximum BTP fragment size for Peripheral TX is always limited to 20B - regardless of ATT_MTU value
- Handshake frame has invalid first byte 0x6e (0x65 in the spec)

#### Change overview
Fixed all the above issues and increase the default BTP window size to speed up the commissioning process.
The overall commissioning time depends on BLE connection parameters, but can be done in under 2 seconds (tested with nRF Connect platform).

#### Testing
Tested manually with Python CHIP controller and Android CHIP Tool against nRF Connect platform. Inspected fields in BTP payload using BLE Sniffer.
