### PR TITLE
Fix dockerhub version to 0.5.11 (latest currently) instead of using `:latest`

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -21,7 +21,7 @@ on:
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
-  
+
 jobs:
     android:
         name: Build Android
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-android:latest
+            image: connectedhomeip/chip-build-android:0.5.11
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:latest
+            image: connectedhomeip/chip-build:0.5.11
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:latest
+            image: connectedhomeip/chip-build:0.5.11
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options:

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -29,7 +29,7 @@ jobs:
         timeout-minutes: 60
         
         env:
-            DOCKER_RUN_VERSION: 0.4.21
+            DOCKER_RUN_VERSION: 0.5.11
             GITHUB_CACHE_PATH: /tmp/cirque-cache/
 
         runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
 # need to run with privilege, which isn't supported by job.XXX.contaner
 #  https://github.com/actions/container-action/issues/2
 #         container:
-#             image: connectedhomeip/chip-build-cirque:0.4.10
+#             image: connectedhomeip/chip-build-cirque:0.5.11
 #             volumes:
 #                 - "/tmp:/tmp"
 #                 - "/dev/pts:/dev/pts"

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-infineon:latest
+            image: connectedhomeip/chip-build-infineon:0.5.11
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:latest
+            image: connectedhomeip/chip-build:0.5.11
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -21,13 +21,13 @@ on:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
-    cancel-in-progress: true    
+    cancel-in-progress: true
 
 jobs:
     mbedos:
         name: Mbed OS examples building
         timeout-minutes: 60
-        
+
         env:
             BUILD_TYPE: mbedos
             APP_PROFILE: release
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-mbed-os:latest
+            image: connectedhomeip/chip-build-mbed-os:0.5.11
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:latest
+            image: connectedhomeip/chip-build-nrf-platform:0.5.11
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:latest
+            image: connectedhomeip/chip-build:0.5.11
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:latest
+            image: connectedhomeip/chip-build-telink:0.5.11
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -28,7 +28,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-tizen:latest
+            image: connectedhomeip/chip-build-tizen:0.5.11
             options: --user root
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:latest
+            image: connectedhomeip/chip-build:0.5.11
             options:
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -37,7 +37,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:latest
+            image: connectedhomeip/chip-build:0.5.11
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
                 - "/tmp/happy_test_logs:/tmp/happy_test_logs"

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,4 +1,4 @@
-# NOTE: /workspace/ is the persistent directory across steps for
+# NOTE: /workspace/ is the persistent directory across steps
 steps:
     - name: "connectedhomeip/chip-build-vscode:0.5.11"
       id: "CompileAll"

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,6 +1,6 @@
 # NOTE: /workspace/ is the persistent directory across steps for
 steps:
-    - name: "connectedhomeip/chip-build-vscode:latest"
+    - name: "connectedhomeip/chip-build-vscode:0.5.11"
       id: "CompileAll"
       entrypoint: "./scripts/run_in_build_env.sh"
       args:


### PR DESCRIPTION
#### Problem
Dockerhub pushes affect builds, which have unintended consequences of CI failing without an obvious code change.

This was shown on ESP cryptography/PEM changes and may manifest itself on SDK update when branch can stop compiling (saw it for TE6)

#### Change overview
Uses 0.5.11 as a version for CI and devcontainer.

#### Testing
CI
