### PR TITLE
Update Message Header with spec

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -328,7 +328,7 @@ void StartPinging(streamer_t * stream, char * destination)
     err = EstablishSecureSession(stream, GetEchoPeerAddress());
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, SessionHandle(kTestDeviceNodeId, 0, 0, gFabricIndex));
+    err = gEchoClient.Init(&gExchangeManager, SessionHandle(kTestDeviceNodeId, 1, 1, gFabricIndex));
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     uint32_t payloadSize = gSendArguments.GetPayloadSize();
 
     // Create a new exchange context.
-    auto * ec = gExchangeManager.NewContext(SessionHandle(kTestDeviceNodeId, 0, 0, gFabricIndex), &gMockAppDelegate);
+    auto * ec = gExchangeManager.NewContext(SessionHandle(kTestDeviceNodeId, 1, 1, gFabricIndex), &gMockAppDelegate);
     VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     payloadBuf = MessagePacketBuffer::New(payloadSize);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabric
     SuccessOrExit(err);
 
     // Create a new exchange context.
-    mpExchangeCtx = mpExchangeMgr->NewContext(secureSession.ValueOr(SessionHandle(aNodeId, 0, 0, aFabricIndex)), this);
+    mpExchangeCtx = mpExchangeMgr->NewContext(secureSession.ValueOr(SessionHandle(aNodeId, 1, 1, aFabricIndex)), this);
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     mpExchangeCtx->SetResponseTimeout(timeout);

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -258,7 +258,7 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricInde
     ClearExistingExchangeContext();
 
     // Create a new exchange context.
-    mpExchangeCtx = mpExchangeMgr->NewContext(apSecureSession.ValueOr(SessionHandle(aNodeId, 0, 0, aFabricIndex)), this);
+    mpExchangeCtx = mpExchangeMgr->NewContext(apSecureSession.ValueOr(SessionHandle(aNodeId, 1, 1, aFabricIndex)), this);
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(timeout);
 

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -313,7 +313,7 @@ CHIP_ERROR SendReadRequest()
 
     printf("\nSend read request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex));
+    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
     readPrepareParams.mTimeout                     = gMessageTimeoutMsec;
     readPrepareParams.mpAttributePathParamsList    = &attributePathParams;
     readPrepareParams.mAttributePathParamsListSize = 1;
@@ -374,7 +374,7 @@ CHIP_ERROR SendSubscribeRequest()
     CHIP_ERROR err   = CHIP_NO_ERROR;
     gLastMessageTime = chip::System::SystemClock().GetMonotonicMilliseconds();
 
-    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex));
+    chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
     chip::app::EventPathParams eventPathParams[2];
     chip::app::AttributePathParams attributePathParams[1];
     readPrepareParams.mpEventPathParamsList                = eventPathParams;

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -50,6 +50,8 @@ constexpr size_t kSHA1_Hash_Length                = 20;
 constexpr size_t CHIP_CRYPTO_GROUP_SIZE_BYTES      = kP256_FE_Length;
 constexpr size_t CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES = kP256_Point_Length;
 
