### PR TITLE
[DNS-SD] Redesign ServiceAdvertiser and Resolver interfaces

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -34,9 +34,8 @@ public:
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().StartResolver(&chip::DeviceLayer::InetLayer, kMdnsPort));
-        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(nullptr));
-        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(this));
+        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().Init(&chip::DeviceLayer::InetLayer, kMdnsPort));
+        chip::Mdns::Resolver::Instance().SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Mdns: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Mdns::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
                                                               chip::Inet::kIPAddressType_Any);

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -24,8 +24,6 @@
 #include <controller/DeviceAddressUpdateDelegate.h>
 #include <lib/mdns/Resolver.h>
 
-constexpr uint16_t kMdnsPort = 5353;
-
 class Resolve : public DiscoverCommand, public chip::Mdns::ResolverDelegate
 {
 public:
@@ -34,7 +32,7 @@ public:
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().Init(&chip::DeviceLayer::InetLayer, kMdnsPort));
+        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().Init(&chip::DeviceLayer::InetLayer));
         chip::Mdns::Resolver::Instance().SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Mdns: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Mdns::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),

--- a/examples/minimal-mdns/advertiser.cpp
+++ b/examples/minimal-mdns/advertiser.cpp
@@ -255,7 +255,7 @@ int main(int argc, char ** args)
         return 1;
     }
 
-    if (chip::Mdns::ServiceAdvertiser::Instance().Start(&DeviceLayer::InetLayer, Mdns::kMdnsPort) != CHIP_NO_ERROR)
+    if (chip::Mdns::ServiceAdvertiser::Instance().Init(&DeviceLayer::InetLayer) != CHIP_NO_ERROR)
     {
         fprintf(stderr, "FAILED to start MDNS advertisement\n");
         return 1;

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -176,10 +176,10 @@ bool MdnsServer::OnExpiration(uint64_t expirationMs)
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
-    err = Mdns::ServiceAdvertiser::Instance().CompleteServiceUpdate();
+    err = Mdns::ServiceAdvertiser::Instance().FinalizeServiceUpdate();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to complete service update: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to finalize service update: %s", chip::ErrorStr(err));
     }
 
     return true;
@@ -477,10 +477,10 @@ void MdnsServer::StartServer(chip::Mdns::CommissioningMode mode)
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
-    err = Mdns::ServiceAdvertiser::Instance().CompleteServiceUpdate();
+    err = Mdns::ServiceAdvertiser::Instance().FinalizeServiceUpdate();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to complete service update: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to finalize service update: %s", chip::ErrorStr(err));
     }
 }
 

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -148,7 +148,7 @@ bool MdnsServer::OnExpiration(uint64_t expirationMs)
 
     ChipLogDetail(Discovery, "OnExpiration - valid time out");
 
-    CHIP_ERROR err = Mdns::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer, chip::Mdns::kMdnsPort);
+    CHIP_ERROR err = Mdns::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to initialize advertiser: %s", chip::ErrorStr(err));
@@ -412,7 +412,7 @@ void MdnsServer::StartServer(chip::Mdns::CommissioningMode mode)
 
     ClearTimeouts();
 
-    CHIP_ERROR err = Mdns::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer, chip::Mdns::kMdnsPort);
+    CHIP_ERROR err = Mdns::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to initialize advertiser: %s", chip::ErrorStr(err));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -187,7 +187,7 @@ exit:
 
 void Server::Shutdown()
 {
-    chip::Mdns::ServiceAdvertiser::Instance().StopPublishDevice();
+    chip::Mdns::ServiceAdvertiser::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     mExchangeMgr.Shutdown();
     mSessions.Shutdown();

--- a/src/controller/AbstractMdnsDiscoveryController.cpp
+++ b/src/controller/AbstractMdnsDiscoveryController.cpp
@@ -67,7 +67,7 @@ void AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(const chip::Mdns::
 CHIP_ERROR AbstractMdnsDiscoveryController::SetUpNodeDiscovery()
 {
 #if CONFIG_DEVICE_LAYER
-    ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer, kMdnsPort));
+    ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer));
 #endif
     mResolver->SetResolverDelegate(this);
 

--- a/src/controller/AbstractMdnsDiscoveryController.cpp
+++ b/src/controller/AbstractMdnsDiscoveryController.cpp
@@ -66,10 +66,10 @@ void AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(const chip::Mdns::
 
 CHIP_ERROR AbstractMdnsDiscoveryController::SetUpNodeDiscovery()
 {
-    ReturnErrorOnFailure(mResolver->SetResolverDelegate(this));
 #if CONFIG_DEVICE_LAYER
-    ReturnErrorOnFailure(mResolver->StartResolver(&DeviceLayer::InetLayer, kMdnsPort));
+    ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer, kMdnsPort));
 #endif
+    mResolver->SetResolverDelegate(this);
 
     auto discoveredNodes = GetDiscoveredNodes();
     for (auto & discoveredNode : discoveredNodes)

