### PR TITLE
ESP32: Read WiFi Network Diagnostics at runtime

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -33,6 +33,7 @@
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.cpp>
 #endif
 
+#include <esp_wifi.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/internal/BLEManager.h>
@@ -68,6 +69,93 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     OnWiFiPlatformEvent(event);
 #endif
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiSecurityType(uint8_t & securityType)
+{
+    securityType = 0;
+    wifi_ap_record_t ap_info;
+    esp_err_t err;
+
+    err = esp_wifi_sta_get_ap_info(&ap_info);
+    if (err == ESP_OK)
+    {
+        securityType = ap_info.authmode;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiChannelNumber(uint16_t & channelNumber)
+{
+    channelNumber = 0;
+    wifi_ap_record_t ap_info;
+    esp_err_t err;
+
+    err = esp_wifi_sta_get_ap_info(&ap_info);
+    if (err == ESP_OK)
+    {
+        channelNumber = ap_info.primary;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiRssi(int8_t & rssi)
+{
+    rssi = 0;
+    wifi_ap_record_t ap_info;
+    esp_err_t err;
+
+    err = esp_wifi_sta_get_ap_info(&ap_info);
+
+    if (err == ESP_OK)
+    {
+        rssi = ap_info.rssi;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
+{
+    beaconLostCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
+{
+    currentMaxRate = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
+{
+    packetMulticastRxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
+{
+    packetMulticastTxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
+{
+    packetUnicastRxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
+{
+    packetUnicastTxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiOverrunCount(uint64_t & overrunCount)
+{
+    overrunCount = 0;
+    return CHIP_NO_ERROR;
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -112,6 +112,17 @@ private:
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
+    CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
+    CHIP_ERROR _GetWiFiChannelNumber(uint16_t & channelNumber);
+    CHIP_ERROR _GetWiFiRssi(int8_t & rssi);
+    CHIP_ERROR _GetWiFiBeaconLostCount(uint32_t & beaconLostCount);
+    CHIP_ERROR _GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount);
+    CHIP_ERROR _GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount);
+    CHIP_ERROR _GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount);
+    CHIP_ERROR _GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount);
+    CHIP_ERROR _GetWiFiCurrentMaxRate(uint64_t & currentMaxRate);
+    CHIP_ERROR _GetWiFiOverrunCount(uint64_t & overrunCount);
+
     // ===== Members for internal use by the following friends.
 
     friend ConnectivityManager & ConnectivityMgr(void);


### PR DESCRIPTION
#### Problem
* Actual value from the platform is not populated at runtime for WiFi Network diagnostics attributes.

#### Change overview
* Read WiFi Network Diagnostic attributes from a platform at runtime

#### Testing
* All clusters app is compiled and checked using python controller.
