### PR TITLE
Log error on BLE deferred sending

### DIFF
--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -171,7 +171,11 @@ void BLEBase::OnEndPointConnectComplete(BLEEndPoint * endPoint, CHIP_ERROR err)
     {
         if (!mPendingPackets[i].IsNull())
         {
-            endPoint->Send(std::move(mPendingPackets[i]));
+            err = endPoint->Send(std::move(mPendingPackets[i]));
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Inet, "Deferred sending failed: %s", ErrorStr(err));
+            }
         }
     }
     ChipLogDetail(Inet, "BLE EndPoint %p Connection Complete", endPoint);


### PR DESCRIPTION
#### Problem
Silent 'Send' over ble for deferred packets, without any error reporting

#### Change overview
Add error reporting.

#### Testing
Compile only.
