### PR TITLE
Switch lock PIN and RFID to octet string.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
@@ -150,7 +150,7 @@ bool emberAfDoorLockClusterGetLogRecordCallback(app::CommandHandler * commandObj
             SuccessOrExit(err = writer->Put(TLV::ContextTag(3), entry.source));
             SuccessOrExit(err = writer->Put(TLV::ContextTag(4), entry.eventId));
             SuccessOrExit(err = writer->Put(TLV::ContextTag(5), entry.userId));
-            SuccessOrExit(err = writer->PutBytes(TLV::ContextTag(6), entry.pin + 1, entry.pin[0]));
+            SuccessOrExit(err = writer->Put(TLV::ContextTag(6), ByteSpan::fromZclString(entry.pin)));
             SuccessOrExit(err = commandObj->FinishCommand());
         }
     }

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -161,7 +161,7 @@ static void printUserTables(void)
 }
 
 // Returns status byte for use in SetPinResponse and SetRfidResponse commands.
-static uint8_t setUser(uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * code,
+static uint8_t setUser(uint16_t userId, uint8_t userStatus, uint8_t userType, ByteSpan & code,
                        EmberAfPluginDoorLockServerUser * userTable, uint8_t userTableSize)
 {
     bool success = false;
@@ -170,9 +170,9 @@ static uint8_t setUser(uint16_t userId, uint8_t userStatus, uint8_t userType, ui
     // of the table entry field. Note there are potentially different max
     // lengths for PIN v. RFID.
     bool validCodeLength = false;
-    if (code != NULL &&
-        ((userTable == pinUserTable && emberAfStringLength(code) <= EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_MAX_PIN_LENGTH) ||
-         (emberAfStringLength(code) <= EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_MAX_RFID_LENGTH)))
+    if (!code.empty() &&
+        ((userTable == pinUserTable && code.size() <= EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_MAX_PIN_LENGTH) ||
+         (code.size() <= EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_MAX_RFID_LENGTH)))
     {
         validCodeLength = true;
     }
@@ -184,8 +184,9 @@ static uint8_t setUser(uint16_t userId, uint8_t userStatus, uint8_t userType, ui
         user->status = static_cast<EmberAfDoorLockUserStatus>(userStatus);
         // TODO: Need to check validity.  https://github.com/project-chip/connectedhomeip/issues/3580
         user->type = static_cast<EmberAfDoorLockUserType>(userType);
-        memmove(user->code.rfid, code,
-                emberAfStringLength(code) + 1); // + 1 for Zigbee string length byte
+        // Our length checks above make this cast safe.
+        user->code.rfid[0] = static_cast<uint8_t>(code.size());
+        memmove(user->code.rfid + 1, code.data(), code.size());
 
         emberAfDoorLockClusterPrintln("***RX SET %s ***", (userTable == pinUserTable ? "PIN" : "RFID"));
         printUserTables();
@@ -295,7 +296,7 @@ bool emAfPluginDoorLockServerSetPinUserType(uint16_t userId, EmberAfDoorLockUser
 // PIN handling
 
 bool emberAfDoorLockClusterSetPinCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                          EndpointId endpoint, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin,
+                                          EndpointId endpoint, uint16_t userId, uint8_t userStatus, uint8_t userType, ByteSpan pin,
                                           Commands::SetPin::DecodableType & commandData)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -316,12 +317,13 @@ bool emberAfDoorLockClusterSetPinCallback(app::CommandHandler * commandObj, cons
     // get bitmask so we can check if we should send event notification
     emberAfReadServerAttribute(DOOR_LOCK_SERVER_ENDPOINT, ZCL_DOOR_LOCK_CLUSTER_ID, ZCL_RF_PROGRAMMING_EVENT_MASK_ATTRIBUTE_ID,
                                (uint8_t *) &rfProgrammingEventMask, sizeof(rfProgrammingEventMask));
-    if ((rfProgrammingEventMask & EMBER_BIT(2)) && !status && (pin != NULL))
+    if ((rfProgrammingEventMask & EMBER_BIT(2)) && !status && !pin.empty())
     {
         emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_PROGRAMMING_EVENT_NOTIFICATION_COMMAND_ID, "uuvsuuws", EMBER_ZCL_DOOR_LOCK_EVENT_SOURCE_RF,
-                                  EMBER_ZCL_DOOR_LOCK_PROGRAMMING_EVENT_CODE_PIN_ADDED, userId, pin, userType, userStatus,
-                                  0 /*emberAfGetCurrentTime() #2507*/, pin);
+                                  ZCL_PROGRAMMING_EVENT_NOTIFICATION_COMMAND_ID, "uuvSuuwS", EMBER_ZCL_DOOR_LOCK_EVENT_SOURCE_RF,
+                                  EMBER_ZCL_DOOR_LOCK_PROGRAMMING_EVENT_CODE_PIN_ADDED, userId, pin.data(),
+                                  static_cast<uint8_t>(pin.size()), userType, userStatus, 0 /*emberAfGetCurrentTime() #2507*/,
+                                  pin.data(), static_cast<uint8_t>(pin.size()));
         SEND_COMMAND_UNICAST_TO_BINDINGS();
     }
 exit:
@@ -366,7 +368,7 @@ bool emberAfDoorLockClusterGetPinCallback(app::CommandHandler * commandObj, cons
             SuccessOrExit(err = writer->Put(TLV::ContextTag(2), user.type));
             if (getSendPinOverTheAir())
             {
-                SuccessOrExit(err = writer->PutBytes(TLV::ContextTag(3), user.code.pin + 1, user.code.pin[0]));
+                SuccessOrExit(err = writer->Put(TLV::ContextTag(3), ByteSpan::fromZclString(user.code.pin)));
             }
             else
             {
@@ -468,7 +470,7 @@ exit:
 
 bool emberAfDoorLockClusterSetRfidCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                            EndpointId endpoint, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                           uint8_t * rfid, Commands::SetRfid::DecodableType & commandData)
+                                           ByteSpan rfid, Commands::SetRfid::DecodableType & commandData)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status =
@@ -508,7 +510,7 @@ bool emberAfDoorLockClusterGetRfidCallback(app::CommandHandler * commandObj, con
             SuccessOrExit(err = writer->Put(TLV::ContextTag(0), userId));
             SuccessOrExit(err = writer->Put(TLV::ContextTag(1), user.status));
             SuccessOrExit(err = writer->Put(TLV::ContextTag(2), user.type));
-            SuccessOrExit(err = writer->PutBytes(TLV::ContextTag(3), user.code.pin + 1, user.code.pin[0]));
+            SuccessOrExit(err = writer->Put(TLV::ContextTag(3), ByteSpan::fromZclString(user.code.pin)));
             SuccessOrExit(err = commandObj->FinishCommand());
         }
     }
@@ -602,7 +604,7 @@ static void printSuccessOrFailure(bool success)
  * Note that the "pin" parameter is a Zigbee string, so the first byte is the
  * length of the remaining bytes
  */
-static bool verifyPin(uint8_t * pin, uint8_t * userId)
+static bool verifyPin(ByteSpan & pin, uint8_t * userId)
 {
     bool pinRequired = false;
     EmberAfStatus status;
@@ -615,7 +617,7 @@ static bool verifyPin(uint8_t * pin, uint8_t * userId)
     {
         return true;
     }
-    else if (pin == NULL)
+    else if (pin.empty())
     {
         return false;
     }
@@ -623,8 +625,7 @@ static bool verifyPin(uint8_t * pin, uint8_t * userId)
     for (i = 0; i < EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE; i++)
     {
         EmberAfPluginDoorLockServerUser * user = &pinUserTable[i];
-        uint8_t userPinLength                  = emberAfStringLength(user->code.pin);
-        if (userPinLength == emberAfStringLength(pin) && 0 == memcmp(&user->code.pin[1], &pin[1], userPinLength))
+        if (pin.data_equal(ByteSpan::fromZclString(user->code.pin)))
         {
             *userId = i;
             return true;
@@ -635,7 +636,7 @@ static bool verifyPin(uint8_t * pin, uint8_t * userId)
 }
 
 bool emberAfDoorLockClusterLockDoorCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                            EndpointId endpoint, uint8_t * PIN, Commands::LockDoor::DecodableType & commandData)
+                                            EndpointId endpoint, ByteSpan PIN, Commands::LockDoor::DecodableType & commandData)
 {
     uint8_t userId                = 0;
     bool pinVerified              = verifyPin(PIN, &userId);
@@ -676,18 +677,20 @@ bool emberAfDoorLockClusterLockDoorCallback(app::CommandHandler * commandObj, co
     // Possibly send operation event
     if (doorLocked)
     {
-        if (rfOperationEventMask & EMBER_BIT(1) && (PIN != NULL))
+        if (rfOperationEventMask & EMBER_BIT(1) && !PIN.empty())
         {
             emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                      ZCL_OPERATION_EVENT_NOTIFICATION_COMMAND_ID, "uuvsws", 0x01, 0x03, userId, PIN, 0X00, PIN);
+                                      ZCL_OPERATION_EVENT_NOTIFICATION_COMMAND_ID, "uuvSwS", 0x01, 0x03, userId, PIN.data(),
+                                      static_cast<uint8_t>(PIN.size()), 0X00, PIN.data(), static_cast<uint8_t>(PIN.size()));
         }
     }
     else
     {
-        if (rfOperationEventMask & EMBER_BIT(3) && (PIN != NULL))
+        if (rfOperationEventMask & EMBER_BIT(3) && !PIN.empty())
         {
             emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                      ZCL_OPERATION_EVENT_NOTIFICATION_COMMAND_ID, "uuvsws", 0x01, 0x03, userId, PIN, 0x00, PIN);
+                                      ZCL_OPERATION_EVENT_NOTIFICATION_COMMAND_ID, "uuvSwS", 0x01, 0x03, userId, PIN.data(),
+                                      static_cast<uint8_t>(PIN.size()), 0x00, PIN.data(), static_cast<uint8_t>(PIN.size()));
         }
     }
     SEND_COMMAND_UNICAST_TO_BINDINGS();
