### PR TITLE
Update emberAf*AttributeChange callbacks

### DIFF
--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -16,35 +16,10 @@
  *    limitations under the License.
  */
 
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
-
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app/Command.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/server/Mdns.h>
-#include <app/util/af-types.h>
 #include <app/util/af.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
-#include <lib/core/CHIPError.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/RandUtils.h>
 
 #include "AppMain.h"
-
-#include <cassert>
-#include <iostream>
-
-using namespace chip;
-using namespace chip::Inet;
-using namespace chip::Transport;
-using namespace chip::DeviceLayer;
-
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
 
 bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj)
 {

--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -21,29 +21,25 @@
  */
 
 #include "AppConfig.h"
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "LightingManager.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/util/af-types.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId == OnOff::Id)
-    {
-        if (attributeId != OnOff::Attributes::OnOff::Id)
-        {
-            ChipLogError(Zcl, "ON OFF attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
-                         ChipLogValueMEI(attributeId), type, *value, size);
-            return;
-        }
+    ClusterId clusterId     = attributePath.mClusterId;
+    AttributeId attributeId = attributePath.mAttributeId;
+    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
+    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
+    {
         LightMgr().InitiateAction(AppEvent::kEventType_Light, *value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION);
     }
     else if (clusterId == LevelControl::Id)

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -16,54 +16,27 @@
  *    limitations under the License.
  */
 
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
+#include "LightingManager.h"
+#include <AppMain.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
-
-#include "LightingManager.h"
-
-#include <AppMain.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #if defined(PW_RPC_ENABLED)
 #include "Rpc.h"
 #endif // PW_RPC_ENABLED
 
-#include <cassert>
-#include <iostream>
-
 using namespace chip;
 using namespace chip::app::Clusters;
-using namespace chip::DeviceLayer;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
-        return;
-    }
-
-    if (*value)
-    {
-        LightingMgr().InitiateAction(LightingManager::ON_ACTION);
-    }
-    else
-    {
-        LightingMgr().InitiateAction(LightingManager::OFF_ACTION);
+        LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION);
     }
 }
 

--- a/examples/lighting-app/mbed/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/mbed/main/ZclCallbacks.cpp
@@ -16,43 +16,31 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/command-id.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
-
 #include "AppTask.h"
 #include "LightingManager.h"
 
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
+
 using namespace chip;
+using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    ChipLogProgress(Zcl, "Cluster callback: %" PRIx32, clusterId);
+    ClusterId clusterId     = attributePath.mClusterId;
+    AttributeId attributeId = attributePath.mAttributeId;
+    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
-    if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
     {
-        if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
-        {
-            ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
-            return;
-        }
-
         LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION,
                                      AppEvent::kEventType_Lighting, size, value);
     }
-    else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
+    else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::CurrentLevel::Id)
     {
-        if (attributeId != ZCL_CURRENT_LEVEL_ATTRIBUTE_ID)
-        {
-            ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
-            return;
-        }
-
         ChipLogProgress(Zcl, "Value: %u, length %u", *value, size);
         if (size == 1)
         {
@@ -62,11 +50,6 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         {
             ChipLogError(Zcl, "wrong length for level: %d", size);
         }
-    }
-    else
-    {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
-        return;
     }
 }
 

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -16,23 +16,23 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
+#include "AppTask.h"
+#include "LightingManager.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app-common/zap-generated/ids/Commands.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
-
-#include "AppTask.h"
-#include "LightingManager.h"
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
+    ClusterId clusterId     = attributePath.mClusterId;
+    AttributeId attributeId = attributePath.mAttributeId;
+
     if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
     {
         ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8, *value);

--- a/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -15,43 +15,23 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppConfig.h"
 #include "BoltLockManager.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
-        return;
-    }
-
-    if (*value)
-    {
-        BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
-    }
-    else
-    {
-        BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
+        BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
     }
 }
 

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -25,33 +25,19 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/util/af-types.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        EFR32_LOG("Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        EFR32_LOG("Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
-        return;
-    }
-
-    if (*value)
-    {
-        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock, BoltLockManager::LOCK_ACTION);
-    }
-    else
-    {
-        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock, BoltLockManager::UNLOCK_ACTION);
+        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock,
+                                     *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
     }
 }
 

--- a/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #include "CHIPDeviceManager.h"
+#include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
@@ -92,13 +93,14 @@ exit:
 } // namespace DeviceManager
 } // namespace chip
 
-void emberAfPostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
     chip::DeviceManager::CHIPDeviceManagerCallbacks * cb =
         chip::DeviceManager::CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
     if (cb != nullptr)
     {
-        cb->PostAttributeChangeCallback(endpointId, clusterId, attributeId, mask, manufacturerCode, type, size, value);
+        cb->PostAttributeChangeCallback(attributePath.mEndpointId, attributePath.mClusterId, attributePath.mAttributeId, mask, 0x0,
+                                        type, size, value);
     }
 }

--- a/examples/lock-app/mbed/main/ZclCallbacks.cpp
+++ b/examples/lock-app/mbed/main/ZclCallbacks.cpp
@@ -16,35 +16,24 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppTask.h"
 #include "BoltLockManager.h"
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/command-id.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %d", clusterId);
-        return;
+        BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
     }
-
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %d", attributeId);
-        return;
-    }
-
-    BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
 }
 
 /** @brief OnOff Cluster Init

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -16,25 +16,22 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppTask.h"
 #include "BoltLockManager.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8, *value);
         BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
     }
 }

--- a/examples/lock-app/p6/src/ZclCallbacks.cpp
+++ b/examples/lock-app/p6/src/ZclCallbacks.cpp
@@ -24,37 +24,21 @@
 #include "AppTask.h"
 #include "BoltLockManager.h"
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        P6_LOG("Unknown cluster ID: %ld", clusterId);
-        return;
-    }
-
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
-    {
-        P6_LOG("Unknown attribute ID: %ld", attributeId);
-        return;
-    }
-
-    if (*value)
-    {
-        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock, BoltLockManager::Action::kLock);
-    }
-    else
-    {
-        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock, BoltLockManager::Action::kUnlock);
+        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock,
+                                     *value ? BoltLockManager::Action::kLock : BoltLockManager::Action::kUnlock);
     }
 }
 

--- a/examples/lock-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg/src/ZclCallbacks.cpp
@@ -16,42 +16,23 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppTask.h"
 #include "BoltLockManager.h"
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
-        return;
-    }
-
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
-        return;
-    }
-
-    if (*value)
-    {
-        BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
-    }
-    else
-    {
-        BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
+        BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
     }
 }
 

--- a/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -15,44 +15,23 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppConfig.h"
 #include "PumpManager.h"
 
-#include <app-common/zap-generated/enums.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
-        return;
-    }
-
-    if (*value)
-    {
-        PumpMgr().InitiateAction(0, PumpManager::LOCK_ACTION);
-    }
-    else
-    {
-        PumpMgr().InitiateAction(0, PumpManager::UNLOCK_ACTION);
+        PumpMgr().InitiateAction(0, *value ? PumpManager::LOCK_ACTION : PumpManager::UNLOCK_ACTION);
     }
 }
 

--- a/examples/pump-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/pump-app/nrfconnect/main/ZclCallbacks.cpp
@@ -15,41 +15,22 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppTask.h"
 #include "PumpManager.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
+#include <app/ConcreteAttributePath.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
-        return;
-    }
-
-    if (*value)
-    {
-        PumpMgr().InitiateAction(0, PumpManager::START_ACTION);
-    }
-    else
-    {
-        PumpMgr().InitiateAction(0, PumpManager::STOP_ACTION);
+        PumpMgr().InitiateAction(0, *value ? PumpManager::START_ACTION : PumpManager::STOP_ACTION);
     }
 }
 

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -15,44 +15,23 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppConfig.h"
 #include "PumpManager.h"
 
-#include <app-common/zap-generated/enums.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
-        return;
-    }
-
-    if (*value)
-    {
-        PumpMgr().InitiateAction(0, PumpManager::LOCK_ACTION);
-    }
-    else
-    {
-        PumpMgr().InitiateAction(0, PumpManager::UNLOCK_ACTION);
+        PumpMgr().InitiateAction(0, *value ? PumpManager::LOCK_ACTION : PumpManager::UNLOCK_ACTION);
     }
 }
 

--- a/examples/pump-controller-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/ZclCallbacks.cpp
@@ -15,41 +15,22 @@
  *    limitations under the License.
  */
 
-#include <lib/support/logging/CHIPLogging.h>
-
 #include "AppTask.h"
 #include "PumpManager.h"
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
+#include <app/ConcreteAttributePath.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value)
 {
-    if (clusterId != OnOff::Id)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
-        return;
-    }
-
-    if (attributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
-        return;
-    }
-
-    if (*value)
-    {
-        PumpMgr().InitiateAction(0, PumpManager::START_ACTION);
-    }
-    else
-    {
-        PumpMgr().InitiateAction(0, PumpManager::STOP_ACTION);
+        PumpMgr().InitiateAction(0, *value ? PumpManager::START_ACTION : PumpManager::STOP_ACTION);
     }
 }
 

--- a/examples/thermostat/linux/main.cpp
+++ b/examples/thermostat/linux/main.cpp
@@ -16,33 +16,17 @@
  *    limitations under the License.
  */
 
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
+#include "AppMain.h"
 
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/Command.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/server/Mdns.h>
-#include <app/util/af-types.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/util/af.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
-#include <lib/core/CHIPError.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/RandUtils.h>
-
-#include "AppMain.h"
-
-#include <cassert>
-#include <iostream>
 
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
-using namespace chip::Inet;
-using namespace chip::Transport;
-using namespace chip::DeviceLayer;
 
 bool emberAfBasicClusterMfgSpecificPingCallback(Command * commandObj)
 {

--- a/examples/thermostat/linux/main.cpp
+++ b/examples/thermostat/linux/main.cpp
@@ -19,9 +19,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/callback.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/Command.h>
 #include <app/chip-zcl-zpro-codec.h>
 #include <app/server/Mdns.h>
@@ -39,30 +38,28 @@
 #include <iostream>
 
 using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
-bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj)
+bool emberAfBasicClusterMfgSpecificPingCallback(Command * commandObj)
 {
     emberAfSendDefaultResponse(emberAfCurrentCommand(), EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-// emberAfPreAttributeChangeCallback() is called for every cluster.
+// MatterPreAttributeChangeCallback() is called for every cluster.
 // As of 8/17/21 cluster specific PreAttributeChangeCalbacks are not yet implemented.
 
-EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                                uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const ConcreteAttributePath & attributePath, uint8_t mask,
+                                                                     uint8_t type, uint16_t size, uint8_t * value)
 {
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    if (clusterId == ZCL_THERMOSTAT_CLUSTER_ID)
+    Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::Success;
+    if (attributePath.mClusterId == Thermostat::Id)
     {
-        status = emberAfThermostatClusterServerPreAttributeChangedCallback(endpoint, attributeId, type, size, value);
+        status = MatterThermostatClusterServerPreAttributeChangedCallback(attributePath, type, size, value);
     }
     return status;
 }

--- a/examples/tv-app/linux/include/cluster-change-attribute.cpp
+++ b/examples/tv-app/linux/include/cluster-change-attribute.cpp
@@ -16,11 +16,13 @@
  *    limitations under the License.
  */
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app/util/af.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
+using namespace ::chip::app::Clusters;
 
 enum TvCommand
 {
@@ -44,19 +46,19 @@ void runTvCommand(TvCommand command)
     }
 }
 
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterAfPostAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                         uint16_t size, uint8_t * value)
 {
-    if (clusterId == ZCL_ON_OFF_CLUSTER_ID && attributeId == ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributePath.mClusterId == OnOff::Id && attributePath.mAttributeId == OnOff::Attributes::OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Received on/off command for cluster id: %d", clusterId);
+        ChipLogProgress(Zcl, "Received on/off command for cluster id: " ChipLogFormatMEI, ChipLogValueMEI(OnOff::Id));
 
-        if (endpoint == 0)
+        if (attributePath.mEndpointId == 0)
         {
             ChipLogProgress(Zcl, "Execute POWER_TOGGLE");
             runTvCommand(PowerToggle);
         }
-        else if (endpoint == 1)
+        else if (attributePath.mEndpointId == 1)
         {
             ChipLogProgress(Zcl, "Execute MUTE_TOGGLE");
             runTvCommand(MuteToggle);

--- a/examples/tv-app/linux/main.cpp
+++ b/examples/tv-app/linux/main.cpp
@@ -16,27 +16,14 @@
  *    limitations under the License.
  */
 
-#include <cassert>
-#include <iostream>
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
-
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app/Command.h>
-#include <app/chip-zcl-zpro-codec.h>
-#include <app/util/af-types.h>
-#include <app/util/af.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/util.h>
-#include <lib/core/CHIPError.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/RandUtils.h>
-
 #include "AppMain.h"
 
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/Command.h>
+#include <app/util/af.h>
+
 #include <iostream>
-#include <lib/support/ErrorStr.h>
 
 #include "include/application-launcher/ApplicationLauncherManager.h"
 #include "include/audio-output/AudioOutputManager.h"
@@ -50,10 +37,6 @@
 using namespace chip;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
-
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
-{}
 
 bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj)
 {

--- a/examples/window-app/common/src/ZclCallbacks.cpp
+++ b/examples/window-app/common/src/ZclCallbacks.cpp
@@ -22,74 +22,75 @@
 
 #include <AppConfig.h>
 #include <WindowApp.h>
-#include <app-common/zap-generated/attribute-id.h>
+
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/window-covering-server/window-covering-server.h>
-#include <app/util/af-types.h>
 #include <app/util/af.h>
 
-using namespace chip::app::Clusters::WindowCovering;
+using namespace ::chip;
+using namespace ::chip::app::Clusters::WindowCovering;
 
-void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                       uint8_t * value)
 {
-    if (ZCL_WINDOW_COVERING_CLUSTER_ID == clusterId)
+    if (attributePath.mClusterId == Id)
     {
-        WindowApp & app = WindowApp::Instance();
-        uint16_t current;
-        uint16_t target;
-
-        switch (attributeId)
-        {
-        case ZCL_WC_TYPE_ATTRIBUTE_ID:
-            app.PostEvent(WindowApp::Event(WindowApp::EventId::CoverTypeChange, endpoint));
-            break;
-
-        case ZCL_WC_CURRENT_POSITION_LIFT_PERCENT100_THS_ATTRIBUTE_ID:
-            app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftChanged, endpoint));
-            break;
-
-        case ZCL_WC_CURRENT_POSITION_TILT_PERCENT100_THS_ATTRIBUTE_ID:
-            app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltChanged, endpoint));
-            break;
-
-        case ZCL_WC_TARGET_POSITION_LIFT_PERCENT100_THS_ATTRIBUTE_ID:
-            Attributes::TargetPositionLiftPercent100ths::Get(endpoint, &target);
-            Attributes::CurrentPositionLiftPercent100ths::Get(endpoint, &current);
-            if (current > target)
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftDown, endpoint));
-            }
-            else if (current < target)
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftUp, endpoint));
-            }
-            break;
-
-        case ZCL_WC_TARGET_POSITION_TILT_PERCENT100_THS_ATTRIBUTE_ID:
-            Attributes::TargetPositionTiltPercent100ths::Get(endpoint, &target);
-            Attributes::CurrentPositionTiltPercent100ths::Get(endpoint, &current);
-            if (current > target)
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltDown, endpoint));
-            }
-            else if (current < target)
-            {
-                app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltUp, endpoint));
-            }
-            break;
-
-        default:
-            break;
-        }
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(attributePath.mClusterId));
     }
