### PR TITLE
Change asLowerCamelCase to not convert NOCValue to nOCValue.

### DIFF
--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -334,6 +334,19 @@ function hasSpecificAttributes(options)
 function asLowerCamelCase(label)
 {
   let str = string.toCamelCase(label, true);
+  // Check for the case when were:
+  // 1. A single word (that's the regexp at the beginning, which matches the
+  //    word-splitting regexp in string.toCamelCase).
+  // 2. Starting with multiple capital letters in a row.
+  // 3. But not _all_ capital letters (which we purposefully
+  //    convert to all-lowercase).
+  //
+  // and if all those conditions hold, preserve the leading capital letters by
+  // uppercasing the first one, which got lowercased.
+  if (!/ |_|-|\//.test(label) && label.length > 1 && label.substring(0, 2).toUpperCase() == label.substring(0, 2)
+      && label.toUpperCase() != label) {
+    str = str[0].toUpperCase() + str.substring(1);
+  }
   return str.replace(/[\.:]/g, '');
 }
 

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -7718,14 +7718,14 @@ public:
             jint routerId            = entries[i].RouterId;
             jint nextHop             = entries[i].NextHop;
             jint pathCost            = entries[i].PathCost;
-            jint lQIIn               = entries[i].LQIIn;
-            jint lQIOut              = entries[i].LQIOut;
+            jint LQIIn               = entries[i].LQIIn;
+            jint LQIOut              = entries[i].LQIOut;
             jint age                 = entries[i].Age;
             jboolean allocated       = entries[i].Allocated;
             jboolean linkEstablished = entries[i].LinkEstablished;
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, extAddress, rloc16, routerId, nextHop, pathCost,
-                                                  lQIIn, lQIOut, age, allocated, linkEstablished);
+                                                  LQIIn, LQIOut, age, allocated, linkEstablished);
             VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create RouteTableListAttribute object"));
 
             env->CallBooleanMethod(arrayListObj, arrayListAddMethod, attributeObj);
@@ -8205,14 +8205,14 @@ exit:
     }
 }
 JNI_METHOD(void, AdministratorCommissioningCluster, openCommissioningWindow)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint commissioningTimeout, jbyteArray pAKEVerifier,
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint commissioningTimeout, jbyteArray PAKEVerifier,
  jint discriminator, jlong iterations, jbyteArray salt, jint passcodeID)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     AdministratorCommissioningCluster * cppCluster;
 
-    JniByteArray pAKEVerifierArr(env, pAKEVerifier);
+    JniByteArray PAKEVerifierArr(env, PAKEVerifier);
     JniByteArray saltArr(env, salt);
     CHIPDefaultSuccessCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
@@ -8226,7 +8226,7 @@ JNI_METHOD(void, AdministratorCommissioningCluster, openCommissioningWindow)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->OpenCommissioningWindow(onSuccess->Cancel(), onFailure->Cancel(), commissioningTimeout,
-                                              chip::ByteSpan((const uint8_t *) pAKEVerifierArr.data(), pAKEVerifierArr.size()),
+                                              chip::ByteSpan((const uint8_t *) PAKEVerifierArr.data(), PAKEVerifierArr.size()),
                                               discriminator, iterations,
                                               chip::ByteSpan((const uint8_t *) saltArr.data(), saltArr.size()), passcodeID);
     SuccessOrExit(err);
@@ -22505,16 +22505,16 @@ JNI_METHOD(jlong, OperationalCredentialsCluster, initWithDevice)(JNIEnv * env, j
 }
 
 JNI_METHOD(void, OperationalCredentialsCluster, addNOC)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray nOCValue, jbyteArray iCACValue, jbyteArray iPKValue,
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray NOCValue, jbyteArray ICACValue, jbyteArray IPKValue,
  jlong caseAdminNode, jint adminVendorId)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
-    JniByteArray nOCValueArr(env, nOCValue);
-    JniByteArray iCACValueArr(env, iCACValue);
-    JniByteArray iPKValueArr(env, iPKValue);
+    JniByteArray NOCValueArr(env, NOCValue);
+    JniByteArray ICACValueArr(env, ICACValue);
+    JniByteArray IPKValueArr(env, IPKValue);
     CHIPOperationalCredentialsClusterNOCResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -22527,9 +22527,9 @@ JNI_METHOD(void, OperationalCredentialsCluster, addNOC)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->AddNOC(
-        onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t *) nOCValueArr.data(), nOCValueArr.size()),
-        chip::ByteSpan((const uint8_t *) iCACValueArr.data(), iCACValueArr.size()),
-        chip::ByteSpan((const uint8_t *) iPKValueArr.data(), iPKValueArr.size()), caseAdminNode, adminVendorId);
+        onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t *) NOCValueArr.data(), NOCValueArr.size()),
+        chip::ByteSpan((const uint8_t *) ICACValueArr.data(), ICACValueArr.size()),
+        chip::ByteSpan((const uint8_t *) IPKValueArr.data(), IPKValueArr.size()), caseAdminNode, adminVendorId);
     SuccessOrExit(err);
 
 exit:
@@ -22701,13 +22701,13 @@ exit:
     }
 }
 JNI_METHOD(void, OperationalCredentialsCluster, opCSRRequest)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray cSRNonce)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray CSRNonce)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
-    JniByteArray cSRNonceArr(env, cSRNonce);
+    JniByteArray CSRNonceArr(env, CSRNonce);
     CHIPOperationalCredentialsClusterOpCSRResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -22720,7 +22720,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, opCSRRequest)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->OpCSRRequest(onSuccess->Cancel(), onFailure->Cancel(),
-                                   chip::ByteSpan((const uint8_t *) cSRNonceArr.data(), cSRNonceArr.size()));
+                                   chip::ByteSpan((const uint8_t *) CSRNonceArr.data(), CSRNonceArr.size()));
     SuccessOrExit(err);
 
 exit:
@@ -22892,14 +22892,14 @@ exit:
     }
 }
 JNI_METHOD(void, OperationalCredentialsCluster, updateNOC)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray nOCValue, jbyteArray iCACValue)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray NOCValue, jbyteArray ICACValue)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
-    JniByteArray nOCValueArr(env, nOCValue);
-    JniByteArray iCACValueArr(env, iCACValue);
+    JniByteArray NOCValueArr(env, NOCValue);
+    JniByteArray ICACValueArr(env, ICACValue);
     CHIPOperationalCredentialsClusterNOCResponseCallback * onSuccess;
     CHIPDefaultFailureCallback * onFailure;
 
@@ -22912,8 +22912,8 @@ JNI_METHOD(void, OperationalCredentialsCluster, updateNOC)
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->UpdateNOC(onSuccess->Cancel(), onFailure->Cancel(),
-                                chip::ByteSpan((const uint8_t *) nOCValueArr.data(), nOCValueArr.size()),
-                                chip::ByteSpan((const uint8_t *) iCACValueArr.data(), iCACValueArr.size()));
+                                chip::ByteSpan((const uint8_t *) NOCValueArr.data(), NOCValueArr.size()),
+                                chip::ByteSpan((const uint8_t *) ICACValueArr.data(), ICACValueArr.size()));
     SuccessOrExit(err);
 
 exit:

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -139,7 +139,7 @@ public class ChipClusters {
     public void openCommissioningWindow(
         DefaultClusterCallback callback,
         int commissioningTimeout,
-        byte[] pAKEVerifier,
+        byte[] PAKEVerifier,
         int discriminator,
         long iterations,
         byte[] salt,
@@ -148,7 +148,7 @@ public class ChipClusters {
           chipClusterPtr,
           callback,
           commissioningTimeout,
-          pAKEVerifier,
+          PAKEVerifier,
           discriminator,
           iterations,
           salt,
@@ -166,7 +166,7 @@ public class ChipClusters {
         long chipClusterPtr,
         DefaultClusterCallback callback,
         int commissioningTimeout,
-        byte[] pAKEVerifier,
+        byte[] PAKEVerifier,
         int discriminator,
         long iterations,
         byte[] salt,
@@ -4014,12 +4014,12 @@ public class ChipClusters {
 
     public void addNOC(
         NOCResponseCallback callback,
-        byte[] nOCValue,
-        byte[] iCACValue,
-        byte[] iPKValue,
+        byte[] NOCValue,
+        byte[] ICACValue,
+        byte[] IPKValue,
         long caseAdminNode,
         int adminVendorId) {
-      addNOC(chipClusterPtr, callback, nOCValue, iCACValue, iPKValue, caseAdminNode, adminVendorId);
+      addNOC(chipClusterPtr, callback, NOCValue, ICACValue, IPKValue, caseAdminNode, adminVendorId);
     }
 
     public void addTrustedRootCertificate(DefaultClusterCallback callback, byte[] rootCertificate) {
@@ -4035,8 +4035,8 @@ public class ChipClusters {
       certificateChainRequest(chipClusterPtr, callback, certificateType);
     }
 
-    public void opCSRRequest(OpCSRResponseCallback callback, byte[] cSRNonce) {
-      opCSRRequest(chipClusterPtr, callback, cSRNonce);
+    public void opCSRRequest(OpCSRResponseCallback callback, byte[] CSRNonce) {
+      opCSRRequest(chipClusterPtr, callback, CSRNonce);
     }
 
     public void removeFabric(NOCResponseCallback callback, int fabricIndex) {
@@ -4052,16 +4052,16 @@ public class ChipClusters {
       updateFabricLabel(chipClusterPtr, callback, label);
     }
 
-    public void updateNOC(NOCResponseCallback callback, byte[] nOCValue, byte[] iCACValue) {
-      updateNOC(chipClusterPtr, callback, nOCValue, iCACValue);
+    public void updateNOC(NOCResponseCallback callback, byte[] NOCValue, byte[] ICACValue) {
+      updateNOC(chipClusterPtr, callback, NOCValue, ICACValue);
     }
 
     private native void addNOC(
         long chipClusterPtr,
         NOCResponseCallback callback,
-        byte[] nOCValue,
-        byte[] iCACValue,
-        byte[] iPKValue,
+        byte[] NOCValue,
+        byte[] ICACValue,
+        byte[] IPKValue,
         long caseAdminNode,
         int adminVendorId);
 
@@ -4075,7 +4075,7 @@ public class ChipClusters {
         long chipClusterPtr, CertificateChainResponseCallback callback, int certificateType);
 
     private native void opCSRRequest(
-        long chipClusterPtr, OpCSRResponseCallback callback, byte[] cSRNonce);
+        long chipClusterPtr, OpCSRResponseCallback callback, byte[] CSRNonce);
 
     private native void removeFabric(
         long chipClusterPtr, NOCResponseCallback callback, int fabricIndex);
@@ -4087,7 +4087,7 @@ public class ChipClusters {
         long chipClusterPtr, NOCResponseCallback callback, String label);
 
     private native void updateNOC(
-        long chipClusterPtr, NOCResponseCallback callback, byte[] nOCValue, byte[] iCACValue);
+        long chipClusterPtr, NOCResponseCallback callback, byte[] NOCValue, byte[] ICACValue);
 
     public interface AttestationResponseCallback {
       void onSuccess(byte[] AttestationElements, byte[] Signature);
@@ -5615,8 +5615,8 @@ public class ChipClusters {
       public int routerId;
       public int nextHop;
       public int pathCost;
-      public int lQIIn;
-      public int lQIOut;
+      public int LQIIn;
+      public int LQIOut;
       public int age;
       public boolean allocated;
       public boolean linkEstablished;
@@ -5627,8 +5627,8 @@ public class ChipClusters {
           int routerId,
           int nextHop,
           int pathCost,
-          int lQIIn,
-          int lQIOut,
+          int LQIIn,
+          int LQIOut,
           int age,
           boolean allocated,
           boolean linkEstablished) {
@@ -5637,8 +5637,8 @@ public class ChipClusters {
         this.routerId = routerId;
         this.nextHop = nextHop;
         this.pathCost = pathCost;
-        this.lQIIn = lQIIn;
-        this.lQIOut = lQIOut;
+        this.LQIIn = LQIIn;
+        this.LQIOut = LQIOut;
         this.age = age;
         this.allocated = allocated;
         this.linkEstablished = linkEstablished;

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -404,14 +404,14 @@ chip::ChipError::StorageType chip_ime_AppendCommand_AdministratorCommissioning_O
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow(
     chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t commissioningTimeout,
-    const uint8_t * pAKEVerifier, uint32_t pAKEVerifier_Len, uint16_t discriminator, uint32_t iterations, const uint8_t * salt,
+    const uint8_t * PAKEVerifier, uint32_t PAKEVerifier_Len, uint16_t discriminator, uint32_t iterations, const uint8_t * salt,
     uint32_t salt_Len, uint16_t passcodeID)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::AdministratorCommissioningCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .OpenCommissioningWindow(nullptr, nullptr, commissioningTimeout, chip::ByteSpan(pAKEVerifier, pAKEVerifier_Len),
+        .OpenCommissioningWindow(nullptr, nullptr, commissioningTimeout, chip::ByteSpan(PAKEVerifier, PAKEVerifier_Len),
                                  discriminator, iterations, chip::ByteSpan(salt, salt_Len), passcodeID)
         .AsInteger();
 }
@@ -4110,16 +4110,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOffSwitchConfiguration_Clu
 
 chip::ChipError::StorageType
 chip_ime_AppendCommand_OperationalCredentials_AddNOC(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                     chip::GroupId, const uint8_t * nOCValue, uint32_t nOCValue_Len,
-                                                     const uint8_t * iCACValue, uint32_t iCACValue_Len, const uint8_t * iPKValue,
-                                                     uint32_t iPKValue_Len, chip::NodeId caseAdminNode, uint16_t adminVendorId)
+                                                     chip::GroupId, const uint8_t * NOCValue, uint32_t NOCValue_Len,
+                                                     const uint8_t * ICACValue, uint32_t ICACValue_Len, const uint8_t * IPKValue,
+                                                     uint32_t IPKValue_Len, chip::NodeId caseAdminNode, uint16_t adminVendorId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OperationalCredentialsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .AddNOC(nullptr, nullptr, chip::ByteSpan(nOCValue, nOCValue_Len), chip::ByteSpan(iCACValue, iCACValue_Len),
-                chip::ByteSpan(iPKValue, iPKValue_Len), caseAdminNode, adminVendorId)
+        .AddNOC(nullptr, nullptr, chip::ByteSpan(NOCValue, NOCValue_Len), chip::ByteSpan(ICACValue, ICACValue_Len),
+                chip::ByteSpan(IPKValue, IPKValue_Len), caseAdminNode, adminVendorId)
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate(
@@ -4152,13 +4152,13 @@ chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_Certi
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(chip::Controller::Device * device,
                                                                                         chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId, const uint8_t * cSRNonce,
-                                                                                        uint32_t cSRNonce_Len)
+                                                                                        chip::GroupId, const uint8_t * CSRNonce,
+                                                                                        uint32_t CSRNonce_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OperationalCredentialsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.OpCSRRequest(nullptr, nullptr, chip::ByteSpan(cSRNonce, cSRNonce_Len)).AsInteger();
+    return cluster.OpCSRRequest(nullptr, nullptr, chip::ByteSpan(CSRNonce, CSRNonce_Len)).AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(chip::Controller::Device * device,
                                                                                         chip::EndpointId ZCLendpointId,
@@ -4191,13 +4191,13 @@ chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_Updat
 }
 chip::ChipError::StorageType
 chip_ime_AppendCommand_OperationalCredentials_UpdateNOC(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                        chip::GroupId, const uint8_t * nOCValue, uint32_t nOCValue_Len,
-                                                        const uint8_t * iCACValue, uint32_t iCACValue_Len)
+                                                        chip::GroupId, const uint8_t * NOCValue, uint32_t NOCValue_Len,
+                                                        const uint8_t * ICACValue, uint32_t ICACValue_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OperationalCredentialsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.UpdateNOC(nullptr, nullptr, chip::ByteSpan(nOCValue, nOCValue_Len), chip::ByteSpan(iCACValue, iCACValue_Len))
+    return cluster.UpdateNOC(nullptr, nullptr, chip::ByteSpan(NOCValue, NOCValue_Len), chip::ByteSpan(ICACValue, ICACValue_Len))
         .AsInteger();
 }
 

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -73,7 +73,7 @@ class ChipClusters:
                     "commandName": "OpenCommissioningWindow",
                     "args": {
                         "commissioningTimeout": "int",
-                        "pAKEVerifier": "bytes",
+                        "PAKEVerifier": "bytes",
                         "discriminator": "int",
                         "iterations": "int",
                         "salt": "bytes",
@@ -2349,9 +2349,9 @@ class ChipClusters:
                     "commandId": 0x00000006,
                     "commandName": "AddNOC",
                     "args": {
-                        "nOCValue": "bytes",
-                        "iCACValue": "bytes",
-                        "iPKValue": "bytes",
+                        "NOCValue": "bytes",
+                        "ICACValue": "bytes",
+                        "IPKValue": "bytes",
                         "caseAdminNode": "int",
                         "adminVendorId": "int",
                     },
@@ -2381,7 +2381,7 @@ class ChipClusters:
                     "commandId": 0x00000004,
                     "commandName": "OpCSRRequest",
                     "args": {
-                        "cSRNonce": "bytes",
+                        "CSRNonce": "bytes",
                     },
                 },
             0x0000000A: {
@@ -2409,8 +2409,8 @@ class ChipClusters:
                     "commandId": 0x00000007,
                     "commandName": "UpdateNOC",
                     "args": {
-                        "nOCValue": "bytes",
-                        "iCACValue": "bytes",
+                        "NOCValue": "bytes",
+                        "ICACValue": "bytes",
                     },
                 },
             },
@@ -4017,9 +4017,9 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow(
                 device, ZCLendpoint, ZCLgroupid, commissioningTimeout
         )
-    def ClusterAdministratorCommissioning_CommandOpenCommissioningWindow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, commissioningTimeout: int, pAKEVerifier: bytes, discriminator: int, iterations: int, salt: bytes, passcodeID: int):
+    def ClusterAdministratorCommissioning_CommandOpenCommissioningWindow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, commissioningTimeout: int, PAKEVerifier: bytes, discriminator: int, iterations: int, salt: bytes, passcodeID: int):
         return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow(
-                device, ZCLendpoint, ZCLgroupid, commissioningTimeout, pAKEVerifier, len(pAKEVerifier), discriminator, iterations, salt, len(salt), passcodeID
+                device, ZCLendpoint, ZCLgroupid, commissioningTimeout, PAKEVerifier, len(PAKEVerifier), discriminator, iterations, salt, len(salt), passcodeID
         )
     def ClusterAdministratorCommissioning_CommandRevokeCommissioning(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning(
@@ -4485,9 +4485,9 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_OnOff_Toggle(
                 device, ZCLendpoint, ZCLgroupid
         )
-    def ClusterOperationalCredentials_CommandAddNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nOCValue: bytes, iCACValue: bytes, iPKValue: bytes, caseAdminNode: int, adminVendorId: int):
+    def ClusterOperationalCredentials_CommandAddNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, NOCValue: bytes, ICACValue: bytes, IPKValue: bytes, caseAdminNode: int, adminVendorId: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC(
-                device, ZCLendpoint, ZCLgroupid, nOCValue, len(nOCValue), iCACValue, len(iCACValue), iPKValue, len(iPKValue), caseAdminNode, adminVendorId
+                device, ZCLendpoint, ZCLgroupid, NOCValue, len(NOCValue), ICACValue, len(ICACValue), IPKValue, len(IPKValue), caseAdminNode, adminVendorId
         )
     def ClusterOperationalCredentials_CommandAddTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rootCertificate: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate(
@@ -4501,9 +4501,9 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest(
                 device, ZCLendpoint, ZCLgroupid, certificateType
         )
-    def ClusterOperationalCredentials_CommandOpCSRRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, cSRNonce: bytes):
+    def ClusterOperationalCredentials_CommandOpCSRRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, CSRNonce: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(
-                device, ZCLendpoint, ZCLgroupid, cSRNonce, len(cSRNonce)
+                device, ZCLendpoint, ZCLgroupid, CSRNonce, len(CSRNonce)
         )
     def ClusterOperationalCredentials_CommandRemoveFabric(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, fabricIndex: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(
@@ -4518,9 +4518,9 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(
                 device, ZCLendpoint, ZCLgroupid, label, len(label)
         )
-    def ClusterOperationalCredentials_CommandUpdateNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nOCValue: bytes, iCACValue: bytes):
+    def ClusterOperationalCredentials_CommandUpdateNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, NOCValue: bytes, ICACValue: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC(
-                device, ZCLendpoint, ZCLgroupid, nOCValue, len(nOCValue), iCACValue, len(iCACValue)
+                device, ZCLendpoint, ZCLgroupid, NOCValue, len(NOCValue), ICACValue, len(ICACValue)
         )
     def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: bytes, clusterId: int, length: int, value: int):
         sceneName = sceneName.encode("utf-8") + b'\x00'

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)openBasicCommissioningWindow:(uint16_t)commissioningTimeout responseHandler:(ResponseHandler)responseHandler;
 - (void)openCommissioningWindow:(uint16_t)commissioningTimeout
-                   pAKEVerifier:(NSData *)pAKEVerifier
+                   PAKEVerifier:(NSData *)PAKEVerifier
                   discriminator:(uint16_t)discriminator
                      iterations:(uint32_t)iterations
                            salt:(NSData *)salt
@@ -1141,20 +1141,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPOperationalCredentials : CHIPCluster
 
-- (void)addNOC:(NSData *)nOCValue
-          iCACValue:(NSData *)iCACValue
-           iPKValue:(NSData *)iPKValue
+- (void)addNOC:(NSData *)NOCValue
+          ICACValue:(NSData *)ICACValue
+           IPKValue:(NSData *)IPKValue
       caseAdminNode:(uint64_t)caseAdminNode
       adminVendorId:(uint16_t)adminVendorId
     responseHandler:(ResponseHandler)responseHandler;
 - (void)addTrustedRootCertificate:(NSData *)rootCertificate responseHandler:(ResponseHandler)responseHandler;
 - (void)attestationRequest:(NSData *)attestationNonce responseHandler:(ResponseHandler)responseHandler;
 - (void)certificateChainRequest:(uint8_t)certificateType responseHandler:(ResponseHandler)responseHandler;
-- (void)opCSRRequest:(NSData *)cSRNonce responseHandler:(ResponseHandler)responseHandler;
+- (void)opCSRRequest:(NSData *)CSRNonce responseHandler:(ResponseHandler)responseHandler;
 - (void)removeFabric:(uint8_t)fabricIndex responseHandler:(ResponseHandler)responseHandler;
 - (void)removeTrustedRootCertificate:(NSData *)trustedRootIdentifier responseHandler:(ResponseHandler)responseHandler;
 - (void)updateFabricLabel:(NSString *)label responseHandler:(ResponseHandler)responseHandler;
-- (void)updateNOC:(NSData *)nOCValue iCACValue:(NSData *)iCACValue responseHandler:(ResponseHandler)responseHandler;
+- (void)updateNOC:(NSData *)NOCValue ICACValue:(NSData *)ICACValue responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeFabricsListWithResponseHandler:(ResponseHandler)responseHandler;
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -73,7 +73,7 @@ using chip::Callback::Cancelable;
 }
 
 - (void)openCommissioningWindow:(uint16_t)commissioningTimeout
-                   pAKEVerifier:(NSData *)pAKEVerifier
+                   PAKEVerifier:(NSData *)PAKEVerifier
                   discriminator:(uint16_t)discriminator
                      iterations:(uint32_t)iterations
                            salt:(NSData *)salt
@@ -81,7 +81,7 @@ using chip::Callback::Cancelable;
                 responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OpenCommissioningWindow(success, failure, commissioningTimeout, [self asSpan:pAKEVerifier],
+        return self.cppCluster.OpenCommissioningWindow(success, failure, commissioningTimeout, [self asSpan:PAKEVerifier],
             discriminator, iterations, [self asSpan:salt], passcodeID);
     });
 }
@@ -3288,16 +3288,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)addNOC:(NSData *)nOCValue
-          iCACValue:(NSData *)iCACValue
-           iPKValue:(NSData *)iPKValue
+- (void)addNOC:(NSData *)NOCValue
+          ICACValue:(NSData *)ICACValue
+           IPKValue:(NSData *)IPKValue
       caseAdminNode:(uint64_t)caseAdminNode
       adminVendorId:(uint16_t)adminVendorId
     responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddNOC(success, failure, [self asSpan:nOCValue], [self asSpan:iCACValue], [self asSpan:iPKValue],
+            return self.cppCluster.AddNOC(success, failure, [self asSpan:NOCValue], [self asSpan:ICACValue], [self asSpan:IPKValue],
                 caseAdminNode, adminVendorId);
         });
 }
@@ -3325,11 +3325,11 @@ using chip::Callback::Cancelable;
         });
 }
 