@@ -700,7 +703,7 @@ exit:
 }
 
 bool emberAfDoorLockClusterUnlockDoorCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                              EndpointId endpoint, uint8_t * pin, Commands::UnlockDoor::DecodableType & commandData)
+                                              EndpointId endpoint, ByteSpan pin, Commands::UnlockDoor::DecodableType & commandData)
 {
     uint8_t userId                = 0;
     bool pinVerified              = verifyPin(pin, &userId);
@@ -737,12 +740,13 @@ bool emberAfDoorLockClusterUnlockDoorCallback(app::CommandHandler * commandObj, 
                                (uint8_t *) &rfOperationEventMask, sizeof(rfOperationEventMask));
 
     // send operation event
-    if (doorUnlocked && (rfOperationEventMask & EMBER_BIT(2)) && (pin != NULL))
+    if (doorUnlocked && (rfOperationEventMask & EMBER_BIT(2)) && !pin.empty())
     {
         emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_OPERATION_EVENT_NOTIFICATION_COMMAND_ID, "uuvsws", EMBER_ZCL_DOOR_LOCK_EVENT_SOURCE_RF,
-                                  EMBER_ZCL_DOOR_LOCK_OPERATION_EVENT_CODE_UNLOCK, userId, pin,
-                                  0 /*emberAfGetCurrentTime() #2507 */, pin);
+                                  ZCL_OPERATION_EVENT_NOTIFICATION_COMMAND_ID, "uuvSwS", EMBER_ZCL_DOOR_LOCK_EVENT_SOURCE_RF,
+                                  EMBER_ZCL_DOOR_LOCK_OPERATION_EVENT_CODE_UNLOCK, userId, pin.data(),
+                                  static_cast<uint8_t>(pin.size()), 0 /*emberAfGetCurrentTime() #2507 */, pin.data(),
+                                  static_cast<uint8_t>(pin.size()));
         SEND_COMMAND_UNICAST_TO_BINDINGS();
     }
 exit:
@@ -890,7 +894,7 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, A
 }
 
 bool emberAfDoorLockClusterUnlockWithTimeoutCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                                     EndpointId endpoint, uint16_t timeoutS, uint8_t * pin,
+                                                     EndpointId endpoint, uint16_t timeoutS, ByteSpan pin,
                                                      Commands::UnlockWithTimeout::DecodableType & commandData)
 {
     uint8_t userId;

--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -1312,13 +1312,13 @@ limitations under the License.
       <description>
         Locks the door
       </description>
-      <arg name="PIN" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="PIN" type="OCTET_STRING" introducedIn="ha-1.2-05-3520-29"/>
     </command>
     <command source="client" code="0x01" name="UnlockDoor" optional="false" cli="zcl lock unlock">
       <description>
         Unlocks the door
       </description>
-      <arg name="PIN" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="PIN" type="OCTET_STRING" introducedIn="ha-1.2-05-3520-29"/>
     </command>
     <command source="client" code="0x02" name="Toggle" optional="true" introducedIn="ha-1.2-05-3520-29">
       <description>
@@ -1331,7 +1331,7 @@ limitations under the License.
          Unlock the door with a timeout. When the timeout expires, the door will automatically re-lock.
        </description>
       <arg name="timeoutInSeconds" type="INT16U"/>
-      <arg name="pin" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="pin" type="OCTET_STRING" introducedIn="ha-1.2-05-3520-29"/>
     </command>
     <command source="client" code="0x04" name="GetLogRecord" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-log-record">
       <description>
@@ -1346,7 +1346,7 @@ limitations under the License.
       <arg name="userId" type="INT16U"/>
       <arg name="userStatus" type="DoorLockUserStatus"/>
       <arg name="userType" type="DoorLockUserType"/>
-      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="pin" type="OCTET_STRING"/>
     </command>
     <command source="client" code="0x06" name="GetPin" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-pin">
       <description>
@@ -1468,7 +1468,7 @@ limitations under the License.
       <arg name="userId" type="INT16U"/>
       <arg name="userStatus" type="DoorLockUserStatus"/>
       <arg name="userType" type="DoorLockUserType"/>
-      <arg name="id" type="CHAR_STRING"/>
+      <arg name="id" type="OCTET_STRING"/>
     </command>
     <command source="client" code="0x17" name="GetRfid" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-rfid">
       <description>
@@ -1521,7 +1521,7 @@ limitations under the License.
       <arg name="source" type="INT8U"/>
       <arg name="eventIdOrAlarmCode" type="INT8U"/>
       <arg name="userId" type="INT16U"/>
-      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="pin" type="OCTET_STRING"/>
     </command>
     <command source="server" code="0x05" name="SetPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
       <description>
@@ -1536,7 +1536,7 @@ limitations under the License.
       <arg name="userId" type="INT16U"/>
       <arg name="userStatus" type="DoorLockUserStatus"/>
       <arg name="userType" type="DoorLockUserType"/>
-      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="pin" type="OCTET_STRING"/>
     </command>
     <command source="server" code="0x07" name="ClearPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
       <description>
@@ -1658,7 +1658,7 @@ limitations under the License.
       <arg name="userId" type="INT16U"/>
       <arg name="userStatus" type="DoorLockUserStatus"/>
       <arg name="userType" type="DoorLockUserType"/>
-      <arg name="rfid" type="CHAR_STRING"/>
+      <arg name="rfid" type="OCTET_STRING"/>
     </command>
     <command source="server" code="0x18" name="ClearRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
       <description>
@@ -1679,7 +1679,7 @@ limitations under the License.
       <arg name="source" type="INT8U"/>
       <arg name="eventCode" type="DoorLockOperationEventCode"/>
       <arg name="userId" type="INT16U"/>
-      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="pin" type="OCTET_STRING"/>
       <arg name="timeStamp" type="epoch_s"/>
       <arg name="data" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
     </command>
@@ -1690,7 +1690,7 @@ limitations under the License.
       <arg name="source" type="INT8U"/>
       <arg name="eventCode" type="DoorLockProgrammingEventCode"/>
       <arg name="userId" type="INT16U"/>
-      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="pin" type="OCTET_STRING"/>
       <arg name="userType" type="DoorLockUserType"/>
       <arg name="userStatus" type="DoorLockUserStatus"/>
       <arg name="timeStamp" type="epoch_s"/>

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -1725,7 +1725,7 @@ public:
     };
 
     static void CallbackFn(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-                           uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+                           uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1733,8 +1733,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetLogRecordResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString pinStr(env, "");
+        jbyteArray pinArr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1744,13 +1743,20 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err =
-            JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIII[B)V", &javaMethod);
         SuccessOrExit(err);
+
+        pinArr = env->NewByteArray(pin.size());
+        VerifyOrExit(pinArr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+        env->SetByteArrayRegion(pinArr, 0, pin.size(), reinterpret_cast<const jbyte *>(pin.data()));
+        VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(logEntryId), static_cast<jlong>(timestamp),
                             static_cast<jint>(eventType), static_cast<jint>(source), static_cast<jint>(eventIdOrAlarmCode),
-                            static_cast<jint>(userId), pinStr.jniValue());
+                            static_cast<jint>(userId), pinArr);
+
+        env->DeleteLocalRef(pinArr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1798,7 +1804,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
+    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1806,8 +1812,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetPinResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString pinStr(env, "");
+        jbyteArray pinArr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1817,11 +1822,19 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III[B)V", &javaMethod);
         SuccessOrExit(err);
 
+        pinArr = env->NewByteArray(pin.size());
+        VerifyOrExit(pinArr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+        env->SetByteArrayRegion(pinArr, 0, pin.size(), reinterpret_cast<const jbyte *>(pin.data()));
+        VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
+
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
-                            static_cast<jint>(userType), pinStr.jniValue());
+                            static_cast<jint>(userType), pinArr);
+
+        env->DeleteLocalRef(pinArr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1869,7 +1882,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1877,8 +1890,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetRfidResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString rfidStr(env, "");
+        jbyteArray rfidArr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1888,11 +1900,19 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III[B)V", &javaMethod);
         SuccessOrExit(err);
 
+        rfidArr = env->NewByteArray(rfid.size());
+        VerifyOrExit(rfidArr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+        env->SetByteArrayRegion(rfidArr, 0, rfid.size(), reinterpret_cast<const jbyte *>(rfid.data()));
+        VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
+
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
-                            static_cast<jint>(userType), rfidStr.jniValue());
+                            static_cast<jint>(userType), rfidArr);
+
+        env->DeleteLocalRef(rfidArr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -15779,13 +15799,13 @@ exit:
         env->CallVoidMethod(callback, method, exception);
     }
 }
-JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring pin)
+JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray pin)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
-    JniUtfString pinStr(env, pin);
+    JniByteArray pinArr(env, pin);
     CHIPDoorLockClusterLockDoorResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -15798,7 +15818,7 @@ JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong cl
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->LockDoor(onSuccess->Cancel(), onFailure->Cancel(),
-                               chip::ByteSpan((const uint8_t *) pin, strlen(pinStr.c_str())));
+                               chip::ByteSpan((const uint8_t *) pinArr.data(), pinArr.size()));
     SuccessOrExit(err);
 
 exit:
@@ -15875,13 +15895,13 @@ exit:
     }
 }
 JNI_METHOD(void, DoorLockCluster, setPin)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userStatus, jint userType, jstring pin)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userStatus, jint userType, jbyteArray pin)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
-    JniUtfString pinStr(env, pin);
+    JniByteArray pinArr(env, pin);
     CHIPDoorLockClusterSetPinResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -15894,7 +15914,7 @@ JNI_METHOD(void, DoorLockCluster, setPin)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->SetPin(onSuccess->Cancel(), onFailure->Cancel(), userId, userStatus, userType,
-                             chip::ByteSpan((const uint8_t *) pin, strlen(pinStr.c_str())));
+                             chip::ByteSpan((const uint8_t *) pinArr.data(), pinArr.size()));
     SuccessOrExit(err);
 
 exit:
@@ -15923,13 +15943,13 @@ exit:
     }
 }
 JNI_METHOD(void, DoorLockCluster, setRfid)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userStatus, jint userType, jstring id)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userStatus, jint userType, jbyteArray id)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
-    JniUtfString idStr(env, id);
+    JniByteArray idArr(env, id);
     CHIPDoorLockClusterSetRfidResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -15942,7 +15962,7 @@ JNI_METHOD(void, DoorLockCluster, setRfid)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->SetRfid(onSuccess->Cancel(), onFailure->Cancel(), userId, userStatus, userType,
-                              chip::ByteSpan((const uint8_t *) id, strlen(idStr.c_str())));
+                              chip::ByteSpan((const uint8_t *) idArr.data(), idArr.size()));
     SuccessOrExit(err);
 
 exit:
@@ -16112,13 +16132,13 @@ exit:
         env->CallVoidMethod(callback, method, exception);
     }
 }
-JNI_METHOD(void, DoorLockCluster, unlockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring pin)
+JNI_METHOD(void, DoorLockCluster, unlockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray pin)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
-    JniUtfString pinStr(env, pin);
+    JniByteArray pinArr(env, pin);
     CHIPDoorLockClusterUnlockDoorResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -16131,7 +16151,7 @@ JNI_METHOD(void, DoorLockCluster, unlockDoor)(JNIEnv * env, jobject self, jlong 
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->UnlockDoor(onSuccess->Cancel(), onFailure->Cancel(),
-                                 chip::ByteSpan((const uint8_t *) pin, strlen(pinStr.c_str())));
+                                 chip::ByteSpan((const uint8_t *) pinArr.data(), pinArr.size()));
     SuccessOrExit(err);
 
 exit:
@@ -16160,13 +16180,13 @@ exit:
     }
 }
 JNI_METHOD(void, DoorLockCluster, unlockWithTimeout)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint timeoutInSeconds, jstring pin)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint timeoutInSeconds, jbyteArray pin)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
-    JniUtfString pinStr(env, pin);
+    JniByteArray pinArr(env, pin);
     CHIPDoorLockClusterUnlockWithTimeoutResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -16179,7 +16199,7 @@ JNI_METHOD(void, DoorLockCluster, unlockWithTimeout)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->UnlockWithTimeout(onSuccess->Cancel(), onFailure->Cancel(), timeoutInSeconds,
-                                        chip::ByteSpan((const uint8_t *) pin, strlen(pinStr.c_str())));
+                                        chip::ByteSpan((const uint8_t *) pinArr.data(), pinArr.size()));
     SuccessOrExit(err);
 
 exit:

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -1954,7 +1954,7 @@ public class ChipClusters {
       getYeardaySchedule(chipClusterPtr, callback, scheduleId, userId);
     }
 