--- a/src/controller/AbstractMdnsDiscoveryController.h
+++ b/src/controller/AbstractMdnsDiscoveryController.h
@@ -27,8 +27,6 @@ namespace chip {
 
 namespace Controller {
 
-constexpr uint16_t kMdnsPort = 5353;
-
 /**
  * @brief
  *   Convenient superclass for controller implementations that need to discover

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     params.systemState->ExchangeMgr()->SetDelegate(this);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    Mdns::Resolver::Instance().Init(params.systemState->InetLayer(), kMdnsPort);
+    Mdns::Resolver::Instance().Init(params.systemState->InetLayer());
     Mdns::Resolver::Instance().SetResolverDelegate(this);
     RegisterDeviceAddressUpdateDelegate(params.deviceAddressUpdateDelegate);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -135,10 +135,10 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     params.systemState->ExchangeMgr()->SetDelegate(this);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    ReturnErrorOnFailure(Mdns::Resolver::Instance().SetResolverDelegate(this));
+    Mdns::Resolver::Instance().Init(params.systemState->InetLayer(), kMdnsPort);
+    Mdns::Resolver::Instance().SetResolverDelegate(this);
     RegisterDeviceAddressUpdateDelegate(params.deviceAddressUpdateDelegate);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
-    Mdns::Resolver::Instance().StartResolver(params.systemState->InetLayer(), kMdnsPort);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
     InitDataModelHandler(params.systemState->ExchangeMgr());
@@ -217,7 +217,7 @@ CHIP_ERROR DeviceController::Shutdown()
     mState = State::NotInitialized;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    Mdns::Resolver::Instance().ShutdownResolver();
+    Mdns::Resolver::Instance().Shutdown();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
     mStorageDelegate = nullptr;

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -33,8 +33,6 @@ namespace {
 using DiscoverSuccessCallback = void (*)(uint64_t fabricId, uint64_t nodeId, uint32_t interfaceId, const char * ip, uint16_t port);
 using DiscoverFailureCallback = void (*)(uint64_t fabricId, uint64_t nodeId, ChipError::StorageType error_code);
 
-constexpr uint16_t kMdnsPort = 5353;
-
 class PythonResolverDelegate : public ResolverDelegate
 {
 public:
@@ -95,7 +93,7 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
     CHIP_ERROR result = CHIP_NO_ERROR;
 
     chip::python::ChipMainThreadScheduleAndWait([&] {
-        result = Resolver::Instance().Init(&chip::DeviceLayer::InetLayer, kMdnsPort);
+        result = Resolver::Instance().Init(&chip::DeviceLayer::InetLayer);
         ReturnOnFailure(result);
         Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
 

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -95,11 +95,9 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
     CHIP_ERROR result = CHIP_NO_ERROR;
 
     chip::python::ChipMainThreadScheduleAndWait([&] {
-        result = Resolver::Instance().StartResolver(&chip::DeviceLayer::InetLayer, kMdnsPort);
+        result = Resolver::Instance().Init(&chip::DeviceLayer::InetLayer, kMdnsPort);
         ReturnOnFailure(result);
-
-        result = Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
-        ReturnOnFailure(result);
+        Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
 
         result = Resolver::Instance().ResolveNodeId(chip::PeerId().SetCompressedFabricId(fabricId).SetNodeId(nodeId),
                                                     chip::Inet::IPAddressType::kIPAddressType_Any);

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -31,17 +31,16 @@ namespace {
 class MockResolver : public Resolver
 {
 public:
-    CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return SetResolverDelegateStatus; }
-    CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return StartResolverStatus; }
-    void ShutdownResolver() override {}
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return InitStatus; }
+    void Shutdown() override {}
+    void SetResolverDelegate(ResolverDelegate *) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
-    CHIP_ERROR SetResolverDelegateStatus = CHIP_NO_ERROR;
-    CHIP_ERROR StartResolverStatus       = CHIP_NO_ERROR;
-    CHIP_ERROR ResolveNodeIdStatus       = CHIP_NO_ERROR;
-    CHIP_ERROR FindCommissionersStatus   = CHIP_NO_ERROR;
+    CHIP_ERROR InitStatus              = CHIP_NO_ERROR;
+    CHIP_ERROR ResolveNodeIdStatus     = CHIP_NO_ERROR;
+    CHIP_ERROR FindCommissionersStatus = CHIP_NO_ERROR;
 };
 
 } // namespace
@@ -143,18 +142,10 @@ void TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter(nlTestSuite * inSuit
                        CHIP_NO_ERROR);
 }
 
-void TestDiscoverCommissioners_SetResolverDelegateError_ReturnsError(nlTestSuite * inSuite, void * inContext)
+void TestDiscoverCommissioners_InitError_ReturnsError(nlTestSuite * inSuite, void * inContext)
 {
     MockResolver resolver;
-    resolver.SetResolverDelegateStatus = CHIP_ERROR_INTERNAL;
-    CommissionableNodeController controller(&resolver);
-    NL_TEST_ASSERT(inSuite, controller.DiscoverCommissioners() != CHIP_NO_ERROR);
-}
-
-void TestDiscoverCommissioners_StartResolverError_ReturnsError(nlTestSuite * inSuite, void * inContext)
-{
-    MockResolver resolver;
-    resolver.StartResolverStatus = CHIP_ERROR_INTERNAL;
+    resolver.InitStatus = CHIP_ERROR_INTERNAL;
     CommissionableNodeController controller(&resolver);
     NL_TEST_ASSERT(inSuite, controller.DiscoverCommissioners() != CHIP_NO_ERROR);
 }
@@ -178,8 +169,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr", TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCase", TestDiscoverCommissioners_HappyCase),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter", TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter),
-    NL_TEST_DEF("TestDiscoverCommissioners_SetResolverDelegateError_ReturnsError", TestDiscoverCommissioners_SetResolverDelegateError_ReturnsError),
-    NL_TEST_DEF("TestDiscoverCommissioners_StartResolverError_ReturnsError", TestDiscoverCommissioners_StartResolverError_ReturnsError),
+    NL_TEST_DEF("TestDiscoverCommissioners_InitError_ReturnsError", TestDiscoverCommissioners_InitError_ReturnsError),
     NL_TEST_DEF("TestDiscoverCommissioners_FindCommissionersError_ReturnsError", TestDiscoverCommissioners_FindCommissionersError_ReturnsError),
     NL_TEST_SENTINEL()
 };

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -31,7 +31,7 @@ namespace {
 class MockResolver : public Resolver
 {
 public:
-    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return InitStatus; }
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override { return InitStatus; }
     void Shutdown() override {}
     void SetResolverDelegate(ResolverDelegate *) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -99,7 +99,8 @@ public:
                              const Span<const char * const> & aSubTypes, const Span<const Mdns::TextEntry> & aTxtEntries,
                              uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
-    CHIP_ERROR RemoveAllSrpServices();
+    CHIP_ERROR InvalidateAllSrpServices(); ///< Mark all SRP services as invalid
+    CHIP_ERROR RemoveInvalidSrpServices(); ///< Remove SRP services marked as invalid
     CHIP_ERROR SetupSrpHost(const char * aHostName);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
@@ -259,9 +260,14 @@ inline CHIP_ERROR ThreadStackManager::RemoveSrpService(const char * aInstanceNam
     return static_cast<ImplClass *>(this)->_RemoveSrpService(aInstanceName, aName);
 }
 
-inline CHIP_ERROR ThreadStackManager::RemoveAllSrpServices()
+inline CHIP_ERROR ThreadStackManager::InvalidateAllSrpServices()
 {
-    return static_cast<ImplClass *>(this)->_RemoveAllSrpServices();
+    return static_cast<ImplClass *>(this)->_InvalidateAllSrpServices();
+}
+
+inline CHIP_ERROR ThreadStackManager::RemoveInvalidSrpServices()
+{
+    return static_cast<ImplClass *>(this)->_RemoveInvalidSrpServices();
 }
 
 inline CHIP_ERROR ThreadStackManager::SetupSrpHost(const char * aHostName)

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -307,7 +307,7 @@ public:
      * The method must be called before other methods of this class.
      * If the advertiser has already been initialized, the method exits immediately with no error.
      */
-    virtual CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
+    virtual CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) = 0;
 
     /**
      * Shuts down the advertiser.

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -294,7 +294,7 @@ private:
  * occur:
  * 1. Call the `RemoveServices` method.
  * 2. Call one of the `Advertise` methods for each service to be added or updated.
- * 3. Call the `CompleteServiceUpdate` method to complete the update and apply all pending changes.
+ * 3. Call the `FinalizeServiceUpdate` method to finalize the update and apply all pending changes.
  */
 class ServiceAdvertiser
 {
@@ -318,7 +318,7 @@ public:
      * Removes or marks all services being advertised for removal.
      *
      * Depending on the implementation, the method may either stop advertising existing services
-     * immediately, or mark them for removal upon the subsequent `CompleteServiceUpdate` method call.
+     * immediately, or mark them for removal upon the subsequent `FinalizeServiceUpdate` method call.
      */
     virtual CHIP_ERROR RemoveServices() = 0;
 
@@ -333,12 +333,12 @@ public:
     virtual CHIP_ERROR Advertise(const CommissionAdvertisingParameters & params) = 0;
 
     /**
-     * Completes updating advertised services.
+     * Finalizes updating advertised services.
      *
      * This method can be used by some implementations to apply changes made with the `RemoveServices`
      * and `Advertise` methods in case they could not be applied immediately.
      */
-    virtual CHIP_ERROR CompleteServiceUpdate() = 0;
+    virtual CHIP_ERROR FinalizeServiceUpdate() = 0;
 
     /**
      * Returns the commissionable node service instance name formatted as hex string.

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -120,7 +120,7 @@ public:
     CHIP_ERROR RemoveServices() override;
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;
     CHIP_ERROR Advertise(const CommissionAdvertisingParameters & params) override;
-    CHIP_ERROR CompleteServiceUpdate() override { return CHIP_NO_ERROR; }
+    CHIP_ERROR FinalizeServiceUpdate() override { return CHIP_NO_ERROR; }
     CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override;
 
     // MdnsPacketDelegate

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -115,7 +115,7 @@ public:
     ~AdvertiserMinMdns() {}
 
     // Service advertiser
-    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override;
     void Shutdown() override;
     CHIP_ERROR RemoveServices() override;
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;
@@ -274,7 +274,7 @@ void AdvertiserMinMdns::OnQuery(const QueryData & data)
     }
 }
 
-CHIP_ERROR AdvertiserMinMdns::Init(chip::Inet::InetLayer * inetLayer, uint16_t port)
+CHIP_ERROR AdvertiserMinMdns::Init(chip::Inet::InetLayer * inetLayer)
 {
     GlobalMinimalMdnsServer::Server().Shutdown();
 
@@ -284,7 +284,7 @@ CHIP_ERROR AdvertiserMinMdns::Init(chip::Inet::InetLayer * inetLayer, uint16_t p
     // GlobalMinimalMdnsServer (used for testing).
     mResponseSender.SetServer(&GlobalMinimalMdnsServer::Server());
 
-    ReturnErrorOnFailure(GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, port));
+    ReturnErrorOnFailure(GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, kMdnsPort));
 
     ChipLogProgress(Discovery, "CHIP minimal mDNS started advertising.");
 

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -115,10 +115,12 @@ public:
     ~AdvertiserMinMdns() {}
 
     // Service advertiser
-    CHIP_ERROR Start(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    void Shutdown() override;
+    CHIP_ERROR RemoveServices() override;
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;
     CHIP_ERROR Advertise(const CommissionAdvertisingParameters & params) override;
-    CHIP_ERROR StopPublishDevice() override;
+    CHIP_ERROR CompleteServiceUpdate() override { return CHIP_NO_ERROR; }
     CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override;
 
     // MdnsPacketDelegate
@@ -272,7 +274,7 @@ void AdvertiserMinMdns::OnQuery(const QueryData & data)
     }
 }
 
-CHIP_ERROR AdvertiserMinMdns::Start(chip::Inet::InetLayer * inetLayer, uint16_t port)
+CHIP_ERROR AdvertiserMinMdns::Init(chip::Inet::InetLayer * inetLayer, uint16_t port)
 {
     GlobalMinimalMdnsServer::Server().Shutdown();
 
@@ -291,8 +293,12 @@ CHIP_ERROR AdvertiserMinMdns::Start(chip::Inet::InetLayer * inetLayer, uint16_t 
     return CHIP_NO_ERROR;
 }
 
-/// Stops the advertiser.
-CHIP_ERROR AdvertiserMinMdns::StopPublishDevice()
+void AdvertiserMinMdns::Shutdown()
+{
+    GlobalMinimalMdnsServer::Server().Shutdown();
+}
+
+CHIP_ERROR AdvertiserMinMdns::RemoveServices()
 {
     for (auto & allocator : mQueryResponderAllocatorOperational)
     {

--- a/src/lib/mdns/Advertiser_ImplNone.cpp
+++ b/src/lib/mdns/Advertiser_ImplNone.cpp
@@ -26,9 +26,17 @@ namespace {
 class NoneAdvertiser : public ServiceAdvertiser
 {
 public:
-    CHIP_ERROR Start(chip::Inet::InetLayer * inetLayet, uint16_t port) override
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayet, uint16_t port) override
     {
-        ChipLogError(Discovery, "mDNS advertising not available. mDNS start disabled.");
+        ChipLogError(Discovery, "mDNS advertising not available. mDNS init disabled.");
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    void Shutdown() override {}
+
+    CHIP_ERROR RemoveServices() override
+    {
+        ChipLogError(Discovery, "mDNS advertising not available. Removing services failed.");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
@@ -44,10 +52,9 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-    /// Stops the advertiser.
-    CHIP_ERROR StopPublishDevice() override
+    CHIP_ERROR CompleteServiceUpdate() override
     {
-        ChipLogError(Discovery, "mDNS advertising not available. mDNS stop not available.");
+        ChipLogError(Discovery, "mDNS advertising not available. Completing service update failed.");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 

--- a/src/lib/mdns/Advertiser_ImplNone.cpp
+++ b/src/lib/mdns/Advertiser_ImplNone.cpp
@@ -52,9 +52,9 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-    CHIP_ERROR CompleteServiceUpdate() override
+    CHIP_ERROR FinalizeServiceUpdate() override
     {
-        ChipLogError(Discovery, "mDNS advertising not available. Completing service update failed.");
+        ChipLogError(Discovery, "mDNS advertising not available. Finalizing service update failed.");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 

--- a/src/lib/mdns/Advertiser_ImplNone.cpp
+++ b/src/lib/mdns/Advertiser_ImplNone.cpp
@@ -26,7 +26,7 @@ namespace {
 class NoneAdvertiser : public ServiceAdvertiser
 {
 public:
-    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayet, uint16_t port) override
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayet) override
     {
         ChipLogError(Discovery, "mDNS advertising not available. mDNS init disabled.");
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -91,7 +91,7 @@ void DiscoveryImplPlatform::HandleMdnsError(void * context, CHIP_ERROR error)
         {
             publisher->Advertise(publisher->mCommissionerAdvertisingParams);
         }
-        publisher->CompleteServiceUpdate();
+        publisher->FinalizeServiceUpdate();
     }
     else
     {
@@ -443,9 +443,9 @@ CHIP_ERROR DiscoveryImplPlatform::RemoveServices()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DiscoveryImplPlatform::CompleteServiceUpdate()
+CHIP_ERROR DiscoveryImplPlatform::FinalizeServiceUpdate()
 {
-    return ChipMdnsCompleteServiceUpdate();
+    return ChipMdnsFinalizeServiceUpdate();
 }
 
 CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type)

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -43,30 +43,20 @@ MdnsCache<CHIP_CONFIG_MDNS_CACHE_SIZE> DiscoveryImplPlatform::sMdnsCache;
 
 DiscoveryImplPlatform::DiscoveryImplPlatform() = default;
 
-CHIP_ERROR DiscoveryImplPlatform::Init()
+CHIP_ERROR DiscoveryImplPlatform::InitImpl()
 {
-    if (!mMdnsInitialized)
-    {
-        ReturnErrorOnFailure(ChipMdnsInit(HandleMdnsInit, HandleMdnsError, this));
-        mCommissionInstanceName = GetRandU64();
-        mMdnsInitialized        = true;
-    }
+    ReturnErrorCodeIf(mMdnsInitialized, CHIP_NO_ERROR);
+    ReturnErrorOnFailure(ChipMdnsInit(HandleMdnsInit, HandleMdnsError, this));
+    mCommissionInstanceName = GetRandU64();
+    mMdnsInitialized        = true;
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DiscoveryImplPlatform::Start(Inet::InetLayer * inetLayer, uint16_t port)
+void DiscoveryImplPlatform::Shutdown()
 {
-    ReturnErrorOnFailure(Init());
-
-    CHIP_ERROR error = ChipMdnsStopPublish();
-
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "Failed to initialize platform mdns: %s", ErrorStr(error));
-    }
-
-    return error;
+    VerifyOrReturn(mMdnsInitialized);
+    ChipMdnsShutdown();
 }
 
 void DiscoveryImplPlatform::HandleMdnsInit(void * context, CHIP_ERROR initError)
@@ -101,6 +91,7 @@ void DiscoveryImplPlatform::HandleMdnsError(void * context, CHIP_ERROR error)
         {
             publisher->Advertise(publisher->mCommissionerAdvertisingParams);
         }
+        publisher->CompleteServiceUpdate();
     }
     else
     {
@@ -441,28 +432,25 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     return error;
 }
 
-CHIP_ERROR DiscoveryImplPlatform::StopPublishDevice()
+CHIP_ERROR DiscoveryImplPlatform::RemoveServices()
 {
-    CHIP_ERROR error = ChipMdnsStopPublish();
+    ReturnErrorOnFailure(ChipMdnsRemoveServices());
 
-    if (error == CHIP_NO_ERROR)
-    {
-        mIsOperationalPublishing        = false;
-        mIsCommissionableNodePublishing = false;
-        mIsCommissionerPublishing       = false;
-    }
-    return error;
+    mIsOperationalPublishing        = false;
+    mIsCommissionableNodePublishing = false;
+    mIsCommissionerPublishing       = false;
+
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DiscoveryImplPlatform::SetResolverDelegate(ResolverDelegate * delegate)
+CHIP_ERROR DiscoveryImplPlatform::CompleteServiceUpdate()
 {
-    mResolverDelegate = delegate;
-    return CHIP_NO_ERROR;
+    return ChipMdnsCompleteServiceUpdate();
 }
 
 CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type)
 {
-    ReturnErrorOnFailure(Init());
+    ReturnErrorOnFailure(InitImpl());
 
 #if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
     Inet::IPAddress addr;
@@ -541,7 +529,7 @@ void DiscoveryImplPlatform::HandleNodeResolve(void * context, MdnsService * resu
 
 CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter)
 {
-    ReturnErrorOnFailure(Init());
+    ReturnErrorOnFailure(InitImpl());
     char serviceName[kMaxCommisisonableServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionableNode));
 
@@ -551,7 +539,7 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter
 
 CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
 {
-    ReturnErrorOnFailure(Init());
+    ReturnErrorOnFailure(InitImpl());
     char serviceName[kMaxCommisisonerServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionerNode));
 

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -36,35 +36,21 @@ namespace Mdns {
 class DiscoveryImplPlatform : public ServiceAdvertiser, public Resolver
 {
 public:
-    CHIP_ERROR Init();
+    /// Members that implement both ServiceAdveriser and Resolver interfaces.
+    CHIP_ERROR Init(Inet::InetLayer *, uint16_t /* port */) override { return InitImpl(); }
+    void Shutdown() override;
 
-    /// Starts the service advertiser if not yet started. Otherwise, removes all existing services.
-    CHIP_ERROR Start(Inet::InetLayer * inetLayer, uint16_t port) override;
-
-    /// Starts the service resolver if not yet started
-    CHIP_ERROR StartResolver(Inet::InetLayer * inetLayer, uint16_t port) override { return Init(); }
-    void ShutdownResolver() override { ChipMdnsShutdown(); }
-
-    /// Advertises the CHIP node as an operational node
+    // Members that implement ServiceAdvertiser interface.
+    CHIP_ERROR RemoveServices() override;
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;
-
-    /// Advertises the CHIP node as a commissioner/commissionable node
     CHIP_ERROR Advertise(const CommissionAdvertisingParameters & params) override;
-
-    /// This function stops publishing the device on mDNS.
-    CHIP_ERROR StopPublishDevice() override;
-
-    /// Returns DNS-SD instance name formatted as hex string
+    CHIP_ERROR CompleteServiceUpdate() override;
     CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override;
 
-    /// Registers a resolver delegate if none has been registered before
-    CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) override;
-
-    /// Requests resolution of a node ID to its address
+    // Members that implement Resolver interface.
+    void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
-
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
-
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
     static DiscoveryImplPlatform & GetInstance();
