### PR TITLE
[log] Add hex dump capability.

### DIFF
--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -199,6 +199,115 @@ DLL_EXPORT void SetLogFilter(uint8_t category)
 }
 #endif // CHIP_LOG_FILTERING
 
+/**
+ * This static method outputs a line of the memory dump.
+ *
+ * @param[in]  module    The LogModule generating the log message.
+ * @param[in]  category  The LogCategory for filtering log level.
+ * @param[in]  aBuf      A pointer to the buffer.
+ * @param[in]  aLength   Number of bytes in the buffer.
+ *
+ */
+static void DumpLine(uint8_t module, uint8_t category, const void * aBuf, const size_t aLength)
+{
+    char buf[80];
+    char * cur = buf;
+
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "|");
+    cur += strlen(cur);
+
+    for (size_t i = 0; i < 16; i++)
+    {
+        if (i < aLength)
+        {
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " %02X", ((uint8_t *) (aBuf))[i]);
+            cur += strlen(cur);
+        }
+        else
+        {
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " ..");
+            cur += strlen(cur);
+        }
+
+        if (!((i + 1) % 8))
+        {
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " |");
+            cur += strlen(cur);
+        }
+    }
+
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " ");
+    cur += strlen(cur);
+
+    for (size_t i = 0; i < 16; i++)
+    {
+        char c = 0x7f & ((char *) (aBuf))[i];
+
+        if (i < aLength && isprint(c))
+        {
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "%c", c);
+            cur += strlen(cur);
+        }
+        else
+        {
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), ".");
+            cur += strlen(cur);
+        }
+    }
+
+    Log(module, category, "%s", buf);
+}
+
+/**
+ * This method dumps bytes to the log in a human-readable fashion.
+ *
+ * @param[in]  module    The LogModule generating the log message.
+ * @param[in]  category  The LogCategory for filtering log level.
+ * @param[in]  msg       A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf      A pointer to the buffer.
+ * @param[in]  aLength   Number of bytes to print.
+ *
+ */
+void Dump(uint8_t module, uint8_t category, const char * msg, const void * aBuf, const unsigned aLength)
+{
+    size_t idlen       = strlen(msg);
+    const size_t width = 72;
+    char buf[80];
+    char * cur = buf;
+
+    for (size_t i = 0; i < (width - idlen) / 2 - 5; i++)
+    {
+        snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "=");
+        cur += strlen(cur);
+    }
+
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "[%s len=%03u]", msg, static_cast<uint16_t>(aLength));
+    cur += strlen(cur);
+
+    for (size_t i = 0; i < (width - idlen) / 2 - 4; i++)
+    {
+        snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "=");
+        cur += strlen(cur);
+    }
+
+    Log(module, category, "%s", buf);
+
+    for (size_t i = 0; i < aLength; i += 16)
+    {
+        DumpLine(module, category, (uint8_t *) (aBuf) + i, (aLength - i) < 16 ? (aLength - i) : 16);
+    }
+
+    cur = buf;
+
+    for (size_t i = 0; i < width; i++)
+    {
+        snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "-");
+        cur += strlen(cur);
+    }
+
+    Log(module, category, "%s", buf);
+}
+
 #endif /* _CHIP_USE_LOGGING */
 
 } // namespace Logging

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -87,6 +87,7 @@ void SetLogRedirectCallback(LogRedirectCallback_t callback);
 
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list args);
 void Log(uint8_t module, uint8_t category, const char * msg, ...) ENFORCE_FORMAT(3, 4);
+void Dump(uint8_t module, uint8_t category, const char * msg, const void * aBuf, const unsigned aLength);
 
 uint8_t GetLogFilter();
 void SetLogFilter(uint8_t category);
@@ -156,6 +157,15 @@ void SetLogFilter(uint8_t category);
 #endif
 #else
 #define ChipLogDetail(MOD, MSG, ...) ((void) 0)
+#endif
+
+#if CHIP_DETAIL_LOGGING
+#ifndef ChipLogDumpDetail
+#define ChipLogDumpDetail(MOD, MSG, BUF, LEN)                                                                                      \
+    chip::Logging::Dump(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Detail, MSG, BUF, LEN)
+#endif
+#else
+#define ChipLogDumpDetail(MOD, MSG, BUF, LEN) ((void) 0)
 #endif
 
 #if CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING


### PR DESCRIPTION
## Problem
When developing and debugging a protocol stack, it is often necessary to log raw packet buffers in hex.
The chip::Logging module in the SDK does not have a hexDump capability currently.

## Change overview
Add ChipLogDumpDetail() macro and underlying implementation to log byte arrays and buffers.

## Testing
Manual testing.

## Example:

```
[1633135518.371724][1194293:1194298] CHIP:SC: Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation...
[1633135518.371745][1194293:1194298] CHIP:SC: ========[CryptoContext: initialized new encryption keys len=048]=========
[1633135518.371759][1194293:1194298] CHIP:SC: | 44 D4 3C 91 D2 27 F3 BA | 08 24 C5 D8 7C B8 1B 33 | DT<.R's:.$EX|8.3
[1633135518.371771][1194293:1194298] CHIP:SC: | AC C1 8F 06 C7 BC 9B E8 | 24 6A 67 8C B1 F8 BA 3D | ,A..G<.h$jg.1x:=
[1633135518.371782][1194293:1194298] CHIP:SC: | 85 59 68 78 04 E7 3C AB | 7E 92 8D A5 CE D9 B2 9A | .Yhx.g<+~..%NY2.
[
```