-    public void lockDoor(LockDoorResponseCallback callback, String pin) {
+    public void lockDoor(LockDoorResponseCallback callback, byte[] pin) {
       lockDoor(chipClusterPtr, callback, pin);
     }
 
@@ -1974,12 +1974,12 @@ public class ChipClusters {
     }
 
     public void setPin(
-        SetPinResponseCallback callback, int userId, int userStatus, int userType, String pin) {
+        SetPinResponseCallback callback, int userId, int userStatus, int userType, byte[] pin) {
       setPin(chipClusterPtr, callback, userId, userStatus, userType, pin);
     }
 
     public void setRfid(
-        SetRfidResponseCallback callback, int userId, int userStatus, int userType, String id) {
+        SetRfidResponseCallback callback, int userId, int userStatus, int userType, byte[] id) {
       setRfid(chipClusterPtr, callback, userId, userStatus, userType, id);
     }
 
@@ -2018,12 +2018,12 @@ public class ChipClusters {
           chipClusterPtr, callback, scheduleId, userId, localStartTime, localEndTime);
     }
 
-    public void unlockDoor(UnlockDoorResponseCallback callback, String pin) {
+    public void unlockDoor(UnlockDoorResponseCallback callback, byte[] pin) {
       unlockDoor(chipClusterPtr, callback, pin);
     }
 
     public void unlockWithTimeout(
-        UnlockWithTimeoutResponseCallback callback, int timeoutInSeconds, String pin) {
+        UnlockWithTimeoutResponseCallback callback, int timeoutInSeconds, byte[] pin) {
       unlockWithTimeout(chipClusterPtr, callback, timeoutInSeconds, pin);
     }
 
@@ -2078,7 +2078,7 @@ public class ChipClusters {
         int userId);
 
     private native void lockDoor(
-        long chipClusterPtr, LockDoorResponseCallback callback, String pin);
+        long chipClusterPtr, LockDoorResponseCallback callback, byte[] pin);
 
     private native void setHolidaySchedule(
         long chipClusterPtr,
@@ -2094,7 +2094,7 @@ public class ChipClusters {
         int userId,
         int userStatus,
         int userType,
-        String pin);
+        byte[] pin);
 
     private native void setRfid(
         long chipClusterPtr,
@@ -2102,7 +2102,7 @@ public class ChipClusters {
         int userId,
         int userStatus,
         int userType,
-        String id);
+        byte[] id);
 
     private native void setUserType(
         long chipClusterPtr, SetUserTypeResponseCallback callback, int userId, int userType);
@@ -2127,13 +2127,13 @@ public class ChipClusters {
         long localEndTime);
 
     private native void unlockDoor(
-        long chipClusterPtr, UnlockDoorResponseCallback callback, String pin);
+        long chipClusterPtr, UnlockDoorResponseCallback callback, byte[] pin);
 
     private native void unlockWithTimeout(
         long chipClusterPtr,
         UnlockWithTimeoutResponseCallback callback,
         int timeoutInSeconds,
-        String pin);
+        byte[] pin);
 
     public interface ClearAllPinsResponseCallback {
       void onSuccess(int status);
@@ -2196,19 +2196,19 @@ public class ChipClusters {
           int source,
           int eventIdOrAlarmCode,
           int userId,
-          String pin);
+          byte[] pin);
 
       void onError(Exception error);
     }
 
     public interface GetPinResponseCallback {
-      void onSuccess(int userId, int userStatus, int userType, String pin);
+      void onSuccess(int userId, int userStatus, int userType, byte[] pin);
 
       void onError(Exception error);
     }
 
     public interface GetRfidResponseCallback {
-      void onSuccess(int userId, int userStatus, int userType, String rfid);
+      void onSuccess(int userId, int userStatus, int userType, byte[] rfid);
 
       void onError(Exception error);
     }

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -1225,7 +1225,7 @@ class ChipClusters:
                     "commandId": 0x00000000,
                     "commandName": "LockDoor",
                     "args": {
-                        "pin": "str",
+                        "pin": "bytes",
                     },
                 },
             0x00000011: {
@@ -1245,7 +1245,7 @@ class ChipClusters:
                         "userId": "int",
                         "userStatus": "int",
                         "userType": "int",
-                        "pin": "str",
+                        "pin": "bytes",
                     },
                 },
             0x00000016: {
@@ -1255,7 +1255,7 @@ class ChipClusters:
                         "userId": "int",
                         "userStatus": "int",
                         "userType": "int",
-                        "id": "str",
+                        "id": "bytes",
                     },
                 },
             0x00000014: {
@@ -1293,7 +1293,7 @@ class ChipClusters:
                     "commandId": 0x00000001,
                     "commandName": "UnlockDoor",
                     "args": {
-                        "pin": "str",
+                        "pin": "bytes",
                     },
                 },
             0x00000003: {
@@ -1301,7 +1301,7 @@ class ChipClusters:
                     "commandName": "UnlockWithTimeout",
                     "args": {
                         "timeoutInSeconds": "int",
-                        "pin": "str",
+                        "pin": "bytes",
                     },
                 },
             },
@@ -4212,7 +4212,6 @@ class ChipClusters:
                 device, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
     def ClusterDoorLock_CommandLockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
-        pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor(
                 device, ZCLendpoint, ZCLgroupid, pin, len(pin)
         )
@@ -4221,12 +4220,10 @@ class ChipClusters:
                 device, ZCLendpoint, ZCLgroupid, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday
         )
     def ClusterDoorLock_CommandSetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, pin: bytes):
-        pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin(
                 device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, pin, len(pin)
         )
     def ClusterDoorLock_CommandSetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, id: bytes):
-        id = id.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid(
                 device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, id, len(id)
         )
@@ -4243,12 +4240,10 @@ class ChipClusters:
                 device, ZCLendpoint, ZCLgroupid, scheduleId, userId, localStartTime, localEndTime
         )
     def ClusterDoorLock_CommandUnlockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
-        pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor(
                 device, ZCLendpoint, ZCLgroupid, pin, len(pin)
         )
     def ClusterDoorLock_CommandUnlockWithTimeout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, timeoutInSeconds: int, pin: bytes):
-        pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(
                 device, ZCLendpoint, ZCLgroupid, timeoutInSeconds, pin, len(pin)
         )

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -543,7 +543,7 @@ void CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge::OnSuccessFn(vo
 };
 
 void CHIPDoorLockClusterGetLogRecordResponseCallbackBridge::OnSuccessFn(void * context, uint16_t logEntryId, uint32_t timestamp,
-    uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+    uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
 {
     DispatchSuccess(context, @ {
         @"logEntryId" : [NSNumber numberWithUnsignedShort:logEntryId],
@@ -552,29 +552,29 @@ void CHIPDoorLockClusterGetLogRecordResponseCallbackBridge::OnSuccessFn(void * c
         @"source" : [NSNumber numberWithUnsignedChar:source],
         @"eventIdOrAlarmCode" : [NSNumber numberWithUnsignedChar:eventIdOrAlarmCode],
         @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"pin" : [NSString stringWithFormat:@"%s", pin],
+        @"pin" : [NSData dataWithBytes:pin.data() length:pin.size()],
     });
 };
 
 void CHIPDoorLockClusterGetPinResponseCallbackBridge::OnSuccessFn(
-    void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
+    void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
 {
     DispatchSuccess(context, @ {
         @"userId" : [NSNumber numberWithUnsignedShort:userId],
         @"userStatus" : [NSNumber numberWithUnsignedChar:userStatus],
         @"userType" : [NSNumber numberWithUnsignedChar:userType],
-        @"pin" : [NSString stringWithFormat:@"%s", pin],
+        @"pin" : [NSData dataWithBytes:pin.data() length:pin.size()],
     });
 };
 
 void CHIPDoorLockClusterGetRfidResponseCallbackBridge::OnSuccessFn(
-    void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+    void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
 {
     DispatchSuccess(context, @ {
         @"userId" : [NSNumber numberWithUnsignedShort:userId],
         @"userStatus" : [NSNumber numberWithUnsignedChar:userStatus],
         @"userType" : [NSNumber numberWithUnsignedChar:userType],
-        @"rfid" : [NSString stringWithFormat:@"%s", rfid],
+        @"rfid" : [NSData dataWithBytes:rfid.data() length:rfid.size()],
     });
 };
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -570,7 +570,7 @@ public:
         CHIPCallbackBridge<DoorLockClusterGetLogRecordResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-                            uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin);
+                            uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin);
 };
 
 class CHIPDoorLockClusterGetPinResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetPinResponseCallback>
@@ -580,7 +580,7 @@ public:
                                                     bool keepAlive = false) :
         CHIPCallbackBridge<DoorLockClusterGetPinResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin);
