### PR TITLE
Use latest dockerhub image for cirque instead of 0.4.21

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -27,9 +27,9 @@ jobs:
     cirque:
         name: Cirque
         timeout-minutes: 60
-        
+
         env:
-            DOCKER_RUN_VERSION: 0.4.21
+            DOCKER_RUN_VERSION: latest
             GITHUB_CACHE_PATH: /tmp/cirque-cache/
 
         runs-on: ubuntu-latest


### PR DESCRIPTION
#### Problem
Cirque CI does not seem to pickup the latest changes to dockerhub.

#### Change overview
Replace 0.4.21 with "latest" as a tag to use for cirque tests

#### Testing
CI
