### PR TITLE
Make ConfigurationManager virtual

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -320,14 +320,14 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
     advertiseParameters.SetShortDiscriminator(static_cast<uint8_t>(value & 0xFF)).SetLongDiscriminator(value);
 
     if (DeviceLayer::ConfigurationMgr().IsCommissionableDeviceTypeEnabled() &&
-        DeviceLayer::ConfigurationMgr().GetDeviceType(value) == CHIP_NO_ERROR)
+        DeviceLayer::ConfigurationMgr().GetDeviceTypeId(value) == CHIP_NO_ERROR)
     {
         advertiseParameters.SetDeviceType(chip::Optional<uint16_t>::Value(value));
     }
 
     char deviceName[chip::Dnssd::kKeyDeviceNameMaxLength + 1];
     if (DeviceLayer::ConfigurationMgr().IsCommissionableDeviceNameEnabled() &&
-        DeviceLayer::ConfigurationMgr().GetDeviceName(deviceName, sizeof(deviceName)) == CHIP_NO_ERROR)
+        DeviceLayer::ConfigurationMgr().GetCommissionableDeviceName(deviceName, sizeof(deviceName)) == CHIP_NO_ERROR)
     {
         advertiseParameters.SetDeviceName(chip::Optional<const char *>::Value(deviceName));
     }

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -68,38 +68,38 @@ public:
         kMaxMACAddressLength = 8,
     };
 
-    virtual CHIP_ERROR GetVendorName(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId) = 0;
-    virtual CHIP_ERROR GetProductName(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetProductId(uint16_t & productId) = 0;
-    virtual CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetProductRevision(uint16_t & productRev) = 0;
-    virtual CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) = 0;
-    virtual CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) = 0;
-    virtual CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) = 0;
-    virtual CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) = 0;
+    virtual CHIP_ERROR GetVendorName(char * buf, size_t bufSize)                                    = 0;
+    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId)                                             = 0;
+    virtual CHIP_ERROR GetProductName(char * buf, size_t bufSize)                                   = 0;
+    virtual CHIP_ERROR GetProductId(uint16_t & productId)                                           = 0;
+    virtual CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize)                         = 0;
+    virtual CHIP_ERROR GetProductRevision(uint16_t & productRev)                                    = 0;
+    virtual CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen)           = 0;
+    virtual CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf)                                    = 0;
+    virtual CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf)                                      = 0;
+    virtual CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf)                                    = 0;
     virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) = 0;
-    virtual CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev) = 0;
-    virtual CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode) = 0;
-    virtual CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) = 0;
+    virtual CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize)                        = 0;
+    virtual CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev)                                  = 0;
+    virtual CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode)                                     = 0;
+    virtual CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator)                         = 0;
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     // Lifetime counter is monotonic counter that is incremented only in the case of a factory reset
     virtual CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) = 0;
 #endif
-    virtual CHIP_ERROR GetRegulatoryLocation(uint32_t & location) = 0;
-    virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) = 0;
-    virtual CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb) = 0;
-    virtual CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) = 0;
-    virtual CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf) = 0;
-    virtual CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf) = 0;
+    virtual CHIP_ERROR GetRegulatoryLocation(uint32_t & location)                      = 0;
+    virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)    = 0;
+    virtual CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb)                            = 0;
+    virtual CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen)  = 0;
+    virtual CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf)                 = 0;
+    virtual CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf)               = 0;
     virtual CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) = 0;
-    virtual CHIP_ERROR StoreProductRevision(uint16_t productRev) = 0;
-    virtual CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode) = 0;
-    virtual CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator) = 0;
-    virtual CHIP_ERROR StoreRegulatoryLocation(uint32_t location) = 0;
-    virtual CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) = 0;
-    virtual CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb) = 0;
+    virtual CHIP_ERROR StoreProductRevision(uint16_t productRev)                       = 0;
+    virtual CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode)                        = 0;
+    virtual CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator)            = 0;
+    virtual CHIP_ERROR StoreRegulatoryLocation(uint32_t location)                      = 0;
+    virtual CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen)             = 0;
+    virtual CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb)                            = 0;
 
     virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 
@@ -107,18 +107,18 @@ public:
     virtual CHIP_ERROR RunUnitTests() = 0;
 #endif
 
-    virtual bool IsFullyProvisioned() = 0;
+    virtual bool IsFullyProvisioned()   = 0;
     virtual void InitiateFactoryReset() = 0;
 
     virtual void LogDeviceConfig() = 0;
 
-    virtual bool IsCommissionableDeviceTypeEnabled() = 0;
-    virtual CHIP_ERROR GetDeviceType(uint16_t & deviceType) = 0;
-    virtual bool IsCommissionableDeviceNameEnabled() = 0;
-    virtual CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) = 0;
-    virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) = 0;
+    virtual bool IsCommissionableDeviceTypeEnabled()                              = 0;
+    virtual CHIP_ERROR GetDeviceType(uint16_t & deviceType)                       = 0;
+    virtual bool IsCommissionableDeviceNameEnabled()                              = 0;
+    virtual CHIP_ERROR GetDeviceName(char * buf, size_t bufSize)                  = 0;
+    virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint)              = 0;
+    virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize)   = 0;
+    virtual CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint)            = 0;
     virtual CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) = 0;
 
 protected:
@@ -133,15 +133,15 @@ protected:
     friend CHIP_ERROR(::chip::Platform::PersistedStorage::Read)(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
     friend CHIP_ERROR(::chip::Platform::PersistedStorage::Write)(::chip::Platform::PersistedStorage::Key key, uint32_t value);
 
-    virtual CHIP_ERROR Init() = 0;
-    virtual bool CanFactoryReset() = 0;
-    virtual CHIP_ERROR GetFailSafeArmed(bool & val) = 0;
-    virtual CHIP_ERROR SetFailSafeArmed(bool val) = 0;
+    virtual CHIP_ERROR Init()                                                                                   = 0;
+    virtual bool CanFactoryReset()                                                                              = 0;
+    virtual CHIP_ERROR GetFailSafeArmed(bool & val)                                                             = 0;
+    virtual CHIP_ERROR SetFailSafeArmed(bool val)                                                               = 0;
     virtual CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) = 0;
-    virtual CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) = 0;
+    virtual CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)  = 0;
 
     // Construction/destruction limited to subclasses.
-    ConfigurationManager() = default;
+    ConfigurationManager()          = default;
     virtual ~ConfigurationManager() = default;
 
     // No copy, move or assignment.

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -68,60 +68,60 @@ public:
         kMaxMACAddressLength = 8,
     };
 
-    CHIP_ERROR GetVendorName(char * buf, size_t bufSize);
-    CHIP_ERROR GetVendorId(uint16_t & vendorId);
-    CHIP_ERROR GetProductName(char * buf, size_t bufSize);
-    CHIP_ERROR GetProductId(uint16_t & productId);
-    CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize);
-    CHIP_ERROR GetProductRevision(uint16_t & productRev);
-    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen);
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf);
-    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf);
-    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
-    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
-    CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize);
-    CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev);
-    CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode);
-    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator);
+    virtual CHIP_ERROR GetVendorName(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId) = 0;
+    virtual CHIP_ERROR GetProductName(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetProductId(uint16_t & productId) = 0;
+    virtual CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetProductRevision(uint16_t & productRev) = 0;
+    virtual CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) = 0;
+    virtual CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) = 0;
+    virtual CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) = 0;
+    virtual CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) = 0;
+    virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) = 0;
+    virtual CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev) = 0;
+    virtual CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode) = 0;
+    virtual CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) = 0;
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     // Lifetime counter is monotonic counter that is incremented only in the case of a factory reset
-    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter);
+    virtual CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) = 0;
 #endif
