### PR TITLE
Improve our logging of the "how do I commission this" information.

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -108,8 +108,12 @@ static bool EnsureWifiIsStarted()
 
 int ChipLinuxAppInit(int argc, char ** argv)
 {
-    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+#if CONFIG_NETWORK_LAYER_BLE
     chip::RendezvousInformationFlags rendezvousFlags = chip::RendezvousInformationFlag::kBLE;
+#else  // CONFIG_NETWORK_LAYER_BLE
+    chip::RendezvousInformationFlag rendezvousFlags = RendezvousInformationFlag::kOnNetwork;
+#endif // CONFIG_NETWORK_LAYER_BLE
 
 #ifdef CONFIG_RENDEZVOUS_MODE
     rendezvousFlags = static_cast<chip::RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);
@@ -284,6 +288,13 @@ void ChipLinuxAppMainLoop()
 
     // Init ZCL Data Model and CHIP App Server
     chip::Server::GetInstance().Init(nullptr, securePort, unsecurePort);
+
+    // Now that the server has started and we are done with our startup logging,
+    // log our discovery/onboarding information again so it's not lost in the
+    // noise.
+    ConfigurationMgr().LogDeviceConfig();
+
+    PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());


### PR DESCRIPTION
Two changes here:

1) On "linux" (which includes Darwin), don't claim the BLE rendezvous
   mode when we don't even have the BLE network layer compiled.

2) On "linux" add device config and QR code logging right after server
   startup, so it's easier to notice when the server starts.  I left
   the existing such logging at the very beginning of startup, so it
   also appears at the very beginning of the log, for people who
   prefer finding it there.

#### Problem
When compiled without BLE on Linux/Mac, chip-all-clusters-app still outputs as QR code that claims BLE-only commissioning, and using that code does not work.

#### Change overview
Fix the code that's printed, and also print it in a more easily located spot.

#### Testing
No behavior changes other than the logging.  Verified that I can commission with the QR code that gets printed now, both places.