### PR TITLE
Add //config/qpg/chip-gn to have standalone Matter build

### DIFF
--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -82,6 +82,10 @@ jobs:
                     qpg qpg6100+debug persistent-storage-app \
                     out/persistent-storage_app_debug/chip-qpg6100-persistent_storage-example.out \
                     /tmp/bloat_reports/
+            - name: Build Matter SDK library
+              timeout-minutes: 5
+              run: |
+                  config/qpg/chip-gn/build.sh
             - name: Binary artifact suffix
               id: outsuffix
               uses: haya14busa/action-cond@v1.0.0

--- a/config/qpg/chip-gn/.gn
+++ b/config/qpg/chip-gn/.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+# The location of the build configuration file.
+buildconfig = "//build/config/BUILDCONFIG.gn"
+
+# CHIP uses angle bracket includes.
+check_system_includes = true
+
+default_args = {
+  target_cpu = "arm"
+  target_os = "freertos"
+
+  import("//config/qpg/chip-gn/args.gni")
+}

--- a/config/qpg/chip-gn/BUILD.gn
+++ b/config/qpg/chip-gn/BUILD.gn
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/qpg_sdk.gni")
+import("//third_party/qpg_sdk/qpg_sdk.gni")
+
+import("//build/chip/tests.gni")
+
+assert(current_os == "freertos")
+
+declare_args() {
+}
+
+examples_plat_dir = "//examples/platform/qpg"
+qpg_sdk("sdk") {
+  sources = [ "//examples/platform/qpg/app/include/Service.h" ]
+
+  include_dirs = [
+    "//src/platform/qpg",
+    "${examples_plat_dir}/project_include",
+  ]
+}
+
+static_library("qpg") {
+  deps = [
+    "//src/app/server",
+    "//src/lib",
+  ]
+
+  if (chip_build_tests) {
+    deps += [ "${chip_root}/src:tests" ]
+  }
+
+  output_name = "libMatterStack"
+
+  output_dir = "${root_out_dir}/lib"
+
+  complete_static_lib = true
+}
+
+group("default") {
+  deps = [
+    ":qpg",
+    "//src/setup_payload",
+    "//third_party/openthread/platforms:libopenthread-platform",
+    "//third_party/openthread/platforms:libopenthread-platform-utils",
+    "//third_party/openthread/repo:libopenthread-cli-mtd",
+    "//third_party/openthread/repo:libopenthread-mtd",
+  ]
+}

--- a/config/qpg/chip-gn/args.gni
+++ b/config/qpg/chip-gn/args.gni
@@ -1,0 +1,42 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//examples/platform/qpg/args.gni")
+qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
+
+chip_device_platform = "qpg"
+
+is_debug = false
+chip_enable_openthread = true
+chip_config_network_layer_ble = true
+chip_inet_config_enable_ipv4 = false
+chip_enable_nfc = false
+chip_build_tests = false
+chip_monolithic_tests = false
+chip_inet_config_enable_tcp_endpoint = false
+chip_inet_config_enable_dns_resolver = false
+chip_build_libshell = false
+qpg_ar = "arm-none-eabi-ar"
+qpg_cc = "arm-none-eabi-gcc"
+qpg_cxx = "arm-none-eabi-g++"
+chip_mdns = "platform"
+
+chip_project_config_include_dirs =
+    [ "//examples/platform/qpg/project_include/" ]
+chip_project_config_include = "<CHIPProjectConfig.h>"
+chip_system_project_config_include = "<CHIPProjectConfig.h>"
+chip_ble_project_config_include = ""
+
+custom_toolchain = "//config/qpg/chip-gn/toolchain:qpgtoolchain"

--- a/config/qpg/chip-gn/build.sh
+++ b/config/qpg/chip-gn/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source "$(dirname "$0")/../../../scripts/activate.sh"
+set -ex
+env
+
+GN_ROOT_TARGET=$(dirname "$0")
+CHIP_ROOT=$GN_ROOT_TARGET/../../../
+OUTDIR=$CHIP_ROOT/out
+
+mkdir -p "$OUTDIR"
+gn \
+    --root="$CHIP_ROOT" \
+    --root-target=//config/qpg/chip-gn \
+    --dotfile="$GN_ROOT_TARGET/.gn" \
+    --script-executable=python3 \
+    --export-compile-commands \
+    gen \
+    --check \
+    --fail-on-unused-args \
+    "$OUTDIR"
+ninja -C "$OUTDIR"

--- a/config/qpg/chip-gn/toolchain/BUILD.gn
+++ b/config/qpg/chip-gn/toolchain/BUILD.gn
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${build_root}/toolchain/arm_gcc/arm_toolchain.gni")
+
+declare_args() {
+  qpg_ar = ""
+  qpg_cc = ""
+  qpg_cxx = ""
+}
+
+gcc_toolchain("qpgtoolchain") {
+  ar = qpg_ar
+  cc = qpg_cc
+  cxx = qpg_cxx
+
+  toolchain_args = {
+    current_os = "freertos"
+    is_clang = false
+  }
+}


### PR DESCRIPTION
#### Problem
Qorvo will use Matter built as a '.a' library to build it's silicon SDK examples.

#### Change overview
Add files to build Matter as a standalone library.
This is done using a 'chip-gn' gn configuration under //config/qpg/chip-gn, similar to what is used for CMake integration for other silicon flavors.

#### Testing
Adding a GitHub workflow as build-test.