-- (void)opCSRRequest:(NSData *)cSRNonce responseHandler:(ResponseHandler)responseHandler
+- (void)opCSRRequest:(NSData *)CSRNonce responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.OpCSRRequest(success, failure, [self asSpan:cSRNonce]);
+            return self.cppCluster.OpCSRRequest(success, failure, [self asSpan:CSRNonce]);
         });
 }
 
@@ -3356,11 +3356,11 @@ using chip::Callback::Cancelable;
         });
 }
 
-- (void)updateNOC:(NSData *)nOCValue iCACValue:(NSData *)iCACValue responseHandler:(ResponseHandler)responseHandler
+- (void)updateNOC:(NSData *)NOCValue ICACValue:(NSData *)ICACValue responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateNOC(success, failure, [self asSpan:nOCValue], [self asSpan:iCACValue]);
+            return self.cppCluster.UpdateNOC(success, failure, [self asSpan:NOCValue], [self asSpan:ICACValue]);
         });
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -3534,13 +3534,13 @@ namespace Attributes {
 
 namespace PHYRate {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pHYRate)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * PHYRate)
 {
-    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) pHYRate, sizeof(*pHYRate));
+    return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) PHYRate, sizeof(*PHYRate));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pHYRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t PHYRate)
 {
-    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) &pHYRate,
+    return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, PHYRate::Id, (uint8_t *) &PHYRate,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -1313,8 +1313,8 @@ namespace EthernetNetworkDiagnostics {
 namespace Attributes {
 
 namespace PHYRate {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pHYRate); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pHYRate);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * PHYRate); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t PHYRate);
 } // namespace PHYRate
 
 namespace FullDuplex {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -5889,8 +5889,8 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kRouterId)), routerId));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNextHop)), nextHop));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPathCost)), pathCost));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLQIIn)), lQIIn));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLQIOut)), lQIOut));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLQIIn)), LQIIn));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLQIOut)), LQIOut));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAge)), age));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAllocated)), allocated));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kLinkEstablished)), linkEstablished));