-    else
+
+    WindowApp & app     = WindowApp::Instance();
+    EndpointId endpoint = attributePath.mEndpointId;
+    uint16_t current;
+    uint16_t target;
+
+    switch (attributePath.mAttributeId)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %ld", clusterId);
+    case Attributes::Type::Id:
+        app.PostEvent(WindowApp::Event(WindowApp::EventId::CoverTypeChange, endpoint));
+        break;
+
+    case Attributes::CurrentPositionLiftPercent100ths::Id:
+        app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftChanged, endpoint));
+        break;
+
+    case Attributes::CurrentPositionTiltPercent100ths::Id:
+        app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltChanged, endpoint));
+        break;
+
+    case Attributes::TargetPositionLiftPercent100ths::Id:
+        Attributes::TargetPositionLiftPercent100ths::Get(endpoint, &target);
+        Attributes::CurrentPositionLiftPercent100ths::Get(endpoint, &current);
+        if (current > target)
+        {
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftDown, endpoint));
+        }
+        else if (current < target)
+        {
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::LiftUp, endpoint));
+        }
+        break;
+
+    case Attributes::TargetPositionTiltPercent100ths::Id:
+        Attributes::TargetPositionTiltPercent100ths::Get(endpoint, &target);
+        Attributes::CurrentPositionTiltPercent100ths::Get(endpoint, &current);
+        if (current > target)
+        {
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltDown, endpoint));
+        }
+        else if (current < target)
+        {
+            app.PostEvent(WindowApp::Event(WindowApp::EventId::TiltUp, endpoint));
+        }
+        break;
+
+    default:
+        break;
     }
 }
 

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * A representation of a concrete attribute path.
+ */
+struct ConcreteAttributePath
+{
+    ConcreteAttributePath(EndpointId aEndpointId, ClusterId aClusterId, AttributeId aAttributeId) :
+        mEndpointId(aEndpointId), mClusterId(aClusterId), mAttributeId(aAttributeId)
+    {}
+
+    const EndpointId mEndpointId   = 0;
+    const ClusterId mClusterId     = 0;
+    const AttributeId mAttributeId = 0;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -49,6 +49,7 @@
 #include <app/util/time-util.h>
 
 #include <app/CommandHandler.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
 #include <lib/support/CodeUtils.h>
 
@@ -875,9 +876,9 @@ void emberAfPluginDoorLockServerRelockEventHandler(void)
     emberAfDoorLockClusterPrintln("Door automatically relocked: 0x%X", status);
 }
 
-void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId)
+void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)
 {
-    if (endpoint == DOOR_LOCK_SERVER_ENDPOINT && attributeId == ZCL_LOCK_STATE_ATTRIBUTE_ID)
+    if (attributePath.mEndpointId == DOOR_LOCK_SERVER_ENDPOINT && attributePath.mAttributeId == ZCL_LOCK_STATE_ATTRIBUTE_ID)
     {
         uint8_t lockState;
         EmberAfStatus status = emberAfReadServerAttribute(DOOR_LOCK_SERVER_ENDPOINT, ZCL_DOOR_LOCK_CLUSTER_ID,

--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -212,22 +212,23 @@ static void enrollWithClient(EndpointId endpoint)
     }
 }
 
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId,
-                                                                     EmberAfAttributeType attributeType, uint16_t size,
-                                                                     uint8_t * value)
+Protocols::InteractionModel::Status
+MatterIasZoneClusterServerPreAttributeChangedCallback(const app::ConcreteAttributePath & attributePath,
+                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value)
 {
     uint8_t i;
     bool zeroAddress;
     EmberBindingTableEntry bindingEntry;
     EmberBindingTableEntry currentBind;
     NodeId destNodeId;
+    EndpointId endpoint   = attributePath.mEndpointId;
     uint8_t ieeeAddress[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     // If this is not a CIE Address write, the CIE address has already been
     // written, or the IAS Zone server is already enrolled, do nothing.
-    if (attributeId != ZCL_IAS_CIE_ADDRESS_ATTRIBUTE_ID || emberAfCurrentCommand() == NULL)
+    if (attributePath.mAttributeId != ZCL_IAS_CIE_ADDRESS_ATTRIBUTE_ID || emberAfCurrentCommand() == NULL)
     {
-        return EMBER_ZCL_STATUS_SUCCESS;
+        return Protocols::InteractionModel::Status::Success;
     }
 
     memcpy(&destNodeId, value, sizeof(NodeId));
@@ -295,7 +296,7 @@ EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(EndpointId 
                                           EMBER_AF_STAY_AWAKE);
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
 EmberAfStatus emberAfPluginIasZoneClusterSetEnrollmentMethod(EndpointId endpoint, EmberAfIasZoneEnrollmentMode method)

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -146,10 +146,11 @@ static inline void identify_deactivate(Identify * identify)
     }
 }
 
-void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId)
+void MatterIdentifyClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)
 {
-    if (attributeId == Clusters::Identify::Attributes::IdentifyTime::Id)
+    if (attributePath.mAttributeId == Clusters::Identify::Attributes::IdentifyTime::Id)
     {
+        EndpointId endpoint = attributePath.mEndpointId;
         Identify * identify = inst(endpoint);
         uint16_t identifyTime;
 

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -17,13 +17,9 @@
 
 #include <app/util/af.h>
 
+#include <app/ConcreteAttributePath.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
-
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/enums.h>
 
 using namespace chip;
 
@@ -33,8 +29,9 @@ void emberAfPumpConfigurationAndControlClusterServerInitCallback(EndpointId endp
     // TODO
 }
 
-void emberAfPumpConfigurationAndControlClusterServerAttributeChangedCallback(EndpointId endpoint, AttributeId attributeId)
+void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)
 {
-    emberAfDebugPrintln("PCC Server Cluster Attribute changed [EP:%d, ID:0x%x]", endpoint, attributeId);
+    emberAfDebugPrintln("PCC Server Cluster Attribute changed [EP:%d, ID:0x%x]", attributePath.mEndpointId,
+                        attributePath.mAttributeId);
     // TODO
 }

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -30,7 +30,9 @@
 #include <app-common/zap-generated/enums.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/CommandHandler.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/util/error-mapping.h>
 #include <lib/core/CHIPEncoding.h>
 
 using namespace chip;
@@ -66,14 +68,15 @@ void emberAfThermostatClusterServerInitCallback()
     // or should this just be the responsibility of the thermostat application?
 }
 
-EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value)
+Protocols::InteractionModel::Status
+MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    EndpointId endpoint  = attributePath.mEndpointId;
     int16_t requested;
 
-    switch (attributeId)
+    switch (attributePath.mAttributeId)
     {
     case OccupiedHeatingSetpoint::Id: {
         int16_t AbsMinHeatSetpointLimit;
@@ -253,7 +256,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
         break;
     }
 
-    return status;
+    return app::ToInteractionModelStatus(status);
 }
 
 bool emberAfThermostatClusterClearWeeklyScheduleCallback(app::CommandHandler * commandObj,

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -55,6 +55,7 @@
 #include <app/util/basic-types.h>
 #include <app/util/types_stub.h> // For various types.
 
+#include <app/ConcreteAttributePath.h>
 #include <lib/support/Variant.h>
 #include <messaging/ExchangeContext.h>
 
@@ -1227,23 +1228,14 @@ typedef void (*EmberAfInitFunction)(chip::EndpointId endpoint);
  *
  * This function is called just after an attribute changes.
  */
-typedef void (*EmberAfClusterAttributeChangedCallback)(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/**
- * @brief Type for referring to the manufacturer specific
- *        attribute changed callback function.
- *
- * This function is called just after a manufacturer specific attribute changes.
- */
-typedef void (*EmberAfManufacturerSpecificClusterAttributeChangedCallback)(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
+typedef void (*EmberAfClusterAttributeChangedCallback)(const chip::app::ConcreteAttributePath & attributePath);
 
 /**
  * @brief Type for referring to the pre-attribute changed callback function.
  *
  * This function is called before an attribute changes.
  */
-typedef EmberAfStatus (*EmberAfClusterPreAttributeChangedCallback)(chip::EndpointId endpoint, chip::AttributeId attributeId,
+typedef EmberAfStatus (*EmberAfClusterPreAttributeChangedCallback)(const chip::app::ConcreteAttributePath & attributePath,
                                                                    EmberAfAttributeType attributeType, uint16_t size,
                                                                    uint8_t * value);
 

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -43,6 +43,7 @@
 
 //#include PLATFORM_HEADER
 #include <app/AttributeAccessInterface.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/util/af.h>
 
 #if !defined(EMBER_SCRIPTED_TEST)
@@ -200,13 +201,11 @@ void emAfSaveAttributeToToken(uint8_t * data, chip::EndpointId endpoint, chip::C
                               EmberAfAttributeMetadata * metadata);
 
 // Calls the attribute changed callback
-void emAfClusterAttributeChangedCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                         uint8_t clientServerMask, uint16_t manufacturerCode);
+void emAfClusterAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t clientServerMask);
 
 // Calls the attribute changed callback for a specific cluster.
-EmberAfStatus emAfClusterPreAttributeChangedCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                     chip::AttributeId attributeId, uint8_t clientServerMask,
-                                                     uint16_t manufacturerCode, EmberAfAttributeType attributeType, uint16_t size,
+EmberAfStatus emAfClusterPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     uint8_t clientServerMask, EmberAfAttributeType attributeType, uint16_t size,
                                                      uint8_t * value);
 
 // Calls the default response callback for a specific cluster, and wraps emberAfClusterDefaultResponseWithMfgCodeCallback

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -49,8 +49,10 @@
 #include "app/util/common.h"
 #include <app-common/zap-generated/callback.h>
 #include <app/util/af-main.h>
+#include <app/util/error-mapping.h>
 
 #include <app/reporting/reporting.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -566,19 +568,21 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
     // write the data unless this is only a test
     if (!justTest)
     {
+        const app::ConcreteAttributePath attributePath(endpoint, cluster, attributeID);
+
         // Pre write attribute callback for all attribute changes,
         // regardless of cluster.
-        EmberAfStatus status = emberAfPreAttributeChangeCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataType,
-                                                                 emberAfAttributeSize(metadata), data);
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        Protocols::InteractionModel::Status imStatus =
+            MatterPreAttributeChangeCallback(attributePath, mask, dataType, emberAfAttributeSize(metadata), data);
+        if (imStatus != Protocols::InteractionModel::Status::Success)
         {
-            return status;
+            return app::ToEmberAfStatus(imStatus);
         }
 
         // Pre-write attribute callback specific
         // to the cluster that the attribute lives in.
-        status = emAfClusterPreAttributeChangedCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataType,
-                                                        emberAfAttributeSize(metadata), data);
+        EmberAfStatus status =
+            emAfClusterPreAttributeChangedCallback(attributePath, mask, dataType, emberAfAttributeSize(metadata), data);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             return status;
@@ -604,12 +608,11 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
 
         // Post write attribute callback for all attributes changes, regardless
         // of cluster.
-        emberAfPostAttributeChangeCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataType,
-                                           emberAfAttributeSize(metadata), data);
+        MatterPostAttributeChangeCallback(attributePath, mask, dataType, emberAfAttributeSize(metadata), data);
 
         // Post-write attribute callback specific
         // to the cluster that the attribute lives in.