-    CHIP_ERROR GetRegulatoryLocation(uint32_t & location);
-    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen);
-    CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb);
-    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen);
-    CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf);
-    CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf);
-    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen);
-    CHIP_ERROR StoreProductRevision(uint16_t productRev);
-    CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode);
-    CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator);
-    CHIP_ERROR StoreRegulatoryLocation(uint32_t location);
-    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen);
-    CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb);
+    virtual CHIP_ERROR GetRegulatoryLocation(uint32_t & location) = 0;
+    virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) = 0;
+    virtual CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb) = 0;
+    virtual CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) = 0;
+    virtual CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf) = 0;
+    virtual CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf) = 0;
+    virtual CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) = 0;
+    virtual CHIP_ERROR StoreProductRevision(uint16_t productRev) = 0;
+    virtual CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode) = 0;
+    virtual CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator) = 0;
+    virtual CHIP_ERROR StoreRegulatoryLocation(uint32_t location) = 0;
+    virtual CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) = 0;
+    virtual CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb) = 0;
 
-    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo);
+    virtual CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) = 0;
 
 #if !defined(NDEBUG)
-    CHIP_ERROR RunUnitTests();
+    virtual CHIP_ERROR RunUnitTests() = 0;
 #endif
 
-    bool IsFullyProvisioned();
-    void InitiateFactoryReset();
+    virtual bool IsFullyProvisioned() = 0;
+    virtual void InitiateFactoryReset() = 0;
 
-    void LogDeviceConfig();
+    virtual void LogDeviceConfig() = 0;
 
-    bool IsCommissionableDeviceTypeEnabled();
-    CHIP_ERROR GetDeviceType(uint16_t & deviceType);
-    bool IsCommissionableDeviceNameEnabled();
-    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize);
-    CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint);
-    CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize);
-    CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint);
-    CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize);
+    virtual bool IsCommissionableDeviceTypeEnabled() = 0;
+    virtual CHIP_ERROR GetDeviceType(uint16_t & deviceType) = 0;
+    virtual bool IsCommissionableDeviceNameEnabled() = 0;
+    virtual CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) = 0;
+    virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) = 0;
+    virtual CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) = 0;
 
-private:
+protected:
     // ===== Members for internal use by the following friends.
 
     friend class ::chip::DeviceLayer::PlatformManagerImpl;
@@ -133,19 +133,16 @@ private:
     friend CHIP_ERROR(::chip::Platform::PersistedStorage::Read)(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
     friend CHIP_ERROR(::chip::Platform::PersistedStorage::Write)(::chip::Platform::PersistedStorage::Key key, uint32_t value);
 
-    using ImplClass = ::chip::DeviceLayer::ConfigurationManagerImpl;
+    virtual CHIP_ERROR Init() = 0;
+    virtual bool CanFactoryReset() = 0;
+    virtual CHIP_ERROR GetFailSafeArmed(bool & val) = 0;
+    virtual CHIP_ERROR SetFailSafeArmed(bool val) = 0;
+    virtual CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) = 0;
+    virtual CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) = 0;
 
-    CHIP_ERROR Init();
-    bool CanFactoryReset();
-    CHIP_ERROR GetFailSafeArmed(bool & val);
-    CHIP_ERROR SetFailSafeArmed(bool val);
-    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
-
-protected:
     // Construction/destruction limited to subclasses.
-    ConfigurationManager()  = default;
-    ~ConfigurationManager() = default;
+    ConfigurationManager() = default;
+    virtual ~ConfigurationManager() = default;
 
     // No copy, move or assignment.
     ConfigurationManager(const ConfigurationManager &)  = delete;
@@ -181,298 +178,3 @@ extern ConfigurationManagerImpl & ConfigurationMgrImpl();
 #define CONFIGURATIONMANAGERIMPL_HEADER <platform/CHIP_DEVICE_LAYER_TARGET/ConfigurationManagerImpl.h>
 #include CONFIGURATIONMANAGERIMPL_HEADER
 #endif // defined(CHIP_DEVICE_LAYER_TARGET)