@@ -5926,10 +5926,10 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
             ReturnErrorOnFailure(DataModel::Decode(reader, pathCost));
             break;
         case to_underlying(Fields::kLQIIn):
-            ReturnErrorOnFailure(DataModel::Decode(reader, lQIIn));
+            ReturnErrorOnFailure(DataModel::Decode(reader, LQIIn));
             break;
         case to_underlying(Fields::kLQIOut):
-            ReturnErrorOnFailure(DataModel::Decode(reader, lQIOut));
+            ReturnErrorOnFailure(DataModel::Decode(reader, LQIOut));
             break;
         case to_underlying(Fields::kAge):
             ReturnErrorOnFailure(DataModel::Decode(reader, age));
@@ -6242,7 +6242,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     ReturnErrorOnFailure(
         DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kCommissioningTimeout)), commissioningTimeout));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPAKEVerifier)), pAKEVerifier));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPAKEVerifier)), PAKEVerifier));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kDiscriminator)), discriminator));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIterations)), iterations));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSalt)), salt));
@@ -6267,7 +6267,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
             ReturnErrorOnFailure(DataModel::Decode(reader, commissioningTimeout));
             break;
         case to_underlying(Fields::kPAKEVerifier):
-            ReturnErrorOnFailure(DataModel::Decode(reader, pAKEVerifier));
+            ReturnErrorOnFailure(DataModel::Decode(reader, PAKEVerifier));
             break;
         case to_underlying(Fields::kDiscriminator):
             ReturnErrorOnFailure(DataModel::Decode(reader, discriminator));
