### PR TITLE
P6: Added support of BLE GATT Notification instead of GATT Indication…

### DIFF
--- a/src/platform/P6/BLEManagerImpl.cpp
+++ b/src/platform/P6/BLEManagerImpl.cpp
@@ -351,7 +351,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
 exit:
     if (gatt_err != WICED_BT_GATT_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %ld", gatt_err);
+        ChipLogError(DeviceLayer, "BLEManagerImpl::SendNotification() failed: %ld", gatt_err);
         return false;
     }
     else

--- a/src/platform/P6/BLEManagerImpl.cpp
+++ b/src/platform/P6/BLEManagerImpl.cpp
@@ -254,8 +254,8 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
                             PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
         break;
 
-    case DeviceEventType::kCHIPoBLEIndicateConfirm:
-        HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
+    case DeviceEventType::kCHIPoBLENotifyConfirm:
+        HandleIndicationConfirmation(event->CHIPoBLENotifyConfirm.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
         break;
 
     case DeviceEventType::kCHIPoBLEConnectionError:
@@ -342,17 +342,25 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     VerifyOrExit(conState != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
 
 #ifdef BLE_DEBUG
-    ChipLogDetail(DeviceLayer, "Sending indication for CHIPoBLE TX characteristic (con %u, len %u)", conId, dataLen);
+    ChipLogDetail(DeviceLayer, "Sending notification for CHIPoBLE TX characteristic (con %u, len %u)", conId, dataLen);
 #endif
 
-    // Send a indication for the CHIPoBLE TX characteristic to the client containing the supplied data.
-    gatt_err = wiced_bt_gatt_send_indication((uint16_t) conId, HDLC_CHIP_SERVICE_CHAR_C2_VALUE, dataLen, data->Start());
+    // Send a notification for the CHIPoBLE TX characteristic to the client containing the supplied data.
+    gatt_err = wiced_bt_gatt_send_notification((uint16_t) conId, HDLC_CHIP_SERVICE_CHAR_C2_VALUE, dataLen, data->Start());
 
 exit:
     if (gatt_err != WICED_BT_GATT_SUCCESS)
     {
         ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %ld", gatt_err);
         return false;
+    }
+    else
+    {
+        // Post an event to the CHIP queue.
+        ChipDeviceEvent event;
+        event.Type                        = DeviceEventType::kCHIPoBLENotifyConfirm;
+        event.CHIPoBLENotifyConfirm.ConId = conId;
+        err                               = PlatformMgr().PostEvent(&event);
     }
     return err == CHIP_NO_ERROR;
 }
@@ -616,27 +624,6 @@ wiced_bt_gatt_status_t BLEManagerImpl::HandleGattServiceMtuReq(wiced_bt_gatt_att
 }
 
 /*
- * Process GATT Indication Confirm from the client
- */
-wiced_bt_gatt_status_t BLEManagerImpl::HandleGattServiceIndCfm(uint16_t conn_id, uint16_t handle)
-{
-#ifdef BLE_DEBUG
-    ChipLogDetail(DeviceLayer, "GATT Ind Cfm received con:%04x handle:%d", conn_id, handle);
-#endif
-    if (handle == HDLC_CHIP_SERVICE_CHAR_C2_VALUE)
-    {
-        ChipDeviceEvent event;
-        event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
-        event.CHIPoBLEIndicateConfirm.ConId = conn_id;
-        if (PlatformMgr().PostEvent(&event) != CHIP_NO_ERROR)
-        {
-            return WICED_BT_GATT_INTERNAL_ERROR;
-        }
-    }
-    return WICED_BT_GATT_SUCCESS;
-}
-
-/*
  * Process GATT attribute requests
  */
 wiced_bt_gatt_status_t BLEManagerImpl::HandleGattServiceRequestEvent(wiced_bt_gatt_attribute_request_t * p_request,
@@ -656,10 +643,6 @@ wiced_bt_gatt_status_t BLEManagerImpl::HandleGattServiceRequestEvent(wiced_bt_ga
 
     case GATTS_REQ_TYPE_MTU:
         result = HandleGattServiceMtuReq(p_request, p_conn);
-        break;
-
-    case GATTS_REQ_TYPE_CONF:
-        result = HandleGattServiceIndCfm(p_request->conn_id, p_request->data.handle);
         break;
 
     default:


### PR DESCRIPTION
P6: Added support of BLE GATT Notification instead of GATT Indication for C2 GATT Characteristic.

#### Problem
Using BLE GATT Notification is required by Matter spec (section  4.15.3.2. BTP GATT Service)


#### Change overview
Updated BLEManagerImpl.cpp to use GATT Notification instead of GATT Indication for C2 GATT Characteristic

#### Testing
Manual tested BLE commission procedure after update. Test was done on infineon-p6-lock example. Log attached
[commission.log](https://github.com/project-chip/connectedhomeip/files/7307288/commission.log)
 