### PR TITLE
Fixing commissioning issues: Initializing device attestation config/verifier

### DIFF
--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -19,6 +19,10 @@
 #include <app/server/Mdns.h>
 #include <app/server/Server.h>
 #include <controller/CHIPCommissionableNodeController.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/DeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <credentials/examples/DeviceAttestationVerifierExample.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -28,6 +32,7 @@
 
 using namespace chip;
 using namespace chip::Controller;
+using namespace chip::Credentials;
 using chip::ArgParser::HelpOptions;
 using chip::ArgParser::OptionDef;
 using chip::ArgParser::OptionSet;
@@ -186,6 +191,12 @@ int main(int argc, char * argv[])
 
     SuccessOrExit(err = chip::Platform::MemoryInit());
     SuccessOrExit(err = chip::DeviceLayer::PlatformMgr().InitChipStack());
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+
+    // Initialize device attestation verifier
+    SetDeviceAttestationVerifier(Examples::GetExampleDACVerifier());
 
     if (!chip::ArgParser::ParseArgs(argv[0], argc, argv, allOptions))
     {


### PR DESCRIPTION
#### Problem
Commissioning of the tv-casting-app was failing with a segfault since the following changes were made: https://github.com/project-chip/connectedhomeip/commit/0e52970c6d821eb04dcc485448fbd5ea10269ab7

#### Change overview
Initializing device attestation config/verifier for the tv-casting-app

#### Testing
Verified that commissioning succeeded using the chip-tool onnetwork commissioning command.