@@ -6609,7 +6609,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kCSRNonce)), cSRNonce));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kCSRNonce)), CSRNonce));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -6627,7 +6627,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
         case to_underlying(Fields::kCSRNonce):
-            ReturnErrorOnFailure(DataModel::Decode(reader, cSRNonce));
+            ReturnErrorOnFailure(DataModel::Decode(reader, CSRNonce));
             break;
         default:
             break;
@@ -6644,7 +6644,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNOCSRElements)), nOCSRElements));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNOCSRElements)), NOCSRElements));
     ReturnErrorOnFailure(
         DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAttestationSignature)), attestationSignature));
     ReturnErrorOnFailure(writer.EndContainer(outer));
@@ -6664,7 +6664,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
         case to_underlying(Fields::kNOCSRElements):
-            ReturnErrorOnFailure(DataModel::Decode(reader, nOCSRElements));
+            ReturnErrorOnFailure(DataModel::Decode(reader, NOCSRElements));
             break;
         case to_underlying(Fields::kAttestationSignature):
             ReturnErrorOnFailure(DataModel::Decode(reader, attestationSignature));
@@ -6684,9 +6684,9 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNOCValue)), nOCValue));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kICACValue)), iCACValue));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIPKValue)), iPKValue));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNOCValue)), NOCValue));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kICACValue)), ICACValue));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kIPKValue)), IPKValue));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kCaseAdminNode)), caseAdminNode));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminVendorId)), adminVendorId));
     ReturnErrorOnFailure(writer.EndContainer(outer));
