### PR TITLE
Increase overall test timeout for nrfconnect.

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     nrfconnect:
         name: nRF Connect SDK
-        timeout-minutes: 60
+        timeout-minutes: 90
 
         env:
             BUILD_TYPE: nrfconnect


### PR DESCRIPTION
The nrfconnect workflow builds 10 example apps.  Each of those builds
takes 4-5 minutes.  That's 40-50 minutes right there.

Wither another 1-3 minutes each for container init and checkout, and
5+ minutes for bootstrap, it's fairly common to hit the 60 minute
overall timeout.

#### Problem
See above.

#### Change overview
Bumps timeout from 60 to 90 minutes.

#### Testing
Will see how timeout frequency behaves.