@@ -75,6 +61,7 @@ private:
     DiscoveryImplPlatform(const DiscoveryImplPlatform &) = delete;
     DiscoveryImplPlatform & operator=(const DiscoveryImplPlatform &) = delete;
 
+    CHIP_ERROR InitImpl();
     CHIP_ERROR PublishUnprovisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface);
     CHIP_ERROR PublishProvisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface);
 

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -36,8 +36,8 @@ namespace Mdns {
 class DiscoveryImplPlatform : public ServiceAdvertiser, public Resolver
 {
 public:
-    /// Members that implement both ServiceAdveriser and Resolver interfaces.
-    CHIP_ERROR Init(Inet::InetLayer *, uint16_t /* port */) override { return InitImpl(); }
+    // Members that implement both ServiceAdveriser and Resolver interfaces.
+    CHIP_ERROR Init(Inet::InetLayer *) override { return InitImpl(); }
     void Shutdown() override;
 
     // Members that implement ServiceAdvertiser interface.

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -44,7 +44,7 @@ public:
     CHIP_ERROR RemoveServices() override;
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;
     CHIP_ERROR Advertise(const CommissionAdvertisingParameters & params) override;
-    CHIP_ERROR CompleteServiceUpdate() override;
+    CHIP_ERROR FinalizeServiceUpdate() override;
     CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override;
 
     // Members that implement Resolver interface.

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -244,32 +244,60 @@ public:
     virtual void OnNodeDiscoveryComplete(const DiscoveredNodeData & nodeData) = 0;
 };
 
-/// Interface for resolving CHIP services
+/**
+ * Interface for resolving CHIP DNS-SD services
+ */
 class Resolver
 {
 public:
     virtual ~Resolver() {}
 
-    /// Ensures that the resolver is started.
-    /// Must be called before any ResolveNodeId calls.
-    ///
-    /// Unsual name to allow base MDNS classes to implement both Advertiser and Resolver interfaces.
-    virtual CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
-    virtual void ShutdownResolver()                                                    = 0;
+    /**
+     * Initializes the resolver.
+     *
+     * The method must be called before other methods of this class.
+     * If the resolver has already been initialized, the method exits immediately with no error.
+     */
+    virtual CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
 
-    /// Registers a resolver delegate if none has been registered before
-    virtual CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) = 0;
+    /**
+     * Shuts down the resolver if it has been initialized before.
+     */
+    virtual void Shutdown() = 0;
 
-    /// Requests resolution of a node ID to its address
+    /**
+     * Registers a resolver delegate.
+     */
+    virtual void SetResolverDelegate(ResolverDelegate * delegate) = 0;
+
+    /**
+     * Requests resolution of the given operational node service.
+     *
+     * When the operation succeeds or fails, and a resolver delegate has been registered,
+     * the result of the operation is passed to the delegate's `OnNodeIdResolved` or
+     * `OnNodeIdResolutionFailed` method, respectively.
+     */
     virtual CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) = 0;
 