@@ -6706,13 +6706,13 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
         case to_underlying(Fields::kNOCValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, nOCValue));
+            ReturnErrorOnFailure(DataModel::Decode(reader, NOCValue));
             break;
         case to_underlying(Fields::kICACValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, iCACValue));
+            ReturnErrorOnFailure(DataModel::Decode(reader, ICACValue));
             break;
         case to_underlying(Fields::kIPKValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, iPKValue));
+            ReturnErrorOnFailure(DataModel::Decode(reader, IPKValue));
             break;
         case to_underlying(Fields::kCaseAdminNode):
             ReturnErrorOnFailure(DataModel::Decode(reader, caseAdminNode));
@@ -6735,8 +6735,8 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNOCValue)), nOCValue));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kICACValue)), iCACValue));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNOCValue)), NOCValue));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kICACValue)), ICACValue));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -6754,10 +6754,10 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
         case to_underlying(Fields::kNOCValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, nOCValue));
+            ReturnErrorOnFailure(DataModel::Decode(reader, NOCValue));
             break;
         case to_underlying(Fields::kICACValue):
-            ReturnErrorOnFailure(DataModel::Decode(reader, iCACValue));
+            ReturnErrorOnFailure(DataModel::Decode(reader, ICACValue));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -4736,8 +4736,8 @@ public:
     uint8_t routerId;
     uint8_t nextHop;
     uint8_t pathCost;
-    uint8_t lQIIn;
-    uint8_t lQIOut;
+    uint8_t LQIIn;
+    uint8_t LQIOut;
     uint8_t age;
     bool allocated;
     bool linkEstablished;
@@ -5022,7 +5022,7 @@ public:
     static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
 
     uint16_t commissioningTimeout;
-    chip::ByteSpan pAKEVerifier;
+    chip::ByteSpan PAKEVerifier;
     uint16_t discriminator;
     uint32_t iterations;
     chip::ByteSpan salt;
@@ -5038,7 +5038,7 @@ public:
     static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
 
     uint16_t commissioningTimeout;
-    chip::ByteSpan pAKEVerifier;
+    chip::ByteSpan PAKEVerifier;
     uint16_t discriminator;
     uint32_t iterations;
     chip::ByteSpan salt;
