### PR TITLE
Remove RPC support for the efr32 lock app

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -217,7 +217,6 @@
                 "android-x86-chip-tool",
                 "efr32-brd4161a-light-rpc",
                 "efr32-brd4161a-light",
-                "efr32-brd4161a-lock-rpc",
                 "efr32-brd4161a-lock",
                 "efr32-brd4161a-window-covering",
                 "esp32-c3devkit-all-clusters",

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -99,7 +99,7 @@ def Efr32Targets():
                         board=Efr32Board.BRD4161A)
 
     yield efr_target.Extend('window-covering', app=Efr32App.WINDOW_COVERING)
-    yield efr_target.Extend('lock', app=Efr32App.LOCK),
+    yield efr_target.Extend('lock', app=Efr32App.LOCK)
 
     rpc_aware_targets = [
         efr_target.Extend('light', app=Efr32App.LIGHT),

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -99,10 +99,10 @@ def Efr32Targets():
                         board=Efr32Board.BRD4161A)
 
     yield efr_target.Extend('window-covering', app=Efr32App.WINDOW_COVERING)
+    yield efr_target.Extend('lock', app=Efr32App.LOCK),
 
     rpc_aware_targets = [
         efr_target.Extend('light', app=Efr32App.LIGHT),
-        efr_target.Extend('lock', app=Efr32App.LOCK),
     ]
 
     for target in rpc_aware_targets:

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -5,7 +5,6 @@ android-x86-chip-tool
 efr32-brd4161a-light
 efr32-brd4161a-light-rpc
 efr32-brd4161a-lock
-efr32-brd4161a-lock-rpc
 efr32-brd4161a-window-covering
 esp32-c3devkit-all-clusters
 esp32-devkitc-all-clusters

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -55,9 +55,6 @@ gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/efr32 '
 # Generating efr32-brd4161a-lock
 gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-lock
 
-# Generating efr32-brd4161a-lock-rpc
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A" import("//with_pw_rpc.gni")' {out}/efr32-brd4161a-lock-rpc
-
 # Generating efr32-brd4161a-window-covering
 gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-window-covering
 
@@ -254,9 +251,6 @@ ninja -C {out}/efr32-brd4161a-light-rpc
 
 # Building efr32-brd4161a-lock
 ninja -C {out}/efr32-brd4161a-lock
-
-# Building efr32-brd4161a-lock-rpc
-ninja -C {out}/efr32-brd4161a-lock-rpc
 
 # Building efr32-brd4161a-window-covering
 ninja -C {out}/efr32-brd4161a-window-covering


### PR DESCRIPTION
#### Problem
Lock app does not support RPC (compilation fails):

```
2021-10-05 15:59:42 INFO    /home/vscode/pigweed/env/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: obj/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/pw_kvs.entry.cc.o: in function `pw::kvs::internal::Entry::Read(pw::kvs::FlashPartition&, unsigned long, pw::kvs::internal::EntryFormats const&, pw::kvs::internal::Entry*)':
2021-10-05 15:59:42 INFO    out/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/entry.cc:54: undefined reference to `pw_Log'
2021-10-05 15:59:42 INFO    /home/vscode/pigweed/env/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: obj/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/pw_kvs.entry.cc.o: in function `pw::kvs::internal::Entry::VerifyChecksumInFlash() const':
2021-10-05 15:59:42 INFO    out/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/entry.cc:214: undefined reference to `pw_Log'
2021-10-05 15:59:42 INFO    /home/vscode/pigweed/env/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: obj/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/pw_kvs.entry_cache.cc.o: in function `pw::kvs::internal::EntryCache::Find(pw::kvs::FlashPartition&, pw::kvs::internal::Sectors const&, pw::kvs::internal::EntryFormats const&, pw::kvs::Key, pw::kvs::internal::EntryMetadata*) const':
2021-10-05 15:59:42 INFO    out/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/entry_cache.cc:96: undefined reference to `pw_Log'
2021-10-05 15:59:42 INFO    /home/vscode/pigweed/env/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: out/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/entry_cache.cc:105: undefined reference to `pw_Log'
2021-10-05 15:59:42 INFO    /home/vscode/pigweed/env/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: out/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/entry_cache.cc:112: undefined reference to `pw_Log'
2021-10-05 15:59:42 INFO    /home/vscode/pigweed/env/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: obj/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/pw_kvs.entry_cache.cc.o:out/third_party/connectedhomeip/third_party/pigweed/repo/pw_kvs/entry_cache.cc:159: more undefined references to `pw_Log' follow
2021-10-05 15:59:42 INFO    collect2: error: ld returned 1 exit status
2021-10-05 15:59:42 INFO    ninja: build stopped: subcommand failed.
```

#### Change overview
Remove -rpc variant from efr32-lock

#### Testing
unit test shows variant was removed
