### PR TITLE
Missing chip namespace in PersistentStorageMacro.h

### DIFF
--- a/src/lib/support/PersistentStorageMacros.h
+++ b/src/lib/support/PersistentStorageMacros.h
@@ -38,8 +38,8 @@ constexpr const char kNextAvailableKeyID[]        = "StartKeyID";
     {                                                                                                                              \
         constexpr size_t len = std::extent<decltype(keyPrefix)>::value;                                                            \
         nlSTATIC_ASSERT_PRINT(len > 0, "keyPrefix length must be known at compile time");                                          \
-        /* 2 * sizeof(NodeId) to accomodate 2 character for each byte in Node Id */                                                \
-        char key[len + 2 * sizeof(NodeId) + 1];                                                                                    \
+        /* 2 * sizeof(chip::NodeId) to accomodate 2 character for each byte in Node Id */                                          \
+        char key[len + 2 * sizeof(chip::NodeId) + 1];                                                                              \
         nlSTATIC_ASSERT_PRINT(sizeof(node) <= sizeof(uint64_t), "Node ID size is greater than expected");                          \
         snprintf(key, sizeof(key), "%s%" PRIx64, keyPrefix, node);                                                                 \
         action;                                                                                                                    \


### PR DESCRIPTION
#### Problem

The `chip` namespace is missing from the macro defined into `src/lib/support/PersistentStorageMacros.h`. It may cause some build error if one try to use this macro from outside the `chip` namespace

#### Change overview
 * Add the missing namespace

#### Testing
 Just namespace fixing. Should not change anything to the output...