@@ -5294,7 +5294,7 @@ public:
     static constexpr CommandId GetCommandId() { return OpCSRRequest::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan cSRNonce;
+    chip::ByteSpan CSRNonce;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5305,7 +5305,7 @@ public:
     static constexpr CommandId GetCommandId() { return OpCSRRequest::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan cSRNonce;
+    chip::ByteSpan CSRNonce;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OpCSRRequest
@@ -5323,7 +5323,7 @@ public:
     static constexpr CommandId GetCommandId() { return OpCSRResponse::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan nOCSRElements;
+    chip::ByteSpan NOCSRElements;
     chip::ByteSpan attestationSignature;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
@@ -5335,7 +5335,7 @@ public:
     static constexpr CommandId GetCommandId() { return OpCSRResponse::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan nOCSRElements;
+    chip::ByteSpan NOCSRElements;
     chip::ByteSpan attestationSignature;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5357,9 +5357,9 @@ public:
     static constexpr CommandId GetCommandId() { return AddNOC::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan nOCValue;
-    chip::ByteSpan iCACValue;
-    chip::ByteSpan iPKValue;
+    chip::ByteSpan NOCValue;
+    chip::ByteSpan ICACValue;
+    chip::ByteSpan IPKValue;
     chip::NodeId caseAdminNode;
     uint16_t adminVendorId;
 
@@ -5372,9 +5372,9 @@ public:
     static constexpr CommandId GetCommandId() { return AddNOC::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan nOCValue;
-    chip::ByteSpan iCACValue;
-    chip::ByteSpan iPKValue;
+    chip::ByteSpan NOCValue;
+    chip::ByteSpan ICACValue;
+    chip::ByteSpan IPKValue;
     chip::NodeId caseAdminNode;
     uint16_t adminVendorId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -5394,8 +5394,8 @@ public:
     static constexpr CommandId GetCommandId() { return UpdateNOC::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan nOCValue;
-    chip::ByteSpan iCACValue;
+    chip::ByteSpan NOCValue;
+    chip::ByteSpan ICACValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
 };
@@ -5406,8 +5406,8 @@ public:
     static constexpr CommandId GetCommandId() { return UpdateNOC::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::ByteSpan nOCValue;
-    chip::ByteSpan iCACValue;
+    chip::ByteSpan NOCValue;
+    chip::ByteSpan ICACValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace UpdateNOC

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -188,7 +188,7 @@ exit:
 
 CHIP_ERROR AdministratorCommissioningCluster::OpenCommissioningWindow(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
-                                                                      uint16_t commissioningTimeout, chip::ByteSpan pAKEVerifier,
+                                                                      uint16_t commissioningTimeout, chip::ByteSpan PAKEVerifier,
                                                                       uint16_t discriminator, uint32_t iterations,
                                                                       chip::ByteSpan salt, uint16_t passcodeID)
 {
@@ -214,8 +214,8 @@ CHIP_ERROR AdministratorCommissioningCluster::OpenCommissioningWindow(Callback::
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // commissioningTimeout: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), commissioningTimeout));
-    // pAKEVerifier: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), pAKEVerifier));
+    // PAKEVerifier: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), PAKEVerifier));
     // discriminator: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), discriminator));
     // iterations: int32u
@@ -7669,7 +7669,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), hardwareVersion));
     // softwareVersion: int32u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), softwareVersion));
-    // protocolsSupported: oTADownloadProtocol
+    // protocolsSupported: OTADownloadProtocol
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), protocolsSupported));
     // location: charString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), location));
@@ -7737,7 +7737,7 @@ CHIP_ERROR OtaSoftwareUpdateRequestorCluster::AnnounceOtaProvider(Callback::Canc
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), providerLocation));
     // vendorId: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
-    // announcementReason: oTAAnnouncementReason
+    // announcementReason: OTAAnnouncementReason
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), announcementReason));
     // metadataForNode: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), metadataForNode));
@@ -8329,7 +8329,7 @@ CHIP_ERROR OnOffSwitchConfigurationCluster::ReadAttributeClusterRevision(Callbac
 
 // OperationalCredentials Cluster Commands
 CHIP_ERROR OperationalCredentialsCluster::AddNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 chip::ByteSpan nOCValue, chip::ByteSpan iCACValue, chip::ByteSpan iPKValue,
+                                                 chip::ByteSpan NOCValue, chip::ByteSpan ICACValue, chip::ByteSpan IPKValue,
                                                  chip::NodeId caseAdminNode, uint16_t adminVendorId)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
@@ -8351,12 +8351,12 @@ CHIP_ERROR OperationalCredentialsCluster::AddNOC(Callback::Cancelable * onSucces
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // nOCValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), nOCValue));
-    // iCACValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), iCACValue));
-    // iPKValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), iPKValue));
+    // NOCValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), NOCValue));
+    // ICACValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), ICACValue));
+    // IPKValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), IPKValue));
     // caseAdminNode: nodeId
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), caseAdminNode));
     // adminVendorId: int16u
@@ -8507,7 +8507,7 @@ exit:
 }
 
 CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback, chip::ByteSpan cSRNonce)
+                                                       Callback::Cancelable * onFailureCallback, chip::ByteSpan CSRNonce)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     app::CommandSender * sender = nullptr;
@@ -8529,8 +8529,8 @@ CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * on
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // cSRNonce: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), cSRNonce));
+    // CSRNonce: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), CSRNonce));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -8676,8 +8676,8 @@ exit:
 }
 
 CHIP_ERROR OperationalCredentialsCluster::UpdateNOC(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, chip::ByteSpan nOCValue,
-                                                    chip::ByteSpan iCACValue)
+                                                    Callback::Cancelable * onFailureCallback, chip::ByteSpan NOCValue,
+                                                    chip::ByteSpan ICACValue)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     app::CommandSender * sender = nullptr;
@@ -8698,10 +8698,10 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateNOC(Callback::Cancelable * onSuc
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // nOCValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), nOCValue));
-    // iCACValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), iCACValue));
+    // NOCValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), NOCValue));
+    // ICACValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), ICACValue));
 
     SuccessOrExit(err = sender->FinishCommand());
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -58,7 +58,7 @@ public:
     CHIP_ERROR OpenBasicCommissioningWindow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint16_t commissioningTimeout);
     CHIP_ERROR OpenCommissioningWindow(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                       uint16_t commissioningTimeout, chip::ByteSpan pAKEVerifier, uint16_t discriminator,
+                                       uint16_t commissioningTimeout, chip::ByteSpan PAKEVerifier, uint16_t discriminator,
                                        uint32_t iterations, chip::ByteSpan salt, uint16_t passcodeID);
     CHIP_ERROR RevokeCommissioning(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
@@ -968,8 +968,8 @@ public:
     ~OperationalCredentialsCluster() {}
 
     // Cluster Commands
-    CHIP_ERROR AddNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, chip::ByteSpan nOCValue,
-                      chip::ByteSpan iCACValue, chip::ByteSpan iPKValue, chip::NodeId caseAdminNode, uint16_t adminVendorId);
+    CHIP_ERROR AddNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, chip::ByteSpan NOCValue,
+                      chip::ByteSpan ICACValue, chip::ByteSpan IPKValue, chip::NodeId caseAdminNode, uint16_t adminVendorId);
     CHIP_ERROR AddTrustedRootCertificate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          chip::ByteSpan rootCertificate);
     CHIP_ERROR AttestationRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -977,7 +977,7 @@ public:
     CHIP_ERROR CertificateChainRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint8_t certificateType);
     CHIP_ERROR OpCSRRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                            chip::ByteSpan cSRNonce);
