### PR TITLE
Add a safer API for encoding a command data response to CommandHandler.

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -142,7 +142,7 @@ void Command::ShutdownInternal()
     mCommandIndex = 0;
 }
 
-CHIP_ERROR Command::PrepareCommand(const CommandPathParams & aCommandPathParams, bool aIsStatus)
+CHIP_ERROR Command::PrepareCommand(const CommandPathParams & aCommandPathParams, bool aStartDataStruct)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandDataElement::Builder commandDataElement;
@@ -154,7 +154,7 @@ CHIP_ERROR Command::PrepareCommand(const CommandPathParams & aCommandPathParams,
     err = ConstructCommandPath(aCommandPathParams, commandDataElement);
     SuccessOrExit(err);
 
-    if (!aIsStatus)
+    if (aStartDataStruct)
     {
         err = commandDataElement.GetWriter()->StartContainer(TLV::ContextTag(CommandDataElement::kCsTag_Data),
                                                              TLV::kTLVType_Structure, mDataElementContainerType);
@@ -168,12 +168,12 @@ TLV::TLVWriter * Command::GetCommandDataElementTLVWriter()
     return mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuilder().GetWriter();
 }
 
-CHIP_ERROR Command::FinishCommand(bool aIsStatus)
+CHIP_ERROR Command::FinishCommand(bool aEndDataStruct)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     CommandDataElement::Builder commandDataElement = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuilder();
-    if (!aIsStatus)
+    if (aEndDataStruct)
     {
         err = commandDataElement.GetWriter()->EndContainer(mDataElementContainerType);
         SuccessOrExit(err);

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -91,9 +91,9 @@ public:
      */
     CHIP_ERROR FinalizeCommandsMessage(System::PacketBufferHandle & commandPacket);
 
-    CHIP_ERROR PrepareCommand(const CommandPathParams & aCommandPathParams, bool aIsStatus = false);
+    CHIP_ERROR PrepareCommand(const CommandPathParams & aCommandPathParams, bool aStartDataStruct = true);
     TLV::TLVWriter * GetCommandDataElementTLVWriter();
-    CHIP_ERROR FinishCommand(bool aIsStatus = false);
+    CHIP_ERROR FinishCommand(bool aEndDataStruct = true);
     virtual CHIP_ERROR AddStatusCode(const CommandPathParams & aCommandPathParams,
                                      const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
                                      const Protocols::Id aProtocolId, const Protocols::InteractionModel::Status aStatus)

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -139,7 +139,7 @@ CHIP_ERROR CommandHandler::AddStatusCode(const CommandPathParams & aCommandPathP
     CHIP_ERROR err = CHIP_NO_ERROR;
     StatusElement::Builder statusElementBuilder;
 
-    err = PrepareCommand(aCommandPathParams, true /* isStatus */);
+    err = PrepareCommand(aCommandPathParams, false /* aStartDataStruct */);
     SuccessOrExit(err);
 
     statusElementBuilder =
@@ -149,10 +149,18 @@ CHIP_ERROR CommandHandler::AddStatusCode(const CommandPathParams & aCommandPathP
     err = statusElementBuilder.GetError();
     SuccessOrExit(err);
 
-    err = FinishCommand(true /* isStatus */);
+    err = FinishCommand(false /* aEndDataStruct */);
 
 exit:
     return err;
+}
+
+CHIP_ERROR CommandHandler::PrepareResponse(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommand)
+{
+    CommandPathParams params = { aRequestCommandPath.mEndpointId,
+                                 0, // GroupId
+                                 aRequestCommandPath.mClusterId, aResponseCommand, (CommandPathFlags::kEndpointIdValid) };
+    return PrepareCommand(params, false /* aStartDataStruct */);
 }
 
 } // namespace app

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -25,7 +25,11 @@
 #pragma once
 
 #include <app/Command.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/MessageDef/CommandDataElement.h>
+#include <app/data-model/Encode.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLV.h>
 #include <lib/core/CHIPTLVDebug.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
@@ -48,10 +52,32 @@ public:
                              const Protocols::SecureChannel::GeneralStatusCode aGeneralCode, const Protocols::Id aProtocolId,
                              const Protocols::InteractionModel::Status aStatus) override;
 
+    /**
+     * API for adding a data response.  The template parameter T is generally
+     * expected to be a ClusterName::Commands::CommandName::Type struct, but any
+     * object that can be encoded using the DataModel::Encode machinery and
+     * exposes the right command id will work.
+     *
+     * @param [in] aRequestCommandPath the concrete path of the command we are
+     *             responding to.
+     * @param [in] aData the data for the response.
+     */
+    template <typename CommandData>
+    CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
+    {
+        ReturnErrorOnFailure(PrepareResponse(aRequestCommandPath, CommandData::CommandId));
+        TLV::TLVWriter * writer = GetCommandDataElementTLVWriter();
+        VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        ReturnErrorOnFailure(DataModel::Encode(*writer, TLV::ContextTag(CommandDataElement::kCsTag_Data), aData));
+
+        return FinishCommand(/* aEndDataStruct = */ false);
+    }
+
 private:
     friend class TestCommandInteraction;
     CHIP_ERROR SendCommandResponse();
     CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) override;