+    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin);
 };
 
 class CHIPDoorLockClusterGetRfidResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetRfidResponseCallback>
@@ -590,7 +590,7 @@ public:
                                                      bool keepAlive = false) :
         CHIPCallbackBridge<DoorLockClusterGetRfidResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid);
+    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid);
 };
 
 class CHIPDoorLockClusterGetUserTypeResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetUserTypeResponseCallback>

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -607,7 +607,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getUserType:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler;
 - (void)getWeekdaySchedule:(uint8_t)scheduleId userId:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler;
 - (void)getYeardaySchedule:(uint8_t)scheduleId userId:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler;
-- (void)lockDoor:(NSString *)pin responseHandler:(ResponseHandler)responseHandler;
+- (void)lockDoor:(NSData *)pin responseHandler:(ResponseHandler)responseHandler;
 - (void)setHolidaySchedule:(uint8_t)scheduleId
                 localStartTime:(uint32_t)localStartTime
                   localEndTime:(uint32_t)localEndTime
@@ -616,12 +616,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setPin:(uint16_t)userId
          userStatus:(uint8_t)userStatus
            userType:(uint8_t)userType
-                pin:(NSString *)pin
+                pin:(NSData *)pin
     responseHandler:(ResponseHandler)responseHandler;
 - (void)setRfid:(uint16_t)userId
          userStatus:(uint8_t)userStatus
            userType:(uint8_t)userType
-                 id:(NSString *)id
+                 id:(NSData *)id
     responseHandler:(ResponseHandler)responseHandler;
 - (void)setUserType:(uint16_t)userId userType:(uint8_t)userType responseHandler:(ResponseHandler)responseHandler;
 - (void)setWeekdaySchedule:(uint8_t)scheduleId
@@ -637,8 +637,8 @@ NS_ASSUME_NONNULL_BEGIN
             localStartTime:(uint32_t)localStartTime
               localEndTime:(uint32_t)localEndTime
            responseHandler:(ResponseHandler)responseHandler;
-- (void)unlockDoor:(NSString *)pin responseHandler:(ResponseHandler)responseHandler;
-- (void)unlockWithTimeout:(uint16_t)timeoutInSeconds pin:(NSString *)pin responseHandler:(ResponseHandler)responseHandler;
+- (void)unlockDoor:(NSData *)pin responseHandler:(ResponseHandler)responseHandler;
+- (void)unlockWithTimeout:(uint16_t)timeoutInSeconds pin:(NSData *)pin responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeLockStateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeLockStateWithMinInterval:(uint16_t)minInterval

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -1774,7 +1774,7 @@ using chip::Callback::Cancelable;
         });
 }
 
-- (void)lockDoor:(NSString *)pin responseHandler:(ResponseHandler)responseHandler
+- (void)lockDoor:(NSData *)pin responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDoorLockClusterLockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -1798,7 +1798,7 @@ using chip::Callback::Cancelable;
 - (void)setPin:(uint16_t)userId
          userStatus:(uint8_t)userStatus
            userType:(uint8_t)userType
-                pin:(NSString *)pin
+                pin:(NSData *)pin
     responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDoorLockClusterSetPinResponseCallbackBridge(
@@ -1810,7 +1810,7 @@ using chip::Callback::Cancelable;
 - (void)setRfid:(uint16_t)userId
          userStatus:(uint8_t)userStatus
            userType:(uint8_t)userType
-                 id:(NSString *)id
+                 id:(NSData *)id
     responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDoorLockClusterSetRfidResponseCallbackBridge(
@@ -1855,7 +1855,7 @@ using chip::Callback::Cancelable;
         });
 }
 
-- (void)unlockDoor:(NSString *)pin responseHandler:(ResponseHandler)responseHandler
+- (void)unlockDoor:(NSData *)pin responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDoorLockClusterUnlockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -1863,7 +1863,7 @@ using chip::Callback::Cancelable;
         });
 }
 
-- (void)unlockWithTimeout:(uint16_t)timeoutInSeconds pin:(NSString *)pin responseHandler:(ResponseHandler)responseHandler
+- (void)unlockWithTimeout:(uint16_t)timeoutInSeconds pin:(NSData *)pin responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -96,6 +96,21 @@ public:
         mDataLen = new_size;
     }
 
+    // Allow creating ByteSpans from ZCL octet strings, so we don't have to
+    // reinvent it various places.
+    template <class U,
+              typename = std::enable_if_t<std::is_same<T, const U>::value && std::is_same<uint8_t, std::remove_const_t<U>>::value>>
+    static Span fromZclString(U * bytes)
+    {
+        size_t length = bytes[0];
+        // Treat 0xFF (aka "null string") as zero-length.
+        if (length == 0xFF)
+        {
+            length = 0;
+        }
+        return Span(&bytes[1], length);
+    }
+
 private:
     pointer mDataBuf;
     size_t mDataLen;

--- a/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
@@ -2910,7 +2910,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
         case Commands::LockDoor::Id: {
             Commands::LockDoor::DecodableType commandData;
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2941,8 +2941,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2963,8 +2962,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterLockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                    const_cast<uint8_t *>(PIN), commandData);
+                wasHandled =
+                    emberAfDoorLockClusterLockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, PIN, commandData);
             }
             break;
         }
@@ -3047,7 +3046,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -3087,8 +3086,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3110,7 +3108,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterSetPinCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, userId,
-                                                                  userStatus, userType, const_cast<uint8_t *>(pin), commandData);
+                                                                  userStatus, userType, pin, commandData);
             }
             break;
         }
@@ -3120,7 +3118,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * id;
+            chip::ByteSpan id;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -3160,8 +3158,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.Get(id);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3183,7 +3180,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterSetRfidCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, userId,
-                                                                   userStatus, userType, const_cast<uint8_t *>(id), commandData);
+                                                                   userStatus, userType, id, commandData);
             }
             break;
         }
@@ -3412,7 +3409,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
         case Commands::UnlockDoor::Id: {
             Commands::UnlockDoor::DecodableType commandData;
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -3443,8 +3440,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3465,8 +3461,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                      const_cast<uint8_t *>(PIN), commandData);
+                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, PIN,
+                                                                      commandData);
             }
             break;
         }
@@ -3474,7 +3470,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             Commands::UnlockWithTimeout::DecodableType commandData;
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3508,8 +3504,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3530,9 +3525,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfDoorLockClusterUnlockWithTimeoutCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                    timeoutInSeconds, const_cast<uint8_t *>(pin), commandData);
+                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
+                                                                             timeoutInSeconds, pin, commandData);
             }
             break;
         }

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -16102,7 +16102,7 @@ bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(
  */
 bool emberAfDoorLockClusterLockDoorCallback(chip::app::CommandHandler * commandObj,
                                             const chip::app::ConcreteCommandPath & commandPath, chip::EndpointId endpoint,
-                                            uint8_t * PIN,
+                                            chip::ByteSpan PIN,
                                             chip::app::Clusters::DoorLock::Commands::LockDoor::DecodableType & fields);
 /**
  * @brief Door Lock Cluster LockDoorResponse Command callback (from server)
@@ -16114,7 +16114,7 @@ bool emberAfDoorLockClusterLockDoorResponseCallback(chip::EndpointId endpoint, c
  */
 bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::CommandHandler * commandObj,
                                               const chip::app::ConcreteCommandPath & commandPath, chip::EndpointId endpoint,
-                                              uint8_t * PIN,
+                                              chip::ByteSpan PIN,
                                               chip::app::Clusters::DoorLock::Commands::UnlockDoor::DecodableType & fields);
 /**
  * @brief Door Lock Cluster UnlockDoorResponse Command callback (from server)
@@ -16136,7 +16136,8 @@ bool emberAfDoorLockClusterToggleResponseCallback(chip::EndpointId endpoint, chi
  */
 bool emberAfDoorLockClusterUnlockWithTimeoutCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath, chip::EndpointId endpoint,