+                            chip::ByteSpan CSRNonce);
     CHIP_ERROR RemoveFabric(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                             uint8_t fabricIndex);
     CHIP_ERROR RemoveTrustedRootCertificate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -985,7 +985,7 @@ public:
     CHIP_ERROR UpdateFabricLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                  chip::ByteSpan label);
     CHIP_ERROR UpdateNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                         chip::ByteSpan nOCValue, chip::ByteSpan iCACValue);
+                         chip::ByteSpan NOCValue, chip::ByteSpan ICACValue);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);

--- a/zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.cpp
@@ -1986,7 +1986,7 @@ CHIP_ERROR ElectricalMeasurementClusterTest::WriteAttributeClusterRevision(Callb
 }
 
 CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributePHYRate(Callback::Cancelable * onSuccessCallback,
-                                                                        Callback::Cancelable * onFailureCallback, uint8_t pHYRate)
+                                                                        Callback::Cancelable * onFailureCallback, uint8_t PHYRate)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -1997,7 +1997,7 @@ CHIP_ERROR EthernetNetworkDiagnosticsClusterTest::WriteAttributePHYRate(Callback
     attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
-    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, pHYRate));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, PHYRate));
 
     return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
@@ -169,7 +169,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), hardwareVersion));
     // softwareVersion: int32u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), softwareVersion));
-    // protocolsSupported: oTADownloadProtocol
+    // protocolsSupported: OTADownloadProtocol
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), protocolsSupported));
     // location: charString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), location));

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
@@ -478,7 +478,7 @@ CHIP_ERROR NetworkCommissioningCluster::ReadAttributeClusterRevision(Callback::C
 
 // OperationalCredentials Cluster Commands
 CHIP_ERROR OperationalCredentialsCluster::AddNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 chip::ByteSpan nOCValue, chip::ByteSpan iCACValue, chip::ByteSpan iPKValue,
+                                                 chip::ByteSpan NOCValue, chip::ByteSpan ICACValue, chip::ByteSpan IPKValue,
                                                  chip::NodeId caseAdminNode, uint16_t adminVendorId)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
@@ -500,12 +500,12 @@ CHIP_ERROR OperationalCredentialsCluster::AddNOC(Callback::Cancelable * onSucces
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // nOCValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), nOCValue));
-    // iCACValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), iCACValue));
-    // iPKValue: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), iPKValue));
+    // NOCValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), NOCValue));
+    // ICACValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), ICACValue));
+    // IPKValue: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), IPKValue));
     // caseAdminNode: nodeId
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), caseAdminNode));
     // adminVendorId: int16u
@@ -656,7 +656,7 @@ exit:
 }
 
 CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback, chip::ByteSpan cSRNonce)
+                                                       Callback::Cancelable * onFailureCallback, chip::ByteSpan CSRNonce)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     app::CommandSender * sender = nullptr;
@@ -678,8 +678,8 @@ CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * on
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    // cSRNonce: octetString
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), cSRNonce));
+    // CSRNonce: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), CSRNonce));
 
     SuccessOrExit(err = sender->FinishCommand());
 

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.h
@@ -85,8 +85,8 @@ public:
     ~OperationalCredentialsCluster() {}
 
     // Cluster Commands
-    CHIP_ERROR AddNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, chip::ByteSpan nOCValue,
-                      chip::ByteSpan iCACValue, chip::ByteSpan iPKValue, chip::NodeId caseAdminNode, uint16_t adminVendorId);
+    CHIP_ERROR AddNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, chip::ByteSpan NOCValue,
+                      chip::ByteSpan ICACValue, chip::ByteSpan IPKValue, chip::NodeId caseAdminNode, uint16_t adminVendorId);
     CHIP_ERROR AddTrustedRootCertificate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                          chip::ByteSpan rootCertificate);
     CHIP_ERROR AttestationRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -94,7 +94,7 @@ public:
     CHIP_ERROR CertificateChainRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint8_t certificateType);
     CHIP_ERROR OpCSRRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                            chip::ByteSpan cSRNonce);
+                            chip::ByteSpan CSRNonce);
     CHIP_ERROR RemoveFabric(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                             uint8_t fabricIndex);
     CHIP_ERROR UpdateFabricLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,


### PR DESCRIPTION
It would make sense to convert to nocValue or maybe nocvalue, or to
leave as NOCValue, but doing nOCValue just looks very weird.

Choosing to leave as NOCValue.

#### Problem
See above.

#### Change overview
See above..

#### Testing
No behavior changes.  Things compile.