### PR TITLE
Update the ResetWifiNetworkDiagnosticsCounts method in ConnectivityMan…

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -174,6 +174,10 @@ private:
 
     CHIP_ERROR ResetEthernetStatsCount();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    CHIP_ERROR ResetWiFiStatsCount();
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     void DriveAPState();
     CHIP_ERROR ConfigureWiFiAP();
@@ -206,6 +210,12 @@ private:
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    uint32_t mBeaconLostCount        = 0;
+    uint32_t mPacketMulticastRxCount = 0;
+    uint32_t mPacketMulticastTxCount = 0;
+    uint32_t mPacketUnicastRxCount   = 0;
+    uint32_t mPacketUnicastTxCount   = 0;
+    uint64_t mOverrunCount           = 0;
     char mWiFiIfName[IFNAMSIZ];
 #endif
 };


### PR DESCRIPTION
…ager

#### Problem
What is being fixed?  Examples:
* Currently, ResetWifiNetworkDiagnosticsCounts do nothing since on Linux simulation, the packet statistic information are shared by all running programs, the current running program does not have permission to reset those counts.

* This could be done by grabbing a starting set of initial counts at start of the connectivity manager impl, and then always reporting difference between current and initial counts. To "reset" counters to zero, you can just replace the initial counts with current counts.

#### Change overview
Update the ResetWifiNetworkDiagnosticsCounts method in ConnectivityManager

#### Testing
How was this tested? (at least one bullet point required)
```
chip-device-ctrl > zclread WiFiNetworkDiagnostics PacketUnicastRxCount 12344321 0 0 
[1633368820.148601][1488733:1488741] CHIP:IN: Prepared plaintext message 0x102b670 to 0x0000000000000000 of type 0x30 and protocolId (0, 0) on exchange 14123i with MessageCounter:1804648825.
[1633368820.148618][1488733:1488741] CHIP:IN: Sending plaintext msg 0x102b670 with MessageCounter:1804648825 to 0x0000000000000000 at monotonic time: 1123477638 msec
[1633368820.148703][1488733:1488741] CHIP:IN: Prepared encrypted message 0x102b688 to 0x0000000000BC5C01 of type 0x2 and protocolId (0, 1) on exchange 14124i with MessageCounter:2.
[1633368820.148715][1488733:1488741] CHIP:IN: Sending encrypted msg 0x102b688 with MessageCounter:2 to 0x0000000000BC5C01 at monotonic time: 1123477638 msec
[1633368820.337330][1488733:1488741] CHIP:EM: Received message of type 0x31 with protocolId (0, 0) and MessageCounter:470167403 on exchange 14123i
[1633368820.338226][1488733:1488741] CHIP:IN: Prepared plaintext message 0x102b670 to 0x0000000000000000 of type 0x32 and protocolId (0, 0) on exchange 14123i with MessageCounter:1804648826.
[1633368820.338237][1488733:1488741] CHIP:IN: Sending plaintext msg 0x102b670 with MessageCounter:1804648826 to 0x0000000000000000 at monotonic time: 1123477828 msec
[1633368820.338357][1488733:1488741] CHIP:EM: Received message of type 0x5 with protocolId (0, 1) and MessageCounter:2 on exchange 14124i
[1633368820.338659][1488733:1488741] CHIP:ZCL: ReadAttributesResponse:
[1633368820.338667][1488733:1488741] CHIP:ZCL:   ClusterId: 0x0000_0036
[1633368820.338671][1488733:1488741] CHIP:ZCL:   attributeId: 0x0000_0009
[1633368820.338674][1488733:1488741] CHIP:ZCL:   status: Success                (0x0000)
[1633368820.338677][1488733:1488741] CHIP:ZCL:   attribute TLV Type: 0x04
[1633368820.338683][1488733:1488741] CHIP:ZCL:   attributeValue: 116

chip-device-ctrl > zcl WiFiNetworkDiagnostics ResetCounts 12344321 0 0 
[1633368824.956109][1488733:1488741] CHIP:IN: Prepared encrypted message 0x102b670 to 0x0000000000BC5C01 of type 0x8 and protocolId (0, 1) on exchange 14125i with MessageCounter:0.
[1633368824.956156][1488733:1488741] CHIP:IN: Sending encrypted msg 0x102b670 with MessageCounter:0 to 0x0000000000BC5C01 at monotonic time: 1123482446 msec
[1633368824.976493][1488733:1488741] CHIP:EM: Received message of type 0x9 with protocolId (0, 1) and MessageCounter:1 on exchange 14125i
SetCommandIndexStatus commandHandle=1 commandIndex=1
[1633368824.977793][1488733:1488741] CHIP:ZCL: DefaultResponse:
[1633368824.977817][1488733:1488741] CHIP:ZCL:   Transaction: 0x7f06984d3af8
[1633368824.977827][1488733:1488741] CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)

chip-device-ctrl > zclread WiFiNetworkDiagnostics PacketUnicastRxCount 12344321 0 0 
[1633368829.883250][1488733:1488741] CHIP:IN: Prepared encrypted message 0x102b670 to 0x0000000000BC5C01 of type 0x2 and protocolId (0, 1) on exchange 14126i with MessageCounter:2.
[1633368829.883283][1488733:1488741] CHIP:IN: Sending encrypted msg 0x102b670 with MessageCounter:2 to 0x0000000000BC5C01 at monotonic time: 1123487373 msec
[1633368829.921947][1488733:1488741] CHIP:EM: Received message of type 0x5 with protocolId (0, 1) and MessageCounter:2 on exchange 14126i
[1633368829.922199][1488733:1488741] CHIP:ZCL: ReadAttributesResponse:
[1633368829.922206][1488733:1488741] CHIP:ZCL:   ClusterId: 0x0000_0036
[1633368829.922228][1488733:1488741] CHIP:ZCL:   attributeId: 0x0000_0009
[1633368829.922232][1488733:1488741] CHIP:ZCL:   status: Success                (0x0000)
[1633368829.922237][1488733:1488741] CHIP:ZCL:   attribute TLV Type: 0x04
[1633368829.922267][1488733:1488741] CHIP:ZCL:   attributeValue: 20

```


