### PR TITLE
Enable Fabric Scoped Storage

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -29,9 +29,10 @@ public:
     CHIP_ERROR Init();
 
     /////////// PersistentStorageDelegate Interface /////////
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+    CHIP_ERROR SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override;
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override;
 
     uint16_t GetListenPort();
     chip::Logging::LogCategory GetLoggingLevel();

--- a/examples/ota-requestor-app/linux/PersistentStorage.cpp
+++ b/examples/ota-requestor-app/linux/PersistentStorage.cpp
@@ -91,11 +91,23 @@ exit:
     return err;
 }
 
-CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
+String GetSectionName(const CompressedFabricId fabricId)
+{
+    if (fabricId == kUndefinedCompressedFabricId)
+    {
+        return kDefaultSectionName;
+    }
+    else
+    {
+        return std::to_string(fabricId);
+    }
+}
+
+CHIP_ERROR PersistentStorage::SyncGetKeyValue(const CompressedFabricId fabricId, const char * key, void * value, uint16_t & size)
 {
     std::string iniValue;
 
-    auto section = mConfig.sections[kDefaultSectionName];
+    auto section = mConfig.sections[GetSectionName(fabricId)];
     auto it      = section.find(key);
     ReturnErrorCodeIf(it == section.end(), CHIP_ERROR_KEY_NOT_FOUND);
 
@@ -116,18 +128,19 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PersistentStorage::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
+CHIP_ERROR PersistentStorage::SyncSetKeyValue(const CompressedFabricId fabricId, const char * key, const void * value,
+                                              uint16_t size)
 {
-    auto section = mConfig.sections[kDefaultSectionName];
+    auto section = mConfig.sections[GetSectionName(fabricId)];
     section[key] = StringToBase64(std::string(static_cast<const char *>(value), size));
 
     mConfig.sections[kDefaultSectionName] = section;
     return CommitConfig();
 }
 
-CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const char * key)
+CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const CompressedFabricId fabricId, const char * key)
 {
-    auto section = mConfig.sections[kDefaultSectionName];
+    auto section = mConfig.sections[GetSectionName(fabricId)];
     section.erase(key);
 
     mConfig.sections[kDefaultSectionName] = section;
@@ -163,7 +176,7 @@ uint16_t PersistentStorage::GetListenPort()
 
     char value[6];
     uint16_t size = static_cast<uint16_t>(sizeof(value));
-    err           = SyncGetKeyValue(kPortKey, value, size);
+    err           = SyncGetKeyValue(kUndefinedCompressedFabricId, kPortKey, value, size);
     if (CHIP_NO_ERROR == err)
     {
         uint16_t tmpValue;
@@ -185,7 +198,7 @@ LogCategory PersistentStorage::GetLoggingLevel()
 
     char value[9];
     uint16_t size = static_cast<uint16_t>(sizeof(value));
-    err           = SyncGetKeyValue(kLoggingKey, value, size);
+    err           = SyncGetKeyValue(kUndefinedCompressedFabricId, kLoggingKey, value, size);
     if (CHIP_NO_ERROR == err)
     {
         if (strcasecmp(value, "none") == 0)
@@ -215,7 +228,7 @@ NodeId PersistentStorage::GetNodeId(const char * key, NodeId defaultVal)
 
     uint64_t nodeId;
     uint16_t size = static_cast<uint16_t>(sizeof(nodeId));
-    err           = SyncGetKeyValue(key, &nodeId, size);
+    err           = SyncGetKeyValue(kUndefinedCompressedFabricId, key, &nodeId, size);
     if (err == CHIP_NO_ERROR)
     {
         return static_cast<NodeId>(Encoding::LittleEndian::HostSwap64(nodeId));
@@ -237,7 +250,7 @@ NodeId PersistentStorage::GetRemoteNodeId()
 CHIP_ERROR PersistentStorage::SetNodeId(const char * key, NodeId value)
 {
     uint64_t nodeId = Encoding::LittleEndian::HostSwap64(value);
-    return SyncSetKeyValue(key, &nodeId, sizeof(nodeId));
+    return SyncSetKeyValue(kUndefinedCompressedFabricId, key, &nodeId, sizeof(nodeId));
 }
 
 CHIP_ERROR PersistentStorage::SetLocalNodeId(NodeId nodeId)

--- a/examples/ota-requestor-app/linux/PersistentStorage.h
+++ b/examples/ota-requestor-app/linux/PersistentStorage.h
@@ -29,9 +29,10 @@ public:
     CHIP_ERROR Init();
 
     /////////// PersistentStorageDelegate Interface /////////
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+    CHIP_ERROR SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override;
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override;
 
     uint16_t GetListenPort();
     chip::Logging::LogCategory GetLoggingLevel();

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -185,19 +185,19 @@ using namespace ::chip::Controller;
 
 class MyServerStorageDelegate : public PersistentStorageDelegate
 {
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    CHIP_ERROR SyncGetKeyValue(const CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override
     {
         ChipLogProgress(AppServer, "Retrieved value from server storage.");
         return PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
     }
 
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    CHIP_ERROR SyncSetKeyValue(const CompressedFabricId fabricId, const char * key, const void * value, uint16_t size) override
     {
         ChipLogProgress(AppServer, "Stored value in server storage");
         return PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
     }
 
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+    CHIP_ERROR SyncDeleteKeyValue(const CompressedFabricId fabricId, const char * key) override
     {
         ChipLogProgress(AppServer, "Delete value in server storage");
         return PersistedStorage::KeyValueStoreMgr().Delete(key);

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -86,23 +86,24 @@ private:
 
     static Server sServer;
 
+    // TODO Server implementations do not separate storage based on fabric
     class ServerStorageDelegate : public PersistentStorageDelegate
     {
-        CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+        CHIP_ERROR SyncGetKeyValue(const CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override
         {
             ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size));
             ChipLogProgress(AppServer, "Retrieved from server storage: %s", key);
             return CHIP_NO_ERROR;
         }
 
-        CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+        CHIP_ERROR SyncSetKeyValue(const CompressedFabricId fabricId, const char * key, const void * value, uint16_t size) override
         {
             ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size));
             ChipLogProgress(AppServer, "Saved into server storage: %s", key);
             return CHIP_NO_ERROR;
         }
 
-        CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+        CHIP_ERROR SyncDeleteKeyValue(const CompressedFabricId fabricId, const char * key) override
         {
             ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key));
             ChipLogProgress(AppServer, "Deleted from server storage: %s", key);

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -171,7 +171,7 @@ public:
      *   still using them, it can lead to unknown behavior and crashes.
      *
      * @param[in] params       Wrapper object for transport manager etc.
-     * @param[in] fabric        Local administrator that's initializing this device object
+     * @param[in] fabric       Local administrator that's initializing this device object
      */
     void Init(ControllerDeviceInitParams params, FabricIndex fabric)
     {
@@ -186,6 +186,14 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
+        if (mFabricsTable != nullptr && mFabricIndex != kUndefinedFabricIndex)
+        {
+            FabricInfo * fabricInfo = mFabricsTable->FindFabricWithIndex(mFabricIndex);
+            if (fabricInfo != nullptr)
+            {
+                mCompressedFabricId = fabricInfo->GetCompressedFabricId();
+            }
+        }
     }
 
     /**
@@ -202,7 +210,7 @@ public:
      * @param[in] params       Wrapper object for transport manager etc.
      * @param[in] deviceId     Node ID of the device
      * @param[in] peerAddress  The location of the peer. MUST be of type Transport::Type::kUdp
-     * @param[in] fabric        Local administrator that's initializing this device object
+     * @param[in] fabric       Local administrator that's initializing this device object
      */
     void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress, FabricIndex fabric)
     {
@@ -524,7 +532,8 @@ private:
     static void OnOpenPairingWindowSuccessResponse(void * context);
     static void OnOpenPairingWindowFailureResponse(void * context, uint8_t status);
 
-    FabricIndex mFabricIndex = kUndefinedFabricIndex;
+    CompressedFabricId mCompressedFabricId = kUndefinedCompressedFabricId;
+    FabricIndex mFabricIndex               = kUndefinedFabricIndex;
 
     FabricTable * mFabricsTable = nullptr;
 
@@ -605,8 +614,9 @@ typedef struct SerializableDevice
     PASESessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
-    uint16_t mDevicePort;  /* This field is serialized in LittleEndian byte order */
-    uint16_t mFabricIndex; /* This field is serialized in LittleEndian byte order */
+    uint16_t mDevicePort;         /* This field is serialized in LittleEndian byte order */
+    uint16_t mFabricIndex;        /* This field is serialized in LittleEndian byte order */
+    uint64_t mCompressedFabricId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceTransport;
     uint8_t mDeviceOperationalCertProvisioned;
     uint8_t mInterfaceName[kMaxInterfaceName];

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -54,7 +54,7 @@ struct SetupParams
 
     FabricId fabricId = kUndefinedFabricId;
 
-    uint16_t controllerVendorId;
+    uint16_t controllerVendorId = CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID;
 
     // The Device Pairing Delegated used to initialize a Commissioner
     DevicePairingDelegate * pairingDelegate = nullptr;

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -52,14 +52,16 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
     Crypto::P256SerializedKeypair serializedKey;
     uint16_t keySize = static_cast<uint16_t>(sizeof(serializedKey));
 
-    if (storage.SyncGetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize) != CHIP_NO_ERROR)
+    if (storage.SyncGetKeyValue(kUndefinedCompressedFabricId, kOperationalCredentialsIssuerKeypairStorage, &serializedKey,
+                                keySize) != CHIP_NO_ERROR)
     {
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIssuer.Initialize());
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
 
         keySize = static_cast<uint16_t>(sizeof(serializedKey));
-        ReturnErrorOnFailure(storage.SyncSetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize));
+        ReturnErrorOnFailure(storage.SyncSetKeyValue(kUndefinedCompressedFabricId, kOperationalCredentialsIssuerKeypairStorage,
+                                                     &serializedKey, keySize));
     }
     else
     {
@@ -69,15 +71,16 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
 
     keySize = static_cast<uint16_t>(sizeof(serializedKey));
 
-    if (storage.SyncGetKeyValue(kOperationalCredentialsIntermediateIssuerKeypairStorage, &serializedKey, keySize) != CHIP_NO_ERROR)
+    if (storage.SyncGetKeyValue(kUndefinedCompressedFabricId, kOperationalCredentialsIntermediateIssuerKeypairStorage,
+                                &serializedKey, keySize) != CHIP_NO_ERROR)
     {
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIntermediateIssuer.Initialize());
         ReturnErrorOnFailure(mIntermediateIssuer.Serialize(serializedKey));
 
         keySize = static_cast<uint16_t>(sizeof(serializedKey));
-        ReturnErrorOnFailure(
-            storage.SyncSetKeyValue(kOperationalCredentialsIntermediateIssuerKeypairStorage, &serializedKey, keySize));
+        ReturnErrorOnFailure(storage.SyncSetKeyValue(
+            kUndefinedCompressedFabricId, kOperationalCredentialsIntermediateIssuerKeypairStorage, &serializedKey, keySize));
     }
     else
     {
@@ -107,7 +110,7 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
     CHIP_ERROR err      = CHIP_NO_ERROR;
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-                      err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+                      err = mStorage->SyncGetKeyValue(kUndefinedCompressedFabricId, key, rcac.data(), rcacBufLen));
     if (err == CHIP_NO_ERROR)
     {
         // Found root certificate in the storage.
@@ -120,8 +123,9 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
-    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-                      err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
+    PERSISTENT_KEY_OP(
+        fabricId, kOperationalCredentialsRootCertificateStorage, key,
+        err = mStorage->SyncSetKeyValue(kUndefinedCompressedFabricId, key, rcac.data(), static_cast<uint16_t>(rcac.size())));
 
     return err;
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -74,9 +74,10 @@ public:
     void OnStatusChange(void) override;
 
     // PersistentStorageDelegate implementation
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override;
+    CHIP_ERROR SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override;
 
     static AndroidDeviceControllerWrapper * FromJNIHandle(jlong handle)
     {

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -29,7 +29,8 @@
 namespace chip {
 namespace Controller {
 
-CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
+CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * value,
+                                                            uint16_t & size)
 {
     auto val = mStorage.find(key);
     if (val == mStorage.end())
@@ -61,7 +62,8 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, vo
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PythonPersistentStorageDelegate::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
+CHIP_ERROR PythonPersistentStorageDelegate::SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key,
+                                                            const void * value, uint16_t size)
 {
     mStorage[key] = std::string(static_cast<const char *>(value), size);
     ChipLogDetail(Controller, "SyncSetKeyValue on %s", key);
@@ -69,7 +71,7 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncSetKeyValue(const char * key, co
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PythonPersistentStorageDelegate::SyncDeleteKeyValue(const char * key)
+CHIP_ERROR PythonPersistentStorageDelegate::SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key)
 {
     mStorage.erase(key);
     return CHIP_NO_ERROR;

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -36,9 +36,10 @@ class PythonPersistentStorageDelegate : public PersistentStorageDelegate
 {
 public:
     PythonPersistentStorageDelegate() {}
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+    CHIP_ERROR SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override;
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override;
 
 private:
     std::map<std::string, std::string> mStorage;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -38,17 +38,18 @@ class ServerStorageDelegate : public chip::PersistentStorageDelegate
 {
 public:
     CHIP_ERROR
-    SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override
     {
         return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
     }
 
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override
     {
         return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
     }
 
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override
     {
         return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
     }

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -35,7 +35,3 @@ BOOL CHIPIsDevicePaired(uint64_t id);
 BOOL CHIPGetConnectedDevice(CHIPDeviceConnectionCallback completionHandler);
 BOOL CHIPGetConnectedDeviceWithID(uint64_t deviceId, CHIPDeviceConnectionCallback completionHandler);
 void CHIPUnpairDeviceWithID(uint64_t deviceId);
-
-@interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-
-@end

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -65,12 +65,10 @@ void CHIPSetNextAvailableDeviceID(uint64_t id)
 
 CHIPDeviceController * InitializeCHIP(void)
 {
-    static CHIPToolPersistentStorageDelegate * storage = nil;
     static dispatch_once_t onceToken;
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     dispatch_once(&onceToken, ^{
-        storage = [[CHIPToolPersistentStorageDelegate alloc] init];
-        [controller startup:storage vendorId:0 nocSigner:nil];
+        [controller startup:nil fabricId:1 vendorId:kCHIPToolTmpVendorId nocSigner:nil];
     });
 
     return controller;
@@ -117,26 +115,3 @@ void CHIPUnpairDeviceWithID(uint64_t deviceId)
     NSError * error;
     [controller unpairDevice:deviceId error:&error];
 }
-
-@implementation CHIPToolPersistentStorageDelegate
-
-// MARK: CHIPPersistentStorageDelegate
-
-- (NSString *)CHIPGetKeyValue:(NSString *)key
-{
-    NSString * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
-    NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
-    return value;
-}
-
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value
-{
-    CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
-}
-
-- (void)CHIPDeleteKeyValue:(NSString *)key
-{
-    CHIPRemoveDomainValueForKey(kCHIPToolDefaultsDomain, key);
-}
-
-@end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -14,7 +14,6 @@
 @property (nonatomic, strong) UILabel * temperatureLabel;
 @property (nonatomic, strong) UITextField * minIntervalInSecondsTextField;
 @property (nonatomic, strong) UITextField * maxIntervalInSecondsTextField;
-@property (nonatomic, strong) UITextField * deltaInCelsiusTextField;
 @property (nonatomic, strong) UIButton * sendReportingSetup;
 @end
 
@@ -51,7 +50,6 @@
 {
     [_minIntervalInSecondsTextField resignFirstResponder];
     [_maxIntervalInSecondsTextField resignFirstResponder];
-    [_deltaInCelsiusTextField resignFirstResponder];
 }
 
 - (void)setupUI
@@ -119,17 +117,6 @@
     maxIntervalInSecondsView.translatesAutoresizingMaskIntoConstraints = false;
     [maxIntervalInSecondsView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 
-    // Delta
-    _deltaInCelsiusTextField = [UITextField new];
-    _deltaInCelsiusTextField.keyboardType = UIKeyboardTypeNumberPad;
-    UILabel * deltaInCelsiusLabel = [UILabel new];
-    [deltaInCelsiusLabel setText:@"Delta (°C):"];
-    UIView * deltaInCelsiusView = [CHIPUIViewUtils viewWithLabel:deltaInCelsiusLabel textField:_deltaInCelsiusTextField];
-    [stackView addArrangedSubview:deltaInCelsiusView];
-
-    deltaInCelsiusView.translatesAutoresizingMaskIntoConstraints = false;
-    [deltaInCelsiusView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
-
     // Reporting button
     _sendReportingSetup = [UIButton new];
     [_sendReportingSetup setTitle:@"Send reporting settings" forState:UIControlStateNormal];
@@ -194,10 +181,8 @@
 {
     int minIntervalSeconds = [_minIntervalInSecondsTextField.text intValue];
     int maxIntervalSeconds = [_maxIntervalInSecondsTextField.text intValue];
-    int deltaInCelsius = [_deltaInCelsiusTextField.text intValue];
 
-    NSLog(
-        @"Sending temp reporting values: min %@ max %@ value %@", @(minIntervalSeconds), @(maxIntervalSeconds), @(deltaInCelsius));
+    NSLog(@"Sending temp reporting values: min %@ max %@ value %@", @(minIntervalSeconds), @(maxIntervalSeconds));
 
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {
@@ -207,7 +192,6 @@
                 [cluster
                     subscribeAttributeMeasuredValueWithMinInterval:minIntervalSeconds
                                                        maxInterval:maxIntervalSeconds
-                                                            change:deltaInCelsius
                                                    responseHandler:^(NSError * error, NSDictionary * values) {
                                                        if (error == nil)
                                                            return;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -97,10 +97,12 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  * check if the stack needs to be started up.
  *
  * @param[in] storageDelegate The delegate for persistent storage
+ * @param[in] fabricId The fabricId for this controller instance
  * @param[in] vendorId The vendor ID of the commissioner application
  * @param[in] nocSigner The CHIPKeypair that is used to generate and sign Node Operational Credentials
  */
 - (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
+       fabricId:(uint64_t)fabricId
        vendorId:(uint16_t)vendorId
       nocSigner:(nullable id<CHIPKeypair>)nocSigner;
 

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -50,6 +50,8 @@ public:
     void SetDeviceID(chip::NodeId deviceId) { mDeviceBeingPaired = deviceId; }
     void ResetDeviceID() { mDeviceBeingPaired = chip::kUndefinedNodeId; }
 
+    const chip::Crypto::P256PublicKey & GetIssuerPubkey() { return mIssuerKey->Pubkey(); };
+
     CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId,
         const chip::Crypto::P256PublicKey & pubkey, chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
         chip::MutableByteSpan & noc);

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -86,10 +86,11 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::SetIssuerID(CHIPPersistentStorage
 
     char issuerIdString[16];
     uint16_t idStringLen = sizeof(issuerIdString);
-    if (CHIP_NO_ERROR != storage->SyncGetKeyValue(CHIP_COMMISSIONER_CA_ISSUER_ID, issuerIdString, idStringLen)) {
+    if (CHIP_NO_ERROR
+        != storage->SyncGetKeyValue(kUndefinedCompressedFabricId, CHIP_COMMISSIONER_CA_ISSUER_ID, issuerIdString, idStringLen)) {
         mIssuerId = arc4random();
         CHIP_LOG_ERROR("Assigned %d certificate issuer ID to the commissioner", mIssuerId);
-        storage->SyncSetKeyValue(CHIP_COMMISSIONER_CA_ISSUER_ID, &mIssuerId, sizeof(mIssuerId));
+        storage->SyncSetKeyValue(kUndefinedCompressedFabricId, CHIP_COMMISSIONER_CA_ISSUER_ID, &mIssuerId, sizeof(mIssuerId));
     } else {
         CHIP_LOG_ERROR("Found %d certificate issuer ID for the commissioner", mIssuerId);
     }
@@ -208,7 +209,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (!mGenerateRootCert) {
         PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-            err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+            err = mStorage->SyncGetKeyValue(kUndefinedCompressedFabricId, key, rcac.data(), rcacBufLen));
         if (err == CHIP_NO_ERROR) {
             // Found root certificate in the storage.
             rcac.reduce_size(rcacBufLen);
@@ -221,7 +222,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
-        err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
+        err = mStorage->SyncSetKeyValue(kUndefinedCompressedFabricId, key, rcac.data(), static_cast<uint16_t>(rcac.size())));
 
     mGenerateRootCert = false;
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
@@ -20,7 +20,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * The protocol definition for the CHIPPersistenStorageDelegate
+ * The protocol definition for the CHIPPersistentStorageDelegate
+ * Storage is expected to be split across different CompressedFabricIds.
+ * CHIP stores most of its operational data inside a "Fabric" scope with a handful
+ * of metadata items in the "global" scope
+ *
+ * A Compressed FabricId of "0" indicates the "global" scope for storage.
  *
  * All delegate methods will be called on the supplied Delegate Queue.
  */
@@ -31,19 +36,19 @@ NS_ASSUME_NONNULL_BEGIN
  * Get the value for the given key
  *
  */
-- (nullable NSString *)CHIPGetKeyValue:(NSString *)key;
+- (nullable NSString *)CHIPGetKeyValueForFabric:(NSNumber *)CompressedFabricId key:(NSString *)key;
 
 /**
  * Set the value of the key to the given value
  *
  */
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value;
+- (void)CHIPSetKeyValueForFabric:(NSNumber *)CompressedFabricId key:(NSString *)key value:(NSString *)value;
 
 /**
  * Delete the key and corresponding value
  *
  */
-- (void)CHIPDeleteKeyValue:(NSString *)key;
+- (void)CHIPDeleteKeyValueForFabric:(NSNumber *)CompressedFabricId key:(NSString *)key;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -30,11 +30,12 @@ public:
 
     void setFrameworkDelegate(_Nullable id<CHIPPersistentStorageDelegate> delegate);
 
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override;
 
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override;
 
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override;
 
 private:
     id<CHIPPersistentStorageDelegate> mDelegate;

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -85,7 +85,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    BOOL started = [controller startup:nil fabricId:1 vendorId:0 nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -103,7 +103,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
+    BOOL started = [controller startup:nil fabricId:1 vendorId:0 nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -32,11 +32,11 @@
 - (void)testControllerLifecycle
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+    XCTAssertTrue([controller startup:nil fabricId:1 vendorId:0 nocSigner:nil]);
     XCTAssertTrue([controller shutdown]);
 
     // now try to restart the controller
-    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+    XCTAssertTrue([controller startup:nil fabricId:1 vendorId:0 nocSigner:nil]);
     XCTAssertTrue([controller shutdown]);
 }
 
@@ -44,7 +44,7 @@
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     for (int i = 0; i < 5; i++) {
-        XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+        XCTAssertTrue([controller startup:nil fabricId:1 vendorId:0 nocSigner:nil]);
     }
     XCTAssertTrue([controller shutdown]);
 }
@@ -52,7 +52,7 @@
 - (void)testControllerMultipleShutdown
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
+    XCTAssertTrue([controller startup:nil fabricId:1 vendorId:0 nocSigner:nil]);
     for (int i = 0; i < 5; i++) {
         XCTAssertTrue([controller shutdown]);
     }

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2199,6 +2199,16 @@ using CHIP_ERROR = ::chip::ChipError;
 #define CHIP_ERROR_NO_SHARED_TRUSTED_ROOT                      CHIP_CORE_ERROR(0xc9)
 
 /**
+ * @def CHIP_ERROR_ALREADY_EXISTS
+ *
+ * @brief
+ *   The addition of a new item failed because it an existing item was found
+ *   and the container doesn't support overwriting items.
+ *
+ */
+#define CHIP_ERROR_ALREADY_EXISTS                              CHIP_CORE_ERROR(0xca)
+
+/**
  *  @}
  */
 

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -19,10 +19,20 @@
 #pragma once
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/PeerId.h>
 #include <lib/support/DLLUtil.h>
 
 namespace chip {
 
+/**
+ * @brief The Persistent Storage Delegate provides a Fabric scoped storage
+ *        interface for the CHIP stack to store items.
+ *
+ *        The FabricId used here allows for storage to reuse keys within each fabric's scope
+ *        These APIs might be called with `kUndefinedCompressedFabricId` in which case
+ *        The delegate is expected to access a "global" storage scope.
+ *
+ */
 class DLL_EXPORT PersistentStorageDelegate
 {
 public:
@@ -38,7 +48,7 @@ public:
      *   Caller is responsible to take care of any special formatting needs (e.g. byte
      *   order, null terminators, consistency checks or versioning).
      *
-     *
+     * @param[in]      fabricId The compressed Fabric Id where this key is stored
      * @param[in]      key Key to lookup
      * @param[out]     buffer Value for the key
      * @param[in, out] size Input value buffer size, output length of value.
@@ -46,25 +56,27 @@ public:
      *                 such cases, the user should allocate the buffer large
      *                 enough (>= output length), and call the API again.
      */
-    virtual CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) = 0;
+    virtual CHIP_ERROR SyncGetKeyValue(const CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) = 0;
 
     /**
      * @brief
      *   Set the value for the key to a byte buffer.
      *
+     * @param[in] fabricId The compressed Fabric Id where this key should be stored
      * @param[in] key Key to be set
      * @param[in] value Value to be set
      * @param[in] size Size of the Value
      */
-    virtual CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) = 0;
+    virtual CHIP_ERROR SyncSetKeyValue(const CompressedFabricId fabricId, const char * key, const void * value, uint16_t size) = 0;
 
     /**
      * @brief
      *   Deletes the value for the key
      *
+     * @param[in] fabricId The compressed Fabric Id where this key is stored
      * @param[in] key Key to be deleted
      */
-    virtual CHIP_ERROR SyncDeleteKeyValue(const char * key) = 0;
+    virtual CHIP_ERROR SyncDeleteKeyValue(const CompressedFabricId fabricId, const char * key) = 0;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -281,7 +281,7 @@ public:
         }
     }
 
-    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    CHIP_ERROR SyncGetKeyValue(const chip::CompressedFabricId fabricId, const char * key, void * buffer, uint16_t & size) override
     {
         for (int i = 0; i < 16; i++)
         {
@@ -298,7 +298,8 @@ public:
         return CHIP_ERROR_INTERNAL;
     }
 
-    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    CHIP_ERROR SyncSetKeyValue(const chip::CompressedFabricId fabricId, const char * key, const void * value,
+                               uint16_t size) override
     {
         for (int i = 0; i < 16; i++)
         {
@@ -317,7 +318,7 @@ public:
         return CHIP_ERROR_INTERNAL;
     }
 
-    CHIP_ERROR SyncDeleteKeyValue(const char * key) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR SyncDeleteKeyValue(const chip::CompressedFabricId fabricId, const char * key) override { return CHIP_NO_ERROR; }
 
 private:
     char * keys[16];

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -87,6 +87,7 @@ public:
     FabricId GetFabricId() const { return mFabricId; }
     FabricIndex GetFabricIndex() const { return mFabric; }
     uint16_t GetVendorId() const { return mVendorId; }
+    CompressedFabricId GetCompressedFabricId() const { return mOperationalId.GetCompressedFabricId(); }
 
     void SetVendorId(uint16_t vendorId) { mVendorId = vendorId; }
 
@@ -121,23 +122,25 @@ public:
     CHIP_ERROR MatchDestinationID(const ByteSpan & destinationId, const ByteSpan & initiatorRandom, const ByteSpan * ipkList,
                                   size_t ipkListEntries);
 
+    bool Matches(const FabricInfo * info) const;
+
     // TODO - Refactor storing and loading of fabric info from persistent storage.
     //        The op cert array doesn't need to be in RAM except when it's being
     //        transmitted to peer node during CASE session setup.
-    CHIP_ERROR GetRootCert(ByteSpan & cert)
+    CHIP_ERROR GetRootCert(ByteSpan & cert) const
     {
         ReturnErrorCodeIf(mRootCert.empty(), CHIP_ERROR_INCORRECT_STATE);
         cert = mRootCert;
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR GetICACert(ByteSpan & cert)
+    CHIP_ERROR GetICACert(ByteSpan & cert) const
     {
         cert = mICACert;
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR GetNOCCert(ByteSpan & cert)
+    CHIP_ERROR GetNOCCert(ByteSpan & cert) const
     {
         ReturnErrorCodeIf(mNOCCert.empty(), CHIP_ERROR_INCORRECT_STATE);
         cert = mNOCCert;
@@ -177,6 +180,8 @@ public:
         }
         ReleaseOperationalCerts();
     }
+
+    CHIP_ERROR Populate();
 
     CHIP_ERROR SetFabricInfo(FabricInfo & fabric);
 
@@ -356,6 +361,7 @@ public:
 
     void ReleaseFabricIndex(FabricIndex fabricIndex);
 
+    FabricInfo * FindFabricWithCompressedId(CompressedFabricId fabricId);
     FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex);
 
     FabricIndex FindDestinationIDCandidate(const ByteSpan & destinationId, const ByteSpan & initiatorRandom,


### PR DESCRIPTION
#### Problem
Nearly all the operational data needed for a node can be stored within a fabric's scope. Some metadata might need to be stored in a "global" scope but a majority of storage can be scoped to a fabric. 
Also, to support multiple controllers/commissioners in one process we need to be able to section off storage into a "fabric" scope. 
Without this, our storage keys across fabrics would collide in storage and overwrite another fabric's data.

#### Change overview
Enable fabric scoped storage. 
1. The storage delegate APIs now require a CompressedFabricId for each key/value. 
For now the CHIPDeviceController class has been updated to store things within its fabric scope, but there are other pieces (example applications) that do not store things inside a fabric but on the global scope instead. 

2. The Fabric Table has also been updated to store metadata in the global scope (global scope: fabricIndex <-> compressedFabricId) and actual fabric info is stored within the fabric scope (fabricScope: compressedFabricId <-> fabricInfo)

Also contains an unrelated fix for CHIPTool (iOS) compilation. 

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
A lot of this is being tested by unit tests but I also tested it manually with CHIPTool iOS + chip-tool cli. Made sure both are able pair with an M5Stack and control it at the same time. 