-    uint16_t timeoutInSeconds, uint8_t * pin, chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::DecodableType & fields);
+    uint16_t timeoutInSeconds, chip::ByteSpan pin,
+    chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::DecodableType & fields);
 /**
  * @brief Door Lock Cluster UnlockWithTimeoutResponse Command callback (from server)
  */
@@ -16154,13 +16155,13 @@ bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::CommandHandler * comm
  */
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                         uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin);
+                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin);
 /**
  * @brief Door Lock Cluster SetPin Command callback (from client)
  */
 bool emberAfDoorLockClusterSetPinCallback(chip::app::CommandHandler * commandObj,
                                           const chip::app::ConcreteCommandPath & commandPath, chip::EndpointId endpoint,
-                                          uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin,
+                                          uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin,
                                           chip::app::Clusters::DoorLock::Commands::SetPin::DecodableType & fields);
 /**
  * @brief Door Lock Cluster SetPinResponse Command callback (from server)
@@ -16176,7 +16177,7 @@ bool emberAfDoorLockClusterGetPinCallback(chip::app::CommandHandler * commandObj
  * @brief Door Lock Cluster GetPinResponse Command callback (from server)
  */
 bool emberAfDoorLockClusterGetPinResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint16_t userId,
-                                                  uint8_t userStatus, uint8_t userType, uint8_t * pin);
+                                                  uint8_t userStatus, uint8_t userType, chip::ByteSpan pin);
 /**
  * @brief Door Lock Cluster ClearPin Command callback (from client)
  */
@@ -16359,7 +16360,7 @@ bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::EndpointId endpoint
  */
 bool emberAfDoorLockClusterSetRfidCallback(chip::app::CommandHandler * commandObj,
                                            const chip::app::ConcreteCommandPath & commandPath, chip::EndpointId endpoint,
-                                           uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * id,
+                                           uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan id,
                                            chip::app::Clusters::DoorLock::Commands::SetRfid::DecodableType & fields);
 /**
  * @brief Door Lock Cluster SetRfidResponse Command callback (from server)
@@ -16377,7 +16378,7 @@ bool emberAfDoorLockClusterGetRfidCallback(chip::app::CommandHandler * commandOb
  * @brief Door Lock Cluster GetRfidResponse Command callback (from server)
  */
 bool emberAfDoorLockClusterGetRfidResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                   uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid);
+                                                   uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid);
 /**
  * @brief Door Lock Cluster ClearRfid Command callback (from client)
  */
@@ -16405,15 +16406,15 @@ bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::EndpointId endpoi
  * @brief Door Lock Cluster OperationEventNotification Command callback (from server)
  */
 bool emberAfDoorLockClusterOperationEventNotificationCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                              uint8_t source, uint8_t eventCode, uint16_t userId, uint8_t * pin,
-                                                              uint32_t timeStamp, uint8_t * data);
+                                                              uint8_t source, uint8_t eventCode, uint16_t userId,
+                                                              chip::ByteSpan pin, uint32_t timeStamp, uint8_t * data);
 /**
  * @brief Door Lock Cluster ProgrammingEventNotification Command callback (from server)
  */
 bool emberAfDoorLockClusterProgrammingEventNotificationCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                uint8_t source, uint8_t eventCode, uint16_t userId, uint8_t * pin,
-                                                                uint8_t userType, uint8_t userStatus, uint32_t timeStamp,
-                                                                uint8_t * data);
+                                                                uint8_t source, uint8_t eventCode, uint16_t userId,
+                                                                chip::ByteSpan pin, uint8_t userType, uint8_t userStatus,
+                                                                uint32_t timeStamp, uint8_t * data);
 /**
  * @brief Window Covering Cluster UpOrOpen Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/client-command-macro.h
+++ b/zzz_generated/app-common/app-common/zap-generated/client-command-macro.h
@@ -2376,7 +2376,7 @@
 /** @brief Command description for LockDoor
  *
  * Command: LockDoor
- * @param PIN CHAR_STRING
+ * @param PIN OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterLockDoor(PIN) emberAfFillExternalBuffer(mask,                                                                       \
@@ -2396,7 +2396,7 @@
 /** @brief Command description for UnlockDoor
  *
  * Command: UnlockDoor
- * @param PIN CHAR_STRING
+ * @param PIN OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterUnlockDoor(PIN) emberAfFillExternalBuffer(mask,                                                                     \
@@ -2458,7 +2458,7 @@
 /** @brief Command description for UnlockWithTimeout
  *
  * Command: UnlockWithTimeout
- * @param pin CHAR_STRING
+ * @param pin OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterUnlockWithTimeout(pin) emberAfFillExternalBuffer(mask,                                                              \
@@ -2484,7 +2484,7 @@
  * @param source INT8U
  * @param eventIdOrAlarmCode INT8U
  * @param userId INT16U
- * @param pin CHAR_STRING
+ * @param pin OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterGetLogRecordResponse(logEntryId, timestamp, eventType, source, eventIdOrAlarmCode, userId, pin)                     \
@@ -2518,7 +2518,7 @@
  * Command: SetPin
  * @param userStatus DoorLockUserStatus
  * @param userType DoorLockUserType
- * @param pin CHAR_STRING
+ * @param pin OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterSetPin(userStatus, userType, pin)                                                                                   \
@@ -2542,7 +2542,7 @@
  * @param userId INT16U
  * @param userStatus DoorLockUserStatus
  * @param userType DoorLockUserType
- * @param pin CHAR_STRING
+ * @param pin OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterGetPinResponse(userId, userStatus, userType, pin)                                                                   \
@@ -3026,7 +3026,7 @@
  * Command: SetRfid
  * @param userStatus DoorLockUserStatus
  * @param userType DoorLockUserType
- * @param id CHAR_STRING
+ * @param id OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterSetRfid(userStatus, userType, id)                                                                                   \
@@ -3050,7 +3050,7 @@
  * @param userId INT16U
  * @param userStatus DoorLockUserStatus
  * @param userType DoorLockUserType
- * @param rfid CHAR_STRING
+ * @param rfid OCTET_STRING
  */
 #define emberAfFillCommandDoor                                                                                                     \
     LockClusterGetRfidResponse(userId, userStatus, userType, rfid)                                                                 \
@@ -3103,7 +3103,7 @@
  * @param source INT8U
  * @param eventCode DoorLockOperationEventCode
  * @param userId INT16U
- * @param pin CHAR_STRING
+ * @param pin OCTET_STRING
  * @param timeStamp epoch_s
  * @param data CHAR_STRING
  */
@@ -3119,7 +3119,7 @@
  * @param source INT8U
  * @param eventCode DoorLockProgrammingEventCode
  * @param userId INT16U