+constexpr size_t CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES = 16;
+
 constexpr size_t kMax_ECDH_Secret_Length     = kP256_FE_Length;
 constexpr size_t kMax_ECDSA_Signature_Length = kP256_ECDSA_Signature_Length_Raw;
 constexpr size_t kMAX_FE_Length              = kP256_FE_Length;

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -299,7 +299,7 @@ bool ExchangeContext::MatchExchange(SessionHandle session, const PacketHeader & 
 
         // TODO: This check should be already implied by the equality of session check,
         // It should be removed after we have implemented the temporary node id for PASE and CASE sessions
-        && (IsEncryptionRequired() == packetHeader.HasSessionId())
+        && (IsEncryptionRequired() == packetHeader.IsEncrypted())
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -299,7 +299,7 @@ bool ExchangeContext::MatchExchange(SessionHandle session, const PacketHeader & 
 
         // TODO: This check should be already implied by the equality of session check,
         // It should be removed after we have implemented the temporary node id for PASE and CASE sessions
-        && (IsEncryptionRequired() == packetHeader.GetFlags().Has(Header::FlagValues::kEncryptedMessage))
+        && (IsEncryptionRequired() == packetHeader.HasSessionId())
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -293,7 +293,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         ChipLogDetail(ExchangeManager, "Handling via exchange: " ChipLogFormatExchange ", Delegate: 0x%p", ChipLogValueExchange(ec),
                       ec->GetDelegate());
 
-        if (ec->IsEncryptionRequired() != packetHeader.GetFlags().Has(Header::FlagValues::kEncryptedMessage))
+        if (ec->IsEncryptionRequired() != packetHeader.HasSessionId())
         {
             ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(CHIP_ERROR_INVALID_MESSAGE_TYPE));
             ec->Close();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -293,7 +293,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         ChipLogDetail(ExchangeManager, "Handling via exchange: " ChipLogFormatExchange ", Delegate: 0x%p", ChipLogValueExchange(ec),
                       ec->GetDelegate());
 
-        if (ec->IsEncryptionRequired() != packetHeader.HasSessionId())
+        if (ec->IsEncryptionRequired() != packetHeader.IsEncrypted())
         {
             ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(CHIP_ERROR_INVALID_MESSAGE_TYPE));
             ec->Close();

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -256,7 +256,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex));
+    err = gEchoClient.Init(&gExchangeManager, chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -339,8 +339,10 @@ class SecurePairingUsingTestSecret : public PairingSession
 public:
     SecurePairingUsingTestSecret()
     {
-        SetLocalSessionId(0);
-        SetPeerSessionId(0);
+        // Do not set to 0 to prevent unwanted unsecured session
+        // since the session type is unknown.
+        SetLocalSessionId(1);
+        SetPeerSessionId(1);
     }
 
     SecurePairingUsingTestSecret(uint16_t peerSessionId, uint16_t localSessionId)

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -339,8 +339,8 @@ class SecurePairingUsingTestSecret : public PairingSession
 public:
     SecurePairingUsingTestSecret()
     {
-        SetLocalSessionId(0);
-        SetPeerSessionId(0);
+        SetLocalSessionId(1);
+        SetPeerSessionId(1);
     }
 
     SecurePairingUsingTestSecret(uint16_t peerSessionId, uint16_t localSessionId)

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -339,8 +339,8 @@ class SecurePairingUsingTestSecret : public PairingSession
 public:
     SecurePairingUsingTestSecret()
     {
-        SetLocalSessionId(1);
-        SetPeerSessionId(1);
+        SetLocalSessionId(0);
+        SetPeerSessionId(0);
     }
 
     SecurePairingUsingTestSecret(uint16_t peerSessionId, uint16_t localSessionId)

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -24,6 +24,7 @@ namespace chip {
 CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 {
     VerifyOrReturnError(mNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mNextAvailable > kUnsecureSessionId, CHIP_ERROR_INTERNAL);
     id = mNextAvailable;
 
     // TODO - Update SessionID allocator to use freed session IDs
@@ -34,7 +35,7 @@ CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 
 void SessionIDAllocator::Free(uint16_t id)
 {
-    if (mNextAvailable > 0 && (mNextAvailable - 1) == id)
+    if (mNextAvailable > 1 && (mNextAvailable - 1) == id)
     {
         mNextAvailable--;
     }

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -24,7 +24,7 @@ namespace chip {
 CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 {
     VerifyOrReturnError(mNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
-    VerifyOrReturnError(mNextAvailable > kUnsecureSessionId, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(mNextAvailable > kUnsecuredSessionId, CHIP_ERROR_INTERNAL);
     id = mNextAvailable;
 
     // TODO - Update SessionID allocator to use freed session IDs
@@ -36,7 +36,7 @@ CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 void SessionIDAllocator::Free(uint16_t id)
 {
     // As per spec 4.4.1.3 Session ID of 0 is reserved for Unsecure communication
-    if (mNextAvailable > 1 && (mNextAvailable - 1) == id)
+    if (mNextAvailable > (kUnsecuredSessionId + 1) && (mNextAvailable - 1) == id)
     {
         mNextAvailable--;
     }

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -35,6 +35,7 @@ CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 
 void SessionIDAllocator::Free(uint16_t id)
 {
+    // As per spec 4.4.1.3 Session ID of 0 is reserved for Unsecure communication
     if (mNextAvailable > 1 && (mNextAvailable - 1) == id)
     {
         mNextAvailable--;

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -36,7 +36,9 @@ public:
 private:
     // Session ID is a 15 bit value (16th bit indicates unicast/group key)
     static constexpr uint16_t kMaxSessionID = (1 << 15) - 1;
-    uint16_t mNextAvailable                 = 0;
+    static constexpr uint16_t kUnsecureSessionId = 0;
+
+    uint16_t mNextAvailable                 = 1;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -35,10 +35,10 @@ public:
 
 private:
     // Session ID is a 15 bit value (16th bit indicates unicast/group key)
-    static constexpr uint16_t kMaxSessionID = (1 << 15) - 1;
+    static constexpr uint16_t kMaxSessionID      = (1 << 15) - 1;
     static constexpr uint16_t kUnsecureSessionId = 0;
 
-    uint16_t mNextAvailable                 = 1;
+    uint16_t mNextAvailable = 1;
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -18,6 +18,16 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <stdint.h>
+
+// Spec 4.4.1.3
+// ===== Session ID (16 bits)
+// An unsigned integer value identifying the session associated with this message.
+// The session identifies the particular key used to encrypt a message out of the set of
+// available keys (either session or group), and the particular encryption/message
+// integrity algorithm to use for the message.The Session ID field is always present.
+// A Session ID of 0 SHALL indicate an unsecured session with no encryption or message integrity checking.
+
 
 namespace chip {
 
@@ -34,8 +44,8 @@ public:
     uint16_t Peek();
 
 private:
-    // Session ID is a 15 bit value (16th bit indicates unicast/group key)
-    static constexpr uint16_t kMaxSessionID      = (1 << 15) - 1;
+
+    static constexpr uint16_t kMaxSessionID      = UINT16_MAX;
     static constexpr uint16_t kUnsecureSessionId = 0;
 
     uint16_t mNextAvailable = 1;

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -28,7 +28,6 @@
 // integrity algorithm to use for the message.The Session ID field is always present.
 // A Session ID of 0 SHALL indicate an unsecured session with no encryption or message integrity checking.
 
-
 namespace chip {
 
 class SessionIDAllocator
@@ -44,8 +43,7 @@ public:
     uint16_t Peek();
 
 private:
-
-    static constexpr uint16_t kMaxSessionID      = UINT16_MAX;
+    static constexpr uint16_t kMaxSessionID       = UINT16_MAX;
     static constexpr uint16_t kUnsecuredSessionId = 0;
 
     uint16_t mNextAvailable = 1;

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -46,7 +46,7 @@ public:
 private:
 
     static constexpr uint16_t kMaxSessionID      = UINT16_MAX;
-    static constexpr uint16_t kUnsecureSessionId = 0;
+    static constexpr uint16_t kUnsecuredSessionId = 0;
 
     uint16_t mNextAvailable = 1;
 };

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -405,6 +405,10 @@ void CASE_SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     PacketHeader header;
     MessageAuthenticationCode mac;
 
+    header.SetSessionId(1);
+    NL_TEST_ASSERT(inSuite, header.IsEncrypted() == true);
+    NL_TEST_ASSERT(inSuite, header.MICTagLength() == 16);
+
     // Let's try encrypting using original session, and decrypting using deserialized
     {
         CryptoContext session1;

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -302,6 +302,11 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     PacketHeader header;
     MessageAuthenticationCode mac;
 
+    header.SetSessionId(1);
+    NL_TEST_ASSERT(inSuite, header.IsEncrypted() == true);
+    NL_TEST_ASSERT(inSuite, header.MICTagLength() == 16);
+
+
     // Let's try encrypting using original session, and decrypting using deserialized
     {
         CryptoContext session1;

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -306,7 +306,6 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.IsEncrypted() == true);
     NL_TEST_ASSERT(inSuite, header.MICTagLength() == 16);
 
-
     // Let's try encrypting using original session, and decrypting using deserialized
     {
         CryptoContext session1;

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -28,7 +28,7 @@ void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
 
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 0);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 1);
 
     uint16_t id;
 
@@ -36,8 +36,8 @@ void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+        NL_TEST_ASSERT(inSuite, id == i + 1);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 2);
     }
 }
 
@@ -45,7 +45,7 @@ void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
 
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 0);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 1);
 
     uint16_t id;
 
@@ -53,21 +53,21 @@ void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+        NL_TEST_ASSERT(inSuite, id == i + 1);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 2);
     }
 
     // Free an intermediate ID
     allocator.Free(10);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 16);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 17);
 
     // Free the last allocated ID
-    allocator.Free(15);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 15);
+    allocator.Free(16);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 16);
 
     // Free some random unallocated ID
     allocator.Free(100);
-    NL_TEST_ASSERT(inSuite, allocator.Peek() == 15);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 16);
 }
 
 void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
