### PR TITLE
Add overloads of CopyString that take a CharSpan (i.e. Span<const char>).

### DIFF
--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -100,6 +100,37 @@ inline void CopyString(char (&dest)[N], ByteSpan source)
 }
 
 /**
+ * Creates a null-terminated string from a CharSpan.
+ * If dest is nullptr, no copy happens. Non-nullptr result is always null-terminated.
+ *
+ * @param[in]  dest             Destination string buffer or nullptr.
+ *
+ * @param[in]  destLength       Maximum length to be copied. Will need space for null terminator as
+ *                              well (string will be truncated if it does not fit). If 0 this method
+ *                              is a noop.
+ *
+ * @param[in]  source           Data to be copied.
+ */
+inline void CopyString(char * dest, size_t destLength, CharSpan source)
+{
+    if (dest && destLength)
+    {
+        size_t maxChars = std::min(destLength - 1, source.size());
+        memcpy(dest, source.data(), maxChars);
+        dest[maxChars] = '\0';
+    }
+}
+
+/**
+ * Convenience method for CopyString to auto-detect destination size.
+ */
+template <size_t N>
+inline void CopyString(char (&dest)[N], CharSpan source)
+{
+    CopyString(dest, N, source);
+}
+
+/**
  * This function copies a C-style string to memory newly allocated by Platform::MemoryAlloc().
  *
  * @param[in]  string           String to be copied.

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -208,6 +208,7 @@ using MutableByteSpan = Span<uint8_t>;
 template <size_t N>
 using FixedByteSpan = FixedSpan<const uint8_t, N>;
 
+using CharSpan        = Span<const char>;
 using MutableCharSpan = Span<char>;
 
 inline CHIP_ERROR CopySpanToMutableSpan(ByteSpan span_to_copy, MutableByteSpan & out_buf)

--- a/src/lib/support/tests/TestCHIPMemString.cpp
+++ b/src/lib/support/tests/TestCHIPMemString.cpp
@@ -76,6 +76,7 @@ static void TestCopyString(nlTestSuite * inSuite, void * inContext)
 {
     constexpr char testWord[] = "testytest";
     ByteSpan testWordSpan     = ByteSpan(reinterpret_cast<const uint8_t *>(testWord), sizeof(testWord) - 1);
+    CharSpan testWordSpan2(testWord, sizeof(testWord) - 1);
     TestBuffers<sizeof(testWord)> testBuffers;
 
     // CopyString with explicit size
@@ -108,6 +109,22 @@ static void TestCopyString(nlTestSuite * inSuite, void * inContext)
     CopyString(testBuffers.tooSmallBuf, testWordSpan);
     CopyString(testBuffers.wayTooSmallBuf, testWordSpan);
     CopyString(testBuffers.tooBigBuf, testWordSpan);
+    testBuffers.CheckCorrectness(inSuite, testWord);
+
+    // CopyString with explicit size from CharSpan
+    testBuffers.Reset();
+    CopyString(testBuffers.correctSizeBuf, sizeof(testBuffers.correctSizeBuf), testWordSpan2);
+    CopyString(testBuffers.tooSmallBuf, sizeof(testBuffers.tooSmallBuf), testWordSpan2);
+    CopyString(testBuffers.wayTooSmallBuf, sizeof(testBuffers.wayTooSmallBuf), testWordSpan2);
+    CopyString(testBuffers.tooBigBuf, sizeof(testBuffers.tooBigBuf), testWordSpan2);
+    testBuffers.CheckCorrectness(inSuite, testWord);
+
+    // CopyString with array size from CharSpan
+    testBuffers.Reset();
+    CopyString(testBuffers.correctSizeBuf, testWordSpan2);
+    CopyString(testBuffers.tooSmallBuf, testWordSpan2);
+    CopyString(testBuffers.wayTooSmallBuf, testWordSpan2);
+    CopyString(testBuffers.tooBigBuf, testWordSpan2);
     testBuffers.CheckCorrectness(inSuite, testWord);
 }
 


### PR DESCRIPTION
We have various places where we could use this in IM.

#### Problem
Code we're adding would need to create ByteSpan from a CharSpan just to copy it into a null-terminated buffer.

#### Change overview
Add a CopyString overload taking CharSpan.

#### Testing
Unit tests added.