- * @param pin CHAR_STRING
+ * @param pin OCTET_STRING
  * @param userType DoorLockUserType
  * @param userStatus DoorLockUserStatus
  * @param timeStamp epoch_s

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -5658,7 +5658,7 @@ public:
     static constexpr CommandId GetCommandId() { return LockDoor::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    Span<const char> pin;
+    chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5669,7 +5669,7 @@ public:
     static constexpr CommandId GetCommandId() { return LockDoor::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    Span<const char> pin;
+    chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LockDoor
@@ -5714,7 +5714,7 @@ public:
     static constexpr CommandId GetCommandId() { return UnlockDoor::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    Span<const char> pin;
+    chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5725,7 +5725,7 @@ public:
     static constexpr CommandId GetCommandId() { return UnlockDoor::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    Span<const char> pin;
+    chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace UnlockDoor
@@ -5828,7 +5828,7 @@ public:
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
     uint16_t timeoutInSeconds;
-    Span<const char> pin;
+    chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5840,7 +5840,7 @@ public:
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
     uint16_t timeoutInSeconds;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace UnlockWithTimeout
@@ -5925,7 +5925,7 @@ public:
     uint8_t source;
     uint8_t eventIdOrAlarmCode;
     uint16_t userId;
-    Span<const char> pin;
+    chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5942,7 +5942,7 @@ public:
     uint8_t source;
     uint8_t eventIdOrAlarmCode;
     uint16_t userId;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetLogRecordResponse
@@ -5965,7 +5965,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> pin;
+    chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5979,7 +5979,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetPin
@@ -6058,7 +6058,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> pin;
+    chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -6072,7 +6072,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetPinResponse
@@ -7036,7 +7036,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> id;
+    chip::ByteSpan id;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -7050,7 +7050,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> id;
+    chip::ByteSpan id;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetRfid
@@ -7129,7 +7129,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> rfid;
+    chip::ByteSpan rfid;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -7143,7 +7143,7 @@ public:
     uint16_t userId;
     DoorLockUserStatus userStatus;
     DoorLockUserType userType;
-    Span<const char> rfid;
+    chip::ByteSpan rfid;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetRfidResponse
@@ -7276,7 +7276,7 @@ public:
     uint8_t source;
     DoorLockOperationEventCode eventCode;
     uint16_t userId;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     uint32_t timeStamp;
     Span<const char> data;
 
@@ -7292,7 +7292,7 @@ public:
     uint8_t source;
     DoorLockOperationEventCode eventCode;
     uint16_t userId;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     uint32_t timeStamp;
     Span<const char> data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -7321,7 +7321,7 @@ public:
     uint8_t source;
     DoorLockProgrammingEventCode eventCode;
     uint16_t userId;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     DoorLockUserType userType;
     DoorLockUserStatus userStatus;
     uint32_t timeStamp;
@@ -7339,7 +7339,7 @@ public:
     uint8_t source;
     DoorLockProgrammingEventCode eventCode;
     uint16_t userId;
-    Span<const char> pin;
+    chip::ByteSpan pin;
     DoorLockUserType userType;
     DoorLockUserStatus userStatus;
     uint32_t timeStamp;

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -238,7 +238,7 @@ static void OnDoorLockClusterGetHolidayScheduleResponse(void * context, uint8_t 
 }
 
 static void OnDoorLockClusterGetLogRecordResponse(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType,
-                                                  uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+                                                  uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetLogRecordResponse");
 
@@ -246,7 +246,8 @@ static void OnDoorLockClusterGetLogRecordResponse(void * context, uint16_t logEn
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
+static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
+                                            chip::ByteSpan pin)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetPinResponse");
 
@@ -254,7 +255,8 @@ static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uin
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetRfidResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+static void OnDoorLockClusterGetRfidResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
+                                             chip::ByteSpan rfid)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetRfidResponse");
 
@@ -8550,8 +8552,7 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.LockDoor(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                chip::ByteSpan(chip::Uint8::from_char(mPin), strlen(mPin)));
+        return cluster.LockDoor(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mPin);
     }
 
 private:
@@ -8559,7 +8560,7 @@ private:
         new chip::Callback::Callback<DoorLockClusterLockDoorResponseCallback>(OnDoorLockClusterLockDoorResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mPin;
+    chip::ByteSpan mPin;
 };
 
 /*
@@ -8630,8 +8631,7 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.SetPin(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mUserId, mUserStatus, mUserType,
-                              chip::ByteSpan(chip::Uint8::from_char(mPin), strlen(mPin)));
+        return cluster.SetPin(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mUserId, mUserStatus, mUserType, mPin);
     }
 
 private:
@@ -8642,7 +8642,7 @@ private:
     uint16_t mUserId;
     uint8_t mUserStatus;
     uint8_t mUserType;
-    char * mPin;
+    chip::ByteSpan mPin;
 };
 
 /*
@@ -8671,8 +8671,7 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.SetRfid(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mUserId, mUserStatus, mUserType,
-                               chip::ByteSpan(chip::Uint8::from_char(mId), strlen(mId)));
+        return cluster.SetRfid(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mUserId, mUserStatus, mUserType, mId);
     }
 
 private:
@@ -8683,7 +8682,7 @@ private:
     uint16_t mUserId;
     uint8_t mUserStatus;
     uint8_t mUserType;
-    char * mId;
+    chip::ByteSpan mId;
 };
 
 /*
@@ -8835,8 +8834,7 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.UnlockDoor(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                  chip::ByteSpan(chip::Uint8::from_char(mPin), strlen(mPin)));
+        return cluster.UnlockDoor(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mPin);
     }
 
 private:
@@ -8844,7 +8842,7 @@ private:
         new chip::Callback::Callback<DoorLockClusterUnlockDoorResponseCallback>(OnDoorLockClusterUnlockDoorResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mPin;
+    chip::ByteSpan mPin;
 };
 
 /*
@@ -8871,8 +8869,7 @@ public:
 
         chip::Controller::DoorLockCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.UnlockWithTimeout(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mTimeoutInSeconds,
-                                         chip::ByteSpan(chip::Uint8::from_char(mPin), strlen(mPin)));
+        return cluster.UnlockWithTimeout(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mTimeoutInSeconds, mPin);
     }
 
 private:
@@ -8882,7 +8879,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint16_t mTimeoutInSeconds;
-    char * mPin;
+    chip::ByteSpan mPin;
 };
 
 /*

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -1822,7 +1822,7 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(EndpointId endpoin
 
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint16_t logEntryId,
                                                         uint32_t timestamp, uint8_t eventType, uint8_t source,
-                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
 {
     ChipLogProgress(Zcl, "GetLogRecordResponse:");
     ChipLogProgress(Zcl, "  logEntryId: %" PRIu16 "", logEntryId);
@@ -1831,8 +1831,7 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(EndpointId endpoint, app
     ChipLogProgress(Zcl, "  source: %" PRIu8 "", source);
     ChipLogProgress(Zcl, "  eventIdOrAlarmCode: %" PRIu8 "", eventIdOrAlarmCode);
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  pin: %.*s", pin.size(), pin.data());
+    ChipLogProgress(Zcl, "  pin: %zu", pin.size());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetLogRecordResponseCallback");
 
@@ -1843,14 +1842,13 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(EndpointId endpoint, app
 }
 
 bool emberAfDoorLockClusterGetPinResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint16_t userId,
-                                                  uint8_t userStatus, uint8_t userType, uint8_t * pin)
+                                                  uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
 {
     ChipLogProgress(Zcl, "GetPinResponse:");
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
     ChipLogProgress(Zcl, "  userStatus: %" PRIu8 "", userStatus);
     ChipLogProgress(Zcl, "  userType: %" PRIu8 "", userType);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  pin: %.*s", pin.size(), pin.data());
+    ChipLogProgress(Zcl, "  pin: %zu", pin.size());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetPinResponseCallback");
 
@@ -1861,14 +1859,13 @@ bool emberAfDoorLockClusterGetPinResponseCallback(EndpointId endpoint, app::Comm
 }
 
 bool emberAfDoorLockClusterGetRfidResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint16_t userId,
-                                                   uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+                                                   uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
 {
     ChipLogProgress(Zcl, "GetRfidResponse:");
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
     ChipLogProgress(Zcl, "  userStatus: %" PRIu8 "", userStatus);
     ChipLogProgress(Zcl, "  userType: %" PRIu8 "", userType);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  rfid: %.*s", rfid.size(), rfid.data());
+    ChipLogProgress(Zcl, "  rfid: %zu", rfid.size());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetRfidResponseCallback");
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
@@ -52,11 +52,11 @@ typedef void (*DoorLockClusterGetHolidayScheduleResponseCallback)(void * context
                                                                   uint8_t operatingModeDuringHoliday);
 typedef void (*DoorLockClusterGetLogRecordResponseCallback)(void * context, uint16_t logEntryId, uint32_t timestamp,
                                                             uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode,
-                                                            uint16_t userId, uint8_t * pin);
+                                                            uint16_t userId, chip::ByteSpan pin);
 typedef void (*DoorLockClusterGetPinResponseCallback)(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                                      uint8_t * pin);
+                                                      chip::ByteSpan pin);
 typedef void (*DoorLockClusterGetRfidResponseCallback)(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                                       uint8_t * rfid);
+                                                       chip::ByteSpan rfid);
 typedef void (*DoorLockClusterGetUserTypeResponseCallback)(void * context, uint16_t userId, uint8_t userType);
 typedef void (*DoorLockClusterGetWeekdayScheduleResponseCallback)(void * context, uint8_t scheduleId, uint16_t userId,
                                                                   uint8_t status, uint8_t daysMask, uint8_t startHour,

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -4259,7 +4259,7 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // pin: charString
+    // pin: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
     SuccessOrExit(err = sender->FinishCommand());
@@ -4354,7 +4354,7 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), userStatus));
     // userType: doorLockUserType
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), userType));
-    // pin: charString
+    // pin: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
     SuccessOrExit(err = sender->FinishCommand());
@@ -4401,7 +4401,7 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), userStatus));
     // userType: doorLockUserType
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), userType));
-    // id: charString
+    // id: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), id));
 
     SuccessOrExit(err = sender->FinishCommand());
@@ -4586,7 +4586,7 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // pin: charString
+    // pin: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
     SuccessOrExit(err = sender->FinishCommand());
@@ -4629,7 +4629,7 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // timeoutInSeconds: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), timeoutInSeconds));
-    // pin: charString
+    // pin: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
     SuccessOrExit(err = sender->FinishCommand());

--- a/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
@@ -937,7 +937,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             uint8_t source;
             uint8_t eventIdOrAlarmCode;
             uint16_t userId;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[7];
 
             memset(argExists, 0, sizeof argExists);
@@ -986,8 +986,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(userId);
                     break;
                 case 6:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1010,7 +1009,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             {
                 wasHandled = emberAfDoorLockClusterGetLogRecordResponseCallback(aCommandPath.mEndpointId, apCommandObj, logEntryId,
                                                                                 timestamp, eventType, source, eventIdOrAlarmCode,
-                                                                                userId, const_cast<uint8_t *>(pin));
+                                                                                userId, pin);
             }
             break;
         }
@@ -1019,7 +1018,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -1059,8 +1058,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1082,7 +1080,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterGetPinResponseCallback(aCommandPath.mEndpointId, apCommandObj, userId,
-                                                                          userStatus, userType, const_cast<uint8_t *>(pin));
+                                                                          userStatus, userType, pin);
             }
             break;
         }
@@ -1091,7 +1089,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * rfid;
+            chip::ByteSpan rfid;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -1131,8 +1129,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(rfid);
+                    TLVUnpackError = aDataTlv.Get(rfid);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1154,7 +1151,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterGetRfidResponseCallback(aCommandPath.mEndpointId, apCommandObj, userId,
-                                                                           userStatus, userType, const_cast<uint8_t *>(rfid));
+                                                                           userStatus, userType, rfid);
             }
             break;
         }

--- a/zzz_generated/thermostat/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/thermostat/zap-generated/IMClusterCommandHandler.cpp
@@ -2521,7 +2521,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
         case Commands::LockDoor::Id: {
             Commands::LockDoor::DecodableType commandData;
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2552,8 +2552,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2574,8 +2573,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterLockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                    const_cast<uint8_t *>(PIN), commandData);
+                wasHandled =
+                    emberAfDoorLockClusterLockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, PIN, commandData);
             }
             break;
         }
@@ -2658,7 +2657,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -2698,8 +2697,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2721,7 +2719,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterSetPinCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, userId,
-                                                                  userStatus, userType, const_cast<uint8_t *>(pin), commandData);
+                                                                  userStatus, userType, pin, commandData);
             }
             break;
         }
@@ -2731,7 +2729,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * id;
+            chip::ByteSpan id;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -2771,8 +2769,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.Get(id);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2794,7 +2791,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterSetRfidCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, userId,
-                                                                   userStatus, userType, const_cast<uint8_t *>(id), commandData);
+                                                                   userStatus, userType, id, commandData);
             }
             break;
         }
@@ -3023,7 +3020,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
         case Commands::UnlockDoor::Id: {
             Commands::UnlockDoor::DecodableType commandData;
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -3054,8 +3051,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3076,8 +3072,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                      const_cast<uint8_t *>(PIN), commandData);
+                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, PIN,
+                                                                      commandData);
             }
             break;
         }
@@ -3085,7 +3081,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             Commands::UnlockWithTimeout::DecodableType commandData;
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3119,8 +3115,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3141,9 +3136,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfDoorLockClusterUnlockWithTimeoutCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                    timeoutInSeconds, const_cast<uint8_t *>(pin), commandData);
+                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
+                                                                             timeoutInSeconds, pin, commandData);
             }
             break;
         }

--- a/zzz_generated/tv-casting-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/tv-casting-app/zap-generated/IMClusterCommandHandler.cpp
@@ -2521,7 +2521,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
         case Commands::LockDoor::Id: {
             Commands::LockDoor::DecodableType commandData;
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2552,8 +2552,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2574,8 +2573,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterLockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                    const_cast<uint8_t *>(PIN), commandData);
+                wasHandled =
+                    emberAfDoorLockClusterLockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, PIN, commandData);
             }
             break;
         }
@@ -2658,7 +2657,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -2698,8 +2697,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2721,7 +2719,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterSetPinCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, userId,
-                                                                  userStatus, userType, const_cast<uint8_t *>(pin), commandData);
+                                                                  userStatus, userType, pin, commandData);
             }
             break;
         }
@@ -2731,7 +2729,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * id;
+            chip::ByteSpan id;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -2771,8 +2769,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.Get(id);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2794,7 +2791,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterSetRfidCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, userId,
-                                                                   userStatus, userType, const_cast<uint8_t *>(id), commandData);
+                                                                   userStatus, userType, id, commandData);
             }
             break;
         }
@@ -3023,7 +3020,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
         case Commands::UnlockDoor::Id: {
             Commands::UnlockDoor::DecodableType commandData;
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -3054,8 +3051,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3076,8 +3072,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                      const_cast<uint8_t *>(PIN), commandData);
+                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId, PIN,
+                                                                      commandData);
             }
             break;
         }
@@ -3085,7 +3081,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             Commands::UnlockWithTimeout::DecodableType commandData;
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3119,8 +3115,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
                     TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3141,9 +3136,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfDoorLockClusterUnlockWithTimeoutCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
-                                                                    timeoutInSeconds, const_cast<uint8_t *>(pin), commandData);
+                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(apCommandObj, aCommandPath, aCommandPath.mEndpointId,
+                                                                             timeoutInSeconds, pin, commandData);
             }
             break;
         }


### PR DESCRIPTION
These are both octet string per spec.

#### Problem
These are using CHAR_STRING right now, which is going to make conversion to the updated command structs painful _and_ is wrong.

#### Change overview
Use OCTET_STRING.

#### Testing
Tested that things compile.  We do not seem to have door lock test coverage and really need to create some....