### PR TITLE
Adding m5stack esp32 rpc build target

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -226,6 +226,7 @@
                 "esp32-devkitc-shell",
                 "esp32-devkitc-temperature-measurement",
                 "esp32-m5stack-all-clusters",
+                "esp32-m5stack-all-clusters-rpc",
                 "infineon-p6-lock",
                 "linux-arm64-all-clusters",
                 "linux-arm64-chip-tool",

--- a/examples/all-clusters-app/esp32/main/Rpc.cpp
+++ b/examples/all-clusters-app/esp32/main/Rpc.cpp
@@ -46,7 +46,7 @@
 #include "pw_status/try.h"
 #include "wifi_service/wifi_service.rpc.pb.h"
 
-#include "ServiceProvisioning.h"
+#include "WiFiProvisioning.h"
 
 #include "ESP32Utils.h"
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -80,12 +80,20 @@ def HostTargets():
 
 
 def Esp32Targets():
-    target = Target('esp32', Esp32Builder)
+    esp32_target = Target('esp32', Esp32Builder)
 
-    yield target.Extend('m5stack-all-clusters', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS)
-    yield target.Extend('c3devkit-all-clusters', board=Esp32Board.C3DevKit, app=Esp32App.ALL_CLUSTERS)
+    yield esp32_target.Extend('c3devkit-all-clusters', board=Esp32Board.C3DevKit, app=Esp32App.ALL_CLUSTERS)
 
-    devkitc = target.Extend('devkitc', board=Esp32Board.DevKitC)
+    rpc_aware_targets = [
+        esp32_target.Extend('m5stack-all-clusters',
+                            board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS)
+    ]
+
+    for target in rpc_aware_targets:
+        yield target
+        yield target.Extend('rpc', enable_rpcs=True)
+
+    devkitc = esp32_target.Extend('devkitc', board=Esp32Board.DevKitC)
 
     yield devkitc.Extend('all-clusters', app=Esp32App.ALL_CLUSTERS)
     yield devkitc.Extend('shell', app=Esp32App.SHELL)

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -13,6 +13,7 @@ esp32-devkitc-lock
 esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
 esp32-m5stack-all-clusters
+esp32-m5stack-all-clusters-rpc
 infineon-p6-lock
 nrf-nrf52840-light
 nrf-nrf52840-lock

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -93,6 +93,11 @@ cd "{root}"
 bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig_m5stack.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters reconfigure'
 cd -
 
+# Generating esp32-m5stack-all-clusters-rpc
+cd "{root}"
+bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig_m5stack_rpc.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-rpc reconfigure'
+cd -
+
 # Generating infineon-p6-lock
 gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-lock
 
@@ -275,6 +280,9 @@ bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-devkitc-temperatu
 
 # Building esp32-m5stack-all-clusters
 bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-m5stack-all-clusters'"'"''
+
+# Building esp32-m5stack-all-clusters-rpc
+bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-m5stack-all-clusters-rpc'"'"''
 
 # Building infineon-p6-lock
 ninja -C {out}/infineon-p6-lock


### PR DESCRIPTION
#### Problem
m5stack esp32 all clusters app missing rpc ubild target

#### Change overview
Adds m5stack esp32 all-clusters-app rpc build target

#### Testing
How was this tested? (at least one bullet point required)
./scripts/build/build_examples.py –target esp32-m5stack-all-clusters-rpc build
cd out/build/esp32-m5stack-all-clusters-rpc
python chip-all-clusters-app.py flash

RPC test
cd ~/connectedhomeip
source scripts/bootstrap.sh
source scripts/activate.sh
cd examples/common/pigweed/rpc_console
gn gen out/debug
ninja -C out/debug
cd out/debug
pip install chip_rpc_console_wheels/*.whl
python -m chip_rpc.console --device /dev/ttyUSB0
rpcs.chip.rpc.Device.GetDeviceInfo()


