### PR TITLE
Remove some unused System::Layer code

### DIFF
--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -50,6 +50,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ErrorStr.h>
 #include <lib/support/ScopedBuffer.h>
+#include <platform/PlatformManager.h>
 #include <system/SystemClock.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -477,7 +478,7 @@ void ServiceEvents(uint32_t aSleepTimeMilliseconds)
 
         if (sRemainingSystemLayerEventDelay == 0)
         {
-            gSystemLayer.DispatchEvents();
+            chip::DeviceLayer::PlatformMgr().RunEventLoop();
             sRemainingSystemLayerEventDelay = gNetworkOptions.EventDelay;
         }
         else

--- a/src/platform/LwIPEventSupport.cpp
+++ b/src/platform/LwIPEventSupport.cpp
@@ -55,20 +55,6 @@ CHIP_ERROR PlatformEventing::PostEvent(System::Layer & aLayer, System::Object & 
     return PlatformMgr().PostEvent(&event);
 }
 
-CHIP_ERROR PlatformEventing::DispatchEvents(System::Layer & aLayer)
-{
-    PlatformMgr().RunEventLoop();
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR PlatformEventing::DispatchEvent(System::Layer & aLayer, const ChipDeviceEvent * aEvent)
-{
-    PlatformMgr().DispatchEvent(aEvent);
-
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR PlatformEventing::StartTimer(System::Layer & aLayer, uint32_t aMilliseconds)
 {
     return PlatformMgr().StartChipTimer(aMilliseconds);

--- a/src/system/LwIPEventSupport.h
+++ b/src/system/LwIPEventSupport.h
@@ -31,8 +31,6 @@ class PlatformEventing
 public:
     static CHIP_ERROR ScheduleLambdaBridge(System::Layer & aLayer, const LambdaBridge & bridge);
     static CHIP_ERROR PostEvent(System::Layer & aLayer, Object & aTarget, EventType aType, uintptr_t aArgument);
-    static CHIP_ERROR DispatchEvents(System::Layer & aLayer);
-    static CHIP_ERROR DispatchEvent(System::Layer & aLayer, Event aEvent);
     static CHIP_ERROR StartTimer(System::Layer & aLayer, uint32_t aMilliseconds);
 };
 

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -146,34 +146,6 @@ CHIP_ERROR LayerImplLwIP::PostEvent(Object & aTarget, EventType aEventType, uint
 }
 
 /**
- * This is a syntactic wrapper around a platform-specific hook that effects an event loop, waiting on a queue that services this
- * instance, pulling events off of that queue, and then dispatching them for handling.
- *
- *  @return #CHIP_NO_ERROR on success; otherwise, a specific error indicating the reason for initialization failure.
- */
-CHIP_ERROR LayerImplLwIP::DispatchEvents()
-{
-    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    return PlatformEventing::DispatchEvents(*this);
-}
-
-/**
- * This dispatches the specified event for handling by this instance.
- *
- * The unmarshalling of the type and arguments from the event is handled by a platform-specific hook which should then call
- * back to Layer::HandleEvent for the actual dispatch.
- *
- *  @param[in]  aEvent  The platform-specific event object to dispatch for handling.
- *
- * @return CHIP_NO_ERROR on success; otherwise, a specific error indicating the reason for initialization failure.
- */
-CHIP_ERROR LayerImplLwIP::DispatchEvent(Event aEvent)
-{
-    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    return PlatformEventing::DispatchEvent(*this, aEvent);
-}
-
-/**
  * This implements the actual dispatch and handling of a CHIP System Layer event.
  *
  *  @param[in,out]  aTarget     A reference to the layer object to which the event is targeted.

--- a/src/system/SystemLayerImplLwIP.h
+++ b/src/system/SystemLayerImplLwIP.h
@@ -49,14 +49,12 @@ public:
 
 public:
     // Platform implementation.
-    CHIP_ERROR DispatchEvents(void); // XXX called only in a test → PlatformEventing::DispatchEvents → PlatformMgr().RunEventLoop()
     CHIP_ERROR HandleEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument);
     CHIP_ERROR HandlePlatformTimer(void);
 
 private:
     friend class PlatformEventing;
 
-    CHIP_ERROR DispatchEvent(Event aEvent);
     CHIP_ERROR StartPlatformTimer(uint32_t aDelayMilliseconds);
 
     Timer::MutexedList mTimerList;


### PR DESCRIPTION
#### Problem

`System::LayerLwipImpl` has some unused methods.

#### Change overview

- Remove `DispatchEvent()` and `DispatchEvents()` from
  `System::LayerImplLwip` and `PlatformEventing`.

#### Testing

CI; no functional changes.