-        emAfClusterAttributeChangedCallback(endpoint, cluster, attributeID, mask, manufacturerCode);
+        emAfClusterAttributeChangedCallback(attributePath, mask);
     }
     else
     {

--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -3,6 +3,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -329,53 +330,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak)) emberAfPreAttributeChangeCallback(
-    EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size,
-                                                uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak)) emberAfPostAttributeChangeCallback(
-    EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
-    uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size,
-    uint8_t * value)
-{
-}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -565,3 +519,43 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak)) MatterPreAttributeChangeCallback(
+    const chip::app::ConcreteAttributePath & attributePath,
+    uint8_t mask, uint8_t type, uint16_t size, uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(
+    const chip::app::ConcreteAttributePath & attributePath,
+    uint8_t mask, uint8_t type, uint16_t size, uint8_t * value)
+{
+}
+

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -69,39 +69,17 @@ void emberAf{{asUpperCamelCase label}}ClusterClientInitCallback(chip::EndpointId
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAf{{asUpperCamelCase label}}ClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void Matter{{asUpperCamelCase label}}ClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief {{label}} Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAf{{asUpperCamelCase label}}ClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief {{label}} Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAf{{asUpperCamelCase label}}ClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief {{label}} Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAf{{asUpperCamelCase label}}ClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void Matter{{asUpperCamelCase label}}ClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief {{label}} Cluster Server Message Sent
  *
@@ -131,25 +109,23 @@ void emberAf{{asUpperCamelCase label}}ClusterClientMessageSentCallback(const chi
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAf{{asUpperCamelCase label}}ClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status Matter{{asUpperCamelCase label}}ClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief {{label}} Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAf{{asUpperCamelCase label}}ClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status Matter{{asUpperCamelCase label}}ClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief {{label}} Cluster Server Tick
  *

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -11,8 +11,10 @@
 #include <app/Command.h>
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 /** @brief Cluster Init
  *
@@ -433,45 +435,6 @@ bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberSt
 bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                 uint16_t msgLen, uint8_t * message, EmberStatus status);
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size,
-                                                uint8_t * value);
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value);
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -634,3 +597,35 @@ EmberStatus emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, u
  *
  */
 bool emberAfStartMoveCallback();
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                                           uint8_t mask, uint8_t type, uint16_t size, uint8_t * value);
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                       uint8_t mask, uint8_t type, uint16_t size, uint8_t * value);

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -179,7 +179,7 @@ function chip_endpoint_generated_functions()
       }
 
       if (endpointClusterWithAttributeChanged.includes(clusterName)) {
-        functionList     = functionList.concat(`  (EmberAfGenericClusterFunction) emberAf${
+        functionList     = functionList.concat(`  (EmberAfGenericClusterFunction) Matter${
             cHelper.asCamelCased(clusterName, false)}ClusterServerAttributeChangedCallback,\\\n`)
         hasFunctionArray = true
       }
@@ -191,7 +191,7 @@ function chip_endpoint_generated_functions()
       }
 
       if (endpointClusterWithPreAttribute.includes(clusterName)) {
-        functionList     = functionList.concat(`  (EmberAfGenericClusterFunction) emberAf${
+        functionList     = functionList.concat(`  (EmberAfGenericClusterFunction) Matter${
             cHelper.asCamelCased(clusterName, false)}ClusterServerPreAttributeChangedCallback,\\\n`)
         hasFunctionArray = true
       }

--- a/zzz_generated/all-clusters-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -755,50 +756,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -984,3 +941,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -2801,7 +2801,7 @@
 #define GENERATED_FUNCTION_ARRAYS                                                                                                  \
     const EmberAfGenericClusterFunction chipFuncArrayIdentifyServer[] = {                                                          \
         (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerInitCallback,                                                  \
-        (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerAttributeChangedCallback,                                      \
+        (EmberAfGenericClusterFunction) MatterIdentifyClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayBasicServer[] = {                                                             \
         (EmberAfGenericClusterFunction) emberAfBasicClusterServerInitCallback,                                                     \
@@ -2834,11 +2834,11 @@
         (EmberAfGenericClusterFunction) emberAfLevelControlClusterServerInitCallback,                                              \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayDoorLockServer[] = {                                                          \
-        (EmberAfGenericClusterFunction) emberAfDoorLockClusterServerAttributeChangedCallback,                                      \
+        (EmberAfGenericClusterFunction) MatterDoorLockClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayPumpConfigurationAndControlServer[] = {                                       \
         (EmberAfGenericClusterFunction) emberAfPumpConfigurationAndControlClusterServerInitCallback,                               \
-        (EmberAfGenericClusterFunction) emberAfPumpConfigurationAndControlClusterServerAttributeChangedCallback,                   \
+        (EmberAfGenericClusterFunction) MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback,                    \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayColorControlServer[] = {                                                      \
         (EmberAfGenericClusterFunction) emberAfColorControlClusterServerInitCallback,                                              \
@@ -2849,7 +2849,7 @@
     const EmberAfGenericClusterFunction chipFuncArrayIasZoneServer[] = {                                                           \
         (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerInitCallback,                                                   \
         (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerMessageSentCallback,                                            \
-        (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerPreAttributeChangedCallback,                                    \
+        (EmberAfGenericClusterFunction) MatterIasZoneClusterServerPreAttributeChangedCallback,                                     \
     };
 
 #define ZAP_CLUSTER_MASK(mask) CLUSTER_MASK_##mask

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -28,8 +28,10 @@
 #include <app/Command.h>
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 /** @brief Cluster Init
  *
@@ -918,43 +920,17 @@ void emberAfPowerConfigurationClusterClientInitCallback(chip::EndpointId endpoin
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPowerConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterPowerConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Power Configuration Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPowerConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Power Configuration Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPowerConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
-
-/** @brief Power Configuration Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPowerConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
+void MatterPowerConfigurationClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Power Configuration Cluster Server Message Sent
  *
@@ -988,31 +964,25 @@ void emberAfPowerConfigurationClusterClientMessageSentCallback(const chip::Messa
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPowerConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterPowerConfigurationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Power Configuration Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPowerConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterPowerConfigurationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Power Configuration Cluster Server Tick
  *
@@ -1054,45 +1024,19 @@ void emberAfDeviceTemperatureConfigurationClusterClientInitCallback(chip::Endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDeviceTemperatureConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
+void MatterDeviceTemperatureConfigurationClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Device Temperature Configuration Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDeviceTemperatureConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
-
-/** @brief Device Temperature Configuration Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDeviceTemperatureConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
-
-/** @brief Device Temperature Configuration Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDeviceTemperatureConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
+void MatterDeviceTemperatureConfigurationClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Device Temperature Configuration Cluster Server Message Sent
  *
@@ -1126,31 +1070,25 @@ void emberAfDeviceTemperatureConfigurationClusterClientMessageSentCallback(const
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDeviceTemperatureConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterDeviceTemperatureConfigurationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Device Temperature Configuration Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDeviceTemperatureConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterDeviceTemperatureConfigurationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Device Temperature Configuration Cluster Server Tick
  *
@@ -1192,43 +1130,17 @@ void emberAfIdentifyClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIdentifyClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterIdentifyClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Identify Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIdentifyClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Identify Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIdentifyClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              uint16_t manufacturerCode);
-
-/** @brief Identify Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIdentifyClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              uint16_t manufacturerCode);
+void MatterIdentifyClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Identify Cluster Server Message Sent
  *
@@ -1260,29 +1172,27 @@ void emberAfIdentifyClusterClientMessageSentCallback(const chip::MessageSendDest
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIdentifyClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                      EmberAfAttributeType attributeType, uint16_t size,
-                                                                      uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIdentifyClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Identify Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIdentifyClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                      EmberAfAttributeType attributeType, uint16_t size,
-                                                                      uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIdentifyClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Identify Cluster Server Tick
  *
@@ -1324,43 +1234,17 @@ void emberAfGroupsClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGroupsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterGroupsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Groups Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGroupsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Groups Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGroupsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
-
-/** @brief Groups Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGroupsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
+void MatterGroupsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Groups Cluster Server Message Sent
  *
@@ -1392,29 +1276,27 @@ void emberAfGroupsClusterClientMessageSentCallback(const chip::MessageSendDestin
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGroupsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterGroupsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Groups Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGroupsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterGroupsClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Groups Cluster Server Tick
  *
@@ -1456,43 +1338,17 @@ void emberAfScenesClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfScenesClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterScenesClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Scenes Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfScenesClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Scenes Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfScenesClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
-
-/** @brief Scenes Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfScenesClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
+void MatterScenesClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Scenes Cluster Server Message Sent
  *
@@ -1524,29 +1380,27 @@ void emberAfScenesClusterClientMessageSentCallback(const chip::MessageSendDestin
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfScenesClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterScenesClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Scenes Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfScenesClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterScenesClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Scenes Cluster Server Tick
  *
@@ -1588,41 +1442,17 @@ void emberAfOnOffClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOnOffClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterOnOffClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief On/Off Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOnOffClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief On/Off Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOnOffClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
-
-/** @brief On/Off Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOnOffClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
+void MatterOnOffClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief On/Off Cluster Server Message Sent
  *
@@ -1654,29 +1484,27 @@ void emberAfOnOffClusterClientMessageSentCallback(const chip::MessageSendDestina
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOnOffClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                   EmberAfAttributeType attributeType, uint16_t size,
-                                                                   uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterOnOffClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief On/Off Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOnOffClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                   EmberAfAttributeType attributeType, uint16_t size,
-                                                                   uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterOnOffClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief On/Off Cluster Server Tick
  *
@@ -1718,43 +1546,17 @@ void emberAfOnOffSwitchConfigurationClusterClientInitCallback(chip::EndpointId e
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOnOffSwitchConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterOnOffSwitchConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief On/off Switch Configuration Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOnOffSwitchConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief On/off Switch Configuration Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOnOffSwitchConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              uint16_t manufacturerCode);
-
-/** @brief On/off Switch Configuration Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOnOffSwitchConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              uint16_t manufacturerCode);
+void MatterOnOffSwitchConfigurationClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief On/off Switch Configuration Cluster Server Message Sent
  *
@@ -1788,31 +1590,25 @@ void emberAfOnOffSwitchConfigurationClusterClientMessageSentCallback(const chip:
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOnOffSwitchConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      EmberAfAttributeType attributeType,
-                                                                                      uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOnOffSwitchConfigurationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief On/off Switch Configuration Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOnOffSwitchConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      EmberAfAttributeType attributeType,
-                                                                                      uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOnOffSwitchConfigurationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief On/off Switch Configuration Cluster Server Tick
  *
@@ -1854,43 +1650,17 @@ void emberAfLevelControlClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfLevelControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterLevelControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Level Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfLevelControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Level Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfLevelControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
-
-/** @brief Level Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfLevelControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
+void MatterLevelControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Level Control Cluster Server Message Sent
  *
@@ -1922,29 +1692,27 @@ void emberAfLevelControlClusterClientMessageSentCallback(const chip::MessageSend
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfLevelControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterLevelControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Level Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfLevelControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterLevelControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Level Control Cluster Server Tick
  *
@@ -1986,43 +1754,17 @@ void emberAfAlarmsClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAlarmsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterAlarmsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Alarms Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAlarmsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Alarms Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAlarmsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
-
-/** @brief Alarms Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAlarmsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
+void MatterAlarmsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Alarms Cluster Server Message Sent
  *
@@ -2054,29 +1796,27 @@ void emberAfAlarmsClusterClientMessageSentCallback(const chip::MessageSendDestin
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAlarmsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterAlarmsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Alarms Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAlarmsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterAlarmsClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Alarms Cluster Server Tick
  *
@@ -2118,41 +1858,17 @@ void emberAfTimeClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTimeClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterTimeClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Time Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTimeClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Time Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTimeClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          uint16_t manufacturerCode);
-
-/** @brief Time Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTimeClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          uint16_t manufacturerCode);
+void MatterTimeClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Time Cluster Server Message Sent
  *
@@ -2184,29 +1900,27 @@ void emberAfTimeClusterClientMessageSentCallback(const chip::MessageSendDestinat
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTimeClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTimeClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                   EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Time Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTimeClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTimeClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                   EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Time Cluster Server Tick
  *
@@ -2248,43 +1962,17 @@ void emberAfBinaryInputBasicClusterClientInitCallback(chip::EndpointId endpoint)
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBinaryInputBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterBinaryInputBasicClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Binary Input (Basic) Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBinaryInputBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Binary Input (Basic) Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBinaryInputBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
-
-/** @brief Binary Input (Basic) Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBinaryInputBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
+void MatterBinaryInputBasicClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Binary Input (Basic) Cluster Server Message Sent
  *
@@ -2318,31 +2006,27 @@ void emberAfBinaryInputBasicClusterClientMessageSentCallback(const chip::Message
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBinaryInputBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBinaryInputBasicClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Binary Input (Basic) Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBinaryInputBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBinaryInputBasicClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Binary Input (Basic) Cluster Server Tick
  *
@@ -2384,43 +2068,17 @@ void emberAfPowerProfileClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPowerProfileClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterPowerProfileClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Power Profile Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPowerProfileClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Power Profile Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPowerProfileClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
-
-/** @brief Power Profile Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPowerProfileClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
+void MatterPowerProfileClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Power Profile Cluster Server Message Sent
  *
@@ -2452,29 +2110,27 @@ void emberAfPowerProfileClusterClientMessageSentCallback(const chip::MessageSend
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPowerProfileClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterPowerProfileClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Power Profile Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPowerProfileClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterPowerProfileClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Power Profile Cluster Server Tick
  *
@@ -2516,43 +2172,17 @@ void emberAfApplianceControlClusterClientInitCallback(chip::EndpointId endpoint)
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterApplianceControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Appliance Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
-
-/** @brief Appliance Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
+void MatterApplianceControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Control Cluster Server Message Sent
  *
@@ -2586,31 +2216,27 @@ void emberAfApplianceControlClusterClientMessageSentCallback(const chip::Message
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterApplianceControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterApplianceControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Control Cluster Server Tick
  *
@@ -2652,43 +2278,17 @@ void emberAfDescriptorClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDescriptorClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterDescriptorClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Descriptor Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDescriptorClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Descriptor Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDescriptorClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
-
-/** @brief Descriptor Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDescriptorClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
+void MatterDescriptorClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Descriptor Cluster Server Message Sent
  *
@@ -2720,29 +2320,27 @@ void emberAfDescriptorClusterClientMessageSentCallback(const chip::MessageSendDe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDescriptorClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterDescriptorClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Descriptor Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDescriptorClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterDescriptorClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Descriptor Cluster Server Tick
  *
@@ -2784,43 +2382,17 @@ void emberAfPollControlClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPollControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterPollControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Poll Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPollControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Poll Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPollControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
-
-/** @brief Poll Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPollControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
+void MatterPollControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Poll Control Cluster Server Message Sent
  *
@@ -2852,29 +2424,27 @@ void emberAfPollControlClusterClientMessageSentCallback(const chip::MessageSendD
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPollControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterPollControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Poll Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPollControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterPollControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Poll Control Cluster Server Tick
  *
@@ -2916,41 +2486,17 @@ void emberAfBasicClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterBasicClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Basic Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Basic Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
-
-/** @brief Basic Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
+void MatterBasicClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Basic Cluster Server Message Sent
  *
@@ -2982,29 +2528,27 @@ void emberAfBasicClusterClientMessageSentCallback(const chip::MessageSendDestina
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                   EmberAfAttributeType attributeType, uint16_t size,
-                                                                   uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBasicClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Basic Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                   EmberAfAttributeType attributeType, uint16_t size,
-                                                                   uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBasicClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Basic Cluster Server Tick
  *
@@ -3046,45 +2590,17 @@ void emberAfOtaSoftwareUpdateProviderClusterClientInitCallback(chip::EndpointId 
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOtaSoftwareUpdateProviderClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                           chip::AttributeId attributeId);
+void MatterOtaSoftwareUpdateProviderClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief OTA Software Update Provider Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOtaSoftwareUpdateProviderClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                           chip::AttributeId attributeId);
-
-/** @brief OTA Software Update Provider Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOtaSoftwareUpdateProviderClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               uint16_t manufacturerCode);
-
-/** @brief OTA Software Update Provider Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOtaSoftwareUpdateProviderClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               uint16_t manufacturerCode);
+void MatterOtaSoftwareUpdateProviderClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief OTA Software Update Provider Cluster Server Message Sent
  *
@@ -3118,31 +2634,25 @@ void emberAfOtaSoftwareUpdateProviderClusterClientMessageSentCallback(const chip
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOtaSoftwareUpdateProviderClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId,
-                                                                                       EmberAfAttributeType attributeType,
-                                                                                       uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateProviderClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief OTA Software Update Provider Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOtaSoftwareUpdateProviderClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId,
-                                                                                       EmberAfAttributeType attributeType,
-                                                                                       uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateProviderClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief OTA Software Update Provider Cluster Server Tick
  *
@@ -3184,45 +2694,17 @@ void emberAfOtaSoftwareUpdateRequestorClusterClientInitCallback(chip::EndpointId
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOtaSoftwareUpdateRequestorClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId);
+void MatterOtaSoftwareUpdateRequestorClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief OTA Software Update Requestor Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOtaSoftwareUpdateRequestorClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId);
-
-/** @brief OTA Software Update Requestor Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOtaSoftwareUpdateRequestorClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                uint16_t manufacturerCode);
-
-/** @brief OTA Software Update Requestor Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOtaSoftwareUpdateRequestorClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                uint16_t manufacturerCode);
+void MatterOtaSoftwareUpdateRequestorClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief OTA Software Update Requestor Cluster Server Message Sent
  *
@@ -3256,31 +2738,25 @@ void emberAfOtaSoftwareUpdateRequestorClusterClientMessageSentCallback(const chi
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOtaSoftwareUpdateRequestorClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        EmberAfAttributeType attributeType,
-                                                                                        uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateRequestorClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief OTA Software Update Requestor Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOtaSoftwareUpdateRequestorClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        EmberAfAttributeType attributeType,
-                                                                                        uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOtaSoftwareUpdateRequestorClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief OTA Software Update Requestor Cluster Server Tick
  *
@@ -3322,43 +2798,17 @@ void emberAfPowerSourceClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPowerSourceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterPowerSourceClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Power Source Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPowerSourceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Power Source Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPowerSourceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
-
-/** @brief Power Source Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPowerSourceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
+void MatterPowerSourceClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Power Source Cluster Server Message Sent
  *
@@ -3390,29 +2840,27 @@ void emberAfPowerSourceClusterClientMessageSentCallback(const chip::MessageSendD
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPowerSourceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterPowerSourceClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Power Source Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPowerSourceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterPowerSourceClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Power Source Cluster Server Tick
  *
@@ -3454,43 +2902,17 @@ void emberAfGeneralCommissioningClusterClientInitCallback(chip::EndpointId endpo
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGeneralCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterGeneralCommissioningClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief General Commissioning Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGeneralCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief General Commissioning Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGeneralCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          uint16_t manufacturerCode);
-
-/** @brief General Commissioning Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGeneralCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          uint16_t manufacturerCode);
+void MatterGeneralCommissioningClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief General Commissioning Cluster Server Message Sent
  *
@@ -3524,31 +2946,25 @@ void emberAfGeneralCommissioningClusterClientMessageSentCallback(const chip::Mes
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGeneralCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterGeneralCommissioningClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief General Commissioning Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGeneralCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterGeneralCommissioningClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief General Commissioning Cluster Server Tick
  *
@@ -3590,43 +3006,17 @@ void emberAfNetworkCommissioningClusterClientInitCallback(chip::EndpointId endpo
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfNetworkCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterNetworkCommissioningClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Network Commissioning Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfNetworkCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Network Commissioning Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfNetworkCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          uint16_t manufacturerCode);
-
-/** @brief Network Commissioning Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfNetworkCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          uint16_t manufacturerCode);
+void MatterNetworkCommissioningClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Network Commissioning Cluster Server Message Sent
  *
@@ -3660,31 +3050,25 @@ void emberAfNetworkCommissioningClusterClientMessageSentCallback(const chip::Mes
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfNetworkCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterNetworkCommissioningClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Network Commissioning Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfNetworkCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterNetworkCommissioningClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Network Commissioning Cluster Server Tick
  *
@@ -3726,43 +3110,17 @@ void emberAfDiagnosticLogsClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDiagnosticLogsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterDiagnosticLogsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Diagnostic Logs Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDiagnosticLogsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Diagnostic Logs Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDiagnosticLogsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    uint16_t manufacturerCode);
-
-/** @brief Diagnostic Logs Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDiagnosticLogsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    uint16_t manufacturerCode);
+void MatterDiagnosticLogsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Diagnostic Logs Cluster Server Message Sent
  *
@@ -3796,31 +3154,27 @@ void emberAfDiagnosticLogsClusterClientMessageSentCallback(const chip::MessageSe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDiagnosticLogsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            EmberAfAttributeType attributeType, uint16_t size,
-                                                                            uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterDiagnosticLogsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Diagnostic Logs Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDiagnosticLogsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            EmberAfAttributeType attributeType, uint16_t size,
-                                                                            uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterDiagnosticLogsClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Diagnostic Logs Cluster Server Tick
  *
@@ -3862,43 +3216,17 @@ void emberAfGeneralDiagnosticsClusterClientInitCallback(chip::EndpointId endpoin
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGeneralDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterGeneralDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief General Diagnostics Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGeneralDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief General Diagnostics Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGeneralDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
-
-/** @brief General Diagnostics Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGeneralDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
+void MatterGeneralDiagnosticsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief General Diagnostics Cluster Server Message Sent
  *
@@ -3932,31 +3260,25 @@ void emberAfGeneralDiagnosticsClusterClientMessageSentCallback(const chip::Messa
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGeneralDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterGeneralDiagnosticsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief General Diagnostics Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGeneralDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterGeneralDiagnosticsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief General Diagnostics Cluster Server Tick
  *
@@ -3998,43 +3320,17 @@ void emberAfSoftwareDiagnosticsClusterClientInitCallback(chip::EndpointId endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSoftwareDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterSoftwareDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Software Diagnostics Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSoftwareDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Software Diagnostics Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSoftwareDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
-
-/** @brief Software Diagnostics Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSoftwareDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
+void MatterSoftwareDiagnosticsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Software Diagnostics Cluster Server Message Sent
  *
@@ -4068,31 +3364,25 @@ void emberAfSoftwareDiagnosticsClusterClientMessageSentCallback(const chip::Mess
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSoftwareDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSoftwareDiagnosticsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Software Diagnostics Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSoftwareDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSoftwareDiagnosticsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Software Diagnostics Cluster Server Tick
  *
@@ -4134,43 +3424,17 @@ void emberAfThreadNetworkDiagnosticsClusterClientInitCallback(chip::EndpointId e
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfThreadNetworkDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterThreadNetworkDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Thread Network Diagnostics Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfThreadNetworkDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Thread Network Diagnostics Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfThreadNetworkDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              uint16_t manufacturerCode);
-
-/** @brief Thread Network Diagnostics Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfThreadNetworkDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              uint16_t manufacturerCode);
+void MatterThreadNetworkDiagnosticsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Thread Network Diagnostics Cluster Server Message Sent
  *
@@ -4204,31 +3468,25 @@ void emberAfThreadNetworkDiagnosticsClusterClientMessageSentCallback(const chip:
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfThreadNetworkDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      EmberAfAttributeType attributeType,
-                                                                                      uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterThreadNetworkDiagnosticsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Thread Network Diagnostics Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfThreadNetworkDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      EmberAfAttributeType attributeType,
-                                                                                      uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterThreadNetworkDiagnosticsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Thread Network Diagnostics Cluster Server Tick
  *
@@ -4270,43 +3528,17 @@ void emberAfWiFiNetworkDiagnosticsClusterClientInitCallback(chip::EndpointId end
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfWiFiNetworkDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterWiFiNetworkDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief WiFi Network Diagnostics Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfWiFiNetworkDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief WiFi Network Diagnostics Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfWiFiNetworkDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
-
-/** @brief WiFi Network Diagnostics Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfWiFiNetworkDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
+void MatterWiFiNetworkDiagnosticsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief WiFi Network Diagnostics Cluster Server Message Sent
  *
@@ -4340,31 +3572,25 @@ void emberAfWiFiNetworkDiagnosticsClusterClientMessageSentCallback(const chip::M
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfWiFiNetworkDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterWiFiNetworkDiagnosticsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief WiFi Network Diagnostics Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfWiFiNetworkDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterWiFiNetworkDiagnosticsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief WiFi Network Diagnostics Cluster Server Tick
  *
@@ -4406,45 +3632,17 @@ void emberAfEthernetNetworkDiagnosticsClusterClientInitCallback(chip::EndpointId
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfEthernetNetworkDiagnosticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId);
+void MatterEthernetNetworkDiagnosticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ethernet Network Diagnostics Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfEthernetNetworkDiagnosticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId);
-
-/** @brief Ethernet Network Diagnostics Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfEthernetNetworkDiagnosticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                uint16_t manufacturerCode);
-
-/** @brief Ethernet Network Diagnostics Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfEthernetNetworkDiagnosticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                uint16_t manufacturerCode);
+void MatterEthernetNetworkDiagnosticsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ethernet Network Diagnostics Cluster Server Message Sent
  *
@@ -4478,31 +3676,25 @@ void emberAfEthernetNetworkDiagnosticsClusterClientMessageSentCallback(const chi
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfEthernetNetworkDiagnosticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        EmberAfAttributeType attributeType,
-                                                                                        uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterEthernetNetworkDiagnosticsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ethernet Network Diagnostics Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfEthernetNetworkDiagnosticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        EmberAfAttributeType attributeType,
-                                                                                        uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterEthernetNetworkDiagnosticsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ethernet Network Diagnostics Cluster Server Tick
  *
@@ -4544,43 +3736,17 @@ void emberAfBridgedDeviceBasicClusterClientInitCallback(chip::EndpointId endpoin
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBridgedDeviceBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterBridgedDeviceBasicClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bridged Device Basic Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBridgedDeviceBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Bridged Device Basic Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBridgedDeviceBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
-
-/** @brief Bridged Device Basic Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBridgedDeviceBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
+void MatterBridgedDeviceBasicClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bridged Device Basic Cluster Server Message Sent
  *
@@ -4614,31 +3780,25 @@ void emberAfBridgedDeviceBasicClusterClientMessageSentCallback(const chip::Messa
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBridgedDeviceBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBridgedDeviceBasicClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bridged Device Basic Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBridgedDeviceBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBridgedDeviceBasicClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bridged Device Basic Cluster Server Tick
  *
@@ -4680,43 +3840,17 @@ void emberAfSwitchClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSwitchClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterSwitchClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Switch Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSwitchClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Switch Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSwitchClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
-
-/** @brief Switch Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSwitchClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
+void MatterSwitchClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Switch Cluster Server Message Sent
  *
@@ -4748,29 +3882,27 @@ void emberAfSwitchClusterClientMessageSentCallback(const chip::MessageSendDestin
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSwitchClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterSwitchClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Switch Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSwitchClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterSwitchClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Switch Cluster Server Tick
  *
@@ -4812,45 +3944,17 @@ void emberAfAdministratorCommissioningClusterClientInitCallback(chip::EndpointId
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAdministratorCommissioningClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId);
+void MatterAdministratorCommissioningClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief AdministratorCommissioning Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAdministratorCommissioningClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId);
-
-/** @brief AdministratorCommissioning Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAdministratorCommissioningClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                uint16_t manufacturerCode);
-
-/** @brief AdministratorCommissioning Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAdministratorCommissioningClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                uint16_t manufacturerCode);
+void MatterAdministratorCommissioningClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief AdministratorCommissioning Cluster Server Message Sent
  *
@@ -4884,31 +3988,25 @@ void emberAfAdministratorCommissioningClusterClientMessageSentCallback(const chi
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAdministratorCommissioningClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        EmberAfAttributeType attributeType,
-                                                                                        uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterAdministratorCommissioningClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief AdministratorCommissioning Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAdministratorCommissioningClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        EmberAfAttributeType attributeType,
-                                                                                        uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterAdministratorCommissioningClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief AdministratorCommissioning Cluster Server Tick
  *
@@ -4950,43 +4048,17 @@ void emberAfOperationalCredentialsClusterClientInitCallback(chip::EndpointId end
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOperationalCredentialsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterOperationalCredentialsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Operational Credentials Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOperationalCredentialsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Operational Credentials Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOperationalCredentialsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
-
-/** @brief Operational Credentials Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOperationalCredentialsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
+void MatterOperationalCredentialsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Operational Credentials Cluster Server Message Sent
  *
@@ -5020,31 +4092,25 @@ void emberAfOperationalCredentialsClusterClientMessageSentCallback(const chip::M
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOperationalCredentialsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOperationalCredentialsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Operational Credentials Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOperationalCredentialsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOperationalCredentialsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Operational Credentials Cluster Server Tick
  *
@@ -5086,43 +4152,17 @@ void emberAfFixedLabelClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFixedLabelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterFixedLabelClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fixed Label Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFixedLabelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Fixed Label Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFixedLabelClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
-
-/** @brief Fixed Label Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFixedLabelClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
+void MatterFixedLabelClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fixed Label Cluster Server Message Sent
  *
@@ -5154,29 +4194,27 @@ void emberAfFixedLabelClusterClientMessageSentCallback(const chip::MessageSendDe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFixedLabelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFixedLabelClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fixed Label Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFixedLabelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFixedLabelClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fixed Label Cluster Server Tick
  *
@@ -5218,43 +4256,17 @@ void emberAfShadeConfigurationClusterClientInitCallback(chip::EndpointId endpoin
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfShadeConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterShadeConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Shade Configuration Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfShadeConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Shade Configuration Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfShadeConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
-
-/** @brief Shade Configuration Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfShadeConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
+void MatterShadeConfigurationClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Shade Configuration Cluster Server Message Sent
  *
@@ -5288,31 +4300,25 @@ void emberAfShadeConfigurationClusterClientMessageSentCallback(const chip::Messa
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfShadeConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterShadeConfigurationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Shade Configuration Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfShadeConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterShadeConfigurationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Shade Configuration Cluster Server Tick
  *
@@ -5354,43 +4360,17 @@ void emberAfDoorLockClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDoorLockClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterDoorLockClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Door Lock Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDoorLockClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Door Lock Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDoorLockClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              uint16_t manufacturerCode);
-
-/** @brief Door Lock Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDoorLockClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              uint16_t manufacturerCode);
+void MatterDoorLockClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Door Lock Cluster Server Message Sent
  *
@@ -5422,29 +4402,27 @@ void emberAfDoorLockClusterClientMessageSentCallback(const chip::MessageSendDest
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDoorLockClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                      EmberAfAttributeType attributeType, uint16_t size,
-                                                                      uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterDoorLockClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Door Lock Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDoorLockClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                      EmberAfAttributeType attributeType, uint16_t size,
-                                                                      uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterDoorLockClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Door Lock Cluster Server Tick
  *
@@ -5486,43 +4464,17 @@ void emberAfWindowCoveringClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfWindowCoveringClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterWindowCoveringClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Window Covering Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfWindowCoveringClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Window Covering Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfWindowCoveringClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    uint16_t manufacturerCode);
-
-/** @brief Window Covering Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfWindowCoveringClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    uint16_t manufacturerCode);
+void MatterWindowCoveringClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Window Covering Cluster Server Message Sent
  *
@@ -5556,31 +4508,27 @@ void emberAfWindowCoveringClusterClientMessageSentCallback(const chip::MessageSe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfWindowCoveringClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            EmberAfAttributeType attributeType, uint16_t size,
-                                                                            uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterWindowCoveringClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Window Covering Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfWindowCoveringClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            EmberAfAttributeType attributeType, uint16_t size,
-                                                                            uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterWindowCoveringClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Window Covering Cluster Server Tick
  *
@@ -5622,43 +4570,17 @@ void emberAfBarrierControlClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBarrierControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterBarrierControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Barrier Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBarrierControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Barrier Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBarrierControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    uint16_t manufacturerCode);
-
-/** @brief Barrier Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBarrierControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    uint16_t manufacturerCode);
+void MatterBarrierControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Barrier Control Cluster Server Message Sent
  *
@@ -5692,31 +4614,27 @@ void emberAfBarrierControlClusterClientMessageSentCallback(const chip::MessageSe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBarrierControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            EmberAfAttributeType attributeType, uint16_t size,
-                                                                            uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBarrierControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Barrier Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBarrierControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            EmberAfAttributeType attributeType, uint16_t size,
-                                                                            uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBarrierControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                             EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Barrier Control Cluster Server Tick
  *
@@ -5758,45 +4676,17 @@ void emberAfPumpConfigurationAndControlClusterClientInitCallback(chip::EndpointI
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPumpConfigurationAndControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId);
+void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Pump Configuration and Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPumpConfigurationAndControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId);
-
-/** @brief Pump Configuration and Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPumpConfigurationAndControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 uint16_t manufacturerCode);
-
-/** @brief Pump Configuration and Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPumpConfigurationAndControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 uint16_t manufacturerCode);
+void MatterPumpConfigurationAndControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Pump Configuration and Control Cluster Server Message Sent
  *
@@ -5830,31 +4720,25 @@ void emberAfPumpConfigurationAndControlClusterClientMessageSentCallback(const ch
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPumpConfigurationAndControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         EmberAfAttributeType attributeType,
-                                                                                         uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Pump Configuration and Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPumpConfigurationAndControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         EmberAfAttributeType attributeType,
-                                                                                         uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Pump Configuration and Control Cluster Server Tick
  *
@@ -5896,43 +4780,17 @@ void emberAfThermostatClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfThermostatClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterThermostatClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Thermostat Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfThermostatClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Thermostat Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfThermostatClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
-
-/** @brief Thermostat Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfThermostatClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
+void MatterThermostatClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Thermostat Cluster Server Message Sent
  *
@@ -5964,29 +4822,27 @@ void emberAfThermostatClusterClientMessageSentCallback(const chip::MessageSendDe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterThermostatClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Thermostat Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfThermostatClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterThermostatClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Thermostat Cluster Server Tick
  *
@@ -6028,43 +4884,17 @@ void emberAfFanControlClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFanControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterFanControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fan Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFanControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Fan Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFanControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
-
-/** @brief Fan Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFanControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
+void MatterFanControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fan Control Cluster Server Message Sent
  *
@@ -6096,29 +4926,27 @@ void emberAfFanControlClusterClientMessageSentCallback(const chip::MessageSendDe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFanControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFanControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fan Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFanControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFanControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fan Control Cluster Server Tick
  *
@@ -6160,43 +4988,17 @@ void emberAfDehumidificationControlClusterClientInitCallback(chip::EndpointId en
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDehumidificationControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterDehumidificationControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Dehumidification Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDehumidificationControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Dehumidification Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDehumidificationControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
-
-/** @brief Dehumidification Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDehumidificationControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
+void MatterDehumidificationControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Dehumidification Control Cluster Server Message Sent
  *
@@ -6230,31 +5032,25 @@ void emberAfDehumidificationControlClusterClientMessageSentCallback(const chip::
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDehumidificationControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterDehumidificationControlClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Dehumidification Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDehumidificationControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterDehumidificationControlClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Dehumidification Control Cluster Server Tick
  *
@@ -6296,43 +5092,19 @@ void emberAfThermostatUserInterfaceConfigurationClusterClientInitCallback(chip::
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfThermostatUserInterfaceConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId);
+void MatterThermostatUserInterfaceConfigurationClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Thermostat User Interface Configuration Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfThermostatUserInterfaceConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId);
-
-/** @brief Thermostat User Interface Configuration Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfThermostatUserInterfaceConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Thermostat User Interface Configuration Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfThermostatUserInterfaceConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterThermostatUserInterfaceConfigurationClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Thermostat User Interface Configuration Cluster Server Message Sent
  *
@@ -6366,27 +5138,25 @@ void emberAfThermostatUserInterfaceConfigurationClusterClientMessageSentCallback
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfThermostatUserInterfaceConfigurationClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterThermostatUserInterfaceConfigurationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Thermostat User Interface Configuration Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfThermostatUserInterfaceConfigurationClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterThermostatUserInterfaceConfigurationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Thermostat User Interface Configuration Cluster Server Tick
  *
@@ -6428,43 +5198,17 @@ void emberAfColorControlClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfColorControlClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterColorControlClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Color Control Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfColorControlClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Color Control Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfColorControlClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
-
-/** @brief Color Control Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfColorControlClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
+void MatterColorControlClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Color Control Cluster Server Message Sent
  *
@@ -6496,29 +5240,27 @@ void emberAfColorControlClusterClientMessageSentCallback(const chip::MessageSend
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfColorControlClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterColorControlClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Color Control Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfColorControlClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterColorControlClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Color Control Cluster Server Tick
  *
@@ -6560,43 +5302,17 @@ void emberAfBallastConfigurationClusterClientInitCallback(chip::EndpointId endpo
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBallastConfigurationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterBallastConfigurationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ballast Configuration Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBallastConfigurationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Ballast Configuration Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBallastConfigurationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          uint16_t manufacturerCode);
-
-/** @brief Ballast Configuration Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBallastConfigurationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          uint16_t manufacturerCode);
+void MatterBallastConfigurationClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ballast Configuration Cluster Server Message Sent
  *
@@ -6630,31 +5346,25 @@ void emberAfBallastConfigurationClusterClientMessageSentCallback(const chip::Mes
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBallastConfigurationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBallastConfigurationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ballast Configuration Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBallastConfigurationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  EmberAfAttributeType attributeType, uint16_t size,
-                                                                                  uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBallastConfigurationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ballast Configuration Cluster Server Tick
  *
@@ -6696,43 +5406,17 @@ void emberAfIlluminanceMeasurementClusterClientInitCallback(chip::EndpointId end
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIlluminanceMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterIlluminanceMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Illuminance Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIlluminanceMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Illuminance Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIlluminanceMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
-
-/** @brief Illuminance Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIlluminanceMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
+void MatterIlluminanceMeasurementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Illuminance Measurement Cluster Server Message Sent
  *
@@ -6766,31 +5450,25 @@ void emberAfIlluminanceMeasurementClusterClientMessageSentCallback(const chip::M
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIlluminanceMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterIlluminanceMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Illuminance Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIlluminanceMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterIlluminanceMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Illuminance Measurement Cluster Server Tick
  *
@@ -6832,43 +5510,17 @@ void emberAfIlluminanceLevelSensingClusterClientInitCallback(chip::EndpointId en
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIlluminanceLevelSensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterIlluminanceLevelSensingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Illuminance Level Sensing Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIlluminanceLevelSensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Illuminance Level Sensing Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIlluminanceLevelSensingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
-
-/** @brief Illuminance Level Sensing Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIlluminanceLevelSensingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
+void MatterIlluminanceLevelSensingClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Illuminance Level Sensing Cluster Server Message Sent
  *
@@ -6902,31 +5554,25 @@ void emberAfIlluminanceLevelSensingClusterClientMessageSentCallback(const chip::
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIlluminanceLevelSensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterIlluminanceLevelSensingClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Illuminance Level Sensing Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIlluminanceLevelSensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterIlluminanceLevelSensingClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Illuminance Level Sensing Cluster Server Tick
  *
@@ -6968,43 +5614,17 @@ void emberAfTemperatureMeasurementClusterClientInitCallback(chip::EndpointId end
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTemperatureMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterTemperatureMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Temperature Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTemperatureMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Temperature Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTemperatureMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
-
-/** @brief Temperature Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTemperatureMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            uint16_t manufacturerCode);
+void MatterTemperatureMeasurementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Temperature Measurement Cluster Server Message Sent
  *
@@ -7038,31 +5658,25 @@ void emberAfTemperatureMeasurementClusterClientMessageSentCallback(const chip::M
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTemperatureMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterTemperatureMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Temperature Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTemperatureMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId,
-                                                                                    EmberAfAttributeType attributeType,
-                                                                                    uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterTemperatureMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Temperature Measurement Cluster Server Tick
  *
@@ -7104,43 +5718,17 @@ void emberAfPressureMeasurementClusterClientInitCallback(chip::EndpointId endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPressureMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterPressureMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Pressure Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfPressureMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Pressure Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPressureMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
-
-/** @brief Pressure Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfPressureMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
+void MatterPressureMeasurementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Pressure Measurement Cluster Server Message Sent
  *
@@ -7174,31 +5762,25 @@ void emberAfPressureMeasurementClusterClientMessageSentCallback(const chip::Mess
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPressureMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterPressureMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Pressure Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfPressureMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterPressureMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Pressure Measurement Cluster Server Tick
  *
@@ -7240,43 +5822,17 @@ void emberAfFlowMeasurementClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFlowMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterFlowMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Flow Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFlowMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Flow Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFlowMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     uint16_t manufacturerCode);
-
-/** @brief Flow Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFlowMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     uint16_t manufacturerCode);
+void MatterFlowMeasurementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Flow Measurement Cluster Server Message Sent
  *
@@ -7310,31 +5866,27 @@ void emberAfFlowMeasurementClusterClientMessageSentCallback(const chip::MessageS
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFlowMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             EmberAfAttributeType attributeType, uint16_t size,
-                                                                             uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFlowMeasurementClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Flow Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFlowMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             EmberAfAttributeType attributeType, uint16_t size,
-                                                                             uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFlowMeasurementClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Flow Measurement Cluster Server Tick
  *
@@ -7376,45 +5928,17 @@ void emberAfRelativeHumidityMeasurementClusterClientInitCallback(chip::EndpointI
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfRelativeHumidityMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId);
+void MatterRelativeHumidityMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Relative Humidity Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfRelativeHumidityMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId);
-
-/** @brief Relative Humidity Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfRelativeHumidityMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 uint16_t manufacturerCode);
-
-/** @brief Relative Humidity Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfRelativeHumidityMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 uint16_t manufacturerCode);
+void MatterRelativeHumidityMeasurementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Relative Humidity Measurement Cluster Server Message Sent
  *
@@ -7448,31 +5972,25 @@ void emberAfRelativeHumidityMeasurementClusterClientMessageSentCallback(const ch
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         EmberAfAttributeType attributeType,
-                                                                                         uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterRelativeHumidityMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Relative Humidity Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         EmberAfAttributeType attributeType,
-                                                                                         uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterRelativeHumidityMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Relative Humidity Measurement Cluster Server Tick
  *
@@ -7514,43 +6032,17 @@ void emberAfOccupancySensingClusterClientInitCallback(chip::EndpointId endpoint)
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOccupancySensingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterOccupancySensingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Occupancy Sensing Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOccupancySensingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Occupancy Sensing Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOccupancySensingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
-
-/** @brief Occupancy Sensing Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOccupancySensingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
+void MatterOccupancySensingClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Occupancy Sensing Cluster Server Message Sent
  *
@@ -7584,31 +6076,27 @@ void emberAfOccupancySensingClusterClientMessageSentCallback(const chip::Message
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOccupancySensingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterOccupancySensingClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Occupancy Sensing Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOccupancySensingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterOccupancySensingClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Occupancy Sensing Cluster Server Tick
  *
@@ -7650,43 +6138,19 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientInitCallback(chip
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId);
+void MatterCarbonMonoxideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId);
-
-/** @brief Carbon Monoxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Carbon Monoxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfCarbonMonoxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterCarbonMonoxideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Message Sent
  *
@@ -7720,27 +6184,25 @@ void emberAfCarbonMonoxideConcentrationMeasurementClusterClientMessageSentCallba
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterCarbonMonoxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Carbon Monoxide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterCarbonMonoxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Carbon Monoxide Concentration Measurement Cluster Server Tick
  *
@@ -7782,43 +6244,19 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientInitCallback(chip:
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId);
+void MatterCarbonDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId);
-
-/** @brief Carbon Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfCarbonDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Carbon Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfCarbonDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterCarbonDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Message Sent
  *
@@ -7852,27 +6290,25 @@ void emberAfCarbonDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterCarbonDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Carbon Dioxide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterCarbonDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Carbon Dioxide Concentration Measurement Cluster Server Tick
  *
@@ -7914,45 +6350,19 @@ void emberAfEthyleneConcentrationMeasurementClusterClientInitCallback(chip::Endp
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
+void MatterEthyleneConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ethylene Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
-
-/** @brief Ethylene Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfEthyleneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
-
-/** @brief Ethylene Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfEthyleneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
+void MatterEthyleneConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ethylene Concentration Measurement Cluster Server Message Sent
  *
@@ -7986,31 +6396,25 @@ void emberAfEthyleneConcentrationMeasurementClusterClientMessageSentCallback(con
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterEthyleneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ethylene Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfEthyleneConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterEthyleneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ethylene Concentration Measurement Cluster Server Tick
  *
@@ -8052,43 +6456,19 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientInitCallback(chip:
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId);
+void MatterEthyleneOxideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId);
-
-/** @brief Ethylene Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfEthyleneOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Ethylene Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfEthyleneOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterEthyleneOxideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Message Sent
  *
@@ -8122,27 +6502,25 @@ void emberAfEthyleneOxideConcentrationMeasurementClusterClientMessageSentCallbac
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterEthyleneOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ethylene Oxide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfEthyleneOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterEthyleneOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ethylene Oxide Concentration Measurement Cluster Server Tick
  *
@@ -8184,45 +6562,19 @@ void emberAfHydrogenConcentrationMeasurementClusterClientInitCallback(chip::Endp
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
+void MatterHydrogenConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Hydrogen Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
-
-/** @brief Hydrogen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfHydrogenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
-
-/** @brief Hydrogen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfHydrogenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
+void MatterHydrogenConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Hydrogen Concentration Measurement Cluster Server Message Sent
  *
@@ -8256,31 +6608,25 @@ void emberAfHydrogenConcentrationMeasurementClusterClientMessageSentCallback(con
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterHydrogenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Hydrogen Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfHydrogenConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterHydrogenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Hydrogen Concentration Measurement Cluster Server Tick
  *
@@ -8322,43 +6668,19 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientInitCallback(ch
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId);
+void MatterHydrogenSulphideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId);
-
-/** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfHydrogenSulphideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterHydrogenSulphideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Message Sent
  *
@@ -8392,27 +6714,25 @@ void emberAfHydrogenSulphideConcentrationMeasurementClusterClientMessageSentCall
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterHydrogenSulphideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfHydrogenSulphideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterHydrogenSulphideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Hydrogen Sulphide Concentration Measurement Cluster Server Tick
  *
@@ -8454,43 +6774,19 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientInitCallback(chip::E
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId);
+void MatterNitricOxideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId);
-
-/** @brief Nitric Oxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfNitricOxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Nitric Oxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfNitricOxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterNitricOxideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Message Sent
  *
@@ -8524,31 +6820,25 @@ void emberAfNitricOxideConcentrationMeasurementClusterClientMessageSentCallback(
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 EmberAfAttributeType attributeType,
-                                                                                                 uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterNitricOxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Nitric Oxide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfNitricOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 EmberAfAttributeType attributeType,
-                                                                                                 uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterNitricOxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Nitric Oxide Concentration Measurement Cluster Server Tick
  *
@@ -8590,43 +6880,19 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientInitCallback(chi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId);
+void MatterNitrogenDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId);
-
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfNitrogenDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterNitrogenDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Message Sent
  *
@@ -8660,27 +6926,25 @@ void emberAfNitrogenDioxideConcentrationMeasurementClusterClientMessageSentCallb
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterNitrogenDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterNitrogenDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Nitrogen Dioxide Concentration Measurement Cluster Server Tick
  *
@@ -8722,45 +6986,19 @@ void emberAfOxygenConcentrationMeasurementClusterClientInitCallback(chip::Endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
+void MatterOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Oxygen Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
-
-/** @brief Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
-
-/** @brief Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
+void MatterOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Oxygen Concentration Measurement Cluster Server Message Sent
  *
@@ -8794,31 +7032,25 @@ void emberAfOxygenConcentrationMeasurementClusterClientMessageSentCallback(const
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Oxygen Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Oxygen Concentration Measurement Cluster Server Tick
  *
@@ -8860,45 +7092,19 @@ void emberAfOzoneConcentrationMeasurementClusterClientInitCallback(chip::Endpoin
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId);
+void MatterOzoneConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ozone Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId);
-
-/** @brief Ozone Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOzoneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                   chip::AttributeId attributeId,
-                                                                                                   uint16_t manufacturerCode);
-
-/** @brief Ozone Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfOzoneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                   chip::AttributeId attributeId,
-                                                                                                   uint16_t manufacturerCode);
+void MatterOzoneConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Ozone Concentration Measurement Cluster Server Message Sent
  *
@@ -8932,31 +7138,25 @@ void emberAfOzoneConcentrationMeasurementClusterClientMessageSentCallback(const 
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                           chip::AttributeId attributeId,
-                                                                                           EmberAfAttributeType attributeType,
-                                                                                           uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOzoneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ozone Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                           chip::AttributeId attributeId,
-                                                                                           EmberAfAttributeType attributeType,
-                                                                                           uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterOzoneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Ozone Concentration Measurement Cluster Server Tick
  *
@@ -8998,43 +7198,19 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientInitCallback(chip:
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId);
+void MatterSulfurDioxideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId);
-
-/** @brief Sulfur Dioxide Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSulfurDioxideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Sulfur Dioxide Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSulfurDioxideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterSulfurDioxideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Message Sent
  *
@@ -9068,27 +7244,25 @@ void emberAfSulfurDioxideConcentrationMeasurementClusterClientMessageSentCallbac
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSulfurDioxideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSulfurDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSulfurDioxideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sulfur Dioxide Concentration Measurement Cluster Server Tick
  *
@@ -9130,43 +7304,19 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientInitCallback(chi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId);
+void MatterDissolvedOxygenConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId);
-
-/** @brief Dissolved Oxygen Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Dissolved Oxygen Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfDissolvedOxygenConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterDissolvedOxygenConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Message Sent
  *
@@ -9200,27 +7350,25 @@ void emberAfDissolvedOxygenConcentrationMeasurementClusterClientMessageSentCallb
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterDissolvedOxygenConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfDissolvedOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterDissolvedOxygenConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Dissolved Oxygen Concentration Measurement Cluster Server Tick
  *
@@ -9262,45 +7410,19 @@ void emberAfBromateConcentrationMeasurementClusterClientInitCallback(chip::Endpo
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBromateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId);
+void MatterBromateConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bromate Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBromateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId);
-
-/** @brief Bromate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBromateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                     chip::AttributeId attributeId,
-                                                                                                     uint16_t manufacturerCode);
-
-/** @brief Bromate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBromateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                     chip::AttributeId attributeId,
-                                                                                                     uint16_t manufacturerCode);
+void MatterBromateConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bromate Concentration Measurement Cluster Server Message Sent
  *
@@ -9334,31 +7456,25 @@ void emberAfBromateConcentrationMeasurementClusterClientMessageSentCallback(cons
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBromateConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             EmberAfAttributeType attributeType,
-                                                                                             uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBromateConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bromate Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBromateConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             EmberAfAttributeType attributeType,
-                                                                                             uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBromateConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bromate Concentration Measurement Cluster Server Tick
  *
@@ -9400,43 +7516,19 @@ void emberAfChloraminesConcentrationMeasurementClusterClientInitCallback(chip::E
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId);
+void MatterChloraminesConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chloramines Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId);
-
-/** @brief Chloramines Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChloraminesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Chloramines Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChloraminesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterChloraminesConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chloramines Concentration Measurement Cluster Server Message Sent
  *
@@ -9470,31 +7562,25 @@ void emberAfChloraminesConcentrationMeasurementClusterClientMessageSentCallback(
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 EmberAfAttributeType attributeType,
-                                                                                                 uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterChloraminesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chloramines Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChloraminesConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                 chip::AttributeId attributeId,
-                                                                                                 EmberAfAttributeType attributeType,
-                                                                                                 uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterChloraminesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chloramines Concentration Measurement Cluster Server Tick
  *
@@ -9536,45 +7622,19 @@ void emberAfChlorineConcentrationMeasurementClusterClientInitCallback(chip::Endp
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
+void MatterChlorineConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chlorine Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
-
-/** @brief Chlorine Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChlorineConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
-
-/** @brief Chlorine Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChlorineConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
+void MatterChlorineConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chlorine Concentration Measurement Cluster Server Message Sent
  *
@@ -9608,31 +7668,25 @@ void emberAfChlorineConcentrationMeasurementClusterClientMessageSentCallback(con
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChlorineConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterChlorineConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chlorine Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChlorineConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterChlorineConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chlorine Concentration Measurement Cluster Server Tick
  *
@@ -9674,43 +7728,19 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientInitCallba
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId);
+void MatterFecalColiformAndEColiConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId);
-
-/** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterFecalColiformAndEColiConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Message Sent
  *
@@ -9744,27 +7774,27 @@ void emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientMessageSen
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFecalColiformAndEColiConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFecalColiformAndEColiConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterFecalColiformAndEColiConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fecal coliform and E. Coli Concentration Measurement Cluster Server Tick
  *
@@ -9806,45 +7836,19 @@ void emberAfFluorideConcentrationMeasurementClusterClientInitCallback(chip::Endp
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
+void MatterFluorideConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fluoride Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId);
-
-/** @brief Fluoride Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFluorideConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
-
-/** @brief Fluoride Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfFluorideConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                      chip::AttributeId attributeId,
-                                                                                                      uint16_t manufacturerCode);
+void MatterFluorideConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Fluoride Concentration Measurement Cluster Server Message Sent
  *
@@ -9878,31 +7882,25 @@ void emberAfFluorideConcentrationMeasurementClusterClientMessageSentCallback(con
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFluorideConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterFluorideConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fluoride Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfFluorideConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              EmberAfAttributeType attributeType,
-                                                                                              uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterFluorideConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Fluoride Concentration Measurement Cluster Server Tick
  *
@@ -9944,43 +7942,19 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientInitCallback(chi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId);
+void MatterHaloaceticAcidsConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId);
-
-/** @brief Haloacetic Acids Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Haloacetic Acids Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterHaloaceticAcidsConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Message Sent
  *
@@ -10014,27 +7988,25 @@ void emberAfHaloaceticAcidsConcentrationMeasurementClusterClientMessageSentCallb
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterHaloaceticAcidsConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Haloacetic Acids Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfHaloaceticAcidsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterHaloaceticAcidsConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Haloacetic Acids Concentration Measurement Cluster Server Tick
  *
@@ -10076,43 +8048,19 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientInitCallbac
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId);
+void MatterTotalTrihalomethanesConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId);
-
-/** @brief Total Trihalomethanes Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Total Trihalomethanes Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterTotalTrihalomethanesConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Message Sent
  *
@@ -10146,27 +8094,27 @@ void emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientMessageSent
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTotalTrihalomethanesConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTotalTrihalomethanesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTotalTrihalomethanesConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Total Trihalomethanes Concentration Measurement Cluster Server Tick
  *
@@ -10208,43 +8156,19 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientInitCallba
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId);
+void MatterTotalColiformBacteriaConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId);
-
-/** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterTotalColiformBacteriaConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Message Sent
  *
@@ -10278,27 +8202,27 @@ void emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientMessageSen
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTotalColiformBacteriaConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTotalColiformBacteriaConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTotalColiformBacteriaConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Total Coliform Bacteria Concentration Measurement Cluster Server Tick
  *
@@ -10340,43 +8264,19 @@ void emberAfTurbidityConcentrationMeasurementClusterClientInitCallback(chip::End
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId);
+void MatterTurbidityConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Turbidity Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId);
-
-/** @brief Turbidity Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTurbidityConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Turbidity Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTurbidityConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterTurbidityConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Turbidity Concentration Measurement Cluster Server Message Sent
  *
@@ -10410,31 +8310,25 @@ void emberAfTurbidityConcentrationMeasurementClusterClientMessageSentCallback(co
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               EmberAfAttributeType attributeType,
-                                                                                               uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterTurbidityConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Turbidity Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTurbidityConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               EmberAfAttributeType attributeType,
-                                                                                               uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterTurbidityConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Turbidity Concentration Measurement Cluster Server Tick
  *
@@ -10476,45 +8370,19 @@ void emberAfCopperConcentrationMeasurementClusterClientInitCallback(chip::Endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfCopperConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
+void MatterCopperConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Copper Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfCopperConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
-
-/** @brief Copper Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfCopperConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
-
-/** @brief Copper Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfCopperConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
+void MatterCopperConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Copper Concentration Measurement Cluster Server Message Sent
  *
@@ -10548,31 +8416,25 @@ void emberAfCopperConcentrationMeasurementClusterClientMessageSentCallback(const
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfCopperConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterCopperConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Copper Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfCopperConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterCopperConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Copper Concentration Measurement Cluster Server Tick
  *
@@ -10614,45 +8476,19 @@ void emberAfLeadConcentrationMeasurementClusterClientInitCallback(chip::Endpoint
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfLeadConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId);
+void MatterLeadConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Lead Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfLeadConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId);
-
-/** @brief Lead Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfLeadConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                  chip::AttributeId attributeId,
-                                                                                                  uint16_t manufacturerCode);
-
-/** @brief Lead Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfLeadConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                  chip::AttributeId attributeId,
-                                                                                                  uint16_t manufacturerCode);
+void MatterLeadConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Lead Concentration Measurement Cluster Server Message Sent
  *
@@ -10686,31 +8522,25 @@ void emberAfLeadConcentrationMeasurementClusterClientMessageSentCallback(const c
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfLeadConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          EmberAfAttributeType attributeType,
-                                                                                          uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterLeadConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Lead Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfLeadConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                          chip::AttributeId attributeId,
-                                                                                          EmberAfAttributeType attributeType,
-                                                                                          uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterLeadConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Lead Concentration Measurement Cluster Server Tick
  *
@@ -10752,43 +8582,19 @@ void emberAfManganeseConcentrationMeasurementClusterClientInitCallback(chip::End
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId);
+void MatterManganeseConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Manganese Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId);
-
-/** @brief Manganese Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfManganeseConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Manganese Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfManganeseConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterManganeseConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Manganese Concentration Measurement Cluster Server Message Sent
  *
@@ -10822,31 +8628,25 @@ void emberAfManganeseConcentrationMeasurementClusterClientMessageSentCallback(co
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfManganeseConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               EmberAfAttributeType attributeType,
-                                                                                               uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterManganeseConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Manganese Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfManganeseConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               EmberAfAttributeType attributeType,
-                                                                                               uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterManganeseConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Manganese Concentration Measurement Cluster Server Tick
  *
@@ -10888,45 +8688,19 @@ void emberAfSulfateConcentrationMeasurementClusterClientInitCallback(chip::Endpo
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId);
+void MatterSulfateConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sulfate Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId);
-
-/** @brief Sulfate Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSulfateConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                     chip::AttributeId attributeId,
-                                                                                                     uint16_t manufacturerCode);
-
-/** @brief Sulfate Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSulfateConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                     chip::AttributeId attributeId,
-                                                                                                     uint16_t manufacturerCode);
+void MatterSulfateConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sulfate Concentration Measurement Cluster Server Message Sent
  *
@@ -10960,31 +8734,25 @@ void emberAfSulfateConcentrationMeasurementClusterClientMessageSentCallback(cons
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSulfateConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             EmberAfAttributeType attributeType,
-                                                                                             uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSulfateConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sulfate Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSulfateConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             EmberAfAttributeType attributeType,
-                                                                                             uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSulfateConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sulfate Concentration Measurement Cluster Server Tick
  *
@@ -11026,43 +8794,19 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientInitCallbac
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId);
+void MatterBromodichloromethaneConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId);
-
-/** @brief Bromodichloromethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Bromodichloromethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBromodichloromethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterBromodichloromethaneConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Message Sent
  *
@@ -11096,27 +8840,27 @@ void emberAfBromodichloromethaneConcentrationMeasurementClusterClientMessageSent
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBromodichloromethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bromodichloromethane Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBromodichloromethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBromodichloromethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bromodichloromethane Concentration Measurement Cluster Server Tick
  *
@@ -11158,43 +8902,19 @@ void emberAfBromoformConcentrationMeasurementClusterClientInitCallback(chip::End
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId);
+void MatterBromoformConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bromoform Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId);
-
-/** @brief Bromoform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBromoformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Bromoform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBromoformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterBromoformConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Bromoform Concentration Measurement Cluster Server Message Sent
  *
@@ -11228,31 +8948,25 @@ void emberAfBromoformConcentrationMeasurementClusterClientMessageSentCallback(co
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBromoformConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               EmberAfAttributeType attributeType,
-                                                                                               uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBromoformConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bromoform Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBromoformConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               EmberAfAttributeType attributeType,
-                                                                                               uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterBromoformConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Bromoform Concentration Measurement Cluster Server Tick
  *
@@ -11294,43 +9008,19 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientInitCallbac
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId);
+void MatterChlorodibromomethaneConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId);
-
-/** @brief Chlorodibromomethane Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Chlorodibromomethane Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterChlorodibromomethaneConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Message Sent
  *
@@ -11364,27 +9054,27 @@ void emberAfChlorodibromomethaneConcentrationMeasurementClusterClientMessageSent
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterChlorodibromomethaneConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChlorodibromomethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterChlorodibromomethaneConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chlorodibromomethane Concentration Measurement Cluster Server Tick
  *
@@ -11426,43 +9116,19 @@ void emberAfChloroformConcentrationMeasurementClusterClientInitCallback(chip::En
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId);
+void MatterChloroformConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chloroform Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                    chip::AttributeId attributeId);
-
-/** @brief Chloroform Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChloroformConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
-
-/** @brief Chloroform Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfChloroformConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(
-    chip::EndpointId endpoint, chip::AttributeId attributeId, uint16_t manufacturerCode);
+void MatterChloroformConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Chloroform Concentration Measurement Cluster Server Message Sent
  *
@@ -11496,31 +9162,25 @@ void emberAfChloroformConcentrationMeasurementClusterClientMessageSentCallback(c
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChloroformConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                EmberAfAttributeType attributeType,
-                                                                                                uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterChloroformConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chloroform Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfChloroformConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                chip::AttributeId attributeId,
-                                                                                                EmberAfAttributeType attributeType,
-                                                                                                uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterChloroformConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Chloroform Concentration Measurement Cluster Server Tick
  *
@@ -11562,45 +9222,19 @@ void emberAfSodiumConcentrationMeasurementClusterClientInitCallback(chip::Endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
+void MatterSodiumConcentrationMeasurementClusterServerAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sodium Concentration Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId);
-
-/** @brief Sodium Concentration Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSodiumConcentrationMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
-
-/** @brief Sodium Concentration Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSodiumConcentrationMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                                    chip::AttributeId attributeId,
-                                                                                                    uint16_t manufacturerCode);
+void MatterSodiumConcentrationMeasurementClusterClientAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sodium Concentration Measurement Cluster Server Message Sent
  *
@@ -11634,31 +9268,25 @@ void emberAfSodiumConcentrationMeasurementClusterClientMessageSentCallback(const
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSodiumConcentrationMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSodiumConcentrationMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sodium Concentration Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSodiumConcentrationMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                            chip::AttributeId attributeId,
-                                                                                            EmberAfAttributeType attributeType,
-                                                                                            uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSodiumConcentrationMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sodium Concentration Measurement Cluster Server Tick
  *
@@ -11700,43 +9328,17 @@ void emberAfIasZoneClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIasZoneClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterIasZoneClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief IAS Zone Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIasZoneClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief IAS Zone Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIasZoneClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             uint16_t manufacturerCode);
-
-/** @brief IAS Zone Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIasZoneClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             uint16_t manufacturerCode);
+void MatterIasZoneClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief IAS Zone Cluster Server Message Sent
  *
@@ -11768,29 +9370,27 @@ void emberAfIasZoneClusterClientMessageSentCallback(const chip::MessageSendDesti
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIasZoneClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                     EmberAfAttributeType attributeType, uint16_t size,
-                                                                     uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIasZoneClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief IAS Zone Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIasZoneClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                     EmberAfAttributeType attributeType, uint16_t size,
-                                                                     uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIasZoneClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief IAS Zone Cluster Server Tick
  *
@@ -11832,43 +9432,17 @@ void emberAfIasAceClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIasAceClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterIasAceClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief IAS ACE Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIasAceClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief IAS ACE Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIasAceClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
-
-/** @brief IAS ACE Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIasAceClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                            chip::AttributeId attributeId,
-                                                                            uint16_t manufacturerCode);
+void MatterIasAceClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief IAS ACE Cluster Server Message Sent
  *
@@ -11900,29 +9474,27 @@ void emberAfIasAceClusterClientMessageSentCallback(const chip::MessageSendDestin
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIasAceClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIasAceClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief IAS ACE Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIasAceClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                    EmberAfAttributeType attributeType, uint16_t size,
-                                                                    uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIasAceClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                     EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief IAS ACE Cluster Server Tick
  *
@@ -11964,41 +9536,17 @@ void emberAfIasWdClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIasWdClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterIasWdClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief IAS WD Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfIasWdClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief IAS WD Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIasWdClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
-
-/** @brief IAS WD Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfIasWdClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           uint16_t manufacturerCode);
+void MatterIasWdClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief IAS WD Cluster Server Message Sent
  *
@@ -12030,29 +9578,27 @@ void emberAfIasWdClusterClientMessageSentCallback(const chip::MessageSendDestina
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIasWdClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                   EmberAfAttributeType attributeType, uint16_t size,
-                                                                   uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIasWdClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief IAS WD Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfIasWdClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                   EmberAfAttributeType attributeType, uint16_t size,
-                                                                   uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterIasWdClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                    EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief IAS WD Cluster Server Tick
  *
@@ -12094,43 +9640,17 @@ void emberAfWakeOnLanClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfWakeOnLanClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterWakeOnLanClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Wake on LAN Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfWakeOnLanClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Wake on LAN Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfWakeOnLanClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId,
-                                                                               uint16_t manufacturerCode);
-
-/** @brief Wake on LAN Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfWakeOnLanClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId,
-                                                                               uint16_t manufacturerCode);
+void MatterWakeOnLanClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Wake on LAN Cluster Server Message Sent
  *
@@ -12162,29 +9682,27 @@ void emberAfWakeOnLanClusterClientMessageSentCallback(const chip::MessageSendDes
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfWakeOnLanClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                       EmberAfAttributeType attributeType, uint16_t size,
-                                                                       uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterWakeOnLanClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Wake on LAN Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfWakeOnLanClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                       EmberAfAttributeType attributeType, uint16_t size,
-                                                                       uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterWakeOnLanClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Wake on LAN Cluster Server Tick
  *
@@ -12226,43 +9744,17 @@ void emberAfTvChannelClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTvChannelClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterTvChannelClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief TV Channel Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTvChannelClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief TV Channel Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTvChannelClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId,
-                                                                               uint16_t manufacturerCode);
-
-/** @brief TV Channel Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTvChannelClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId,
-                                                                               uint16_t manufacturerCode);
+void MatterTvChannelClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief TV Channel Cluster Server Message Sent
  *
@@ -12294,29 +9786,27 @@ void emberAfTvChannelClusterClientMessageSentCallback(const chip::MessageSendDes
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTvChannelClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                       EmberAfAttributeType attributeType, uint16_t size,
-                                                                       uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTvChannelClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief TV Channel Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTvChannelClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                       EmberAfAttributeType attributeType, uint16_t size,
-                                                                       uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTvChannelClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief TV Channel Cluster Server Tick
  *
@@ -12358,43 +9848,17 @@ void emberAfTargetNavigatorClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTargetNavigatorClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterTargetNavigatorClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Target Navigator Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTargetNavigatorClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Target Navigator Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTargetNavigatorClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     uint16_t manufacturerCode);
-
-/** @brief Target Navigator Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTargetNavigatorClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     uint16_t manufacturerCode);
+void MatterTargetNavigatorClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Target Navigator Cluster Server Message Sent
  *
@@ -12428,31 +9892,27 @@ void emberAfTargetNavigatorClusterClientMessageSentCallback(const chip::MessageS
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTargetNavigatorClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             EmberAfAttributeType attributeType, uint16_t size,
-                                                                             uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTargetNavigatorClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Target Navigator Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTargetNavigatorClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             EmberAfAttributeType attributeType, uint16_t size,
-                                                                             uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTargetNavigatorClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Target Navigator Cluster Server Tick
  *
@@ -12494,43 +9954,17 @@ void emberAfMediaPlaybackClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMediaPlaybackClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterMediaPlaybackClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Media Playback Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMediaPlaybackClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Media Playback Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMediaPlaybackClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId,
-                                                                                   uint16_t manufacturerCode);
-
-/** @brief Media Playback Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMediaPlaybackClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId,
-                                                                                   uint16_t manufacturerCode);
+void MatterMediaPlaybackClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Media Playback Cluster Server Message Sent
  *
@@ -12564,29 +9998,27 @@ void emberAfMediaPlaybackClusterClientMessageSentCallback(const chip::MessageSen
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMediaPlaybackClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           EmberAfAttributeType attributeType, uint16_t size,
-                                                                           uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterMediaPlaybackClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Media Playback Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMediaPlaybackClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                           EmberAfAttributeType attributeType, uint16_t size,
-                                                                           uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterMediaPlaybackClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                            EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Media Playback Cluster Server Tick
  *
@@ -12628,43 +10060,17 @@ void emberAfMediaInputClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMediaInputClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterMediaInputClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Media Input Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMediaInputClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Media Input Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMediaInputClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
-
-/** @brief Media Input Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMediaInputClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                uint16_t manufacturerCode);
+void MatterMediaInputClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Media Input Cluster Server Message Sent
  *
@@ -12696,29 +10102,27 @@ void emberAfMediaInputClusterClientMessageSentCallback(const chip::MessageSendDe
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMediaInputClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterMediaInputClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Media Input Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMediaInputClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                        EmberAfAttributeType attributeType, uint16_t size,
-                                                                        uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterMediaInputClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                         EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Media Input Cluster Server Tick
  *
@@ -12760,43 +10164,17 @@ void emberAfLowPowerClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfLowPowerClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterLowPowerClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Low Power Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfLowPowerClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Low Power Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfLowPowerClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              uint16_t manufacturerCode);
-
-/** @brief Low Power Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfLowPowerClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              uint16_t manufacturerCode);
+void MatterLowPowerClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Low Power Cluster Server Message Sent
  *
@@ -12828,29 +10206,27 @@ void emberAfLowPowerClusterClientMessageSentCallback(const chip::MessageSendDest
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfLowPowerClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                      EmberAfAttributeType attributeType, uint16_t size,
-                                                                      uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterLowPowerClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Low Power Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfLowPowerClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                      EmberAfAttributeType attributeType, uint16_t size,
-                                                                      uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterLowPowerClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                       EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Low Power Cluster Server Tick
  *
@@ -12892,43 +10268,17 @@ void emberAfKeypadInputClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfKeypadInputClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterKeypadInputClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Keypad Input Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfKeypadInputClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Keypad Input Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfKeypadInputClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
-
-/** @brief Keypad Input Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfKeypadInputClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
+void MatterKeypadInputClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Keypad Input Cluster Server Message Sent
  *
@@ -12960,29 +10310,27 @@ void emberAfKeypadInputClusterClientMessageSentCallback(const chip::MessageSendD
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfKeypadInputClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterKeypadInputClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Keypad Input Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfKeypadInputClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterKeypadInputClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Keypad Input Cluster Server Tick
  *
@@ -13024,43 +10372,17 @@ void emberAfContentLauncherClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfContentLauncherClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterContentLauncherClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Content Launcher Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfContentLauncherClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Content Launcher Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfContentLauncherClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     uint16_t manufacturerCode);
-
-/** @brief Content Launcher Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfContentLauncherClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     uint16_t manufacturerCode);
+void MatterContentLauncherClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Content Launcher Cluster Server Message Sent
  *
@@ -13094,31 +10416,27 @@ void emberAfContentLauncherClusterClientMessageSentCallback(const chip::MessageS
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfContentLauncherClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             EmberAfAttributeType attributeType, uint16_t size,
-                                                                             uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterContentLauncherClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Content Launcher Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfContentLauncherClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             EmberAfAttributeType attributeType, uint16_t size,
-                                                                             uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterContentLauncherClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                              EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Content Launcher Cluster Server Tick
  *
@@ -13160,43 +10478,17 @@ void emberAfAudioOutputClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAudioOutputClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterAudioOutputClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Audio Output Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAudioOutputClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Audio Output Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAudioOutputClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
-
-/** @brief Audio Output Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAudioOutputClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
+void MatterAudioOutputClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Audio Output Cluster Server Message Sent
  *
@@ -13228,29 +10520,27 @@ void emberAfAudioOutputClusterClientMessageSentCallback(const chip::MessageSendD
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAudioOutputClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterAudioOutputClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Audio Output Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAudioOutputClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterAudioOutputClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Audio Output Cluster Server Tick
  *
@@ -13292,43 +10582,17 @@ void emberAfApplicationLauncherClusterClientInitCallback(chip::EndpointId endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplicationLauncherClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterApplicationLauncherClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Application Launcher Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplicationLauncherClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Application Launcher Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplicationLauncherClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
-
-/** @brief Application Launcher Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplicationLauncherClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
+void MatterApplicationLauncherClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Application Launcher Cluster Server Message Sent
  *
@@ -13362,31 +10626,25 @@ void emberAfApplicationLauncherClusterClientMessageSentCallback(const chip::Mess
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplicationLauncherClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplicationLauncherClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Application Launcher Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplicationLauncherClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplicationLauncherClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Application Launcher Cluster Server Tick
  *
@@ -13428,43 +10686,17 @@ void emberAfApplicationBasicClusterClientInitCallback(chip::EndpointId endpoint)
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplicationBasicClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterApplicationBasicClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Application Basic Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplicationBasicClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Application Basic Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplicationBasicClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
-
-/** @brief Application Basic Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplicationBasicClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      uint16_t manufacturerCode);
+void MatterApplicationBasicClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Application Basic Cluster Server Message Sent
  *
@@ -13498,31 +10730,27 @@ void emberAfApplicationBasicClusterClientMessageSentCallback(const chip::Message
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplicationBasicClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterApplicationBasicClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Application Basic Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplicationBasicClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                              chip::AttributeId attributeId,
-                                                                              EmberAfAttributeType attributeType, uint16_t size,
-                                                                              uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterApplicationBasicClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                               EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Application Basic Cluster Server Tick
  *
@@ -13564,43 +10792,17 @@ void emberAfAccountLoginClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAccountLoginClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterAccountLoginClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Account Login Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfAccountLoginClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Account Login Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAccountLoginClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
-
-/** @brief Account Login Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfAccountLoginClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                  chip::AttributeId attributeId,
-                                                                                  uint16_t manufacturerCode);
+void MatterAccountLoginClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Account Login Cluster Server Message Sent
  *
@@ -13632,29 +10834,27 @@ void emberAfAccountLoginClusterClientMessageSentCallback(const chip::MessageSend
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAccountLoginClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterAccountLoginClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Account Login Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfAccountLoginClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                          EmberAfAttributeType attributeType, uint16_t size,
-                                                                          uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterAccountLoginClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                           EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Account Login Cluster Server Tick
  *
@@ -13696,43 +10896,17 @@ void emberAfTestClusterClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTestClusterClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterTestClusterClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Test Cluster Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfTestClusterClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Test Cluster Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTestClusterClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
-
-/** @brief Test Cluster Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfTestClusterClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 uint16_t manufacturerCode);
+void MatterTestClusterClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Test Cluster Cluster Server Message Sent
  *
@@ -13764,29 +10938,27 @@ void emberAfTestClusterClusterClientMessageSentCallback(const chip::MessageSendD
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTestClusterClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTestClusterClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Test Cluster Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfTestClusterClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                         EmberAfAttributeType attributeType, uint16_t size,
-                                                                         uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterTestClusterClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                          EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Test Cluster Cluster Server Tick
  *
@@ -13828,43 +11000,17 @@ void emberAfMessagingClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMessagingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterMessagingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Messaging Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMessagingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Messaging Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMessagingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId,
-                                                                               uint16_t manufacturerCode);
-
-/** @brief Messaging Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMessagingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                               chip::AttributeId attributeId,
-                                                                               uint16_t manufacturerCode);
+void MatterMessagingClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Messaging Cluster Server Message Sent
  *
@@ -13896,29 +11042,27 @@ void emberAfMessagingClusterClientMessageSentCallback(const chip::MessageSendDes
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMessagingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                       EmberAfAttributeType attributeType, uint16_t size,
-                                                                       uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterMessagingClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Messaging Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMessagingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                       EmberAfAttributeType attributeType, uint16_t size,
-                                                                       uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterMessagingClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                        EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Messaging Cluster Server Tick
  *
@@ -13960,43 +11104,17 @@ void emberAfApplianceIdentificationClusterClientInitCallback(chip::EndpointId en
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterApplianceIdentificationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Identification Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Appliance Identification Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
-
-/** @brief Appliance Identification Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
+void MatterApplianceIdentificationClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Identification Cluster Server Message Sent
  *
@@ -14030,31 +11148,25 @@ void emberAfApplianceIdentificationClusterClientMessageSentCallback(const chip::
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplianceIdentificationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Identification Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplianceIdentificationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Identification Cluster Server Tick
  *
@@ -14096,43 +11208,17 @@ void emberAfMeterIdentificationClusterClientInitCallback(chip::EndpointId endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMeterIdentificationClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterMeterIdentificationClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Meter Identification Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfMeterIdentificationClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Meter Identification Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMeterIdentificationClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
-
-/** @brief Meter Identification Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfMeterIdentificationClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
+void MatterMeterIdentificationClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Meter Identification Cluster Server Message Sent
  *
@@ -14166,31 +11252,25 @@ void emberAfMeterIdentificationClusterClientMessageSentCallback(const chip::Mess
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMeterIdentificationClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterMeterIdentificationClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Meter Identification Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfMeterIdentificationClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterMeterIdentificationClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Meter Identification Cluster Server Tick
  *
@@ -14232,43 +11312,17 @@ void emberAfApplianceEventsAndAlertClusterClientInitCallback(chip::EndpointId en
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceEventsAndAlertClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterApplianceEventsAndAlertClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Events and Alert Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceEventsAndAlertClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Appliance Events and Alert Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceEventsAndAlertClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
-
-/** @brief Appliance Events and Alert Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceEventsAndAlertClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                             chip::AttributeId attributeId,
-                                                                                             uint16_t manufacturerCode);
+void MatterApplianceEventsAndAlertClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Events and Alert Cluster Server Message Sent
  *
@@ -14302,31 +11356,25 @@ void emberAfApplianceEventsAndAlertClusterClientMessageSentCallback(const chip::
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplianceEventsAndAlertClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Events and Alert Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                     chip::AttributeId attributeId,
-                                                                                     EmberAfAttributeType attributeType,
-                                                                                     uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplianceEventsAndAlertClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Events and Alert Cluster Server Tick
  *
@@ -14368,43 +11416,17 @@ void emberAfApplianceStatisticsClusterClientInitCallback(chip::EndpointId endpoi
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceStatisticsClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterApplianceStatisticsClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Statistics Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfApplianceStatisticsClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Appliance Statistics Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceStatisticsClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
-
-/** @brief Appliance Statistics Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfApplianceStatisticsClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                         chip::AttributeId attributeId,
-                                                                                         uint16_t manufacturerCode);
+void MatterApplianceStatisticsClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Appliance Statistics Cluster Server Message Sent
  *
@@ -14438,31 +11460,25 @@ void emberAfApplianceStatisticsClusterClientMessageSentCallback(const chip::Mess
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceStatisticsClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplianceStatisticsClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Statistics Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfApplianceStatisticsClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                 chip::AttributeId attributeId,
-                                                                                 EmberAfAttributeType attributeType, uint16_t size,
-                                                                                 uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterApplianceStatisticsClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Appliance Statistics Cluster Server Tick
  *
@@ -14504,43 +11520,17 @@ void emberAfElectricalMeasurementClusterClientInitCallback(chip::EndpointId endp
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfElectricalMeasurementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterElectricalMeasurementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Electrical Measurement Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfElectricalMeasurementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Electrical Measurement Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfElectricalMeasurementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                           chip::AttributeId attributeId,
-                                                                                           uint16_t manufacturerCode);
-
-/** @brief Electrical Measurement Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfElectricalMeasurementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                           chip::AttributeId attributeId,
-                                                                                           uint16_t manufacturerCode);
+void MatterElectricalMeasurementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Electrical Measurement Cluster Server Message Sent
  *
@@ -14574,31 +11564,25 @@ void emberAfElectricalMeasurementClusterClientMessageSentCallback(const chip::Me
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfElectricalMeasurementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId,
-                                                                                   EmberAfAttributeType attributeType,
-                                                                                   uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterElectricalMeasurementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Electrical Measurement Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfElectricalMeasurementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                   chip::AttributeId attributeId,
-                                                                                   EmberAfAttributeType attributeType,
-                                                                                   uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterElectricalMeasurementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Electrical Measurement Cluster Server Tick
  *
@@ -14640,43 +11624,17 @@ void emberAfBindingClusterClientInitCallback(chip::EndpointId endpoint);
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBindingClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterBindingClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Binding Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfBindingClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Binding Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBindingClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             uint16_t manufacturerCode);
-
-/** @brief Binding Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfBindingClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                             chip::AttributeId attributeId,
-                                                                             uint16_t manufacturerCode);
+void MatterBindingClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Binding Cluster Server Message Sent
  *
@@ -14708,29 +11666,27 @@ void emberAfBindingClusterClientMessageSentCallback(const chip::MessageSendDesti
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBindingClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                     EmberAfAttributeType attributeType, uint16_t size,
-                                                                     uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBindingClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Binding Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfBindingClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId,
-                                                                     EmberAfAttributeType attributeType, uint16_t size,
-                                                                     uint8_t * value);
+chip::Protocols::InteractionModel::Status
+MatterBindingClusterClientPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Binding Cluster Server Tick
  *
@@ -14772,43 +11728,17 @@ void emberAfGroupKeyManagementClusterClientInitCallback(chip::EndpointId endpoin
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGroupKeyManagementClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterGroupKeyManagementClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Group Key Management Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfGroupKeyManagementClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Group Key Management Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGroupKeyManagementClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
-
-/** @brief Group Key Management Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfGroupKeyManagementClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                        chip::AttributeId attributeId,
-                                                                                        uint16_t manufacturerCode);
+void MatterGroupKeyManagementClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Group Key Management Cluster Server Message Sent
  *
@@ -14842,31 +11772,25 @@ void emberAfGroupKeyManagementClusterClientMessageSentCallback(const chip::Messa
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGroupKeyManagementClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterGroupKeyManagementClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Group Key Management Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfGroupKeyManagementClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                chip::AttributeId attributeId,
-                                                                                EmberAfAttributeType attributeType, uint16_t size,
-                                                                                uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterGroupKeyManagementClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Group Key Management Cluster Server Tick
  *
@@ -14908,43 +11832,17 @@ void emberAfSampleMfgSpecificClusterClusterClientInitCallback(chip::EndpointId e
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSampleMfgSpecificClusterClusterServerAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
+void MatterSampleMfgSpecificClusterClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sample Mfg Specific Cluster Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSampleMfgSpecificClusterClusterClientAttributeChangedCallback(chip::EndpointId endpoint, chip::AttributeId attributeId);
-
-/** @brief Sample Mfg Specific Cluster Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSampleMfgSpecificClusterClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              uint16_t manufacturerCode);
-
-/** @brief Sample Mfg Specific Cluster Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSampleMfgSpecificClusterClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                              chip::AttributeId attributeId,
-                                                                                              uint16_t manufacturerCode);
+void MatterSampleMfgSpecificClusterClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sample Mfg Specific Cluster Cluster Server Message Sent
  *
@@ -14978,31 +11876,25 @@ void emberAfSampleMfgSpecificClusterClusterClientMessageSentCallback(const chip:
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      EmberAfAttributeType attributeType,
-                                                                                      uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSampleMfgSpecificClusterClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sample Mfg Specific Cluster Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSampleMfgSpecificClusterClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                      chip::AttributeId attributeId,
-                                                                                      EmberAfAttributeType attributeType,
-                                                                                      uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSampleMfgSpecificClusterClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sample Mfg Specific Cluster Cluster Server Tick
  *
@@ -15044,45 +11936,17 @@ void emberAfSampleMfgSpecificCluster2ClusterClientInitCallback(chip::EndpointId 
  *
  * Server Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSampleMfgSpecificCluster2ClusterServerAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                           chip::AttributeId attributeId);
+void MatterSampleMfgSpecificCluster2ClusterServerAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Attribute Changed
  *
  * Client Attribute Changed
  *
- * @param endpoint    Endpoint that is being initialized
- * @param attributeId Attribute that changed
+ * @param attributePath Concrete attribute path that changed
  */
-void emberAfSampleMfgSpecificCluster2ClusterClientAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                           chip::AttributeId attributeId);
-
-/** @brief Sample Mfg Specific Cluster 2 Cluster Server Manufacturer Specific Attribute Changed
- *
- * Server Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSampleMfgSpecificCluster2ClusterServerManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               uint16_t manufacturerCode);
-
-/** @brief Sample Mfg Specific Cluster 2 Cluster Client Manufacturer Specific Attribute Changed
- *
- * Client Manufacturer Specific Attribute Changed
- *
- * @param endpoint          Endpoint that is being initialized
- * @param attributeId       Attribute that changed
- * @param manufacturerCode  Manufacturer Code of the attribute that changed
- */
-void emberAfSampleMfgSpecificCluster2ClusterClientManufacturerSpecificAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                               chip::AttributeId attributeId,
-                                                                                               uint16_t manufacturerCode);
+void MatterSampleMfgSpecificCluster2ClusterClientAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath);
 
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Message Sent
  *
@@ -15116,31 +11980,25 @@ void emberAfSampleMfgSpecificCluster2ClusterClientMessageSentCallback(const chip
  *
  * Server Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ClusterServerPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId,
-                                                                                       EmberAfAttributeType attributeType,
-                                                                                       uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSampleMfgSpecificCluster2ClusterServerPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sample Mfg Specific Cluster 2 Cluster Client Pre Attribute Changed
  *
  * Client Pre Attribute Changed
  *
- * @param endpoint      Endpoint that is being initialized
- * @param attributeId   Attribute to be changed
+ * @param attributePath Concrete attribute path to be changed
  * @param attributeType Attribute type
  * @param size          Attribute size
  * @param value         Attribute value
  */
-EmberAfStatus emberAfSampleMfgSpecificCluster2ClusterClientPreAttributeChangedCallback(chip::EndpointId endpoint,
-                                                                                       chip::AttributeId attributeId,
-                                                                                       EmberAfAttributeType attributeType,
-                                                                                       uint16_t size, uint8_t * value);
+chip::Protocols::InteractionModel::Status MatterSampleMfgSpecificCluster2ClusterClientPreAttributeChangedCallback(
+    const chip::app::ConcreteAttributePath & attributePath, EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
 /** @brief Sample Mfg Specific Cluster 2 Cluster Server Tick
  *
@@ -17565,45 +14423,6 @@ bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberSt
 bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame, uint16_t msgLen,
                                 uint8_t * message, EmberStatus status);
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus emberAfPreAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                                uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size,
-                                                uint8_t * value);
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                        uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value);
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -17767,3 +14586,36 @@ EmberStatus emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, u
  *
  */
 bool emberAfStartMoveCallback();
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath,
+                                                                           uint8_t mask, uint8_t type, uint16_t size,
+                                                                           uint8_t * value);
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
+                                       uint16_t size, uint8_t * value);

--- a/zzz_generated/bridge-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/bridge-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -443,50 +444,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -672,3 +629,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/controller-clusters/zap-generated/callback-stub.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -747,50 +748,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -976,3 +933,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/lighting-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/lighting-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -451,50 +452,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -680,3 +637,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/lock-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/lock-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -419,50 +420,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -648,3 +605,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/ota-provider-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/ota-provider-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -339,50 +340,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -568,3 +525,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/ota-requestor-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -331,50 +332,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -560,3 +517,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/pump-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/pump-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -459,50 +460,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -688,3 +645,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/pump-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/pump-app/zap-generated/endpoint_config.h
@@ -990,7 +990,7 @@
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayPumpConfigurationAndControlServer[] = {                                       \
         (EmberAfGenericClusterFunction) emberAfPumpConfigurationAndControlClusterServerInitCallback,                               \
-        (EmberAfGenericClusterFunction) emberAfPumpConfigurationAndControlClusterServerAttributeChangedCallback,                   \
+        (EmberAfGenericClusterFunction) MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback,                    \
     };
 
 #define ZAP_CLUSTER_MASK(mask) CLUSTER_MASK_##mask

--- a/zzz_generated/pump-controller-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -459,50 +460,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -688,3 +645,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/temperature-measurement-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/temperature-measurement-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -411,50 +412,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -640,3 +597,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/thermostat/zap-generated/callback-stub.cpp
+++ b/zzz_generated/thermostat/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -707,50 +708,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -936,3 +893,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/thermostat/zap-generated/endpoint_config.h
+++ b/zzz_generated/thermostat/zap-generated/endpoint_config.h
@@ -2460,7 +2460,7 @@
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayIdentifyServer[] = {                                                          \
         (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerInitCallback,                                                  \
-        (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerAttributeChangedCallback,                                      \
+        (EmberAfGenericClusterFunction) MatterIdentifyClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayGroupsServer[] = {                                                            \
         (EmberAfGenericClusterFunction) emberAfGroupsClusterServerInitCallback,                                                    \
@@ -2475,7 +2475,7 @@
         (EmberAfGenericClusterFunction) emberAfLevelControlClusterServerInitCallback,                                              \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayDoorLockServer[] = {                                                          \
-        (EmberAfGenericClusterFunction) emberAfDoorLockClusterServerAttributeChangedCallback,                                      \
+        (EmberAfGenericClusterFunction) MatterDoorLockClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayColorControlServer[] = {                                                      \
         (EmberAfGenericClusterFunction) emberAfColorControlClusterServerInitCallback,                                              \
@@ -2483,7 +2483,7 @@
     const EmberAfGenericClusterFunction chipFuncArrayIasZoneServer[] = {                                                           \
         (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerInitCallback,                                                   \
         (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerMessageSentCallback,                                            \
-        (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerPreAttributeChangedCallback,                                    \
+        (EmberAfGenericClusterFunction) MatterIasZoneClusterServerPreAttributeChangedCallback,                                     \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayOccupancySensingServer[] = {                                                  \
         (EmberAfGenericClusterFunction) emberAfOccupancySensingClusterServerInitCallback,                                          \

--- a/zzz_generated/tv-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/tv-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -563,50 +564,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -792,3 +749,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/tv-casting-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/tv-casting-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -699,50 +700,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -928,3 +885,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}

--- a/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
@@ -2400,7 +2400,7 @@
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayIdentifyServer[] = {                                                          \
         (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerInitCallback,                                                  \
-        (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerAttributeChangedCallback,                                      \
+        (EmberAfGenericClusterFunction) MatterIdentifyClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayGroupsServer[] = {                                                            \
         (EmberAfGenericClusterFunction) emberAfGroupsClusterServerInitCallback,                                                    \
@@ -2415,7 +2415,7 @@
         (EmberAfGenericClusterFunction) emberAfLevelControlClusterServerInitCallback,                                              \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayDoorLockServer[] = {                                                          \
-        (EmberAfGenericClusterFunction) emberAfDoorLockClusterServerAttributeChangedCallback,                                      \
+        (EmberAfGenericClusterFunction) MatterDoorLockClusterServerAttributeChangedCallback,                                       \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayColorControlServer[] = {                                                      \
         (EmberAfGenericClusterFunction) emberAfColorControlClusterServerInitCallback,                                              \
@@ -2423,7 +2423,7 @@
     const EmberAfGenericClusterFunction chipFuncArrayIasZoneServer[] = {                                                           \
         (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerInitCallback,                                                   \
         (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerMessageSentCallback,                                            \
-        (EmberAfGenericClusterFunction) emberAfIasZoneClusterServerPreAttributeChangedCallback,                                    \
+        (EmberAfGenericClusterFunction) MatterIasZoneClusterServerPreAttributeChangedCallback,                                     \
     };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayOccupancySensingServer[] = {                                                  \
         (EmberAfGenericClusterFunction) emberAfOccupancySensingClusterServerInitCallback,                                          \

--- a/zzz_generated/window-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/window-app/zap-generated/callback-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 
@@ -411,50 +412,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestinati
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * ::EMBER_ZCL_STATUS_SUCCESS to permit the change or any other ::EmberAfStatus
- * to reject it.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-EmberAfStatus __attribute__((weak))
-emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param type   Ver.: always
- * @param size   Ver.: always
- * @param value   Ver.: always
- */
-void __attribute__((weak))
-emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                   uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
-{}
-
 /** @brief External Attribute Read
  *
  * Like emberAfExternalAttributeWriteCallback above, this function is called
@@ -640,3 +597,40 @@ bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
+
+/** @brief Pre Attribute Change
+ *
+ * This function is called by the application framework before it changes an
+ * attribute value.  The value passed into this callback is the value to which
+ * the attribute is to be set by the framework.  The application should return
+ * chip::Protocols::InteractionModel::Status::Success to permit the change or
+ * any other code to reject it.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+chip::Protocols::InteractionModel::Status __attribute__((weak))
+MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
+                                 uint8_t * value)
+{
+    return chip::Protocols::InteractionModel::Status::Success;
+}
+
+/** @brief Post Attribute Change
+ *
+ * This function is called by the application framework after it changes an
+ * attribute value. The value passed into this callback is the value to which
+ * the attribute was set by the framework.
+ *
+ * @param attributePath
+ * @param mask
+ * @param type
+ * @param size
+ * @param value
+ */
+void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
+                                                             uint8_t type, uint16_t size, uint8_t * value)
+{}


### PR DESCRIPTION
#### Problem

This PR adds `chip::app::ConcreteAttributePath` and update the signature of `emberAf*AttributeChange` callbacks across the stack to uses it.

#### Change overview
 * Add `chip::app::ConcreteAttributePath`
 * Update the signature of `emberAf*AttributeChange` callbacks to `Matter*AttributeChange`
 * Remove `manufacturerCode` from the signature since we are using MEI attributes ids
 * Update some headers from various examples to use `ids/Attributes.h` and `ids/Clusters.h`

#### Testing
* there is no huge change across the stack, mostly some signatures. 