-    // Finds all nodes with the given filter that are currently in commissioning mode.
+    /**
+     * Finds all commissionable nodes matching the given filter.
+     *
+     * Whenever a new matching node is found and a resolver delegate has been registered,
+     * the node information is passed to the delegate's `OnNodeDiscoveryComplete` method.
+     */
     virtual CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) = 0;
 
-    // Finds all nodes with the given filter that are currently acting as Commissioners.
+    /**
+     * Finds all commissioner nodes matching the given filter.
+     *
+     * Whenever a new matching node is found and a resolver delegate has been registered,
+     * the node information is passed to the delegate's `OnNodeDiscoveryComplete` method.
+     */
     virtual CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) = 0;
 
-    /// Provides the system-wide implementation of the service resolver
+    /**
+     * Provides the system-wide implementation of the service resolver
+     */
     static Resolver & Instance();
 };
 

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -258,7 +258,7 @@ public:
      * The method must be called before other methods of this class.
      * If the resolver has already been initialized, the method exits immediately with no error.
      */
-    virtual CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
+    virtual CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) = 0;
 
     /**
      * Shuts down the resolver if it has been initialized before.
@@ -266,7 +266,8 @@ public:
     virtual void Shutdown() = 0;
 
     /**
-     * Registers a resolver delegate.
+     * Registers a resolver delegate. If nullptr is passed, the previously registered delegate
+     * is unregistered.
      */
     virtual void SetResolverDelegate(ResolverDelegate * delegate) = 0;
 

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -341,9 +341,9 @@ public:
     void OnMdnsPacketData(const BytesRange & data, const chip::Inet::IPPacketInfo * info) override;
 
     ///// Resolver implementation