+    CHIP_ERROR PrepareResponse(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommand);
 };
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -108,6 +108,7 @@ public:
     static void TestCommandSenderWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendSimpleCommandData(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandHandlerCommandDataEncoding(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendSimpleStatusCode(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendEmptyResponse(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
@@ -357,6 +358,53 @@ void TestCommandInteraction::TestCommandHandlerWithSendSimpleCommandData(nlTestS
     ValidateCommandHandlerWithSendCommand(apSuite, apContext, false /*aNeedStatusCode=false*/);
 }
 
+struct Fields
+{
+    static constexpr chip::CommandId CommandId = 4;
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, uint64_t aTag) const
+    {
+        TLV::TLVType outerContainerType;
+        ReturnErrorOnFailure(aWriter.StartContainer(aTag, TLV::kTLVType_Structure, outerContainerType));
+        ReturnErrorOnFailure(aWriter.PutBoolean(TLV::ContextTag(1), true));
+        return aWriter.EndContainer(outerContainerType);
+    }
+};
+
+void TestCommandInteraction::TestCommandHandlerCommandDataEncoding(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    app::CommandHandler commandHandler;
+    System::PacketBufferHandle commandPacket;
+    err = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    commandHandler.mpExchangeCtx = gExchangeManager.NewContext(SessionHandle(0, 0, 0, 0), nullptr);
+    TestExchangeDelegate delegate;
+    commandHandler.mpExchangeCtx->SetDelegate(&delegate);
+
+    ConcreteCommandPath path(1, // Endpoint
+                             3, // ClusterId
+                             4  // CommandId
+    );
+
+    err = commandHandler.AddResponseData(path, Fields());
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = commandHandler.FinalizeCommandsMessage(commandPacket);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    chip::System::PacketBufferTLVReader reader;
+    InvokeCommand::Parser invokeCommandParser;
+    reader.Init(std::move(commandPacket));
+    err = reader.Next();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeCommandParser.Init(reader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = invokeCommandParser.CheckSchemaValidity();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#endif
+}
+
 void TestCommandInteraction::TestCommandHandlerWithSendSimpleStatusCode(nlTestSuite * apSuite, void * apContext)
 {
     // Send response which has simple status code and command path
@@ -446,6 +494,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestCommandHandlerWithSendEmptyCommand", chip::app::TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand),
     NL_TEST_DEF("TestCommandSenderWithProcessReceivedMsg", chip::app::TestCommandInteraction::TestCommandSenderWithProcessReceivedMsg),
     NL_TEST_DEF("TestCommandHandlerWithSendSimpleCommandData", chip::app::TestCommandInteraction::TestCommandHandlerWithSendSimpleCommandData),
+    NL_TEST_DEF("TestCommandHandlerCommandDataEncoding", chip::app::TestCommandInteraction::TestCommandHandlerCommandDataEncoding),
     NL_TEST_DEF("TestCommandHandlerWithSendSimpleStatusCode", chip::app::TestCommandInteraction::TestCommandHandlerWithSendSimpleStatusCode),
     NL_TEST_DEF("TestCommandHandlerWithProcessReceivedMsg", chip::app::TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg),
     NL_TEST_DEF("TestCommandHandlerWithProcessReceivedNotExistCommand", chip::app::TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistCommand),


### PR DESCRIPTION
#### Problem
Current API for encoding a command data response requires orchestrating several function calls in the right order, knowing the right tag numbers, etc.

#### Change overview
Provide an API that will be able to consume the structs https://github.com/project-chip/connectedhomeip/pull/10171 introduces and do encoding of them in a single function call.

#### Testing
Unit test added in the PR.  Functional testing will happen as we convert cluster implementations to this API using the infrastructure from #10171.