@@ -80,8 +80,8 @@ void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+        NL_TEST_ASSERT(inSuite, id == i + 1);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 2);
     }
 
     allocator.Reserve(100);

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -32,12 +32,12 @@ void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
 
     uint16_t id;
 
-    for (uint16_t i = 0; i < 16; i++)
+    for (uint16_t i = 1; i < 16; i++)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i + 1);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 2);
+        NL_TEST_ASSERT(inSuite, id == i);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
     }
 }
 
@@ -49,12 +49,12 @@ void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
 
     uint16_t id;
 
-    for (uint16_t i = 0; i < 16; i++)
+    for (uint16_t i = 1; i < 17; i++)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i + 1);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 2);
+        NL_TEST_ASSERT(inSuite, id == i);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
     }
 
     // Free an intermediate ID
@@ -76,12 +76,12 @@ void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
 
     uint16_t id;
 
-    for (uint16_t i = 0; i < 16; i++)
+    for (uint16_t i = 1; i < 16; i++)
     {
         CHIP_ERROR err = allocator.Allocate(id);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, id == i + 1);
-        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 2);
+        NL_TEST_ASSERT(inSuite, id == i);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
     }
 
     allocator.Reserve(100);

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -67,8 +67,6 @@ CHIP_ERROR UserDirectedCommissioningClient::EncodeUDCMessage(System::PacketBuffe
 
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(payload));
 