-    CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
-    void ShutdownResolver() override;
-    CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) override;
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    void Shutdown() override;
+    void SetResolverDelegate(ResolverDelegate * delegate) override { mDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
@@ -398,7 +398,7 @@ void MinMdnsResolver::OnMdnsPacketData(const BytesRange & data, const chip::Inet
     }
 }
 
-CHIP_ERROR MinMdnsResolver::StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port)
+CHIP_ERROR MinMdnsResolver::Init(chip::Inet::InetLayer * inetLayer, uint16_t port)
 {
     /// Note: we do not double-check the port as we assume the APP will always use
     /// the same inetLayer and port for mDNS.
@@ -412,15 +412,9 @@ CHIP_ERROR MinMdnsResolver::StartResolver(chip::Inet::InetLayer * inetLayer, uin
     return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, port);
 }
 
-void MinMdnsResolver::ShutdownResolver()
+void MinMdnsResolver::Shutdown()
 {
     GlobalMinimalMdnsServer::Instance().ShutdownServer();
-}
-
-CHIP_ERROR MinMdnsResolver::SetResolverDelegate(ResolverDelegate * delegate)
-{
-    mDelegate = delegate;
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR MinMdnsResolver::SendQuery(mdns::Minimal::FullQName qname, mdns::Minimal::QType type)

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -341,7 +341,7 @@ public:
     void OnMdnsPacketData(const BytesRange & data, const chip::Inet::IPPacketInfo * info) override;
 
     ///// Resolver implementation
-    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override;
     void Shutdown() override;
     void SetResolverDelegate(ResolverDelegate * delegate) override { mDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
@@ -398,7 +398,7 @@ void MinMdnsResolver::OnMdnsPacketData(const BytesRange & data, const chip::Inet
     }
 }
 
-CHIP_ERROR MinMdnsResolver::Init(chip::Inet::InetLayer * inetLayer, uint16_t port)
+CHIP_ERROR MinMdnsResolver::Init(chip::Inet::InetLayer * inetLayer)
 {
     /// Note: we do not double-check the port as we assume the APP will always use
     /// the same inetLayer and port for mDNS.
@@ -409,7 +409,7 @@ CHIP_ERROR MinMdnsResolver::Init(chip::Inet::InetLayer * inetLayer, uint16_t por
 
     mSystemLayer = inetLayer->SystemLayer();
 
-    return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, port);
+    return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, kMdnsPort);
 }
 
 void MinMdnsResolver::Shutdown()

