### PR TITLE
[ZAP] Update zapTypeToClusterObjectType method in order to handle enums

### DIFF
--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -47,11 +47,7 @@ namespace {{name}} {
     struct Type {
     public:
         {{#zcl_struct_items}}
-        {{#if isArray}}
-        DataModel::List<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToEncodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
-        {{else}}
-        {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToEncodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
-        {{/if}}
+        {{#if isArray}}DataModel::List<{{/if}}{{zapTypeToEncodableClusterObjectType type}}{{#if isArray}}>{{/if}} {{asLowerCamelCase label}};
         {{/zcl_struct_items}}
 
         CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
@@ -64,11 +60,7 @@ namespace {{name}} {
     struct DecodableType {
     public:
         {{#zcl_struct_items}}
-        {{#if isArray}}
-        DataModel::DecodableList<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
-        {{else}}
-        {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
-        {{/if}}
+        {{#if isArray}}DataModel::DecodableList<{{/if}}{{zapTypeToDecodableClusterObjectType type}}{{#if isArray}}>{{/if}} {{asLowerCamelCase label}};
         {{/zcl_struct_items}}
         CHIP_ERROR Decode(TLV::TLVReader &reader);
     };
@@ -101,11 +93,7 @@ public:
     static constexpr ClusterId GetClusterId() { return {{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{#if isArray}}
-    DataModel::List<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToEncodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
-    {{else}}
-    {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToEncodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
-    {{/if}}
+    {{#if isArray}}DataModel::List<{{/if}}{{zapTypeToEncodableClusterObjectType type}}{{#if isArray}}>{{/if}} {{asLowerCamelCase label}};
     {{/zcl_command_arguments}}
 
     CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
@@ -117,11 +105,7 @@ public:
     static constexpr ClusterId GetClusterId() { return {{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{#if isArray}}
-    DataModel::DecodableList<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
-    {{else}}
-    {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
-    {{/if}}
+    {{#if isArray}}DataModel::DecodableList<{{/if}}{{zapTypeToDecodableClusterObjectType type}}{{#if isArray}}>{{/if}} {{asLowerCamelCase label}};
     {{/zcl_command_arguments}}
     CHIP_ERROR Decode(TLV::TLVReader &reader);
 };

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -413,30 +413,36 @@ function zapTypeToClusterObjectType(type, isDecodable)
 
   function fn(pkgId)
   {
-    const options = { 'hash' : {} };
-    return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
-      const basicType = ChipTypesHelper.asBasicType(zclType);
-      switch (basicType) {
-      case 'bool':
-      case 'int8_t':
-      case 'uint8_t':
-      case 'int16_t':
-      case 'uint16_t':
-      case 'int24_t':
-      case 'uint24_t':
-      case 'int32_t':
-      case 'uint32_t':
-      case 'int64_t':
-      case 'uint64_t':
-        return zclType;
-      default:
-        if (isDecodable) {
-          return "Structs::" + type + '::DecodableType'
-        } else {
-          return "Structs::" + type + '::Type'
-        }
+    return zclHelper.isEnum(this.global.db, type, pkgId).then(isEnum => {
+      if (isEnum != 'unknown' || type.startsWith('enum')) {
+        return type;
       }
-    })
+
+      const options = { 'hash' : {} };
+      return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
+        const basicType = ChipTypesHelper.asBasicType(zclType);
+        switch (basicType) {
+        case 'bool':
+        case 'int8_t':
+        case 'uint8_t':
+        case 'int16_t':
+        case 'uint16_t':
+        case 'int24_t':
+        case 'uint24_t':
+        case 'int32_t':
+        case 'uint32_t':
+        case 'int64_t':
+        case 'uint64_t':
+          return zclType;
+        default:
+          if (isDecodable) {
+            return 'Structs::' + type + '::DecodableType'
+          } else {
+            return 'Structs::' + type + '::Type'
+          }
+        }
+      });
+    });
   }
 
   const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {


### PR DESCRIPTION
#### Problem

```
 {{#if isArray}}
        DataModel::DecodableList<{{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}}> {{asLowerCamelCase label}};
{{else}}
        {{#if_is_enum type}}{{type}}{{else}}{{zapTypeToDecodableClusterObjectType type}}{{/if_is_enum}} {{asLowerCamelCase label}};
{{/if}}
```

can be simplified to:
```
       {{#if isArray}}DataModel::DecodableList<{{/if}}{{zapTypeToDecodableClusterObjectType type}}{{#if isArray}}>{{/if}} {{asLowerCamelCase label}};
```

#### Change overview
 * Update zapTypeToClusterObjectType so it handle enums internally
 
#### Testing
Running codegen show no changes. Final binary is not impacted.

#fixes #10270