### PR TITLE
ESP32: Read General Diagnostics cluster attribute at runtime

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -50,6 +50,13 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
 #endif
                                        private Internal::ESP32Config
 {
+public:
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount);
+    CHIP_ERROR StoreRebootCount(uint32_t rebootCount);
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
+
+private:
     // Allow the ConfigurationManager interface class to delegate method calls to
     // the implementation methods provided by this class.
     friend class ConfigurationManager;
@@ -60,7 +67,6 @@ class ConfigurationManagerImpl final : public ConfigurationManager,
     friend class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
 #endif
 
-private:
     // ===== Members that implement the ConfigurationManager public interface.
 
     CHIP_ERROR _Init(void);

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -73,6 +73,11 @@ const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_Breadcrumb         = { kConfigNamespace_ChipConfig, "breadcrumb" };
 
+// Keys stored in the Chip-counters namespace
+const ESP32Config::Key ESP32Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };
+const ESP32Config::Key ESP32Config::kCounterKey_UpTime                = { kConfigNamespace_ChipCounters, "up-time" };
+const ESP32Config::Key ESP32Config::kCounterKey_TotalOperationalHours = { kConfigNamespace_ChipCounters, "total-hours" };
+
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char ESP32Config::kGroupKeyNamePrefix[] = "gk-";
 

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -74,6 +74,9 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kCounterKey_RebootCount;
+    static const Key kCounterKey_UpTime;
+    static const Key kCounterKey_TotalOperationalHours;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -25,6 +25,7 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <app-common/zap-generated/enums.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/ESP32/ESP32Utils.h>
 #include <platform/PlatformManager.h>
@@ -85,6 +86,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
     esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
     esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
+    mStartTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
 
     // Initialize the ESP WiFi layer.
     cfg = WIFI_INIT_CONFIG_DEFAULT();
@@ -118,6 +120,31 @@ exit:
     return chip::DeviceLayer::Internal::ESP32Utils::MapError(err);
 }
 
+CHIP_ERROR PlatformManagerImpl::_Shutdown()
+{
+    uint64_t upTime = 0;
+
+    if (_GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalOperationalHours = 0;
+
+        if (ConfigurationMgrImpl().GetTotalOperationalHours(totalOperationalHours) == CHIP_NO_ERROR)
+        {
+            ConfigurationMgrImpl().StoreTotalOperationalHours(totalOperationalHours + static_cast<uint32_t>(upTime / 3600));
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to get total operational hours of the Node");
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
+    }
+
+    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+}
+
 CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
     currentHeapFree = esp_get_free_heap_size();
@@ -133,6 +160,81 @@ CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapUsed(uint64_t & currentHeapUsed)
 CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
 {
     currentHeapHighWatermark = heap_caps_get_total_size(MALLOC_CAP_DEFAULT) - esp_get_minimum_free_heap_size();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetRebootCount(uint16_t & rebootCount)
+{
+    uint32_t count = 0;
+
+    CHIP_ERROR err = ConfigurationMgrImpl().GetRebootCount(count);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(count <= UINT16_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        rebootCount = static_cast<uint16_t>(count);
+    }
+
+    return err;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetUpTime(uint64_t & upTime)
+{
+    uint64_t currentTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
+
+    if (currentTimeMilliseconds >= mStartTimeMilliseconds)
+    {
+        upTime = (currentTimeMilliseconds - mStartTimeMilliseconds) / 1000;
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_INVALID_TIME;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    uint64_t upTime = 0;
+
+    if (_GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalHours = 0;
+        if (ConfigurationMgrImpl().GetTotalOperationalHours(totalHours) == CHIP_NO_ERROR)
+        {
+            VerifyOrReturnError(upTime / 3600 <= UINT32_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+            totalOperationalHours = totalHours + static_cast<uint32_t>(upTime / 3600);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_INVALID_TIME;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetBootReasons(uint8_t & bootReason)
+{
+    bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+    uint8_t reason;
+    reason = static_cast<uint8_t>(esp_reset_reason());
+    if (reason == ESP_RST_UNKNOWN)
+    {
+        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+    }
+    else if (reason == ESP_RST_POWERON)
+    {
+        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT;
+    }
+    else if (reason == ESP_RST_BROWNOUT)
+    {
+        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET;
+    }
+    else if (reason == ESP_RST_SW)
+    {
+        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET;
+    }
+    else if (reason == ESP_RST_INT_WDT)
+    {
+        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET;
+        /* Reboot can be due to hardware or software watchdog*/
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -55,14 +55,21 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _Shutdown();
     CHIP_ERROR _GetCurrentHeapFree(uint64_t & currentHeapFree);
     CHIP_ERROR _GetCurrentHeapUsed(uint64_t & currentHeapUsed);
     CHIP_ERROR _GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
 
+    CHIP_ERROR _GetRebootCount(uint16_t & rebootCount);
+    CHIP_ERROR _GetUpTime(uint64_t & upTime);
+    CHIP_ERROR _GetTotalOperationalHours(uint32_t & totalOperationalHours);
+    CHIP_ERROR _GetBootReasons(uint8_t & bootReasons);
     // ===== Members for internal use by the following friends.
 
     friend PlatformManager & PlatformMgr(void);
     friend PlatformManagerImpl & PlatformMgrImpl(void);
+
+    uint64_t mStartTimeMilliseconds = 0;
 
     static PlatformManagerImpl sInstance;
 };


### PR DESCRIPTION
#### Problem
* Actual value from the platform is not populated at runtime for General diagnostics attributes.

#### Change overview
* Read General Diagnostic attributes from a platform at runtime

#### Testing
* All clusters app is compiled and checked using python controller.