--- a/src/lib/mdns/Resolver_ImplNone.cpp
+++ b/src/lib/mdns/Resolver_ImplNone.cpp
@@ -26,10 +26,9 @@ namespace {
 class NoneResolver : public Resolver
 {
 public:
-    CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return CHIP_NO_ERROR; }
-
-    CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return CHIP_NO_ERROR; }
-    void ShutdownResolver() override {}
+    CHIP_ERROR Init(chip::Inet::InetLayer *, uint16_t /* port */) override { return CHIP_NO_ERROR; }
+    void Shutdown() override {}
+    void SetResolverDelegate(ResolverDelegate *) override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override
     {

--- a/src/lib/mdns/Resolver_ImplNone.cpp
+++ b/src/lib/mdns/Resolver_ImplNone.cpp
@@ -26,7 +26,7 @@ namespace {
 class NoneResolver : public Resolver
 {
 public:
-    CHIP_ERROR Init(chip::Inet::InetLayer *, uint16_t /* port */) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Init(chip::Inet::InetLayer *) override { return CHIP_NO_ERROR; }
     void Shutdown() override {}
     void SetResolverDelegate(ResolverDelegate *) override {}
 

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -221,7 +221,7 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
     // Start a single operational advertiser
     ChipLogProgress(Discovery, "Testing single operational advertiser");
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(operationalParams1) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
 
     // Test for PTR response to _services request.
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");
@@ -258,7 +258,7 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
 
     // If we try to re-advertise with the same operational parameters, we should not get duplicates
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(operationalParams1) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
     ChipLogProgress(Discovery, "Testing single operational advertiser with Advertise called twice");
     // We should get a single PTR back for _services
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");
@@ -284,7 +284,7 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
     server.Reset();
     // Mac is the same, peer id is different
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(operationalParams2) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
 
     // For now, we'll get back two copies of the PTR. Not sure if that's totally correct, but for now, that's expected.
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");
@@ -350,7 +350,7 @@ void CommissionableAdverts(nlTestSuite * inSuite, void * inContext)
     ChipLogProgress(Discovery, "Testing commissionable advertiser");
     // Start very basic - only the mandatory values (short and long discriminator and commissioning modes)
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(commissionableNodeParamsSmall) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
 
     // Test for PTR response to _services request.
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local for small parameters");
@@ -389,7 +389,7 @@ void CommissionableAdverts(nlTestSuite * inSuite, void * inContext)
     // Add more parameters, check that the subtypes and TXT values get set correctly.
     // Also check that we get proper values when the discriminators are small (no leading 0's)
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(commissionableNodeParamsLargeBasic) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local for large basic parameters");
     server.Reset();
     server.AddExpectedRecord(&ptrCommissionableNodeService);
@@ -421,7 +421,7 @@ void CommissionableAdverts(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, server.GetHeaderFound());
 
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(commissionableNodeParamsLargeEnhanced) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local for large enhanced parameters");
     server.Reset();
     server.AddExpectedRecord(&ptrCommissionableNodeService);
@@ -466,7 +466,7 @@ void CommissionableAndOperationalAdverts(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(operationalParams1) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(operationalParams2) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.Advertise(commissionableNodeParamsLargeEnhanced) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsAdvertiser.FinalizeServiceUpdate() == CHIP_NO_ERROR);
 
     // Services listing should have two operational ptrs, the base commissionable node ptr and the various _sub ptrs
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -553,7 +553,7 @@ int TestAdvertiser(void)
     CheckOnlyServer server(&theSuite);
     test::ServerSwapper swapper(&server);
     auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
-    mdnsAdvertiser.Init(nullptr, CHIP_PORT);
+    mdnsAdvertiser.Init(nullptr);
     nlTestRunner(&theSuite, &server);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -140,7 +140,7 @@ CHIP_ERROR ChipMdnsShutdown();
 CHIP_ERROR ChipMdnsRemoveServices();
 
 /**
- * This function publishes a service via mDNS or SRP.
+ * This function publishes a service via DNS-SD.
  *
  * Calling the function again with the same service name, type, protocol,
  * interface and port but different text will update the text published.
@@ -160,7 +160,8 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service);
  *
  * This function can be used by some implementations to apply changes made with the
  * `ChipMdnsRemoveServices` and `ChipMdnsPublishService` functions in case they could
- * not be applied immediately (like in case of implementations using SRP).
+ * not be applied immediately (like in case of, but not limited to, implementations
+ * using SRP).
  *
  * @retval CHIP_NO_ERROR  The service update completion succeeds.
  * @retval Error code     The service update completion fails.

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -129,7 +129,18 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCal
 CHIP_ERROR ChipMdnsShutdown();
 
 /**
- * This function publishes an service via mDNS.
+ * Removes or marks all services being advertised for removal.
+ *
+ * Depending on the implementation, the function may either stop advertising existing services
+ * immediately, or mark them for removal upon the subsequent `ChipMdnsCompleteServiceUpdate` call.
+ *
+ * @retval CHIP_NO_ERROR  The removal succeeds.
+ * @retval Error code     The removal fails.
+ */
+CHIP_ERROR ChipMdnsRemoveServices();
+
+/**
+ * This function publishes a service via mDNS or SRP.
  *
  * Calling the function again with the same service name, type, protocol,
  * interface and port but different text will update the text published.
@@ -145,25 +156,16 @@ CHIP_ERROR ChipMdnsShutdown();
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service);
 
 /**
- * This function stops publishing all services via mDNS.
+ * Completes updating advertised services.
  *
- * @retval CHIP_NO_ERROR                The publish stops successfully.
- * @retval Error code                   Stopping the publish fails.
+ * This function can be used by some implementations to apply changes made with the
+ * `ChipMdnsRemoveServices` and `ChipMdnsPublishService` functions in case they could
+ * not be applied immediately (like in case of implementations using SRP).
  *
+ * @retval CHIP_NO_ERROR  The service update completion succeeds.
+ * @retval Error code     The service update completion fails.
  */
-CHIP_ERROR ChipMdnsStopPublish();
-
-/**
- * This function stops publishing a specific service via mDNS.
- *
- * @param[in] service   The service entry.
- *
- * @retval CHIP_NO_ERROR                The service stop succeeds.
- * @retval CHIP_ERROR_INVALID_ARGUMENT  The service is nullptr.
- * @retval Error code                   The service stop fails.
- *
- */
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service);
+CHIP_ERROR ChipMdnsCompleteServiceUpdate();
 
 /**
  * This function browses the services published by mdns

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -132,7 +132,7 @@ CHIP_ERROR ChipMdnsShutdown();
  * Removes or marks all services being advertised for removal.
  *
  * Depending on the implementation, the function may either stop advertising existing services
- * immediately, or mark them for removal upon the subsequent `ChipMdnsCompleteServiceUpdate` call.
+ * immediately, or mark them for removal upon the subsequent `ChipMdnsFinalizeServiceUpdate` call.
  *
  * @retval CHIP_NO_ERROR  The removal succeeds.
  * @retval Error code     The removal fails.
@@ -156,17 +156,17 @@ CHIP_ERROR ChipMdnsRemoveServices();
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service);
 
 /**
- * Completes updating advertised services.
+ * Finalizes updating advertised services.
  *
  * This function can be used by some implementations to apply changes made with the
  * `ChipMdnsRemoveServices` and `ChipMdnsPublishService` functions in case they could
  * not be applied immediately (like in case of, but not limited to, implementations
- * using SRP).
+ * using SRP or requiring asynchronous interactions with a DNS-SD implementation).
  *
- * @retval CHIP_NO_ERROR  The service update completion succeeds.
- * @retval Error code     The service update completion fails.
+ * @retval CHIP_NO_ERROR  The service update finalization succeeds.
+ * @retval Error code     The service update finalization fails.
  */
-CHIP_ERROR ChipMdnsCompleteServiceUpdate();
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate();
 
 /**
  * This function browses the services published by mdns

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -157,7 +157,7 @@ void TestStub(nlTestSuite * inSuite, void * inContext)
     // without an expected event.
     ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer, kMdnsPort) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
     OperationalAdvertisingParameters params;
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_UNEXPECTED_EVENT);
@@ -168,7 +168,7 @@ void TestOperational(nlTestSuite * inSuite, void * inContext)
     ChipLogError(Discovery, "Test operational");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer, kMdnsPort) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
 
     operationalCall1.callType = test::CallType::kStart;
@@ -189,7 +189,7 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
     ChipLogError(Discovery, "Test commissionable");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer, kMdnsPort) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
 
     commissionableSmall.callType = test::CallType::kStart;

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -20,6 +20,7 @@
 #include <lib/mdns/Discovery_ImplPlatform.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <platform/fake/MdnsImpl.h>
 
 #include <nlunit-test.h>
@@ -156,7 +157,8 @@ void TestStub(nlTestSuite * inSuite, void * inContext)
     // without an expected event.
     ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer, kMdnsPort) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
     OperationalAdvertisingParameters params;
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_UNEXPECTED_EVENT);
 }
@@ -166,7 +168,8 @@ void TestOperational(nlTestSuite * inSuite, void * inContext)
     ChipLogError(Discovery, "Test operational");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer, kMdnsPort) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
 
     operationalCall1.callType = test::CallType::kStart;
     NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall1) == CHIP_NO_ERROR);
@@ -177,6 +180,8 @@ void TestOperational(nlTestSuite * inSuite, void * inContext)
     operationalCall2.callType = test::CallType::kStart;
     NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall2) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(operationalParams2) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.CompleteServiceUpdate() == CHIP_NO_ERROR);
 }
 
 void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
@@ -184,7 +189,8 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
     ChipLogError(Discovery, "Test commissionable");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer, kMdnsPort) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
 
     commissionableSmall.callType = test::CallType::kStart;
     NL_TEST_ASSERT(inSuite,
@@ -210,6 +216,8 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
                                                               sizeof(commissionableLargeEnhanced.instanceName)) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableLargeEnhanced) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsLargeEnhanced) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.CompleteServiceUpdate() == CHIP_NO_ERROR);
 }
 
 const nlTest sTests[] = {

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -181,7 +181,7 @@ void TestOperational(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall2) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(operationalParams2) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.FinalizeServiceUpdate() == CHIP_NO_ERROR);
 }
 
 void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
@@ -217,7 +217,7 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableLargeEnhanced) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsLargeEnhanced) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.CompleteServiceUpdate() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.FinalizeServiceUpdate() == CHIP_NO_ERROR);
 }
 
 const nlTest sTests[] = {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -218,7 +218,7 @@ CHIP_ERROR DnsHandler(int argc, char ** argv)
         return CHIP_NO_ERROR;
     }
 
-    Mdns::Resolver::Instance().Init(&DeviceLayer::InetLayer, Mdns::kMdnsPort);
+    Mdns::Resolver::Instance().Init(&DeviceLayer::InetLayer);
     Mdns::Resolver::Instance().SetResolverDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsSubcommands.ExecCommand(argc, argv);

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -218,7 +218,7 @@ CHIP_ERROR DnsHandler(int argc, char ** argv)
         return CHIP_NO_ERROR;
     }
 
-    Mdns::Resolver::Instance().StartResolver(&DeviceLayer::InetLayer, Mdns::kMdnsPort);
+    Mdns::Resolver::Instance().Init(&DeviceLayer::InetLayer, Mdns::kMdnsPort);
     Mdns::Resolver::Instance().SetResolverDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsSubcommands.ExecCommand(argc, argv);

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -536,7 +536,7 @@ CHIP_ERROR ChipMdnsRemoveServices()
     return MdnsContexts::GetInstance().Removes(ContextType::Register);
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -525,7 +525,7 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     return Register(interfaceId, regtype.c_str(), service->mName, service->mPort, &record);
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
+CHIP_ERROR ChipMdnsRemoveServices()
 {
     GenericContext * sdCtx = nullptr;
     if (CHIP_ERROR_KEY_NOT_FOUND == MdnsContexts::GetInstance().Get(ContextType::Register, &sdCtx))
@@ -536,9 +536,9 @@ CHIP_ERROR ChipMdnsStopPublish()
     return MdnsContexts::GetInstance().Removes(ContextType::Register);
 }
 
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -108,14 +108,14 @@ exit:
     return error;
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
+CHIP_ERROR ChipMdnsRemoveServices()
 {
     return mdns_service_remove_all() == ESP_OK ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
 }
 
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ChipMdnsBrowse(const char * /*type*/, MdnsServiceProtocol /*protocol*/, chip::Inet::IPAddressType addressType,

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR ChipMdnsRemoveServices()
     return mdns_service_remove_all() == ESP_OK ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -798,7 +798,7 @@ CHIP_ERROR ChipMdnsRemoveServices()
     return MdnsAvahi::GetInstance().StopPublish();
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -793,14 +793,14 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     return MdnsAvahi::GetInstance().PublishService(*service);
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
+CHIP_ERROR ChipMdnsRemoveServices()
 {
     return MdnsAvahi::GetInstance().StopPublish();
 }
 
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -104,7 +104,9 @@ protected:
                               const Span<const char * const> & aSubTypes, const Span<const Mdns::TextEntry> & aTxtEntries,
                               uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
-    CHIP_ERROR _RemoveAllSrpServices();
+    CHIP_ERROR _InvalidateAllSrpServices();
+    CHIP_ERROR _RemoveInvalidSrpServices();
+
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
     CHIP_ERROR _DnsBrowse(const char * aServiceName, DnsBrowseCallback aCallback, void * aContext);
@@ -161,6 +163,7 @@ private:
         struct Service
         {
             otSrpClientService mService;
+            bool mIsInvalid;
             uint8_t mServiceBuffer[kServiceBufferSize];
 #if OPENTHREAD_API_VERSION >= 132
             const char * mSubTypes[kSubTypeMaxNumber + 1]; // extra entry for null terminator

--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -72,7 +72,7 @@ CHIP_ERROR ChipMdnsRemoveServices()
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     return ThreadStackMgr().RemoveInvalidSrpServices();

--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -62,25 +62,20 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
+CHIP_ERROR ChipMdnsRemoveServices()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    return ThreadStackMgr().RemoveAllSrpServices();
+    ThreadStackMgr().InvalidateAllSrpServices();
+    return CHIP_NO_ERROR;
 #else
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 }
 
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    if (service == nullptr)
-        return CHIP_ERROR_INVALID_ARGUMENT;
-
-    char serviceType[chip::Mdns::kMdnsTypeAndProtocolMaxSize + 1];
-    snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
-
-    return ThreadStackMgr().RemoveSrpService(service->mName, serviceType);
+    return ThreadStackMgr().RemoveInvalidSrpServices();
 #else
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT

--- a/src/platform/Tizen/MdnsImpl.cpp
+++ b/src/platform/Tizen/MdnsImpl.cpp
@@ -46,7 +46,12 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
+CHIP_ERROR ChipMdnsRemoveServices()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/Tizen/MdnsImpl.cpp
+++ b/src/platform/Tizen/MdnsImpl.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR ChipMdnsRemoveServices()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/android/MdnsImpl.cpp
+++ b/src/platform/android/MdnsImpl.cpp
@@ -57,17 +57,17 @@ CHIP_ERROR ChipMdnsShutdown()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipMdnsRemoveServices()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
-{
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/android/MdnsImpl.cpp
+++ b/src/platform/android/MdnsImpl.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -110,7 +110,7 @@ CHIP_ERROR ChipMdnsRemoveServices()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipMdnsCompleteServiceUpdate()
+CHIP_ERROR ChipMdnsFinalizeServiceUpdate()
 {
     return CHIP_NO_ERROR;
 }

--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -105,14 +105,14 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     return test::CheckExpected(test::CallType::kStart, service);
 }
 
-CHIP_ERROR ChipMdnsStopPublish()
+CHIP_ERROR ChipMdnsRemoveServices()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+CHIP_ERROR ChipMdnsCompleteServiceUpdate()
 {
-    return test::CheckExpected(test::CallType::kStart, service);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,


### PR DESCRIPTION
#### Problem
Existing DNS-SD interfaces suffer form a couple of issues:
* Their API contracts are poorly documented.
* The consequence of the former are certain inconsistencies between implementations and quirks like `DiscoveryImplPlatform::Start` and `DiscoveryImplPlatform::StopPublishDevice` doing almost the same thing.
* "Remove and re-add service" approach is not very SRP-friendly.

#### Change overview
* Change `Resolver::SetResolverDelegate`'s return type to void.
* Replace `ServiceAdvertiser::Start` with `Init`, and `ServiceAdvertiser::StopPublishDevice` with `RemoveServices` as the purpose of the former methods was unclear and the code in `DiscoveryImplPlatform::Start` would do the same as in `DiscoveryImplPlatform::StopPublishDevice`. Now `Init` is meant for one-time operations and `RemoveServices` for removing advertised services so they can be refreshed.
* Likewise, replace `Resolver::Start` with `Init`.
* Add `ServiceAdvertiser::CompleteServiceUpdate` which should be called after publishing all desired services with
  `Advertise` methods. This is particularly useful for Thread-based platforms using SRP instead of mDNS. Such platforms  cannot immediately remove and re-add DNS services. Instead, they must communicate with the SRP server to complete any of these operations. `CompleteServiceUpdate` method allows Thread-based platform to remove services which have been marked for removal with the `RemoveServices` method and have not been re-added with subsequent `Advertise` calls.

#### Testing
There exist unit tests for both the minimal and platform DNS-SD implementations.
There are also basic cirque tests for the resolve and discover operations.
Also, checked manually nRF Connect and Linux lighting-app (using both Avahi and minimal mDNS) for regressions.
