### PR TITLE
Improve logging for minMdns

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -246,7 +246,9 @@ private:
 void AdvertiserMinMdns::OnMdnsPacketData(const BytesRange & data, const chip::Inet::IPPacketInfo * info)
 {
 #ifdef DETAIL_LOGGING
-    ChipLogDetail(Discovery, "MinMdns received a query.");
+    char srcAddressString[chip::Inet::kMaxIPAddressStringLength];
+    VerifyOrDie(info->SrcAddress.ToString(srcAddressString) != nullptr);
+    ChipLogDetail(Discovery, "Received an mDNS query from %s", srcAddressString);
 #endif
 
     mCurrentSource = info;

--- a/src/lib/mdns/minimal/ResponseSender.cpp
+++ b/src/lib/mdns/minimal/ResponseSender.cpp
@@ -161,16 +161,18 @@ CHIP_ERROR ResponseSender::FlushReply()
 
     if (mResponseBuilder.HasResponseRecords())
     {
+        char srcAddressString[chip::Inet::kMaxIPAddressStringLength];
+        VerifyOrDie(mSendState.GetSourceAddress().ToString(srcAddressString) != nullptr);
 
         if (mSendState.SendUnicast())
         {
-            ChipLogProgress(Discovery, "Directly sending mDns reply to peer on port %d", mSendState.GetSourcePort());
+            ChipLogProgress(Discovery, "Directly sending mDns reply to peer %s on port %d", srcAddressString, mSendState.GetSourcePort());
             ReturnErrorOnFailure(mServer->DirectSend(mResponseBuilder.ReleasePacket(), mSendState.GetSourceAddress(),
                                                      mSendState.GetSourcePort(), mSendState.GetSourceInterfaceId()));
         }
         else
         {
-            ChipLogProgress(Discovery, "Broadcasting mDns reply");
+            ChipLogProgress(Discovery, "Broadcasting mDns reply for query from %s", srcAddressString);
             ReturnErrorOnFailure(
                 mServer->BroadcastSend(mResponseBuilder.ReleasePacket(), kMdnsStandardPort, mSendState.GetSourceInterfaceId()));
         }

--- a/src/lib/mdns/minimal/ResponseSender.cpp
+++ b/src/lib/mdns/minimal/ResponseSender.cpp
@@ -166,7 +166,8 @@ CHIP_ERROR ResponseSender::FlushReply()
 
         if (mSendState.SendUnicast())
         {
-            ChipLogProgress(Discovery, "Directly sending mDns reply to peer %s on port %d", srcAddressString, mSendState.GetSourcePort());
+            ChipLogProgress(Discovery, "Directly sending mDns reply to peer %s on port %d", srcAddressString,
+                            mSendState.GetSourcePort());
             ReturnErrorOnFailure(mServer->DirectSend(mResponseBuilder.ReleasePacket(), mSendState.GetSourceAddress(),
                                                      mSendState.GetSourcePort(), mSendState.GetSourceInterfaceId()));
         }

--- a/src/lib/mdns/minimal/responders/QueryResponder.cpp
+++ b/src/lib/mdns/minimal/responders/QueryResponder.cpp
@@ -139,8 +139,6 @@ void QueryResponderBase::MarkAdditionalRepliesFor(QueryResponderIterator it)
 
 void QueryResponderBase::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate)
 {
-    ChipLogProgress(Discovery, "Replying to DNS-SD service listing request");
-
     // reply to dns-sd service list request
     for (size_t i = 0; i < mResponderInfoSize; i++)
     {


### PR DESCRIPTION
#### Problem
- minmdns has `Replying to DNS-SD service listing request` log that is not actually
  correct: it occurs even if no messages get sent, and too frequently, in a way that is
  not helpful.
- Identity of querier that caused the query to be processed is missing, but very useful
  to understand network patterns.

#### Change overview
- Remove duplicate log lines that falsely indicated
  sending when it was just building responses
- When responding, clarify the identity of the querier
  that caused the response to be generated and sent

#### Testing
- Unit tests ran
- Ran unit tests and all-clusters-app commissioning on Linux
