### PR TITLE
[Android] Support to get Compressed Fabric ID

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
@@ -45,9 +45,8 @@ class BasicClientFragment : Fragment() {
 
   override fun onStart() {
     super.onStart()
-    // TODO: use the fabric ID that was used to commission the device
-    val testFabricId = "5544332211"
-    basicClusterFabricIdEd.setText(testFabricId)
+    val compressedFabricId = deviceController.compressedFabricId
+    basicClusterFabricIdEd.setText(compressedFabricId.toULong().toString(16).padStart(16,'0'))
     basicClusterDeviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
   }
 
@@ -79,7 +78,7 @@ class BasicClientFragment : Fragment() {
   private fun updateAddressClick() {
     try {
       deviceController.updateDevice(
-        basicClusterFabricIdEd.text.toString().toULong().toLong(),
+        basicClusterFabricIdEd.text.toString().toULong(16).toLong(),
         basicClusterDeviceIdEd.text.toString().toULong().toLong()
       )
       showMessage("Address update started")

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -83,7 +83,7 @@ class MultiAdminClientFragment : Fragment() {
   }
 
   private fun updateAddressClick() {
-    try{
+    try {
       deviceController.updateDevice(
         multiAdminClusterFabricIdEd.text.toString().toULong(16).toLong(),
         multiAdminClusterDeviceIdEd.text.toString().toULong().toLong()

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -47,11 +47,11 @@ class MultiAdminClientFragment : Fragment() {
 
   override fun onStart() {
     super.onStart()
-    // TODO: use the fabric ID that was used to commission the device
-    val testFabricId = "5544332211"
+    // TODO: use the discriminator and setupPinCode that was used to commission the device
     val testDiscriminator = "3840"
     val testSetupPinCode = 20202021L
-    multiAdminClusterFabricIdEd.setText(testFabricId)
+    val compressedFabricId = deviceController.compressedFabricId
+    multiAdminClusterFabricIdEd.setText(compressedFabricId.toULong().toString(16).padStart(16,'0'))
     multiAdminClusterDeviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
     discriminatorEd.setText(testDiscriminator)
     setupPinCodeEd.setText(testSetupPinCode.toString())
@@ -85,8 +85,8 @@ class MultiAdminClientFragment : Fragment() {
   private fun updateAddressClick() {
     try{
       deviceController.updateDevice(
-              multiAdminClusterFabricIdEd.text.toString().toULong().toLong(),
-              multiAdminClusterDeviceIdEd.text.toString().toULong().toLong()
+        multiAdminClusterFabricIdEd.text.toString().toULong(16).toLong(),
+        multiAdminClusterDeviceIdEd.text.toString().toULong().toLong()
       )
       showMessage("Address update started")
     } catch (ex: Exception) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
@@ -42,9 +42,8 @@ class OpCredClientFragment : Fragment() {
 
   override fun onStart() {
     super.onStart()
-    // TODO: use the fabric ID that was used to commission the device
-    val testFabricId = "5544332211"
-    opCredClusterFabricIdEd.setText(testFabricId)
+    val compressedFabricId = deviceController.compressedFabricId
+    opCredClusterFabricIdEd.setText(compressedFabricId.toULong().toString(16).padStart(16,'0'))
     opCredClusterDeviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
   }
 
@@ -76,8 +75,8 @@ class OpCredClientFragment : Fragment() {
   private fun updateAddressClick() {
     try {
       deviceController.updateDevice(
-              opCredClusterFabricIdEd.text.toString().toULong().toLong(),
-              opCredClusterDeviceIdEd.text.toString().toULong().toLong()
+        opCredClusterFabricIdEd.text.toString().toULong(16).toLong(),
+        opCredClusterDeviceIdEd.text.toString().toULong().toLong()
       )
       showMessage("Address update started")
     } catch (ex: Exception) {

--- a/src/android/CHIPTool/app/src/main/res/layout/multi_admin_client_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/multi_admin_client_fragment.xml
@@ -7,7 +7,7 @@
 
     <EditText
         android:id="@+id/multiAdminClusterFabricIdEd"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
         app:layout_constraintTop_toTopOf="parent"

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -382,6 +382,15 @@ JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlon
     return env->NewStringUTF(addrStr);
 }
 
+JNI_METHOD(jlong, getCompressedFabricId)(JNIEnv * env, jobject self, jlong handle)
+{
+    chip::DeviceLayer::StackLock lock;
+
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    return wrapper->Controller()->GetCompressedFabricId();
+}
+
 JNI_METHOD(void, updateDevice)(JNIEnv * env, jobject self, jlong handle, jlong fabricId, jlong deviceId)
 {
     chip::DeviceLayer::StackLock lock;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -198,6 +198,10 @@ public class ChipDeviceController {
     return getIpAddress(deviceControllerPtr, deviceId);
   }
 
+  public long getCompressedFabricId() {
+    return getCompressedFabricId(deviceControllerPtr);
+  }
+
   public void updateDevice(long fabricId, long deviceId) {
     updateDevice(deviceControllerPtr, fabricId, deviceId);
   }
@@ -248,6 +252,8 @@ public class ChipDeviceController {
   private native void deleteDeviceController(long deviceControllerPtr);
 
   private native String getIpAddress(long deviceControllerPtr, long deviceId);
+
+  private native long getCompressedFabricId(long deviceControllerPtr);
 
   private native void updateDevice(long deviceControllerPtr, long fabricId, long deviceId);
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Need to get Compressed Fabric ID feature and remove test fabric id
* TE6 supports Compressed Fabric ID operations

#### Change overview
* Create new interface to get compressed fabric id and set compressed fabric id to update device

#### Testing
* QR Pairing with Wi-Fi
* Update Address to establish CASE session
* Check utility clusters operation