-
-namespace chip {
-namespace DeviceLayer {
-
-/**
- * Name of the vendor that produced the device.
- */
-inline CHIP_ERROR ConfigurationManager::GetVendorName(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetVendorName(buf, bufSize);
-}
-
-/**
- * Id of the vendor that produced the device.
- */
-inline CHIP_ERROR ConfigurationManager::GetVendorId(uint16_t & vendorId)
-{
-    return static_cast<ImplClass *>(this)->_GetVendorId(vendorId);
-}
-
-/**
- * Name of the product assigned by the vendor.
- */
-inline CHIP_ERROR ConfigurationManager::GetProductName(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetProductName(buf, bufSize);
-}
-
-/**
- * Device product id assigned by the vendor.
- */
-inline CHIP_ERROR ConfigurationManager::GetProductId(uint16_t & productId)
-{
-    return static_cast<ImplClass *>(this)->_GetProductId(productId);
-}
-
-/**
- * Product revision string assigned by the vendor.
- */
-inline CHIP_ERROR ConfigurationManager::GetProductRevisionString(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetProductRevisionString(buf, bufSize);
-}
-
-/**
- * Product revision number assigned by the vendor.
- */
-inline CHIP_ERROR ConfigurationManager::GetProductRevision(uint16_t & productRev)
-{
-    return static_cast<ImplClass *>(this)->_GetProductRevision(productRev);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen)
-{
-    return static_cast<ImplClass *>(this)->_GetSerialNumber(buf, bufSize, serialNumLen);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetPrimaryMACAddress(MutableByteSpan buf)
-{
-    return static_cast<ImplClass *>(this)->_GetPrimaryMACAddress(buf);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetPrimaryWiFiMACAddress(uint8_t * buf)
-{
-    return static_cast<ImplClass *>(this)->_GetPrimaryWiFiMACAddress(buf);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetPrimary802154MACAddress(uint8_t * buf)
-{
-    return static_cast<ImplClass *>(this)->_GetPrimary802154MACAddress(buf);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
-{
-    return static_cast<ImplClass *>(this)->_GetManufacturingDate(year, month, dayOfMonth);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetFirmwareRevisionString(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetFirmwareRevisionString(buf, bufSize);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetFirmwareRevision(uint32_t & firmwareRev)
-{
-    return static_cast<ImplClass *>(this)->_GetFirmwareRevision(firmwareRev);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetSetupPinCode(uint32_t & setupPinCode)
-{
-    return static_cast<ImplClass *>(this)->_GetSetupPinCode(setupPinCode);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetSetupDiscriminator(uint16_t & setupDiscriminator)
-{
-    return static_cast<ImplClass *>(this)->_GetSetupDiscriminator(setupDiscriminator);
-}
-
-#if CHIP_ENABLE_ROTATING_DEVICE_ID
-inline CHIP_ERROR ConfigurationManager::GetLifetimeCounter(uint16_t & lifetimeCounter)
-{
-    return static_cast<ImplClass *>(this)->_GetLifetimeCounter(lifetimeCounter);
-}
-#endif
-
-inline CHIP_ERROR ConfigurationManager::GetRegulatoryLocation(uint32_t & location)
-{
-    return static_cast<ImplClass *>(this)->_GetRegulatoryLocation(location);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
-{
-    return static_cast<ImplClass *>(this)->_GetCountryCode(buf, bufSize, codeLen);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetBreadcrumb(uint64_t & breadcrumb)
-{
-    return static_cast<ImplClass *>(this)->_GetBreadcrumb(breadcrumb);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreSerialNumber(const char * serialNum, size_t serialNumLen)
-{
-    return static_cast<ImplClass *>(this)->_StoreSerialNumber(serialNum, serialNumLen);
-}
-
-inline CHIP_ERROR ConfigurationManager::StorePrimaryWiFiMACAddress(const uint8_t * buf)
-{
-    return static_cast<ImplClass *>(this)->_StorePrimaryWiFiMACAddress(buf);
-}
-
-inline CHIP_ERROR ConfigurationManager::StorePrimary802154MACAddress(const uint8_t * buf)
-{
-    return static_cast<ImplClass *>(this)->_StorePrimary802154MACAddress(buf);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
-{
-    return static_cast<ImplClass *>(this)->_StoreManufacturingDate(mfgDate, mfgDateLen);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreProductRevision(uint16_t productRev)
-{
-    return static_cast<ImplClass *>(this)->_StoreProductRevision(productRev);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreSetupPinCode(uint32_t setupPinCode)
-{
-    return static_cast<ImplClass *>(this)->_StoreSetupPinCode(setupPinCode);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreSetupDiscriminator(uint16_t setupDiscriminator)
-{
-    return static_cast<ImplClass *>(this)->_StoreSetupDiscriminator(setupDiscriminator);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreRegulatoryLocation(uint32_t location)
-{
-    return static_cast<ImplClass *>(this)->_StoreRegulatoryLocation(location);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreCountryCode(const char * code, size_t codeLen)
-{
-    return static_cast<ImplClass *>(this)->_StoreCountryCode(code, codeLen);
-}
-
-inline CHIP_ERROR ConfigurationManager::StoreBreadcrumb(uint64_t breadcrumb)
-{
-    return static_cast<ImplClass *>(this)->_StoreBreadcrumb(breadcrumb);
-}
-
-inline CHIP_ERROR ConfigurationManager::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
-{
-    return static_cast<ImplClass *>(this)->_ReadPersistedStorageValue(key, value);
-}
-
-inline CHIP_ERROR ConfigurationManager::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
-{
-    return static_cast<ImplClass *>(this)->_WritePersistedStorageValue(key, value);
-}
-
-inline CHIP_ERROR ConfigurationManager::GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
-{
-    return static_cast<ImplClass *>(this)->_GetBLEDeviceIdentificationInfo(deviceIdInfo);
-}
-
-inline bool ConfigurationManager::IsFullyProvisioned()
-{
-    return static_cast<ImplClass *>(this)->_IsFullyProvisioned();
-}
-
-inline void ConfigurationManager::InitiateFactoryReset()
-{
-#if CHIP_ENABLE_ROTATING_DEVICE_ID
-    static_cast<ImplClass *>(this)->_IncrementLifetimeCounter();
-#endif
-    static_cast<ImplClass *>(this)->_InitiateFactoryReset();
-}
-
-#if !defined(NDEBUG)
-inline CHIP_ERROR ConfigurationManager::RunUnitTests()
-{
-    return static_cast<ImplClass *>(this)->_RunUnitTests();
-}
-#endif
-
-inline CHIP_ERROR ConfigurationManager::Init()
-{
-    return static_cast<ImplClass *>(this)->_Init();
-}
-
-inline bool ConfigurationManager::CanFactoryReset()
-{
-    return static_cast<ImplClass *>(this)->_CanFactoryReset();
-}
-
-inline CHIP_ERROR ConfigurationManager::GetFailSafeArmed(bool & val)
-{
-    return static_cast<ImplClass *>(this)->_GetFailSafeArmed(val);
-}
-
-inline CHIP_ERROR ConfigurationManager::SetFailSafeArmed(bool val)
-{
-    return static_cast<ImplClass *>(this)->_SetFailSafeArmed(val);
-}
-
-inline void ConfigurationManager::LogDeviceConfig()
-{
-    static_cast<ImplClass *>(this)->_LogDeviceConfig();
-}
-
-/**
- * True if device type in DNS-SD advertisement is enabled
- */
-inline bool ConfigurationManager::IsCommissionableDeviceTypeEnabled()
-{
-    return static_cast<ImplClass *>(this)->_IsCommissionableDeviceTypeEnabled();
-}
-
-/**
- * Device type id.
- */
-inline CHIP_ERROR ConfigurationManager::GetDeviceType(uint16_t & deviceType)
-{
-    return static_cast<ImplClass *>(this)->_GetDeviceType(deviceType);
-}
-
-/**
- * True if device name in DNS-SD advertisement is enabled
- */
-inline bool ConfigurationManager::IsCommissionableDeviceNameEnabled()
-{
-    return static_cast<ImplClass *>(this)->_IsCommissionableDeviceNameEnabled();
-}
-
-/**
- * Name of the device.
- */
-inline CHIP_ERROR ConfigurationManager::GetDeviceName(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetDeviceName(buf, bufSize);
-}
-
-/**
- * Initial pairing hint.
- */
-inline CHIP_ERROR ConfigurationManager::GetInitialPairingHint(uint16_t & pairingHint)
-{
-    return static_cast<ImplClass *>(this)->_GetInitialPairingHint(pairingHint);
-}
-
-/**
- * Secondary pairing hint.
- */
-inline CHIP_ERROR ConfigurationManager::GetSecondaryPairingHint(uint16_t & pairingHint)
-{
-    return static_cast<ImplClass *>(this)->_GetSecondaryPairingHint(pairingHint);
-}
-
-/**
- * Initial pairing instruction.
- */
-inline CHIP_ERROR ConfigurationManager::GetInitialPairingInstruction(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetInitialPairingInstruction(buf, bufSize);
-}
-
-/**
- * Secondary pairing instruction.
- */
-inline CHIP_ERROR ConfigurationManager::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
-{
-    return static_cast<ImplClass *>(this)->_GetSecondaryPairingInstruction(buf, bufSize);
-}
-
-} // namespace DeviceLayer
-} // namespace chip

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -113,9 +113,9 @@ public:
     virtual void LogDeviceConfig() = 0;
 
     virtual bool IsCommissionableDeviceTypeEnabled()                              = 0;
-    virtual CHIP_ERROR GetDeviceType(uint16_t & deviceType)                       = 0;
+    virtual CHIP_ERROR GetDeviceTypeId(uint16_t & deviceType)                     = 0;
     virtual bool IsCommissionableDeviceNameEnabled()                              = 0;
-    virtual CHIP_ERROR GetDeviceName(char * buf, size_t bufSize)                  = 0;
+    virtual CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize)    = 0;
     virtual CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint)              = 0;
     virtual CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize)   = 0;
     virtual CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint)            = 0;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -426,7 +426,7 @@ bool GenericConfigurationManagerImpl<ImplClass>::IsCommissionableDeviceNameEnabl
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetDeviceName(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetCommissionableDeviceName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
@@ -535,7 +535,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 
     {
         uint16_t deviceType;
-        if (GetDeviceType(deviceType) != CHIP_NO_ERROR)
+        if (GetDeviceTypeId(deviceType) != CHIP_NO_ERROR)
         {
             deviceType = 0;
         }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -244,9 +244,9 @@ template <class ImplClass>
 void GenericConfigurationManagerImpl<ImplClass>::InitiateFactoryReset()
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    Impl()->_IncrementLifetimeCounter();
+    _IncrementLifetimeCounter();
 #endif
-    Impl()->InitiateFactoryReset();
+    // Inheriting classes should call this method so the lifetime counter is updated if necessary.
 }
 
 template <class ImplClass>
@@ -375,15 +375,15 @@ GenericConfigurationManagerImpl<ImplClass>::GetBLEDeviceIdentificationInfo(Ble::
 
     deviceIdInfo.Init();
 
-    err = Impl()->GetVendorId(id);
+    err = GetVendorId(id);
     SuccessOrExit(err);
     deviceIdInfo.SetVendorId(id);
 
-    err = Impl()->GetProductId(id);
+    err = GetProductId(id);
     SuccessOrExit(err);
     deviceIdInfo.SetProductId(id);
 
-    err = Impl()->GetSetupDiscriminator(discriminator);
+    err = GetSetupDiscriminator(discriminator);
     SuccessOrExit(err);
     deviceIdInfo.SetDeviceDiscriminator(discriminator);
 
@@ -470,13 +470,13 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
     {
         char serialNum[ConfigurationManager::kMaxSerialNumberLength + 1];
         size_t serialNumLen;
-        err = Impl()->GetSerialNumber(serialNum, sizeof(serialNum), serialNumLen);
+        err = GetSerialNumber(serialNum, sizeof(serialNum), serialNumLen);
         ChipLogProgress(DeviceLayer, "  Serial Number: %s", (err == CHIP_NO_ERROR) ? serialNum : "(not set)");
     }
 
     {
         uint16_t vendorId;
-        if (Impl()->GetVendorId(vendorId) != CHIP_NO_ERROR)
+        if (GetVendorId(vendorId) != CHIP_NO_ERROR)
         {
             vendorId = 0;
         }
@@ -485,7 +485,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 
     {
         uint16_t productId;
-        if (Impl()->GetProductId(productId) != CHIP_NO_ERROR)
+        if (GetProductId(productId) != CHIP_NO_ERROR)
         {
             productId = 0;
         }
@@ -494,7 +494,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 
     {
         uint16_t productRev;
-        if (Impl()->GetProductRevision(productRev) != CHIP_NO_ERROR)
+        if (GetProductRevision(productRev) != CHIP_NO_ERROR)
         {
             productRev = 0;
         }
@@ -503,7 +503,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 
     {
         uint32_t setupPINCode;
-        if (Impl()->GetSetupPinCode(setupPINCode) != CHIP_NO_ERROR)
+        if (GetSetupPinCode(setupPINCode) != CHIP_NO_ERROR)
         {
             setupPINCode = 0;
         }
@@ -512,7 +512,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 
     {
         uint16_t setupDiscriminator;
-        if (Impl()->GetSetupDiscriminator(setupDiscriminator) != CHIP_NO_ERROR)
+        if (GetSetupDiscriminator(setupDiscriminator) != CHIP_NO_ERROR)
         {
             setupDiscriminator = 0;
         }
@@ -522,7 +522,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
     {
         uint16_t year;
         uint8_t month, dayOfMonth;
-        err = Impl()->GetManufacturingDate(year, month, dayOfMonth);
+        err = GetManufacturingDate(year, month, dayOfMonth);
         if (err == CHIP_NO_ERROR)
         {
             ChipLogProgress(DeviceLayer, "  Manufacturing Date: %04" PRIu16 "/%02" PRIu8 "/%02" PRIu8, year, month, dayOfMonth);
@@ -535,7 +535,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 
     {
         uint16_t deviceType;
-        if (Impl()->GetDeviceType(deviceType) != CHIP_NO_ERROR)
+        if (GetDeviceType(deviceType) != CHIP_NO_ERROR)
         {
             deviceType = 0;
         }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -45,7 +45,7 @@ namespace DeviceLayer {
 namespace Internal {
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_Init()
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::Init()
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     mLifetimePersistedCounter.Init(CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY);
@@ -55,7 +55,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_Init()
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetVendorName(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetVendorName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME);
@@ -63,7 +63,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetVendorName(char * buf
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductName(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
@@ -71,7 +71,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductName(char * bu
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevisionString(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevisionString(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING);
@@ -79,7 +79,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevisionStrin
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen)
 {
     CHIP_ERROR err;
     err = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_SerialNum, buf, bufSize, serialNumLen);
@@ -99,25 +99,25 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreSerialNumber(const char * serialNum, size_t serialNumLen)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreSerialNumber(const char * serialNum, size_t serialNumLen)
 {
     return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_SerialNum, serialNum, serialNumLen);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StorePrimaryWiFiMACAddress(const uint8_t * buf)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StorePrimaryWiFiMACAddress(const uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetPrimaryMACAddress(MutableByteSpan buf)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimaryMACAddress(MutableByteSpan buf)
 {
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -145,7 +145,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetPrimaryMACAddress(Mut
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetPrimary802154MACAddress(uint8_t * buf)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetPrimary802154MACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     return ThreadStackManager().GetPrimary802154MACAddress(buf);
@@ -155,13 +155,13 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetPrimary802154MACAddre
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StorePrimary802154MACAddress(const uint8_t * buf)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StorePrimary802154MACAddress(const uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductRevisionString(char * buf, size_t bufSize)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductRevisionString(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING);
@@ -169,7 +169,7 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductRevisio
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductRevision(uint16_t & productRev)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductRevision(uint16_t & productRev)
 {
     CHIP_ERROR err;
     uint32_t val;
@@ -189,13 +189,13 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductRevisio
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreProductRevision(uint16_t productRev)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreProductRevision(uint16_t productRev)
 {
     return Impl()->WriteConfigValue(ImplClass::kConfigKey_ProductRevision, static_cast<uint32_t>(productRev));
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
 {
     CHIP_ERROR err;
     enum
@@ -235,13 +235,22 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen)
 {
     return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_ManufacturingDate, mfgDate, mfgDateLen);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupPinCode(uint32_t & setupPinCode)
+void GenericConfigurationManagerImpl<ImplClass>::InitiateFactoryReset()
+{
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    Impl()->_IncrementLifetimeCounter();
+#endif
+    Impl()->InitiateFactoryReset();
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSetupPinCode(uint32_t & setupPinCode)
 {
     CHIP_ERROR err;
 
@@ -260,13 +269,13 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreSetupPinCode(uint32_t setupPinCode)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreSetupPinCode(uint32_t setupPinCode)
 {
     return Impl()->WriteConfigValue(ImplClass::kConfigKey_SetupPinCode, setupPinCode);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupDiscriminator(uint16_t & setupDiscriminator)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSetupDiscriminator(uint16_t & setupDiscriminator)
 {
     CHIP_ERROR err;
     uint32_t val;
@@ -288,50 +297,50 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreSetupDiscriminator(uint16_t setupDiscriminator)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreSetupDiscriminator(uint16_t setupDiscriminator)
 {
     return Impl()->WriteConfigValue(ImplClass::kConfigKey_SetupDiscriminator, static_cast<uint32_t>(setupDiscriminator));
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetRegulatoryLocation(uint32_t & location)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetRegulatoryLocation(uint32_t & location)
 {
     return Impl()->ReadConfigValue(ImplClass::kConfigKey_RegulatoryLocation, location);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreRegulatoryLocation(uint32_t location)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreRegulatoryLocation(uint32_t location)
 {
     return Impl()->WriteConfigValue(ImplClass::kConfigKey_RegulatoryLocation, location);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
 {
     return Impl()->ReadConfigValueStr(ImplClass::kConfigKey_CountryCode, buf, bufSize, codeLen);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreCountryCode(const char * code, size_t codeLen)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreCountryCode(const char * code, size_t codeLen)
 {
     return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_CountryCode, code, codeLen);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetBreadcrumb(uint64_t & breadcrumb)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetBreadcrumb(uint64_t & breadcrumb)
 {
     return Impl()->ReadConfigValue(ImplClass::kConfigKey_Breadcrumb, breadcrumb);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreBreadcrumb(uint64_t breadcrumb)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreBreadcrumb(uint64_t breadcrumb)
 {
     return Impl()->WriteConfigValue(ImplClass::kConfigKey_Breadcrumb, breadcrumb);
 }
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetLifetimeCounter(uint16_t & lifetimeCounter)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetLifetimeCounter(uint16_t & lifetimeCounter)
 {
     lifetimeCounter = static_cast<uint16_t>(mLifetimePersistedCounter.GetValue());
     return CHIP_NO_ERROR;
@@ -345,20 +354,20 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_IncrementLifetimeCounter
 #endif
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFailSafeArmed(bool & val)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFailSafeArmed(bool & val)
 {
     return Impl()->ReadConfigValue(ImplClass::kConfigKey_FailSafeArmed, val);
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_SetFailSafeArmed(bool val)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::SetFailSafeArmed(bool val)
 {
     return Impl()->WriteConfigValue(ImplClass::kConfigKey_FailSafeArmed, val);
 }
 
 template <class ImplClass>
 CHIP_ERROR
-GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
+GenericConfigurationManagerImpl<ImplClass>::GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo)
 {
     CHIP_ERROR err;
     uint16_t id;
@@ -366,15 +375,15 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
 
     deviceIdInfo.Init();
 
-    err = Impl()->_GetVendorId(id);
+    err = Impl()->GetVendorId(id);
     SuccessOrExit(err);
     deviceIdInfo.SetVendorId(id);
 
-    err = Impl()->_GetProductId(id);
+    err = Impl()->GetProductId(id);
     SuccessOrExit(err);
     deviceIdInfo.SetProductId(id);
 
-    err = Impl()->_GetSetupDiscriminator(discriminator);
+    err = Impl()->GetSetupDiscriminator(discriminator);
     SuccessOrExit(err);
     deviceIdInfo.SetDeviceDiscriminator(discriminator);
 
@@ -383,7 +392,7 @@ exit:
 }
 
 template <class ImplClass>
-bool GenericConfigurationManagerImpl<ImplClass>::_IsFullyProvisioned()
+bool GenericConfigurationManagerImpl<ImplClass>::IsFullyProvisioned()
 {
 #if CHIP_BYPASS_RENDEZVOUS
     return true;
@@ -401,7 +410,7 @@ bool GenericConfigurationManagerImpl<ImplClass>::_IsFullyProvisioned()
 }
 
 template <class ImplClass>
-bool GenericConfigurationManagerImpl<ImplClass>::_IsCommissionableDeviceTypeEnabled()
+bool GenericConfigurationManagerImpl<ImplClass>::IsCommissionableDeviceTypeEnabled()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_TYPE
     return true;
@@ -411,13 +420,13 @@ bool GenericConfigurationManagerImpl<ImplClass>::_IsCommissionableDeviceTypeEnab
 }
 
 template <class ImplClass>
-bool GenericConfigurationManagerImpl<ImplClass>::_IsCommissionableDeviceNameEnabled()
+bool GenericConfigurationManagerImpl<ImplClass>::IsCommissionableDeviceNameEnabled()
 {
     return CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_NAME == 1;
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetDeviceName(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetDeviceName(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_NAME);
@@ -425,7 +434,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetDeviceName(char * buf
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetInitialPairingInstruction(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetInitialPairingInstruction(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_PAIRING_INITIAL_INSTRUCTION);
@@ -433,7 +442,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetInitialPairingInstruc
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSecondaryPairingInstruction(char * buf, size_t bufSize)
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_INSTRUCTION), CHIP_ERROR_BUFFER_TOO_SMALL);
     strcpy(buf, CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_INSTRUCTION);
@@ -442,7 +451,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSecondaryPairingInstr
 
 #if !defined(NDEBUG)
 template <class ImplClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_RunUnitTests()
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::RunUnitTests()
 {
     ChipLogProgress(DeviceLayer, "Running configuration unit test");
     Impl()->RunConfigUnitTest();
@@ -452,7 +461,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_RunUnitTests()
 #endif
 
 template <class ImplClass>
-void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
+void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
 {
     CHIP_ERROR err;
 
@@ -461,13 +470,13 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
     {
         char serialNum[ConfigurationManager::kMaxSerialNumberLength + 1];
         size_t serialNumLen;
-        err = Impl()->_GetSerialNumber(serialNum, sizeof(serialNum), serialNumLen);
+        err = Impl()->GetSerialNumber(serialNum, sizeof(serialNum), serialNumLen);
         ChipLogProgress(DeviceLayer, "  Serial Number: %s", (err == CHIP_NO_ERROR) ? serialNum : "(not set)");
     }
 
     {
         uint16_t vendorId;
-        if (Impl()->_GetVendorId(vendorId) != CHIP_NO_ERROR)
+        if (Impl()->GetVendorId(vendorId) != CHIP_NO_ERROR)
         {
             vendorId = 0;
         }
@@ -476,7 +485,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 
     {
         uint16_t productId;
-        if (Impl()->_GetProductId(productId) != CHIP_NO_ERROR)
+        if (Impl()->GetProductId(productId) != CHIP_NO_ERROR)
         {
             productId = 0;
         }
@@ -485,7 +494,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 
     {
         uint16_t productRev;
-        if (Impl()->_GetProductRevision(productRev) != CHIP_NO_ERROR)
+        if (Impl()->GetProductRevision(productRev) != CHIP_NO_ERROR)
         {
             productRev = 0;
         }
@@ -494,7 +503,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 
     {
         uint32_t setupPINCode;
-        if (Impl()->_GetSetupPinCode(setupPINCode) != CHIP_NO_ERROR)
+        if (Impl()->GetSetupPinCode(setupPINCode) != CHIP_NO_ERROR)
         {
             setupPINCode = 0;
         }
@@ -503,7 +512,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 
     {
         uint16_t setupDiscriminator;
-        if (Impl()->_GetSetupDiscriminator(setupDiscriminator) != CHIP_NO_ERROR)
+        if (Impl()->GetSetupDiscriminator(setupDiscriminator) != CHIP_NO_ERROR)
         {
             setupDiscriminator = 0;
         }
@@ -513,7 +522,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
     {
         uint16_t year;
         uint8_t month, dayOfMonth;
-        err = Impl()->_GetManufacturingDate(year, month, dayOfMonth);
+        err = Impl()->GetManufacturingDate(year, month, dayOfMonth);
         if (err == CHIP_NO_ERROR)
         {
             ChipLogProgress(DeviceLayer, "  Manufacturing Date: %04" PRIu16 "/%02" PRIu8 "/%02" PRIu8, year, month, dayOfMonth);
@@ -526,7 +535,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 
     {
         uint16_t deviceType;
-        if (Impl()->_GetDeviceType(deviceType) != CHIP_NO_ERROR)
+        if (Impl()->GetDeviceType(deviceType) != CHIP_NO_ERROR)
         {
             deviceType = 0;
         }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -84,9 +84,9 @@ public:
     CHIP_ERROR SetFailSafeArmed(bool val) override;
     CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override;
     bool IsCommissionableDeviceTypeEnabled() override;
-    CHIP_ERROR GetDeviceType(uint16_t & deviceType) override;
+    CHIP_ERROR GetDeviceTypeId(uint16_t & deviceType) override;
     bool IsCommissionableDeviceNameEnabled() override;
-    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override;
     CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override;
@@ -141,7 +141,7 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevisio
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetDeviceType(uint16_t & deviceType)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetDeviceTypeId(uint16_t & deviceType)
 {
     deviceType = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_TYPE);
     return CHIP_NO_ERROR;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <lib/support/BitFlags.h>
+#include <platform/ConfigurationManager.h>
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 #include <lib/support/LifetimePersistedCounter.h>
@@ -47,60 +48,63 @@ namespace Internal {
  * parameter.
  */
 template <class ImplClass>
-class GenericConfigurationManagerImpl
+class GenericConfigurationManagerImpl : public ConfigurationManager
 {
 public:
     // ===== Methods that implement the ConfigurationManager abstract interface.
 
-    CHIP_ERROR _Init();
-    CHIP_ERROR _GetVendorName(char * buf, size_t bufSize);
-    CHIP_ERROR _GetVendorId(uint16_t & vendorId);
-    CHIP_ERROR _GetProductName(char * buf, size_t bufSize);
-    CHIP_ERROR _GetProductId(uint16_t & productId);
-    CHIP_ERROR _GetProductRevisionString(char * buf, size_t bufSize);
-    CHIP_ERROR _GetProductRevision(uint16_t & productRev);
-    CHIP_ERROR _StoreProductRevision(uint16_t productRev);
-    CHIP_ERROR _GetFirmwareRevisionString(char * buf, size_t bufSize);
-    CHIP_ERROR _GetFirmwareRevision(uint32_t & firmwareRev);
-    CHIP_ERROR _GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen);
-    CHIP_ERROR _StoreSerialNumber(const char * serialNum, size_t serialNumLen);
-    CHIP_ERROR _GetPrimaryMACAddress(MutableByteSpan buf);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    CHIP_ERROR _StorePrimaryWiFiMACAddress(const uint8_t * buf);
-    CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
-    CHIP_ERROR _StorePrimary802154MACAddress(const uint8_t * buf);
-    CHIP_ERROR _GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
-    CHIP_ERROR _StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen);
-    CHIP_ERROR _GetSetupPinCode(uint32_t & setupPinCode);
-    CHIP_ERROR _StoreSetupPinCode(uint32_t setupPinCode);
-    CHIP_ERROR _GetSetupDiscriminator(uint16_t & setupDiscriminator);
-    CHIP_ERROR _StoreSetupDiscriminator(uint16_t setupDiscriminator);
+    CHIP_ERROR Init() override;
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductRevision(uint16_t & productRev) override;
+    CHIP_ERROR StoreProductRevision(uint16_t productRev) override;
+    CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev) override;
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) override;
+    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override;
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf) override;
+    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override;
+    CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf) override;
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) override;
+    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override;
+    CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode) override;
+    CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode) override;
+    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override;
+    CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator) override;
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    CHIP_ERROR _GetLifetimeCounter(uint16_t & lifetimeCounter);
+    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override;
     CHIP_ERROR _IncrementLifetimeCounter();
 #endif
-    CHIP_ERROR _GetFailSafeArmed(bool & val);
-    CHIP_ERROR _SetFailSafeArmed(bool val);
-    CHIP_ERROR _GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo);
-    bool _IsCommissionableDeviceTypeEnabled();
-    CHIP_ERROR _GetDeviceType(uint16_t & deviceType);
-    bool _IsCommissionableDeviceNameEnabled();
-    CHIP_ERROR _GetDeviceName(char * buf, size_t bufSize);
-    CHIP_ERROR _GetInitialPairingHint(uint16_t & pairingHint);
-    CHIP_ERROR _GetInitialPairingInstruction(char * buf, size_t bufSize);
-    CHIP_ERROR _GetSecondaryPairingHint(uint16_t & pairingHint);
-    CHIP_ERROR _GetSecondaryPairingInstruction(char * buf, size_t bufSize);
-    CHIP_ERROR _GetRegulatoryLocation(uint32_t & location);
-    CHIP_ERROR _StoreRegulatoryLocation(uint32_t location);
-    CHIP_ERROR _GetCountryCode(char * buf, size_t bufSize, size_t & codeLen);
-    CHIP_ERROR _StoreCountryCode(const char * code, size_t codeLen);
-    CHIP_ERROR _GetBreadcrumb(uint64_t & breadcrumb);
-    CHIP_ERROR _StoreBreadcrumb(uint64_t breadcrumb);
+    CHIP_ERROR GetFailSafeArmed(bool & val) override;
+    CHIP_ERROR SetFailSafeArmed(bool val) override;
+    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override;
+    bool IsCommissionableDeviceTypeEnabled() override;
+    CHIP_ERROR GetDeviceType(uint16_t & deviceType) override;
+    bool IsCommissionableDeviceNameEnabled() override;
+    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override;
+    CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override;
+    CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetRegulatoryLocation(uint32_t & location) override;
+    CHIP_ERROR StoreRegulatoryLocation(uint32_t location) override;
+    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) override;
+    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override;
+    CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb) override;
+    CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb) override;
 #if !defined(NDEBUG)
-    CHIP_ERROR _RunUnitTests(void);
+    CHIP_ERROR RunUnitTests(void) override;
 #endif
-    bool _IsFullyProvisioned();
-    void _LogDeviceConfig();
+    bool IsFullyProvisioned() override;
+    void InitiateFactoryReset() override;
+    void LogDeviceConfig() override;
+
+    virtual ~GenericConfigurationManagerImpl() = default;
 
 protected:
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
@@ -116,42 +120,42 @@ private:
 extern template class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetVendorId(uint16_t & vendorId)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetVendorId(uint16_t & vendorId)
 {
     vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
     return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductId(uint16_t & productId)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductId(uint16_t & productId)
 {
     productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
     return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevision(uint32_t & firmwareRev)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevision(uint32_t & firmwareRev)
 {
     firmwareRev = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
     return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetDeviceType(uint16_t & deviceType)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetDeviceType(uint16_t & deviceType)
 {
     deviceType = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_TYPE);
     return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetInitialPairingHint(uint16_t & pairingHint)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetInitialPairingHint(uint16_t & pairingHint)
 {
     pairingHint = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_PAIRING_INITIAL_HINT);
     return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSecondaryPairingHint(uint16_t & pairingHint)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetSecondaryPairingHint(uint16_t & pairingHint)
 {
     pairingHint = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_PAIRING_SECONDARY_HINT);
     return CHIP_NO_ERROR;

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -132,19 +132,19 @@ exit:
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
 exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
 #if TARGET_OS_OSX
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -162,18 +162,18 @@ CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
 #endif // TARGET_OS_OSX
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO(#742): query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     ChipLogError(DeviceLayer, "InitiateFactoryReset not implemented");
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
 
@@ -185,7 +185,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -33,14 +33,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Darwin platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::PosixConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -50,12 +45,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -38,22 +38,22 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1626)
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
     err = CHIP_NO_ERROR;
 
@@ -61,19 +61,19 @@ exit:
     return err;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO: query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
-                                                                uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
+                                                               uint32_t & value)
 {
     // This method reads CHIP Persisted Counter type nvm3 objects.
     // (where persistedStorageKey represents an index to the counter).
@@ -90,8 +90,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
-                                                                 uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
+                                                                uint32_t value)
 {
     // This method reads CHIP Persisted Counter type nvm3 objects.
     // (where persistedStorageKey represents an index to the counter).

--- a/src/platform/EFR32/ConfigurationManagerImpl.h
+++ b/src/platform/EFR32/ConfigurationManagerImpl.h
@@ -34,14 +34,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the EFR32 platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::EFR32Config
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -51,12 +46,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -94,7 +89,7 @@ inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
     return ConfigurationManagerImpl::sInstance;
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -54,7 +54,7 @@ enum
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     uint32_t rebootCount;
@@ -90,7 +90,7 @@ CHIP_ERROR ConfigurationManagerImpl::_Init()
     }
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here (#1266)
@@ -111,10 +111,10 @@ CHIP_ERROR ConfigurationManagerImpl::_Init()
 #endif // CHIP_DEVICE_CONFIG_ENABLE_FACTORY_PROVISIONING
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
     err = CHIP_NO_ERROR;
 
@@ -142,7 +142,7 @@ CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOp
     return WriteConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     wifi_mode_t mode;
@@ -172,18 +172,18 @@ CHIP_ERROR ConfigurationManagerImpl::MapConfigError(esp_err_t error)
     }
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO: query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     ESP32Config::Key configKey{ kConfigNamespace_ChipCounters, key };
 
@@ -195,7 +195,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     ESP32Config::Key configKey{ kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -41,8 +41,7 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the ESP32 platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
                                        public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
 #else
@@ -57,10 +56,6 @@ public:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
 
 private:
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -69,13 +64,13 @@ private:
 
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
     CHIP_ERROR MapConfigError(esp_err_t error);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -44,7 +44,7 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     uint32_t rebootCount;
@@ -59,7 +59,7 @@ CHIP_ERROR ConfigurationManagerImpl::_Init()
     SuccessOrExit(err);
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
     if (ConfigValueExists(kCounterKey_RebootCount))
@@ -90,10 +90,10 @@ CHIP_ERROR ConfigurationManagerImpl::_Init()
     }
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
 
     err = CHIP_NO_ERROR;
@@ -102,7 +102,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     struct ifaddrs * addresses = NULL;
     CHIP_ERROR error           = CHIP_NO_ERROR;
@@ -129,18 +129,18 @@ exit:
     return error;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO(#742): query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
 
@@ -152,7 +152,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     PosixConfig::Key configKey{ kConfigNamespace_ChipCounters, key };
     return WriteConfigValue(configKey, value);

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -34,8 +34,7 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Linux platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::PosixConfig
 {
 public:
@@ -47,10 +46,6 @@ public:
     CHIP_ERROR StoreBootReasons(uint32_t bootReasons);
 
 private:
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -59,12 +54,12 @@ private:
 
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init();
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset();
-    void _InitiateFactoryReset();
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init() override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset() override;
+    void InitiateFactoryReset() override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
     CHIP_ERROR GetWiFiStationSecurityType(Internal::WiFiAuthSecurityType & secType);

--- a/src/platform/P6/ConfigurationManagerImpl.cpp
+++ b/src/platform/P6/ConfigurationManagerImpl.cpp
@@ -40,26 +40,26 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     VerifyOrReturnError(CHIP_NO_ERROR == err, err);
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
 
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     CHIP_ERROR err   = CHIP_NO_ERROR;
     cy_rslt_t result = CY_RSLT_SUCCESS;
@@ -83,18 +83,18 @@ CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
     return err;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO: query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     uint32_t in    = 0;
     CHIP_ERROR err = PersistedStorage::KeyValueStoreMgr().Get(key, &in, 4);
@@ -102,7 +102,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return PersistedStorage::KeyValueStoreMgr().Put(key, static_cast<void *>(&value), 4);
 }

--- a/src/platform/P6/ConfigurationManagerImpl.h
+++ b/src/platform/P6/ConfigurationManagerImpl.h
@@ -35,14 +35,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the PSoC6 platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::P6Config
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -52,12 +47,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -41,29 +41,29 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init(void)
+CHIP_ERROR ConfigurationManagerImpl::Init(void)
 {
-    return Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    return Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset(void)
+bool ConfigurationManagerImpl::CanFactoryReset(void)
 {
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset(void) {}
+void ConfigurationManagerImpl::InitiateFactoryReset(void) {}
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -34,14 +34,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Tizen platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::PosixConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -51,12 +46,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -47,13 +47,13 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
@@ -70,10 +70,10 @@ CHIP_ERROR ConfigurationManagerImpl::_Init()
 #endif // CHIP_DEVICE_CONFIG_ENABLE_FACTORY_PROVISIONING
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
 
     err = CHIP_NO_ERROR;
@@ -82,7 +82,7 @@ exit:
     return err;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -93,8 +93,7 @@ inline bool ConfigurationManagerImpl::_CanFactoryReset()
     return true;
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key,
-                                                                      uint32_t & value)
+inline CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     return ReadConfigValueCounter(key, value);
 }

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -33,14 +33,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Zephyr platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::ZephyrConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -50,12 +45,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -98,18 +93,18 @@ inline bool ConfigurationManagerImpl::_CanFactoryReset()
     return true;
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key,
-                                                                       uint32_t & value)
+inline CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key,
+                                                                      uint32_t & value)
 {
     return ReadConfigValueCounter(key, value);
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+inline CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return WriteConfigValueCounter(key, value);
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * /* buf */)
+inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * /* buf */)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -88,7 +88,7 @@ inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
     return ConfigurationManagerImpl::sInstance;
 }
 
-inline bool ConfigurationManagerImpl::_CanFactoryReset()
+inline bool ConfigurationManagerImpl::CanFactoryReset()
 {
     return true;
 }

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -56,30 +56,30 @@ void ConfigurationManagerImpl::InitializeWithObject(jobject managerObject)
     AndroidConfig::InitializeWithObject(managerObject);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO(#742): query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset() {}
+void ConfigurationManagerImpl::InitiateFactoryReset() {}
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -35,14 +35,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Android platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::AndroidConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -55,12 +50,12 @@ public:
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init();
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset();
-    void _InitiateFactoryReset();
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init() override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset() override;
+    void InitiateFactoryReset() override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
     CHIP_ERROR GetWiFiStationSecurityType(Internal::WiFiAuthSecurityType & secType);

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -58,34 +58,34 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     bool failSafeArmed;
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
     err = CHIP_NO_ERROR;
 
     return err;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO: query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     CC13X2_26X2Config::Key configKey{ { kCC13X2_26X2ChipCounters_Sysid, key } };
 
@@ -97,7 +97,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     CC13X2_26X2Config::Key configKey{ { kCC13X2_26X2ChipCounters_Sysid, key } };
     return WriteConfigValue(configKey, value);

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -33,14 +33,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the CC13X2_26X2 platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::CC13X2_26X2Config
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
@@ -48,12 +43,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -91,7 +86,7 @@ inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
     return ConfigurationManagerImpl::sInstance;
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -68,7 +68,7 @@ private:
     bool IsCommissionableDeviceTypeEnabled() override { return false; }
     CHIP_ERROR GetDeviceTypeId(uint16_t & deviceType) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     bool IsCommissionableDeviceNameEnabled() override { return false; }
-    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -66,7 +66,7 @@ private:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
     bool IsCommissionableDeviceTypeEnabled() override { return false; }
-    CHIP_ERROR GetDeviceType(uint16_t & deviceType) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetDeviceTypeId(uint16_t & deviceType) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     bool IsCommissionableDeviceNameEnabled() override { return false; }
     CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -27,67 +27,64 @@ namespace DeviceLayer {
  */
 class ConfigurationManagerImpl final : public ConfigurationManager
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
+    virtual ~ConfigurationManagerImpl() = default;
 
 private:
-    CHIP_ERROR _Init() { return CHIP_NO_ERROR; }
-    CHIP_ERROR _GetVendorName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetVendorId(uint16_t & vendorId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetProductName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetProductId(uint16_t & productId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetProductRevisionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetProductRevision(uint16_t & productRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreProductRevision(uint16_t productRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetFirmwareRevisionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetFirmwareRevision(uint32_t & firmwareRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreSerialNumber(const char * serialNum, size_t serialNumLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetPrimaryMACAddress(MutableByteSpan buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StorePrimaryWiFiMACAddress(const uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StorePrimary802154MACAddress(const uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetSetupPinCode(uint32_t & setupPinCode) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreSetupPinCode(uint32_t setupPinCode) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetSetupDiscriminator(uint16_t & setupDiscriminator) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreSetupDiscriminator(uint16_t setupDiscriminator) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductId(uint16_t & productId) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductRevision(uint16_t & productRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreProductRevision(uint16_t productRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
-    CHIP_ERROR _GetLifetimeCounter(uint16_t & lifetimeCounter) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _IncrementLifetimeCounter() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif
-    CHIP_ERROR _GetFailSafeArmed(bool & val) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _SetFailSafeArmed(bool val) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo);
-    bool _IsCommissionableDeviceTypeEnabled() { return false; }
-    CHIP_ERROR _GetDeviceType(uint16_t & deviceType) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    bool _IsCommissionableDeviceNameEnabled() { return false; }
-    CHIP_ERROR _GetDeviceName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetInitialPairingHint(uint16_t & pairingHint) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetInitialPairingInstruction(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetSecondaryPairingHint(uint16_t & pairingHint) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetSecondaryPairingInstruction(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetRegulatoryLocation(uint32_t & location) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreRegulatoryLocation(uint32_t location) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreCountryCode(const char * code, size_t codeLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _GetBreadcrumb(uint64_t & breadcrumb) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StoreBreadcrumb(uint64_t breadcrumb) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    bool IsCommissionableDeviceTypeEnabled() override { return false; }
+    CHIP_ERROR GetDeviceType(uint16_t & deviceType) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    bool IsCommissionableDeviceNameEnabled() override { return false; }
+    CHIP_ERROR GetDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetRegulatoryLocation(uint32_t & location) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreRegulatoryLocation(uint32_t location) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetBreadcrumb(uint64_t & breadcrumb) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreBreadcrumb(uint64_t breadcrumb) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #if !defined(NDEBUG)
-    CHIP_ERROR _RunUnitTests(void) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR RunUnitTests(void) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif
-    bool _IsFullyProvisioned() { return false; }
-    void _LogDeviceConfig() {}
-    bool _CanFactoryReset() { return true; }
-    void _InitiateFactoryReset() {}
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+    bool IsFullyProvisioned() override { return false; }
+    void LogDeviceConfig() override {}
+    bool CanFactoryReset() override { return true; }
+    void InitiateFactoryReset() override {}
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -47,7 +47,10 @@ private:
     CHIP_ERROR StorePrimaryWiFiMACAddress(const uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StorePrimary802154MACAddress(const uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
     CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
@@ -58,7 +61,10 @@ private:
 #endif
     CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
     bool IsCommissionableDeviceTypeEnabled() override { return false; }
     CHIP_ERROR GetDeviceType(uint16_t & deviceType) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     bool IsCommissionableDeviceNameEnabled() override { return false; }

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -46,12 +46,12 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     auto interface = WiFiInterface::get_default_instance();
     if (interface)
@@ -86,17 +86,17 @@ CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
     }
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset(void)
+void ConfigurationManagerImpl::InitiateFactoryReset(void)
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     CHIP_ERROR err = ReadConfigValue(key, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
@@ -106,7 +106,7 @@ CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     return WriteCounter(key, value);
 }

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -35,14 +35,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Zephyr platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::MbedConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -52,12 +47,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -43,22 +43,22 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
     err = CHIP_NO_ERROR;
 
@@ -66,19 +66,19 @@ exit:
     return err;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO: query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
-                                                                uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
+                                                               uint32_t & value)
 {
     CHIP_ERROR err;
 
@@ -93,8 +93,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
-                                                                 uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
+                                                                uint32_t value)
 {
     // This method reads Chip Persisted Counter type nvm3 objects.
     // (where persistedStorageKey represents an index to the counter).

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
@@ -34,14 +34,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the K32W platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::K32WConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -51,12 +46,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -94,7 +89,7 @@ inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
     return ConfigurationManagerImpl::sInstance;
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -45,20 +45,20 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
-CHIP_ERROR ConfigurationManagerImpl::_Init()
+CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     bool failSafeArmed;
 
     // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::_Init();
+    err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
     SuccessOrExit(err);
 
     // If the fail-safe was armed when the device last shutdown, initiate a factory reset.
-    if (_GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
+    if (GetFailSafeArmed(failSafeArmed) == CHIP_NO_ERROR && failSafeArmed)
     {
         ChipLogProgress(DeviceLayer, "Detected fail-safe armed on reboot; initiating factory reset");
-        _InitiateFactoryReset();
+        InitiateFactoryReset();
     }
     err = CHIP_NO_ERROR;
 
@@ -66,19 +66,19 @@ exit:
     return err;
 }
 
-bool ConfigurationManagerImpl::_CanFactoryReset()
+bool ConfigurationManagerImpl::CanFactoryReset()
 {
     // TODO: query the application to determine if factory reset is allowed.
     return true;
 }
 
-void ConfigurationManagerImpl::_InitiateFactoryReset()
+void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
-                                                                uint32_t & value)
+CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
+                                                               uint32_t & value)
 {
     CHIP_ERROR err;
     uintmax_t recordKey = persistedStorageKey + kConfigKey_GroupKeyBase;
@@ -96,8 +96,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::_WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
-                                                                 uint32_t value)
+CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key persistedStorageKey,
+                                                                uint32_t value)
 {
     CHIP_ERROR err;
 

--- a/src/platform/qpg/ConfigurationManagerImpl.h
+++ b/src/platform/qpg/ConfigurationManagerImpl.h
@@ -32,14 +32,9 @@ namespace DeviceLayer {
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the platform.
  */
-class ConfigurationManagerImpl final : public ConfigurationManager,
-                                       public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
+class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::QPGConfig
 {
-    // Allow the ConfigurationManager interface class to delegate method calls to
-    // the implementation methods provided by this class.
-    friend class ConfigurationManager;
-
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -49,12 +44,12 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
-    CHIP_ERROR _Init(void);
-    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
-    bool _CanFactoryReset(void);
-    void _InitiateFactoryReset(void);
-    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
-    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
+    CHIP_ERROR Init(void) override;
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
+    bool CanFactoryReset(void) override;
+    void InitiateFactoryReset(void) override;
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
 
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
@@ -92,7 +87,7 @@ inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
     return ConfigurationManagerImpl::sInstance;
 }
 
-inline CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
+inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }


### PR DESCRIPTION
#### Problem
Making the configuration manager virtual will make it easier to change at runtime. Later changes can allow the ConfigurationMgr() accessor to be settable at runtime rather than a hardcoded static instance.

#### Change overview
Makes the ConfigurationManager interface pure virtual. GenericConfigurationManagerImpl now implements it directly, and calls on the Impl() for the ConfigurationManager methods have been removed. Other calls remain for interfaces not defined by the ConfigurationManager (e.g. the methods related to config values).

#### Testing
Ran the unit tests.