-    packetHeader.SetSessionType(Header::SessionType::kSessionTypeNone);
-
     ReturnErrorOnFailure(packetHeader.EncodeBeforeData(payload));
 
     return CHIP_NO_ERROR;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -38,7 +38,7 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
 
     ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
 
-    if (packetHeader.HasSessionId())
+    if (packetHeader.IsEncrypted())
     {
         ChipLogError(AppServer, "UDC encryption flag set - ignoring");
         return;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -38,7 +38,7 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
 
     ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
 
-    if (packetHeader.GetFlags().Has(Header::FlagValues::kEncryptedMessage))
+    if (packetHeader.HasSessionId())
     {
         ChipLogError(AppServer, "UDC encryption flag set - ignoring");
         return;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -180,7 +180,6 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     // check the packet header fields
     PacketHeader packetHeader;
     packetHeader.DecodeAndConsume(payloadBuf);
-    NL_TEST_ASSERT(inSuite, !packetHeader.GetFlags().Has(Header::FlagValues::kEncryptedMessage));
 
     // check the payload header fields
     PayloadHeader payloadHeader;

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -180,6 +180,7 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     // check the packet header fields
     PacketHeader packetHeader;
     packetHeader.DecodeAndConsume(payloadBuf);
+    NL_TEST_ASSERT(inSuite, !packetHeader.IsEncrypted());
 
     // check the payload header fields
     PayloadHeader payloadHeader;

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -165,7 +165,6 @@ CHIP_ERROR CryptoContext::Encrypt(const uint8_t * input, size_t input_length, ui
 
     const size_t taglen = header.MICTagLength();
 
-
     VerifyOrDie(taglen <= kMaxTagLen);
 
     VerifyOrReturnError(mKeyAvailable, CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -163,9 +163,9 @@ CHIP_ERROR CryptoContext::Encrypt(const uint8_t * input, size_t input_length, ui
                                   MessageAuthenticationCode & mac) const
 {
 
-    constexpr Header::SessionType sessionType = Header::SessionType::kAESCCMTagLen16;
+    const size_t taglen = header.MICTagLength();
 
-    const size_t taglen = MessageAuthenticationCode::TagLenForSessionType(sessionType);
+
     VerifyOrDie(taglen <= kMaxTagLen);
 
     VerifyOrReturnError(mKeyAvailable, CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
@@ -194,7 +194,7 @@ CHIP_ERROR CryptoContext::Encrypt(const uint8_t * input, size_t input_length, ui
     ReturnErrorOnFailure(AES_CCM_encrypt(input, input_length, AAD, aadLen, mKeys[usage], Crypto::kAES_CCM128_Key_Length, IV,
                                          sizeof(IV), output, tag, taglen));
 
-    mac.SetTag(&header, sessionType, tag, taglen);
+    mac.SetTag(&header, tag, taglen);
 
     return CHIP_NO_ERROR;
 }
@@ -202,7 +202,7 @@ CHIP_ERROR CryptoContext::Encrypt(const uint8_t * input, size_t input_length, ui
 CHIP_ERROR CryptoContext::Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
                                   const MessageAuthenticationCode & mac) const
 {
-    const size_t taglen = MessageAuthenticationCode::TagLenForSessionType(header.GetSessionType());
+    const size_t taglen = header.MICTagLength();
     const uint8_t * tag = mac.GetTag();
     uint8_t IV[kAESCCMIVLen];
     uint8_t AAD[kMaxAADLen];

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -52,7 +52,9 @@ CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
         .SetMessageCounter(messageCounter) //
         .SetSessionId(state->GetPeerSessionId());
 
-    packetHeader.GetFlags().Set(Header::FlagValues::kEncryptedMessage);
+
+    // TODO set Session Type (Unicast or Group)
+    // packetHeader.SetSessionType(Header::SessionType::kUnicastSession);
 
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(msgBuf));
 
@@ -90,7 +92,7 @@ CHIP_ERROR Decrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
     msg->SetDataLength(len);
 #endif
 
-    uint16_t footerLen = MessageAuthenticationCode::TagLenForSessionType(packetHeader.GetSessionType());
+    uint16_t footerLen = packetHeader.MICTagLength();
     VerifyOrReturnError(footerLen <= len, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     uint16_t taglen = 0;

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -52,7 +52,6 @@ CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
         .SetMessageCounter(messageCounter) //
         .SetSessionId(state->GetPeerSessionId());
 
-
     // TODO set Session Type (Unicast or Group)
     // packetHeader.SetSessionType(Header::SessionType::kUnicastSession);
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -326,7 +326,7 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
 
     ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
 
-    if (packetHeader.HasSessionId())
+    if (packetHeader.IsEncrypted())
     {
         SecureMessageDispatch(packetHeader, peerAddress, std::move(msg));
     }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -326,7 +326,7 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
 
     ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
 
-    if (packetHeader.GetFlags().Has(Header::FlagValues::kEncryptedMessage))
+    if (packetHeader.HasSessionId())
     {
         SecureMessageDispatch(packetHeader, peerAddress, std::move(msg));
     }
@@ -403,7 +403,7 @@ void SessionManager::SecureMessageDispatch(const PacketHeader & packetHeader, co
                  ChipLogError(Inet, "Secure transport received message, but failed to decode/authenticate it, discarding"));
 
     // Verify message counter
-    if (packetHeader.GetFlags().Has(Header::FlagValues::kSecureSessionControlMessage))
+    if (packetHeader.IsSecureSessionControlMsg())
     {
         // TODO: control message counter is not implemented yet
     }
@@ -462,7 +462,7 @@ void SessionManager::SecureMessageDispatch(const PacketHeader & packetHeader, co
         }
     }
 
-    if (packetHeader.GetFlags().Has(Header::FlagValues::kSecureSessionControlMessage))
+    if (packetHeader.IsSecureSessionControlMsg())
     {
         // TODO: control message counter is not implemented yet
     }

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -87,8 +87,6 @@ constexpr uint8_t kMsgFlagsMask = 0x07;
 /// Shift to convert to/from a masked version 8bit value to a 4bit version.
 constexpr int kVersionShift = 4;
 
-
-
 } // namespace
 
 uint16_t PacketHeader::EncodeSizeBytes() const
@@ -153,7 +151,6 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     err = reader.Read8(&securityFlags).StatusCode();
     SuccessOrExit(err);
     mSecFlags.SetRaw(securityFlags);
-
 
     err = reader.Read16(&mSessionId).StatusCode();
     SuccessOrExit(err);
@@ -292,7 +289,6 @@ CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode
 
     uint8_t msgFlags = (kMsgHeaderVersion << kVersionShift) | (messageFlags.Raw() & kMsgFlagsMask);
     uint8_t secFlags = securityFlags.Raw();
-
 
     uint8_t * p = data;
     Write8(p, msgFlags);

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -28,6 +28,7 @@
 
 #include <type_traits>
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/GroupId.h>
 #include <lib/core/Optional.h>
@@ -36,7 +37,6 @@
 #include <lib/support/TypeTraits.h>
 #include <protocols/Protocols.h>
 #include <system/SystemPacketBuffer.h>
-#include <crypto/CHIPCryptoPAL.h>
 
 namespace chip {
 
@@ -53,7 +53,7 @@ namespace Header {
 enum class SessionType
 {
     kUnicastSession = 0,
-    kGroupSession = 1,
+    kGroupSession   = 1,
 };
 
 /**
@@ -78,25 +78,23 @@ enum class ExFlagValues : uint8_t
 enum class MsgFlagValues : uint8_t
 {
     /// Header flag specifying that a source node id is included in the header.
-    kSourceNodeIdPresent = 0b00000100,
-    kDestinationNodeIdAbsent = 0b00000000,
-    kDestinationNodeIdPresent = 0b00000001,
+    kSourceNodeIdPresent       = 0b00000100,
+    kDestinationNodeIdAbsent   = 0b00000000,
+    kDestinationNodeIdPresent  = 0b00000001,
     kDestinationGroupIdPresent = 0b00000010,
-    kDSIZReserved = 0b00000011,
+    kDSIZReserved              = 0b00000011,
 
 };
 
 enum class SecFlagValues : uint8_t
 {
-    kPrivacyFlag            = 0b10000000,
-    kControlMsgFlag         = 0b01000000,
-    kMsgExtensionFlag       = 0b00100000,
-    kSessiontTypeUnicast    = 0b00000000,
-    kSessiontTypeGroup      = 0b00000001,
+    kPrivacyFlag         = 0b10000000,
+    kControlMsgFlag      = 0b01000000,
+    kMsgExtensionFlag    = 0b00100000,
+    kSessiontTypeUnicast = 0b00000000,
+    kSessiontTypeGroup   = 0b00000001,
 
 };
-
-
 
 using MsgFlags = BitFlags<MsgFlagValues>;
 using SecFlags = BitFlags<SecFlagValues>;
@@ -157,7 +155,7 @@ public:
 
     bool IsEncrypted() const { return mSessionId != kMsgSessionIdUnsecured; }
 
-    uint16_t MICTagLength() const { return (IsEncrypted()) ? chip::Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES : 0;}
+    uint16_t MICTagLength() const { return (IsEncrypted()) ? chip::Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES : 0; }
 
     /** Check if it's a secure session control message. */
     bool IsSecureSessionControlMsg() const { return mSecFlags.Has(Header::SecFlagValues::kControlMsgFlag); }
@@ -351,7 +349,6 @@ private:
     /// Flags read from the message.
     Header::MsgFlags mMsgFlags;
     Header::SecFlags mSecFlags;
-
 };
 
 /**

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -36,6 +36,7 @@
 #include <lib/support/TypeTraits.h>
 #include <protocols/Protocols.h>
 #include <system/SystemPacketBuffer.h>
+#include <crypto/CHIPCryptoPAL.h>
 
 namespace chip {
 
@@ -43,7 +44,7 @@ static constexpr size_t kMaxTagLen = 16;
 
 static constexpr size_t kMaxAppMessageLen = 1200;
 
-static constexpr size_t kMsgSessionIdUnsecured = 0x0000;
+static constexpr uint16_t kMsgSessionIdUnsecured = 0x0000;
 
 typedef int PacketHeaderFlags;
 
@@ -51,8 +52,8 @@ namespace Header {
 
 enum class SessionType
 {
-    kSessionTypeNone = 0,
-    kAESCCMTagLen16  = 1,
+    kUnicastSession = 0,
+    kGroupSession = 1,
 };
 
 /**
@@ -74,33 +75,39 @@ enum class ExFlagValues : uint8_t
     kExchangeFlag_VendorIdPresent = 0x10,
 };
 
-enum class FlagValues : uint16_t
+enum class MsgFlagValues : uint8_t
 {
-    /// Header flag specifying that a destination node id is included in the header.
-    kDestinationNodeIdPresent = 0x0001,
-
-    /// Header flag specifying that a destination group id is included in the header.
-    kDestinationGroupIdPresent = 0x0002,
-
     /// Header flag specifying that a source node id is included in the header.
-    kSourceNodeIdPresent = 0x0004,
-
-    /// Header flag specifying that it is a control message for secure session.
-    kSecureSessionControlMessage = 0x4000,
-
-    /// Header flag specifying that it is a encrypted message.
-    kEncryptedMessage = 0x0100,
+    kSourceNodeIdPresent = 0b00000100,
+    kDestinationNodeIdAbsent = 0b00000000,
+    kDestinationNodeIdPresent = 0b00000001,
+    kDestinationGroupIdPresent = 0b00000010,
+    kDSIZReserved = 0b00000011,
 
 };
 
-using Flags   = BitFlags<FlagValues>;
+enum class SecFlagValues : uint8_t
+{
+    kPrivacyFlag            = 0b10000000,
+    kControlMsgFlag         = 0b01000000,
+    kMsgExtensionFlag       = 0b00100000,
+    kSessiontTypeUnicast    = 0b00000000,
+    kSessiontTypeGroup      = 0b00000001,
+
+};
+
+
+
+using MsgFlags = BitFlags<MsgFlagValues>;
+using SecFlags = BitFlags<SecFlagValues>;
+
 using ExFlags = BitFlags<ExFlagValues>;
 
 // Header is a 16-bit value of the form
 //  |  4 bit  | 4 bit |8 bit Security Flags|
 //  +---------+-------+--------------------|
-//  | version | Flags | P | C |Reserved| E |
-//                      |   |            +---Encrypted
+//  | version | Flags | P | C | MX |Reserved| Session Type |
+//                      |   |
 //                      |   +----------------Control message (TODO: Implement this)
 //                      +--------------------Privacy enhancements (TODO: Implement this)
 
@@ -146,80 +153,87 @@ public:
 
     uint16_t GetSessionId() const { return mSessionId; }
 
-    Header::Flags & GetFlags() { return mFlags; }
-    const Header::Flags & GetFlags() const { return mFlags; }
+    bool HasSessionId() const { return mSessionId != kMsgSessionIdUnsecured; }
+
+    bool IsEncrypted() const { return mSessionId != kMsgSessionIdUnsecured; }
+
+    uint16_t MICTagLength() const { return (IsEncrypted()) ? chip::Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES : 0;}
 
     /** Check if it's a secure session control message. */
-    bool IsSecureSessionControlMsg() const { return mFlags.Has(Header::FlagValues::kSecureSessionControlMessage); }
-
-    Header::SessionType GetSessionType() const { return mSessionType; }
+    bool IsSecureSessionControlMsg() const { return mSecFlags.Has(Header::SecFlagValues::kControlMsgFlag); }
 
     PacketHeader & SetSecureSessionControlMsg(bool value)
     {
-        mFlags.Set(Header::FlagValues::kSecureSessionControlMessage, value);
+        mSecFlags.Set(Header::SecFlagValues::kControlMsgFlag, value);
         return *this;
     }
 
     PacketHeader & SetSourceNodeId(NodeId id)
     {
         mSourceNodeId.SetValue(id);
-        mFlags.Set(Header::FlagValues::kSourceNodeIdPresent);
+        mMsgFlags.Set(Header::MsgFlagValues::kSourceNodeIdPresent);
         return *this;
     }
 
     PacketHeader & SetSourceNodeId(Optional<NodeId> id)
     {
         mSourceNodeId = id;
-        mFlags.Set(Header::FlagValues::kSourceNodeIdPresent, id.HasValue());
+        mMsgFlags.Set(Header::MsgFlagValues::kSourceNodeIdPresent, id.HasValue());
         return *this;
     }
 
     PacketHeader & ClearSourceNodeId()
     {
         mSourceNodeId.ClearValue();
-        mFlags.Clear(Header::FlagValues::kSourceNodeIdPresent);
+        mMsgFlags.Clear(Header::MsgFlagValues::kSourceNodeIdPresent);
         return *this;
     }
 
     PacketHeader & SetDestinationNodeId(NodeId id)
     {
         mDestinationNodeId.SetValue(id);
-        mFlags.Set(Header::FlagValues::kDestinationNodeIdPresent);
+        mMsgFlags.Set(Header::MsgFlagValues::kDestinationNodeIdPresent);
         return *this;
     }
 
     PacketHeader & SetDestinationNodeId(Optional<NodeId> id)
     {
         mDestinationNodeId = id;
-        mFlags.Set(Header::FlagValues::kDestinationNodeIdPresent, id.HasValue());
+        mMsgFlags.Set(Header::MsgFlagValues::kDestinationNodeIdPresent, id.HasValue());
         return *this;
     }
 
     PacketHeader & ClearDestinationNodeId()
     {
         mDestinationNodeId.ClearValue();
-        mFlags.Clear(Header::FlagValues::kDestinationNodeIdPresent);
+        mMsgFlags.Clear(Header::MsgFlagValues::kDestinationNodeIdPresent);
         return *this;
     }
 
     PacketHeader & SetDestinationGroupId(GroupId id)
     {
         mDestinationGroupId.SetValue(id);
-        mFlags.Set(Header::FlagValues::kDestinationGroupIdPresent);
+        mMsgFlags.Set(Header::MsgFlagValues::kDestinationGroupIdPresent);
         return *this;
     }
 
     PacketHeader & SetDestinationGroupId(Optional<GroupId> id)
     {
         mDestinationGroupId = id;
-        mFlags.Set(Header::FlagValues::kDestinationGroupIdPresent, id.HasValue());
+        mMsgFlags.Set(Header::MsgFlagValues::kDestinationGroupIdPresent, id.HasValue());
         return *this;
     }
 
     PacketHeader & ClearDestinationGroupId()
     {
         mDestinationGroupId.ClearValue();
-        mFlags.Clear(Header::FlagValues::kDestinationGroupIdPresent);
+        mMsgFlags.Clear(Header::MsgFlagValues::kDestinationGroupIdPresent);
+        return *this;
+    }
+
+    PacketHeader & SetSessionType(Header::SessionType type)
+    {
+        mSessionType = type;
         return *this;
     }
 
@@ -232,12 +246,6 @@ public:
     PacketHeader & SetMessageCounter(uint32_t id)
     {
         mMessageCounter = id;
-        return *this;
-    }
-
-    PacketHeader & SetSessionType(Header::SessionType type)
-    {
-        mSessionType = type;
         return *this;
     }
 
@@ -322,8 +330,8 @@ public:
     }
 
 private:
-    /// Represents the current encode/decode header version
-    static constexpr int kMsgHeaderVersion = 0;
+    /// Represents the current encode/decode header version (4 bits)
+    static constexpr uint8_t kMsgHeaderVersion = 0x00;
 
     /// Value expected to be incremented for each message sent.
     uint32_t mMessageCounter = 0;
@@ -338,11 +346,12 @@ private:
     /// Session ID
     uint16_t mSessionId = kMsgSessionIdUnsecured;
 
-    /// Message flags read from the message.
-    Header::Flags mFlags;
+    Header::SessionType mSessionType = Header::SessionType::kUnicastSession;
 
-    /// Represents session type used for encrypting current packet
-    Header::SessionType mSessionType = Header::SessionType::kAESCCMTagLen16;
+    /// Flags read from the message.
+    Header::MsgFlags mMsgFlags;
+    Header::SecFlags mSecFlags;
+
 };
 
 /**
@@ -582,12 +591,11 @@ public:
     const uint8_t * GetTag() const { return &mTag[0]; }
 
     /** Set the message auth tag for this header. */
-    MessageAuthenticationCode & SetTag(PacketHeader * header, Header::SessionType sessionType, uint8_t * tag, size_t len)
+    MessageAuthenticationCode & SetTag(PacketHeader * header, uint8_t * tag, size_t len)
     {
-        const size_t tagLen = TagLenForSessionType(sessionType);
+        const size_t tagLen = chip::Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
         if (tagLen > 0 && tagLen <= kMaxTagLen && len == tagLen)
         {
-            header->SetSessionType(sessionType);
             memcpy(&mTag, tag, tagLen);
         }
 
@@ -625,8 +633,6 @@ public:
      *    CHIP_ERROR_INVALID_ARGUMENT on insufficient buffer size
      */
     CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, uint16_t size, uint16_t * encode_size) const;
-
-    static uint16_t TagLenForSessionType(Header::SessionType sessionType);
 
 private:
     /// Message authentication tag generated at encryption of the message.

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -95,7 +95,7 @@ enum class MsgFlagValues : uint8_t
 
 // Security flags 8-bit value of the form
 //  | 1 | 1 | 1  | 3 | 2 bits |
-//  +---------+-------+--------|
+//  +------------+---+--------|
 //  | P | C | MX | - | SessionType
 //
 // With :

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -41,6 +41,7 @@ void TestPacketHeaderInitialState(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, header.GetMessageCounter() == 0);
     NL_TEST_ASSERT(inSuite, header.GetSessionId() == 0);
+    NL_TEST_ASSERT(inSuite, !header.HasSessionId());
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetDestinationGroupId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
@@ -127,6 +128,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageCounter() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
+    NL_TEST_ASSERT(inSuite, header.HasSessionId());
     NL_TEST_ASSERT(inSuite, header.GetSessionId() == 2);
 
     header.SetMessageCounter(234).SetSourceNodeId(77).SetDestinationNodeId(88);

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -41,7 +41,9 @@ void TestPacketHeaderInitialState(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, header.GetMessageCounter() == 0);
     NL_TEST_ASSERT(inSuite, header.GetSessionId() == 0);
-    NL_TEST_ASSERT(inSuite, !header.HasSessionId());
+    NL_TEST_ASSERT(inSuite, header.GetSessionType() == Header::SessionType::kUnicastSession);
+    NL_TEST_ASSERT(inSuite, header.IsSessionTypeValid());
+    NL_TEST_ASSERT(inSuite, !header.IsEncrypted());
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetDestinationGroupId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
@@ -128,7 +130,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageCounter() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
-    NL_TEST_ASSERT(inSuite, header.HasSessionId());
+    NL_TEST_ASSERT(inSuite, header.IsEncrypted());
     NL_TEST_ASSERT(inSuite, header.GetSessionId() == 2);
 
     header.SetMessageCounter(234).SetSourceNodeId(77).SetDestinationNodeId(88);
@@ -146,6 +148,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_ERROR_INTERNAL);
 
     header.ClearDestinationNodeId();
+    header.SetSessionType(Header::SessionType::kGroupSession);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding
@@ -256,6 +259,7 @@ void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)
     // Now test encoding/decoding with a source node id and destination group id present.
     header.ClearDestinationNodeId();
     header.SetDestinationGroupId(25);
+    header.SetSessionType(Header::SessionType::kGroupSession);
     for (uint16_t shortLen = minLen; shortLen < minLen + 10; shortLen++)
     {
         NL_TEST_ASSERT(inSuite, header.Encode(buffer, shortLen, &unusedLen) != CHIP_NO_ERROR);

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -79,6 +79,10 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
     PacketHeader packetHeader;
     MessageAuthenticationCode mac;
 
+    packetHeader.SetSessionId(1);
+    NL_TEST_ASSERT(inSuite, packetHeader.IsEncrypted() == true);
+    NL_TEST_ASSERT(inSuite, packetHeader.MICTagLength() == 16);
+
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
@@ -113,6 +117,10 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
     uint8_t encrypted[128];
     PacketHeader packetHeader;
     MessageAuthenticationCode mac;
+
+    packetHeader.SetSessionId(1);
+    NL_TEST_ASSERT(inSuite, packetHeader.IsEncrypted() == true);
+    NL_TEST_ASSERT(inSuite, packetHeader.MICTagLength() == 16);
 
     const char * salt = "Test Salt";
 


### PR DESCRIPTION
#### Problem
Matter message Header is not up to spec.

#### Change overview
- Removed Encrypted flag (replaced with SessionID != 0  spec : 4.4.1.3 ) 
- Removed SessionType from Header (was actually Message Integrity Type) 
- Split Message header into 2 8 bits section as per the specification (Messages flags and Security flags)
- Change Session ID allocator to exclude session id of 0 since it is an unsecure session.
- Updated Unit tests for message header

#### Testing
- Tested with the ./scripts/tests/test_suites.sh 
- Tested with the Units Tests
- Commissioning tested with an EFR32 with Thread