### PR TITLE
Consistently use TLV::Tag for TLV tags.

### DIFF
--- a/src/app/MessageDef/AttributePath.cpp
+++ b/src/app/MessageDef/AttributePath.cpp
@@ -193,7 +193,7 @@ CHIP_ERROR AttributePath::Parser::GetListIndex(chip::ListIndex * const apListInd
     return GetUnsignedInteger(kCsTag_ListIndex, apListIndex);
 }
 
-CHIP_ERROR AttributePath::Builder::_Init(chip::TLV::TLVWriter * const apWriter, const uint64_t aTag)
+CHIP_ERROR AttributePath::Builder::_Init(chip::TLV::TLVWriter * const apWriter, const Tag aTag)
 {
     mpWriter = apWriter;
     mError   = mpWriter->StartContainer(aTag, chip::TLV::kTLVType_List, mOuterContainerType);

--- a/src/app/MessageDef/AttributePath.h
+++ b/src/app/MessageDef/AttributePath.h
@@ -205,7 +205,7 @@ public:
     AttributePath::Builder & EndOfAttributePath();
 
 private:
-    CHIP_ERROR _Init(chip::TLV::TLVWriter * const apWriter, const uint64_t aTag);
+    CHIP_ERROR _Init(TLV::TLVWriter * const apWriter, const TLV::Tag aTag);
 };
 
 }; // namespace AttributePath

--- a/src/app/MessageDef/CommandPath.cpp
+++ b/src/app/MessageDef/CommandPath.cpp
@@ -172,7 +172,7 @@ CHIP_ERROR CommandPath::Parser::GetCommandId(chip::CommandId * const apCommandId
     return GetUnsignedInteger(kCsTag_CommandId, apCommandId);
 }
 
-CHIP_ERROR CommandPath::Builder::_Init(chip::TLV::TLVWriter * const apWriter, const uint64_t aTag)
+CHIP_ERROR CommandPath::Builder::_Init(chip::TLV::TLVWriter * const apWriter, const Tag aTag)
 {
     mpWriter = apWriter;
     mError   = mpWriter->StartContainer(aTag, chip::TLV::kTLVType_List, mOuterContainerType);

--- a/src/app/MessageDef/CommandPath.h
+++ b/src/app/MessageDef/CommandPath.h
@@ -185,7 +185,7 @@ public:
     CommandPath::Builder & EndOfCommandPath();
 
 private:
-    CHIP_ERROR _Init(chip::TLV::TLVWriter * const apWriter, const uint64_t aTag);
+    CHIP_ERROR _Init(TLV::TLVWriter * const apWriter, const TLV::Tag aTag);
 };
 }; // namespace CommandPath
 

--- a/src/app/MessageDef/EventPath.cpp
+++ b/src/app/MessageDef/EventPath.cpp
@@ -176,7 +176,7 @@ CHIP_ERROR EventPath::Parser::GetEventId(chip::EventId * const apEventId) const
     return GetUnsignedInteger(kCsTag_EventId, apEventId);
 }
 
-CHIP_ERROR EventPath::Builder::_Init(chip::TLV::TLVWriter * const apWriter, const uint64_t aTag)
+CHIP_ERROR EventPath::Builder::_Init(chip::TLV::TLVWriter * const apWriter, const Tag aTag)
 {
     mpWriter = apWriter;
     mError   = mpWriter->StartContainer(aTag, chip::TLV::kTLVType_List, mOuterContainerType);

--- a/src/app/MessageDef/EventPath.h
+++ b/src/app/MessageDef/EventPath.h
@@ -185,7 +185,7 @@ public:
     EventPath::Builder & EndOfEventPath();
 
 private:
-    CHIP_ERROR _Init(chip::TLV::TLVWriter * const apWriter, const uint64_t aTag);
+    CHIP_ERROR _Init(TLV::TLVWriter * const apWriter, const TLV::Tag aTag);
 };
 }; // namespace EventPath
 }; // namespace app

--- a/src/app/MessageDef/InvokeCommand.cpp
+++ b/src/app/MessageDef/InvokeCommand.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR InvokeCommand::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        const uint64_t tag = reader.GetTag();
+        const Tag tag = reader.GetTag();
 
         if (chip::TLV::ContextTag(kCsTag_CommandList) == tag)
         {

--- a/src/app/MessageDef/Parser.cpp
+++ b/src/app/MessageDef/Parser.cpp
@@ -41,7 +41,7 @@ void Parser::Init(const chip::TLV::TLVReader & aReader, chip::TLV::TLVType aOute
     mOuterContainerType = aOuterContainerType;
 }
 
-CHIP_ERROR Parser::GetReaderOnTag(const uint64_t aTagToFind, chip::TLV::TLVReader * const apReader) const
+CHIP_ERROR Parser::GetReaderOnTag(const Tag aTagToFind, chip::TLV::TLVReader * const apReader) const
 {
     return mReader.FindElementWithTag(aTagToFind, *apReader);
 }

--- a/src/app/MessageDef/Parser.h
+++ b/src/app/MessageDef/Parser.h
@@ -52,7 +52,7 @@ public:
      *
      *  @return #CHIP_NO_ERROR on success
      */
-    CHIP_ERROR GetReaderOnTag(const uint64_t aTagToFind, chip::TLV::TLVReader * const apReader) const;
+    CHIP_ERROR GetReaderOnTag(const TLV::Tag aTagToFind, TLV::TLVReader * const apReader) const;
 
     /**
      *  @brief Get the TLV Reader

--- a/src/app/MessageDef/ReadRequest.cpp
+++ b/src/app/MessageDef/ReadRequest.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR ReadRequest::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        const uint64_t tag = reader.GetTag();
+        const Tag tag = reader.GetTag();
 
         if (chip::TLV::ContextTag(kCsTag_AttributePathList) == tag)
         {

--- a/src/app/MessageDef/StatusElement.cpp
+++ b/src/app/MessageDef/StatusElement.cpp
@@ -190,7 +190,7 @@ CHIP_ERROR StatusElement::Builder::Init(chip::TLV::TLVWriter * const apWriter, c
 StatusElement::Builder & StatusElement::Builder::EncodeStatusElement(const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
                                                                      const uint32_t aProtocolId, const uint16_t aProtocolCode)
 {
-    uint64_t tag = chip::TLV::AnonymousTag;
+    Tag tag = chip::TLV::AnonymousTag;
 
     SuccessOrExit(mError);
 

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -30,23 +30,23 @@ namespace DataModel {
  * appropriately encodes them to TLV.
  */
 template <typename X, typename std::enable_if_t<std::is_integral<X>::value, int> = 0>
-CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, X x)
+CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, X x)
 {
     return writer.Put(tag, x);
 }
 
 template <typename X, typename std::enable_if_t<std::is_enum<X>::value, int> = 0>
-CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, X x)
+CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, X x)
 {
     return writer.Put(tag, x);
 }
 
-inline CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, ByteSpan x)
+inline CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, ByteSpan x)
 {
     return writer.Put(tag, x);
 }
 
-inline CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, Span<const char> x)
+inline CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, Span<const char> x)
 {
     return writer.PutString(tag, x);
 }
@@ -58,16 +58,16 @@ inline CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, Span<const char>
  * depends on the presence of an Encode method on the object. The signature of that method
  * is as follows:
  *
- * CHIP_ERROR <Object>::Encode(TLVWriter &writer, uint64_t tag) const;
+ * CHIP_ERROR <Object>::Encode(TLVWriter &writer, TLV::Tag tag) const;
  *
  *
  */
 template <
     typename X,
     typename std::enable_if_t<std::is_class<X>::value &&
-                                  std::is_same<decltype(&X::Encode), CHIP_ERROR (X::*)(TLV::TLVWriter &, uint64_t) const>::value,
+                                  std::is_same<decltype(&X::Encode), CHIP_ERROR (X::*)(TLV::TLVWriter &, TLV::Tag) const>::value,
                               X> * = nullptr>
-CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, const X & x)
+CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, const X & x)
 {
     return x.Encode(writer, tag);
 }

--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -52,7 +52,7 @@ struct List : public Span<T>
 };
 
 template <typename X>
-inline CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag, List<X> list)
+inline CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, List<X> list)
 {
     TLV::TLVType type;
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -361,7 +361,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendSimpleCommandData(nlTestS
 struct Fields
 {
     static constexpr chip::CommandId CommandId = 4;
-    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, uint64_t aTag) const
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
     {
         TLV::TLVType outerContainerType;
         ReturnErrorOnFailure(aWriter.StartContainer(aTag, TLV::kTLVType_Structure, outerContainerType));

--- a/src/app/tests/TestDataModelSerialization.cpp
+++ b/src/app/tests/TestDataModelSerialization.cpp
@@ -109,18 +109,18 @@ void TestDataModelSerialization::SetupReader()
 template <typename T>
 struct TagValuePair
 {
-    uint64_t tag;
+    TLV::Tag tag;
     T & value;
 };
 
 template <typename T>
-TagValuePair<T> MakeTagValuePair(uint64_t tag, T & value)
+TagValuePair<T> MakeTagValuePair(TLV::Tag tag, T & value)
 {
     return TagValuePair<T>{ tag, value };
 }
 
 template <typename... ArgTypes>
-CHIP_ERROR EncodeStruct(TLV::TLVWriter & writer, uint64_t tag, ArgTypes... Args)
+CHIP_ERROR EncodeStruct(TLV::TLVWriter & writer, TLV::Tag tag, ArgTypes... Args)
 {
     using expand_type = int[];
     TLV::TLVType type;

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -49,12 +49,12 @@
 
 namespace {
 
-static const chip::NodeId kTestDeviceNodeId1    = 0x18B4300000000001ULL;
-static const chip::NodeId kTestDeviceNodeId2    = 0x18B4300000000002ULL;
-static const chip::ClusterId kLivenessClusterId = 0x00000022;
-static const uint32_t kLivenessChangeEvent      = 1;
-static const chip::EndpointId kTestEndpointId   = 2;
-static const uint64_t kLivenessDeviceStatus     = chip::TLV::ContextTag(1);
+static const chip::NodeId kTestDeviceNodeId1      = 0x18B4300000000001ULL;
+static const chip::NodeId kTestDeviceNodeId2      = 0x18B4300000000002ULL;
+static const chip::ClusterId kLivenessClusterId   = 0x00000022;
+static const uint32_t kLivenessChangeEvent        = 1;
+static const chip::EndpointId kTestEndpointId     = 2;
+static const chip::TLV::Tag kLivenessDeviceStatus = chip::TLV::ContextTag(1);
 static chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 static chip::System::LayerImpl gSystemLayer;
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -62,7 +62,7 @@ chip::EndpointId kTestEndpointId      = 1;
 chip::EventId kTestEventIdDebug       = 1;
 chip::EventId kTestEventIdCritical    = 2;
 uint8_t kTestFieldValue1              = 1;
-uint64_t kTestEventTag                = 1;
+chip::TLV::Tag kTestEventTag          = chip::TLV::ContextTag(1);
 using TestContext                     = chip::Test::MessagingContext;
 TestContext sContext;
 

--- a/src/app/tests/integration/MockEvents.cpp
+++ b/src/app/tests/integration/MockEvents.cpp
@@ -33,9 +33,9 @@
 #include <system/SystemPacketBuffer.h>
 #include <transport/SessionManager.h>
 
-static uint64_t kLivenessDeviceStatus = chip::TLV::ContextTag(1);
-static bool gMockEventStop            = false;
-static bool gEventIsStopped           = false;
+static chip::TLV::Tag kLivenessDeviceStatus = chip::TLV::ContextTag(1);
+static bool gMockEventStop                  = false;
+static bool gEventIsStopped                 = false;
 
 EventGenerator::EventGenerator(size_t aNumStates, size_t aInitialState) : mNumStates(aNumStates), mState(aInitialState) {}
 

--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -11,7 +11,7 @@ namespace Clusters {
 namespace {{asUpperCamelCase name}} {
 {{#zcl_structs}}
 namespace {{asType label}} {
-CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) const{
+CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     {{#zcl_struct_items}}
@@ -52,7 +52,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
 namespace Commands {
 {{#zcl_commands}}
 namespace {{asUpperCamelCase name}} {
-CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) const{
+CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, TLV::Tag tag) const{
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     {{#zcl_command_arguments}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -44,7 +44,7 @@ namespace {{name}} {
         {{/if}}
         {{/zcl_struct_items}}
 
-        CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) const;
+        CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
         {{#unless struct_contains_array}}
         CHIP_ERROR Decode(TLV::TLVReader &reader);
         {{/unless}}
@@ -95,7 +95,7 @@ public:
     {{/if}}
     {{/zcl_command_arguments}}
 
-    CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
 };
 
 struct DecodableType {

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -83,7 +83,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR ConvertDistinguishedName(ASN1Reader & reader, TLVWriter & writer, uint64_t tag, uint64_t & subjectOrIssuer,
+static CHIP_ERROR ConvertDistinguishedName(ASN1Reader & reader, TLVWriter & writer, Tag tag, uint64_t & subjectOrIssuer,
                                            Optional<uint64_t> & fabric)
 {
     CHIP_ERROR err;
@@ -541,7 +541,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConvertECDSASignatureDERToRaw(ASN1Reader & reader, TLVWriter & writer, uint64_t tag)
+CHIP_ERROR ConvertECDSASignatureDERToRaw(ASN1Reader & reader, TLVWriter & writer, Tag tag)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t rawSig[kP256_ECDSA_Signature_Length_Raw];
@@ -572,7 +572,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR ConvertCertificate(ASN1Reader & reader, TLVWriter & writer, uint64_t tag, uint64_t & issuer, uint64_t & subject,
+static CHIP_ERROR ConvertCertificate(ASN1Reader & reader, TLVWriter & writer, Tag tag, uint64_t & issuer, uint64_t & subject,
                                      Optional<uint64_t> & fabric)
 {
     CHIP_ERROR err;

--- a/src/credentials/DeviceAttestationConstructor.cpp
+++ b/src/credentials/DeviceAttestationConstructor.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR DeconstructAttestationElements(const ByteSpan & attestationElements, 
     // loop, since the contextTags come before the profileTags)
     while ((error = tlvReader.Next()) == CHIP_NO_ERROR)
     {
-        uint64_t tag = tlvReader.GetTag();
+        TLV::Tag tag = tlvReader.GetTag();
 
         if (TLV::IsContextTag(tag))
         {

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -190,7 +190,7 @@ public:
      * Advances the TLVReader object to the next TLV element to be read, asserting the tag of
      * the new element.
      *
-     * The Next(uint64_t expectedTag) method is a convenience method that has the
+     * The Next(Tag expectedTag) method is a convenience method that has the
      * same behavior as Next(), but also verifies that the tag of the new TLV element matches
      * the supplied argument.
      *
@@ -210,13 +210,13 @@ public:
      *                                      TLVBackingStore.
      *
      */
-    CHIP_ERROR Next(uint64_t expectedTag);
+    CHIP_ERROR Next(Tag expectedTag);
 
     /**
      * Advances the TLVReader object to the next TLV element to be read, asserting the type and tag of
      * the new element.
      *
-     * The Next(TLVType expectedType, uint64_t expectedTag) method is a convenience method that has the
+     * The Next(TLVType expectedType, Tag expectedTag) method is a convenience method that has the
      * same behavior as Next(), but also verifies that the type and tag of the new TLV element match
      * the supplied arguments.
      *
@@ -239,7 +239,7 @@ public:
      *                                      TLVBackingStore.
      *
      */
-    CHIP_ERROR Next(TLVType expectedType, uint64_t expectedTag);
+    CHIP_ERROR Next(TLVType expectedType, Tag expectedTag);
 
     /**
      * Returns the type of the current TLV element.
@@ -264,7 +264,7 @@ public:
      * @return      An unsigned integer containing information about the tag associated with the current
      *              TLV element.
      */
-    uint64_t GetTag() const { return mElemTag; }
+    Tag GetTag() const { return mElemTag; }
 
     /**
      * Returns the length of data associated with current TLV element.
@@ -836,7 +836,7 @@ public:
      * @retval #CHIP_END_OF_TLV            If the given tag cannot be found
      * @retval other                       Other CHIP or platform error codes
      */
-    CHIP_ERROR FindElementWithTag(const uint64_t tagInApiForm, TLVReader & destReader) const;
+    CHIP_ERROR FindElementWithTag(Tag tagInApiForm, TLVReader & destReader) const;
 
     /**
      * The profile id to be used for profile tags encoded in implicit form.
@@ -860,7 +860,7 @@ public:
     void * AppData;
 
 protected:
-    uint64_t mElemTag;
+    Tag mElemTag;
     uint64_t mElemLenOrVal;
     TLVBackingStore * mBackingStore;
     const uint8_t * mReadPoint;
@@ -882,7 +882,7 @@ protected:
     CHIP_ERROR SkipData();
     CHIP_ERROR SkipToEndOfContainer();
     CHIP_ERROR VerifyElement();
-    uint64_t ReadTag(TLVTagControl tagControl, const uint8_t *& p);
+    Tag ReadTag(TLVTagControl tagControl, const uint8_t *& p);
     CHIP_ERROR EnsureData(CHIP_ERROR noDataErr);
     CHIP_ERROR ReadData(uint8_t * buf, uint32_t len);
     CHIP_ERROR GetElementHeadLength(uint8_t & elemHeadBytes) const;
@@ -1063,7 +1063,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR Put(uint64_t tag, int8_t v);
+    CHIP_ERROR Put(Tag tag, int8_t v);
 
     /**
      * Encodes a TLV signed integer value.
@@ -1095,37 +1095,37 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR Put(uint64_t tag, int8_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, int8_t v, bool preserveSize);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v)
      */
-    CHIP_ERROR Put(uint64_t tag, int16_t v);
+    CHIP_ERROR Put(Tag tag, int16_t v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v, bool preserveSize)
      */
-    CHIP_ERROR Put(uint64_t tag, int16_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, int16_t v, bool preserveSize);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v)
      */
-    CHIP_ERROR Put(uint64_t tag, int32_t v);
+    CHIP_ERROR Put(Tag tag, int32_t v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v, bool preserveSize)
      */
-    CHIP_ERROR Put(uint64_t tag, int32_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, int32_t v, bool preserveSize);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v)
      */
-    CHIP_ERROR Put(uint64_t tag, int64_t v);
+    CHIP_ERROR Put(Tag tag, int64_t v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v, bool preserveSize)
      */
-    CHIP_ERROR Put(uint64_t tag, int64_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, int64_t v, bool preserveSize);
 
     /**
      * Encodes a TLV unsigned integer value.
@@ -1153,7 +1153,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR Put(uint64_t tag, uint8_t v);
+    CHIP_ERROR Put(Tag tag, uint8_t v);
 
     /**
      * Encodes a TLV unsigned integer value.
@@ -1185,37 +1185,37 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR Put(uint64_t tag, uint8_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, uint8_t v, bool preserveSize);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v)
      */
-    CHIP_ERROR Put(uint64_t tag, uint16_t v);
+    CHIP_ERROR Put(Tag tag, uint16_t v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v, bool preserveSize)
      */
-    CHIP_ERROR Put(uint64_t tag, uint16_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, uint16_t v, bool preserveSize);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v)
      */
-    CHIP_ERROR Put(uint64_t tag, uint32_t v);
+    CHIP_ERROR Put(Tag tag, uint32_t v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v, bool preserveSize)
      */
-    CHIP_ERROR Put(uint64_t tag, uint32_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, uint32_t v, bool preserveSize);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v)
      */
-    CHIP_ERROR Put(uint64_t tag, uint64_t v);
+    CHIP_ERROR Put(Tag tag, uint64_t v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v, bool preserveSize)
      */
-    CHIP_ERROR Put(uint64_t tag, uint64_t v, bool preserveSize);
+    CHIP_ERROR Put(Tag tag, uint64_t v, bool preserveSize);
 
     /**
      * Encodes a TLV floating point value.
@@ -1243,12 +1243,12 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR Put(uint64_t tag, double v);
+    CHIP_ERROR Put(Tag tag, double v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, double v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, double v)
      */
-    CHIP_ERROR Put(uint64_t tag, float v);
+    CHIP_ERROR Put(Tag tag, float v);
 
     /**
      * Encodes a TLV byte string value using ByteSpan class.
@@ -1276,13 +1276,13 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR Put(uint64_t tag, ByteSpan data);
+    CHIP_ERROR Put(Tag tag, ByteSpan data);
 
     /**
      * static_cast to enumerations' underlying type when data is an enumeration.
      */
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
-    CHIP_ERROR Put(uint64_t tag, T data)
+    CHIP_ERROR Put(Tag tag, T data)
     {
         return Put(tag, to_underlying(data));
     }
@@ -1313,12 +1313,12 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutBoolean(uint64_t tag, bool v);
+    CHIP_ERROR PutBoolean(Tag tag, bool v);
 
     /**
-     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, bool v)
+     * @overload CHIP_ERROR TLVWriter::Put(Tag tag, bool v)
      */
-    CHIP_ERROR Put(uint64_t tag, bool v)
+    CHIP_ERROR Put(Tag tag, bool v)
     {
         /*
          * In TLV, boolean values are encoded as standalone tags without actual values, so we have a seperate
@@ -1354,7 +1354,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutBytes(uint64_t tag, const uint8_t * buf, uint32_t len);
+    CHIP_ERROR PutBytes(Tag tag, const uint8_t * buf, uint32_t len);
 
     /**
      * Encodes a TLV UTF8 string value.
@@ -1382,7 +1382,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutString(uint64_t tag, const char * buf);
+    CHIP_ERROR PutString(Tag tag, const char * buf);
 
     /**
      * Encodes a TLV UTF8 string value.
@@ -1411,7 +1411,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutString(uint64_t tag, const char * buf, uint32_t len);
+    CHIP_ERROR PutString(Tag tag, const char * buf, uint32_t len);
 
     /**
      * Encodes a TLV UTF8 string value that's passed in as a Span.
@@ -1439,7 +1439,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutString(uint64_t tag, Span<const char> str);
+    CHIP_ERROR PutString(Tag tag, Span<const char> str);
 
     /**
      * @brief
@@ -1485,7 +1485,7 @@ public:
      *               `WriteElementHead` or `GetNewBuffer` -- failed, their
      *               error is immediately forwarded up the call stack.
      */
-    CHIP_ERROR PutStringF(uint64_t tag, const char * fmt, ...);
+    CHIP_ERROR PutStringF(Tag tag, const char * fmt, ...);
 
     /**
      * @brief
@@ -1531,7 +1531,7 @@ public:
      *               `WriteElementHead` or `GetNewBuffer` -- failed, their
      *               error is immediately forwarded up the call stack.
      */
-    CHIP_ERROR VPutStringF(uint64_t tag, const char * fmt, va_list ap);
+    CHIP_ERROR VPutStringF(Tag tag, const char * fmt, va_list ap);
 
     /**
      * Encodes a TLV null value.
@@ -1558,7 +1558,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutNull(uint64_t tag);
+    CHIP_ERROR PutNull(Tag tag);
 
     /**
      * Copies a TLV element from a reader object into the writer.
@@ -1652,7 +1652,7 @@ public:
      *                              function associated with the reader object.
      *
      */
-    CHIP_ERROR CopyElement(uint64_t tag, TLVReader & reader);
+    CHIP_ERROR CopyElement(Tag tag, TLVReader & reader);
 
     /**
      * Begins encoding a new TLV container element.
@@ -1695,7 +1695,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR StartContainer(uint64_t tag, TLVType containerType, TLVType & outerContainerType);
+    CHIP_ERROR StartContainer(Tag tag, TLVType containerType, TLVType & outerContainerType);
 
     /**
      * Completes the encoding of a TLV container element.
@@ -1783,7 +1783,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR OpenContainer(uint64_t tag, TLVType containerType, TLVWriter & containerWriter);
+    CHIP_ERROR OpenContainer(Tag tag, TLVType containerType, TLVWriter & containerWriter);
 
     /**
      * Completes the writing of a TLV container after a call to OpenContainer().
@@ -1859,7 +1859,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR PutPreEncodedContainer(uint64_t tag, TLVType containerType, const uint8_t * data, uint32_t dataLen);
+    CHIP_ERROR PutPreEncodedContainer(Tag tag, TLVType containerType, const uint8_t * data, uint32_t dataLen);
 
     /**
      * Copies a TLV container element from TLVReader object
@@ -1956,7 +1956,7 @@ public:
      *                              TLVBackingStore.
      *
      */
-    CHIP_ERROR CopyContainer(uint64_t tag, TLVReader & container);
+    CHIP_ERROR CopyContainer(Tag tag, TLVReader & container);
 
     /**
      * Encodes a TLV container element that contains member elements from a pre-encoded container
@@ -2000,7 +2000,7 @@ public:
      *                                  TLVBackingStore.
      *
      */
-    CHIP_ERROR CopyContainer(uint64_t tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen);
+    CHIP_ERROR CopyContainer(Tag tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen);
 
     /**
      * Returns the type of container within which the TLVWriter is currently writing.
@@ -2091,8 +2091,8 @@ protected:
 #if CONFIG_HAVE_VCBPRINTF
     static void CHIPTLVWriterPutcharCB(uint8_t c, void * appState);
 #endif
-    CHIP_ERROR WriteElementHead(TLVElementType elemType, uint64_t tag, uint64_t lenOrVal);
-    CHIP_ERROR WriteElementWithData(TLVType type, uint64_t tag, const uint8_t * data, uint32_t dataLen);
+    CHIP_ERROR WriteElementHead(TLVElementType elemType, Tag tag, uint64_t lenOrVal);
+    CHIP_ERROR WriteElementWithData(TLVType type, Tag tag, const uint8_t * data, uint32_t dataLen);
     CHIP_ERROR WriteData(const uint8_t * p, uint32_t len);
 };
 
@@ -2401,7 +2401,7 @@ public:
     CHIP_ERROR DupString(char *& buf) { return mUpdaterReader.DupString(buf); }
 
     TLVType GetType() const { return mUpdaterReader.GetType(); }
-    uint64_t GetTag() const { return mUpdaterReader.GetTag(); }
+    Tag GetTag() const { return mUpdaterReader.GetTag(); }
     uint32_t GetLength() const { return mUpdaterReader.GetLength(); }
     CHIP_ERROR GetDataPtr(const uint8_t *& data) { return mUpdaterReader.GetDataPtr(data); }
     CHIP_ERROR VerifyEndOfContainer() { return mUpdaterReader.VerifyEndOfContainer(); }
@@ -2410,32 +2410,32 @@ public:
     uint32_t GetRemainingLength() const { return mUpdaterReader.GetRemainingLength(); }
 
     // Writer methods
-    CHIP_ERROR Put(uint64_t tag, int8_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, int16_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, int32_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, int64_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, uint8_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, uint16_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, uint32_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, uint64_t v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, int8_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, int16_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, int32_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, int64_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, uint8_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, uint16_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, uint32_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, uint64_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
-    CHIP_ERROR Put(uint64_t tag, float v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR Put(uint64_t tag, double v) { return mUpdaterWriter.Put(tag, v); }
-    CHIP_ERROR PutBoolean(uint64_t tag, bool v) { return mUpdaterWriter.PutBoolean(tag, v); }
-    CHIP_ERROR PutNull(uint64_t tag) { return mUpdaterWriter.PutNull(tag); }
-    CHIP_ERROR PutBytes(uint64_t tag, const uint8_t * buf, uint32_t len) { return mUpdaterWriter.PutBytes(tag, buf, len); }
-    CHIP_ERROR PutString(uint64_t tag, const char * buf) { return mUpdaterWriter.PutString(tag, buf); }
-    CHIP_ERROR PutString(uint64_t tag, const char * buf, uint32_t len) { return mUpdaterWriter.PutString(tag, buf, len); }
+    CHIP_ERROR Put(Tag tag, int8_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, int16_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, int32_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, int64_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, uint8_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, uint16_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, uint32_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, uint64_t v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, int8_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, int16_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, int32_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, int64_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, uint8_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, uint16_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, uint32_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, uint64_t v, bool preserveSize) { return mUpdaterWriter.Put(tag, v, preserveSize); }
+    CHIP_ERROR Put(Tag tag, float v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR Put(Tag tag, double v) { return mUpdaterWriter.Put(tag, v); }
+    CHIP_ERROR PutBoolean(Tag tag, bool v) { return mUpdaterWriter.PutBoolean(tag, v); }
+    CHIP_ERROR PutNull(Tag tag) { return mUpdaterWriter.PutNull(tag); }
+    CHIP_ERROR PutBytes(Tag tag, const uint8_t * buf, uint32_t len) { return mUpdaterWriter.PutBytes(tag, buf, len); }
+    CHIP_ERROR PutString(Tag tag, const char * buf) { return mUpdaterWriter.PutString(tag, buf); }
+    CHIP_ERROR PutString(Tag tag, const char * buf, uint32_t len) { return mUpdaterWriter.PutString(tag, buf, len); }
     CHIP_ERROR CopyElement(TLVReader & reader) { return mUpdaterWriter.CopyElement(reader); }
-    CHIP_ERROR CopyElement(uint64_t tag, TLVReader & reader) { return mUpdaterWriter.CopyElement(tag, reader); }
-    CHIP_ERROR StartContainer(uint64_t tag, TLVType containerType, TLVType & outerContainerType)
+    CHIP_ERROR CopyElement(Tag tag, TLVReader & reader) { return mUpdaterWriter.CopyElement(tag, reader); }
+    CHIP_ERROR StartContainer(Tag tag, TLVType containerType, TLVType & outerContainerType)
     {
         return mUpdaterWriter.StartContainer(tag, containerType, outerContainerType);
     }

--- a/src/lib/core/CHIPTLVDebug.cpp
+++ b/src/lib/core/CHIPTLVDebug.cpp
@@ -58,7 +58,7 @@ namespace Debug {
 static void DumpHandler(DumpWriter aWriter, const char * aIndent, const TLVReader & aReader, size_t aDepth)
 {
     const TLVType type     = aReader.GetType();
-    const uint64_t tag     = aReader.GetTag();
+    const Tag tag          = aReader.GetTag();
     const uint32_t len     = aReader.GetLength();
     const uint8_t * strbuf = nullptr;
     CHIP_ERROR err         = CHIP_NO_ERROR;

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -505,7 +505,7 @@ CHIP_ERROR TLVReader::Next()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Next(uint64_t expectedTag)
+CHIP_ERROR TLVReader::Next(Tag expectedTag)
 {
     CHIP_ERROR err = Next();
     if (err != CHIP_NO_ERROR)
@@ -515,7 +515,7 @@ CHIP_ERROR TLVReader::Next(uint64_t expectedTag)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::Next(TLVType expectedType, uint64_t expectedTag)
+CHIP_ERROR TLVReader::Next(TLVType expectedType, Tag expectedTag)
 {
     CHIP_ERROR err = Next(expectedTag);
     if (err != CHIP_NO_ERROR)
@@ -771,7 +771,7 @@ CHIP_ERROR TLVReader::VerifyElement()
     return CHIP_NO_ERROR;
 }
 
-uint64_t TLVReader::ReadTag(TLVTagControl tagControl, const uint8_t *& p)
+Tag TLVReader::ReadTag(TLVTagControl tagControl, const uint8_t *& p)
 {
     uint16_t vendorId;
     uint16_t profileNum;
@@ -912,7 +912,7 @@ TLVElementType TLVReader::ElementType() const
     return static_cast<TLVElementType>(mControlByte & kTLVTypeMask);
 }
 
-CHIP_ERROR TLVReader::FindElementWithTag(const uint64_t tag, TLVReader & destReader) const
+CHIP_ERROR TLVReader::FindElementWithTag(Tag tag, TLVReader & destReader) const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/lib/core/CHIPTLVUtilities.cpp
+++ b/src/lib/core/CHIPTLVUtilities.cpp
@@ -35,7 +35,7 @@ namespace Utilities {
 
 struct FindContext
 {
-    const uint64_t & mTag;
+    const Tag & mTag;
     TLVReader & mReader;
 };
 
@@ -272,7 +272,7 @@ static CHIP_ERROR FindHandler(const TLVReader & aReader, size_t aDepth, void * a
  *  @retval  #CHIP_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
  *
  */
-CHIP_ERROR Find(const TLVReader & aReader, const uint64_t & aTag, TLVReader & aResult)
+CHIP_ERROR Find(const TLVReader & aReader, const Tag & aTag, TLVReader & aResult)
 {
     constexpr bool recurse = true;
     return Find(aReader, aTag, aResult, recurse);
@@ -297,7 +297,7 @@ CHIP_ERROR Find(const TLVReader & aReader, const uint64_t & aTag, TLVReader & aR
  *  @retval  #CHIP_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
  *
  */
-CHIP_ERROR Find(const TLVReader & aReader, const uint64_t & aTag, TLVReader & aResult, const bool aRecurse)
+CHIP_ERROR Find(const TLVReader & aReader, const Tag & aTag, TLVReader & aResult, const bool aRecurse)
 {
     FindContext theContext = { aTag, aResult };
     CHIP_ERROR retval      = Iterate(aReader, FindHandler, &theContext, aRecurse);

--- a/src/lib/core/CHIPTLVUtilities.hpp
+++ b/src/lib/core/CHIPTLVUtilities.hpp
@@ -54,8 +54,8 @@ extern CHIP_ERROR Iterate(const TLVReader & aReader, IterateHandler aHandler, vo
 extern CHIP_ERROR Count(const TLVReader & aReader, size_t & aCount);
 extern CHIP_ERROR Count(const TLVReader & aReader, size_t & aCount, bool aRecurse);
 
-extern CHIP_ERROR Find(const TLVReader & aReader, const uint64_t & aTag, TLVReader & aResult);
-extern CHIP_ERROR Find(const TLVReader & aReader, const uint64_t & aTag, TLVReader & aResult, bool aRecurse);
+extern CHIP_ERROR Find(const TLVReader & aReader, const Tag & aTag, TLVReader & aResult);
+extern CHIP_ERROR Find(const TLVReader & aReader, const Tag & aTag, TLVReader & aResult, bool aRecurse);
 
 extern CHIP_ERROR Find(const TLVReader & aReader, IterateHandler aHandler, void * aContext, TLVReader & aResult);
 extern CHIP_ERROR Find(const TLVReader & aReader, IterateHandler aHandler, void * aContext, TLVReader & aResult, bool aRecurse);

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -94,48 +94,48 @@ CHIP_ERROR TLVWriter::Finalize()
     return err;
 }
 
-CHIP_ERROR TLVWriter::PutBoolean(uint64_t tag, bool v)
+CHIP_ERROR TLVWriter::PutBoolean(Tag tag, bool v)
 {
     return WriteElementHead((v) ? TLVElementType::BooleanTrue : TLVElementType::BooleanFalse, tag, 0);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v)
 {
     return Put(tag, static_cast<uint64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint8_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::UInt8, tag, v);
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint16_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint16_t v)
 {
     return Put(tag, static_cast<uint64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint16_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint16_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::UInt16, tag, v);
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint32_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint32_t v)
 {
     return Put(tag, static_cast<uint64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint32_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint32_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::UInt32, tag, v);
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint64_t v)
 {
     TLVElementType elemType;
     if (v <= UINT8_MAX)
@@ -149,50 +149,50 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v)
     return WriteElementHead(elemType, tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, uint64_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::UInt64, tag, v);
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v)
 {
     return Put(tag, static_cast<int64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, int8_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::Int8, tag, static_cast<uint8_t>(v));
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int16_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, int16_t v)
 {
     return Put(tag, static_cast<int64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int16_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, int16_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::Int16, tag, static_cast<uint16_t>(v));
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int32_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, int32_t v)
 {
     return Put(tag, static_cast<int64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int32_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, int32_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::Int32, tag, static_cast<uint32_t>(v));
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v)
+CHIP_ERROR TLVWriter::Put(Tag tag, int64_t v)
 {
     TLVElementType elemType;
     if (v >= INT8_MIN && v <= INT8_MAX)
@@ -206,39 +206,39 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v)
     return WriteElementHead(elemType, tag, static_cast<uint64_t>(v));
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v, bool preserveSize)
+CHIP_ERROR TLVWriter::Put(Tag tag, int64_t v, bool preserveSize)
 {
     if (preserveSize)
         return WriteElementHead(TLVElementType::Int64, tag, static_cast<uint64_t>(v));
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, const float v)
+CHIP_ERROR TLVWriter::Put(Tag tag, const float v)
 {
     uint32_t u32;
     memcpy(&u32, &v, sizeof(u32));
     return WriteElementHead(TLVElementType::FloatingPointNumber32, tag, u32);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, const double v)
+CHIP_ERROR TLVWriter::Put(Tag tag, const double v)
 {
     uint64_t u64;
     memcpy(&u64, &v, sizeof(u64));
     return WriteElementHead(TLVElementType::FloatingPointNumber64, tag, u64);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, ByteSpan data)
+CHIP_ERROR TLVWriter::Put(Tag tag, ByteSpan data)
 {
     VerifyOrReturnError(CanCastTo<uint32_t>(data.size()), CHIP_ERROR_MESSAGE_TOO_LONG);
     return PutBytes(tag, data.data(), static_cast<uint32_t>(data.size()));
 }
 
-CHIP_ERROR TLVWriter::PutBytes(uint64_t tag, const uint8_t * buf, uint32_t len)
+CHIP_ERROR TLVWriter::PutBytes(Tag tag, const uint8_t * buf, uint32_t len)
 {
     return WriteElementWithData(kTLVType_ByteString, tag, buf, len);
 }
 
-CHIP_ERROR TLVWriter::PutString(uint64_t tag, const char * buf)
+CHIP_ERROR TLVWriter::PutString(Tag tag, const char * buf)
 {
     size_t len = strlen(buf);
     if (!CanCastTo<uint32_t>(len))
@@ -248,12 +248,12 @@ CHIP_ERROR TLVWriter::PutString(uint64_t tag, const char * buf)
     return PutString(tag, buf, static_cast<uint32_t>(len));
 }
 
-CHIP_ERROR TLVWriter::PutString(uint64_t tag, const char * buf, uint32_t len)
+CHIP_ERROR TLVWriter::PutString(Tag tag, const char * buf, uint32_t len)
 {
     return WriteElementWithData(kTLVType_UTF8String, tag, reinterpret_cast<const uint8_t *>(buf), len);
 }
 
-CHIP_ERROR TLVWriter::PutString(uint64_t tag, Span<const char> str)
+CHIP_ERROR TLVWriter::PutString(Tag tag, Span<const char> str)
 {
     if (!CanCastTo<uint32_t>(str.size()))
     {
@@ -263,7 +263,7 @@ CHIP_ERROR TLVWriter::PutString(uint64_t tag, Span<const char> str)
     return PutString(tag, str.data(), static_cast<uint32_t>(str.size()));
 }
 
-CHIP_ERROR TLVWriter::PutStringF(uint64_t tag, const char * fmt, ...)
+CHIP_ERROR TLVWriter::PutStringF(Tag tag, const char * fmt, ...)
 {
     CHIP_ERROR err;
     va_list ap;
@@ -289,7 +289,7 @@ void TLVWriter::CHIPTLVWriterPutcharCB(uint8_t c, void * appState)
 }
 #endif
 
-CHIP_ERROR TLVWriter::VPutStringF(uint64_t tag, const char * fmt, va_list ap)
+CHIP_ERROR TLVWriter::VPutStringF(Tag tag, const char * fmt, va_list ap)
 {
     va_list aq;
     size_t dataLen;
@@ -401,7 +401,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR TLVWriter::PutNull(uint64_t tag)
+CHIP_ERROR TLVWriter::PutNull(Tag tag)
 {
     return WriteElementHead(TLVElementType::Null, tag, 0);
 }
@@ -413,7 +413,7 @@ CHIP_ERROR TLVWriter::CopyElement(TLVReader & reader)
 
 const size_t kCHIPTLVCopyChunkSize = 16;
 
-CHIP_ERROR TLVWriter::CopyElement(uint64_t tag, TLVReader & reader)
+CHIP_ERROR TLVWriter::CopyElement(Tag tag, TLVReader & reader)
 {
     TLVElementType elemType = reader.ElementType();
     uint64_t elemLenOrVal   = reader.mElemLenOrVal;
@@ -450,7 +450,7 @@ CHIP_ERROR TLVWriter::CopyElement(uint64_t tag, TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWriter & containerWriter)
+CHIP_ERROR TLVWriter::OpenContainer(Tag tag, TLVType containerType, TLVWriter & containerWriter)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -513,7 +513,7 @@ CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
     return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag, 0);
 }
 
-CHIP_ERROR TLVWriter::StartContainer(uint64_t tag, TLVType containerType, TLVType & outerContainerType)
+CHIP_ERROR TLVWriter::StartContainer(Tag tag, TLVType containerType, TLVType & outerContainerType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -555,7 +555,7 @@ CHIP_ERROR TLVWriter::EndContainer(TLVType outerContainerType)
     return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag, 0);
 }
 
-CHIP_ERROR TLVWriter::PutPreEncodedContainer(uint64_t tag, TLVType containerType, const uint8_t * data, uint32_t dataLen)
+CHIP_ERROR TLVWriter::PutPreEncodedContainer(Tag tag, TLVType containerType, const uint8_t * data, uint32_t dataLen)
 {
     if (!TLVTypeIsContainer(containerType))
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -572,7 +572,7 @@ CHIP_ERROR TLVWriter::CopyContainer(TLVReader & container)
     return CopyContainer(container.GetTag(), container);
 }
 
-CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, TLVReader & container)
+CHIP_ERROR TLVWriter::CopyContainer(Tag tag, TLVReader & container)
 {
     // NOTE: This function MUST be used with a TVLReader that is reading from a contiguous buffer.
     if (container.mBackingStore != nullptr)
@@ -598,7 +598,7 @@ CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, TLVReader & container)
                                   static_cast<uint32_t>(container.GetReadPoint() - containerStart));
 }
 
-CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen)
+CHIP_ERROR TLVWriter::CopyContainer(Tag tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen)
 {
     TLVReader reader;
 
@@ -611,7 +611,7 @@ CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, const uint8_t * encodedContain
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, uint64_t lenOrVal)
+CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, Tag tag, uint64_t lenOrVal)
 {
     uint8_t * p;
     uint8_t stagingBuf[17]; // 17 = 1 control byte + 8 tag bytes + 8 length/value bytes
@@ -729,7 +729,7 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, ui
     return WriteData(stagingBuf, static_cast<uint32_t>(p - stagingBuf));
 }
 
-CHIP_ERROR TLVWriter::WriteElementWithData(TLVType type, uint64_t tag, const uint8_t * data, uint32_t dataLen)
+CHIP_ERROR TLVWriter::WriteElementWithData(TLVType type, Tag tag, const uint8_t * data, uint32_t dataLen)
 {
     if (static_cast<uint64_t>(type) & kTLVTypeSizeMask)
     {

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -62,7 +62,7 @@ static const char sLargeString [] =
     "...END";
 // clang-format on
 
-void TestAndOpenContainer(nlTestSuite * inSuite, TLVReader & reader, TLVType type, uint64_t tag, TLVReader & containerReader)
+void TestAndOpenContainer(nlTestSuite * inSuite, TLVReader & reader, TLVType type, Tag tag, TLVReader & containerReader)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == type);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -75,7 +75,7 @@ void TestAndOpenContainer(nlTestSuite * inSuite, TLVReader & reader, TLVType typ
 }
 
 template <class T>
-void TestAndEnterContainer(nlTestSuite * inSuite, T & t, TLVType type, uint64_t tag, TLVType & outerContainerType)
+void TestAndEnterContainer(nlTestSuite * inSuite, T & t, TLVType type, Tag tag, TLVType & outerContainerType)
 {
     NL_TEST_ASSERT(inSuite, t.GetType() == type);
     NL_TEST_ASSERT(inSuite, t.GetTag() == tag);
@@ -204,14 +204,14 @@ struct TestTLVContext
     uint32_t mEvictedBytes;
 };
 
-void TestNull(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag)
+void TestNull(nlTestSuite * inSuite, TLVReader & reader, Tag tag)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_Null);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
     NL_TEST_ASSERT(inSuite, reader.GetLength() == 0);
 }
 
-void TestString(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const char * expectedVal)
+void TestString(nlTestSuite * inSuite, TLVReader & reader, Tag tag, const char * expectedVal)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -228,7 +228,7 @@ void TestString(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const c
     NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen + 1) == 0);
 }
 
-void TestDupString(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const char * expectedVal)
+void TestDupString(nlTestSuite * inSuite, TLVReader & reader, Tag tag, const char * expectedVal)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -245,7 +245,7 @@ void TestDupString(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, cons
     NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen + 1) == 0);
 }
 
-void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const uint8_t * expectedVal, uint32_t expectedLen)
+void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, Tag tag, const uint8_t * expectedVal, uint32_t expectedLen)
 {
     NL_TEST_ASSERT(inSuite, reader.GetType() == kTLVType_UTF8String);
     NL_TEST_ASSERT(inSuite, reader.GetTag() == tag);
@@ -1695,7 +1695,7 @@ static CHIP_ERROR FindContainerWithElement(const TLVReader & aReader, size_t aDe
 {
     TLVReader reader;
     TLVReader result;
-    uint64_t * tag = static_cast<uint64_t *>(aContext);
+    Tag * tag      = static_cast<Tag *>(aContext);
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLVType containerType;
 
@@ -1776,8 +1776,8 @@ void CheckCHIPTLVUtilities(nlTestSuite * inSuite, void * inContext)
 
         // position the reader on the first element
         reader1.Next();
-        uint64_t tag = ProfileTag(TestProfile_1, 1);
-        err          = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        Tag tag = ProfileTag(TestProfile_1, 1);
+        err     = chip::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
         NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_TAG_NOT_FOUND);
 
         tag = ProfileTag(TestProfile_2, 2);
@@ -2842,7 +2842,7 @@ void CheckStrictAliasing(nlTestSuite * inSuite, void * inContext)
     err = reader.Next();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, reader.GetTag() == 0xe00000001);
+    NL_TEST_ASSERT(inSuite, reader.GetTag() == ProfileTag(kProfile_Id, 1));
 }
 
 /**

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -23,8 +23,8 @@ namespace {
 // Use this as a timestamp if not needing to test BDX timeouts.
 constexpr uint64_t kNoAdvanceTime = 0;
 
-const uint64_t tlvStrTag  = TLV::ContextTag(4);
-const uint64_t tlvListTag = TLV::ProfileTag(7777, 8888);
+const TLV::Tag tlvStrTag  = TLV::ContextTag(4);
+const TLV::Tag tlvListTag = TLV::ProfileTag(7777, 8888);
 } // anonymous namespace
 
 // Helper method for generating a complete TLV structure with a list containing a single tag and string

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -446,7 +446,7 @@ struct Sigma1Params
     static constexpr uint8_t initiatorEphPubKeyTag = 4;
     static constexpr uint8_t resumptionIdTag       = 6;
     static constexpr uint8_t initiatorResumeMICTag = 7;
-    static constexpr uint64_t NumToTag(uint8_t num) { return TLV::ContextTag(num); }
+    static constexpr TLV::Tag NumToTag(uint8_t num) { return TLV::ContextTag(num); }
 
     static constexpr bool includeStructEnd = true;
 
@@ -541,7 +541,7 @@ struct Sigma1NoStructEnd : public BadSigma1ParamsBase
 
 struct Sigma1WrongTags : public BadSigma1ParamsBase
 {
-    static constexpr uint64_t NumToTag(uint8_t num) { return TLV::ProfileTag(0, num); }
+    static constexpr TLV::Tag NumToTag(uint8_t num) { return TLV::ProfileTag(0, num); }
 };
 
 struct Sigma1TooLongRandom : public BadSigma1ParamsBase

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -71,7 +71,7 @@ static CHIP_ERROR populateTLVBits(uint8_t * bits, size_t & offset, const uint8_t
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR writeTag(TLV::TLVWriter & writer, uint64_t tag, OptionalQRCodeInfo & info)
+CHIP_ERROR writeTag(TLV::TLVWriter & writer, TLV::Tag tag, OptionalQRCodeInfo & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -91,7 +91,7 @@ CHIP_ERROR writeTag(TLV::TLVWriter & writer, uint64_t tag, OptionalQRCodeInfo & 
     return err;
 }
 
-CHIP_ERROR writeTag(TLV::TLVWriter & writer, uint64_t tag, OptionalQRCodeInfoExtension & info)
+CHIP_ERROR writeTag(TLV::TLVWriter & writer, TLV::Tag tag, OptionalQRCodeInfoExtension & info)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -65,7 +65,7 @@ static CHIP_ERROR readBits(std::vector<uint8_t> buf, size_t & index, uint64_t & 
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR openTLVContainer(TLV::ContiguousBufferTLVReader & reader, TLV::TLVType type, uint64_t tag,
+static CHIP_ERROR openTLVContainer(TLV::ContiguousBufferTLVReader & reader, TLV::TLVType type, TLV::Tag tag,
                                    TLV::ContiguousBufferTLVReader & containerReader)
 {
     VerifyOrReturnError(reader.GetType() == type, CHIP_ERROR_INVALID_ARGUMENT);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -38,7 +38,7 @@ namespace Identify {
 
 namespace Commands {
 namespace Identify {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -73,7 +73,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Identify.
 namespace IdentifyQueryResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -108,7 +108,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace IdentifyQueryResponse.
 namespace IdentifyQuery {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -139,7 +139,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace IdentifyQuery.
 namespace TriggerEffect {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -183,7 +183,7 @@ namespace Groups {
 
 namespace Commands {
 namespace AddGroup {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -222,7 +222,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddGroup.
 namespace AddGroupResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -261,7 +261,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddGroupResponse.
 namespace ViewGroup {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -296,7 +296,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ViewGroup.
 namespace ViewGroupResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -339,7 +339,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ViewGroupResponse.
 namespace GetGroupMembership {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -378,7 +378,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetGroupMembership.
 namespace GetGroupMembershipResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -421,7 +421,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetGroupMembershipResponse.
 namespace RemoveGroup {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -456,7 +456,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveGroup.
 namespace RemoveGroupResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -495,7 +495,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveGroupResponse.
 namespace RemoveAllGroups {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -526,7 +526,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveAllGroups.
 namespace AddGroupIfIdentifying {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -568,7 +568,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace Groups
 namespace Scenes {
 namespace SceneExtensionFieldSet {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -614,7 +614,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace AddScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -666,7 +666,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddScene.
 namespace AddSceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -709,7 +709,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddSceneResponse.
 namespace ViewScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -748,7 +748,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ViewScene.
 namespace ViewSceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -804,7 +804,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ViewSceneResponse.
 namespace RemoveScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -843,7 +843,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveScene.
 namespace RemoveSceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -886,7 +886,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveSceneResponse.
 namespace RemoveAllScenes {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -921,7 +921,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveAllScenes.
 namespace RemoveAllScenesResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -960,7 +960,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveAllScenesResponse.
 namespace StoreScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -999,7 +999,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StoreScene.
 namespace StoreSceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1042,7 +1042,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StoreSceneResponse.
 namespace RecallScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1085,7 +1085,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RecallScene.
 namespace GetSceneMembership {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1120,7 +1120,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetSceneMembership.
 namespace GetSceneMembershipResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1171,7 +1171,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetSceneMembershipResponse.
 namespace EnhancedAddScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1223,7 +1223,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedAddScene.
 namespace EnhancedAddSceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1266,7 +1266,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedAddSceneResponse.
 namespace EnhancedViewScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1305,7 +1305,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedViewScene.
 namespace EnhancedViewSceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1361,7 +1361,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedViewSceneResponse.
 namespace CopyScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1412,7 +1412,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CopyScene.
 namespace CopySceneResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1460,7 +1460,7 @@ namespace OnOff {
 
 namespace Commands {
 namespace Off {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1491,7 +1491,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Off.
 namespace SampleMfgSpecificOffWithTransition {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1522,7 +1522,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SampleMfgSpecificOffWithTransition.
 namespace On {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1553,7 +1553,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace On.
 namespace SampleMfgSpecificOnWithTransition {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1584,7 +1584,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SampleMfgSpecificOnWithTransition.
 namespace SampleMfgSpecificOnWithTransition2 {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1615,7 +1615,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SampleMfgSpecificOnWithTransition2.
 namespace Toggle {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1646,7 +1646,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Toggle.
 namespace SampleMfgSpecificToggleWithTransition {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1677,7 +1677,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SampleMfgSpecificToggleWithTransition.
 namespace SampleMfgSpecificToggleWithTransition2 {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1708,7 +1708,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SampleMfgSpecificToggleWithTransition2.
 namespace OffWithEffect {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1747,7 +1747,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OffWithEffect.
 namespace OnWithRecallGlobalScene {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1778,7 +1778,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OnWithRecallGlobalScene.
 namespace OnWithTimedOff {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1831,7 +1831,7 @@ namespace LevelControl {
 
 namespace Commands {
 namespace MoveToLevel {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1878,7 +1878,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToLevel.
 namespace Move {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1925,7 +1925,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Move.
 namespace Step {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -1976,7 +1976,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Step.
 namespace Stop {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2015,7 +2015,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Stop.
 namespace MoveToLevelWithOnOff {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2054,7 +2054,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToLevelWithOnOff.
 namespace MoveWithOnOff {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2093,7 +2093,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveWithOnOff.
 namespace StepWithOnOff {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2136,7 +2136,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StepWithOnOff.
 namespace StopWithOnOff {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2172,7 +2172,7 @@ namespace Alarms {
 
 namespace Commands {
 namespace ResetAlarm {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2211,7 +2211,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ResetAlarm.
 namespace Alarm {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2250,7 +2250,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Alarm.
 namespace ResetAllAlarms {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2281,7 +2281,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ResetAllAlarms.
 namespace GetAlarmResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2328,7 +2328,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetAlarmResponse.
 namespace GetAlarm {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2359,7 +2359,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetAlarm.
 namespace ResetAlarmLog {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2403,7 +2403,7 @@ namespace Commands {
 } // namespace BinaryInputBasic
 namespace PowerProfile {
 namespace PowerProfileRecord {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2452,7 +2452,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace PowerProfileRecord
 namespace ScheduledPhase {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2492,7 +2492,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace ScheduledPhase
 namespace TransferredPhase {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2551,7 +2551,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace PowerProfileRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2586,7 +2586,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileRequest.
 namespace PowerProfileNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2634,7 +2634,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileNotification.
 namespace PowerProfileStateRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2665,7 +2665,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileStateRequest.
 namespace PowerProfileResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2713,7 +2713,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileResponse.
 namespace GetPowerProfilePriceResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2761,7 +2761,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPowerProfilePriceResponse.
 namespace PowerProfileStateResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2801,7 +2801,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileStateResponse.
 namespace GetOverallSchedulePriceResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2845,7 +2845,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetOverallSchedulePriceResponse.
 namespace GetPowerProfilePrice {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2880,7 +2880,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPowerProfilePrice.
 namespace EnergyPhasesScheduleNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2924,7 +2924,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnergyPhasesScheduleNotification.
 namespace PowerProfilesStateNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -2964,7 +2964,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfilesStateNotification.
 namespace EnergyPhasesScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3008,7 +3008,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnergyPhasesScheduleResponse.
 namespace GetOverallSchedulePrice {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3039,7 +3039,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetOverallSchedulePrice.
 namespace PowerProfileScheduleConstraintsRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3074,7 +3074,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileScheduleConstraintsRequest.
 namespace EnergyPhasesScheduleRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3109,7 +3109,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnergyPhasesScheduleRequest.
 namespace EnergyPhasesScheduleStateRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3144,7 +3144,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnergyPhasesScheduleStateRequest.
 namespace EnergyPhasesScheduleStateResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3188,7 +3188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnergyPhasesScheduleStateResponse.
 namespace GetPowerProfilePriceExtendedResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3236,7 +3236,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPowerProfilePriceExtendedResponse.
 namespace EnergyPhasesScheduleStateNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3280,7 +3280,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnergyPhasesScheduleStateNotification.
 namespace PowerProfileScheduleConstraintsNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3323,7 +3323,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileScheduleConstraintsNotification.
 namespace PowerProfileScheduleConstraintsResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3366,7 +3366,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PowerProfileScheduleConstraintsResponse.
 namespace GetPowerProfilePriceExtended {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3415,7 +3415,7 @@ namespace ApplianceControl {
 
 namespace Commands {
 namespace ExecutionOfACommand {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3450,7 +3450,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ExecutionOfACommand.
 namespace SignalStateResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3494,7 +3494,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SignalStateResponse.
 namespace SignalState {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3525,7 +3525,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SignalState.
 namespace SignalStateNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3569,7 +3569,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SignalStateNotification.
 namespace WriteFunctions {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3612,7 +3612,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace WriteFunctions.
 namespace OverloadPauseResume {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3643,7 +3643,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OverloadPauseResume.
 namespace OverloadPause {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3674,7 +3674,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OverloadPause.
 namespace OverloadWarning {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3712,7 +3712,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace ApplianceControl
 namespace Descriptor {
 namespace DeviceType {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3759,7 +3759,7 @@ namespace PollControl {
 
 namespace Commands {
 namespace CheckIn {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3790,7 +3790,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CheckIn.
 namespace CheckInResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3829,7 +3829,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CheckInResponse.
 namespace FastPollStop {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3860,7 +3860,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace FastPollStop.
 namespace SetLongPollInterval {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3896,7 +3896,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetLongPollInterval.
 namespace SetShortPollInterval {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3937,7 +3937,7 @@ namespace Basic {
 
 namespace Commands {
 namespace StartUp {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3968,7 +3968,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StartUp.
 namespace MfgSpecificPing {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -3999,7 +3999,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MfgSpecificPing.
 namespace ShutDown {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4030,7 +4030,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ShutDown.
 namespace Leave {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4066,7 +4066,7 @@ namespace OtaSoftwareUpdateProvider {
 
 namespace Commands {
 namespace QueryImage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4132,7 +4132,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace QueryImage.
 namespace ApplyUpdateRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4171,7 +4171,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ApplyUpdateRequest.
 namespace NotifyUpdateApplied {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4210,7 +4210,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace NotifyUpdateApplied.
 namespace QueryImageResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4275,7 +4275,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace QueryImageResponse.
 namespace ApplyUpdateRequestResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4319,7 +4319,7 @@ namespace OtaSoftwareUpdateRequestor {
 
 namespace Commands {
 namespace AnnounceOtaProvider {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4375,7 +4375,7 @@ namespace Commands {
 } // namespace PowerSource
 namespace GeneralCommissioning {
 namespace BasicCommissioningInfoType {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4414,7 +4414,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace ArmFailSafe {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4458,7 +4458,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ArmFailSafe.
 namespace ArmFailSafeResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4497,7 +4497,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ArmFailSafeResponse.
 namespace SetRegulatoryConfig {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4544,7 +4544,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetRegulatoryConfig.
 namespace SetRegulatoryConfigResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4583,7 +4583,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetRegulatoryConfigResponse.
 namespace CommissioningComplete {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4614,7 +4614,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CommissioningComplete.
 namespace CommissioningCompleteResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4656,7 +4656,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace GeneralCommissioning
 namespace NetworkCommissioning {
 namespace ThreadInterfaceScanResult {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4692,7 +4692,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace ThreadInterfaceScanResult
 namespace WiFiInterfaceScanResult {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4746,7 +4746,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace ScanNetworks {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4789,7 +4789,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ScanNetworks.
 namespace ScanNetworksResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4836,7 +4836,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ScanNetworksResponse.
 namespace AddWiFiNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4883,7 +4883,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddWiFiNetwork.
 namespace AddWiFiNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4922,7 +4922,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddWiFiNetworkResponse.
 namespace UpdateWiFiNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -4969,7 +4969,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpdateWiFiNetwork.
 namespace UpdateWiFiNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5008,7 +5008,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpdateWiFiNetworkResponse.
 namespace AddThreadNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5052,7 +5052,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddThreadNetwork.
 namespace AddThreadNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5091,7 +5091,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddThreadNetworkResponse.
 namespace UpdateThreadNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5135,7 +5135,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpdateThreadNetwork.
 namespace UpdateThreadNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5174,7 +5174,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpdateThreadNetworkResponse.
 namespace RemoveNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5217,7 +5217,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveNetwork.
 namespace RemoveNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5256,7 +5256,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveNetworkResponse.
 namespace EnableNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5299,7 +5299,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnableNetwork.
 namespace EnableNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5338,7 +5338,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnableNetworkResponse.
 namespace DisableNetwork {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5381,7 +5381,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace DisableNetwork.
 namespace DisableNetworkResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5420,7 +5420,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace DisableNetworkResponse.
 namespace GetLastNetworkCommissioningResult {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5460,7 +5460,7 @@ namespace DiagnosticLogs {
 
 namespace Commands {
 namespace RetrieveLogsRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5504,7 +5504,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RetrieveLogsRequest.
 namespace RetrieveLogsResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5554,7 +5554,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace DiagnosticLogs
 namespace GeneralDiagnostics {
 namespace NetworkInterfaceType {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5617,7 +5617,7 @@ namespace Commands {
 } // namespace GeneralDiagnostics
 namespace SoftwareDiagnostics {
 namespace ThreadMetrics {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5671,7 +5671,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace ResetWatermarks {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5705,7 +5705,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace SoftwareDiagnostics
 namespace ThreadNetworkDiagnostics {
 namespace NeighborTable {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5793,7 +5793,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace NeighborTable
 namespace OperationalDatasetComponents {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5880,7 +5880,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace OperationalDatasetComponents
 namespace RouteTable {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5952,7 +5952,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace RouteTable
 namespace SecurityPolicy {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -5994,7 +5994,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace ResetCounts {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6030,7 +6030,7 @@ namespace WiFiNetworkDiagnostics {
 
 namespace Commands {
 namespace ResetCounts {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6066,7 +6066,7 @@ namespace EthernetNetworkDiagnostics {
 
 namespace Commands {
 namespace ResetCounts {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6102,7 +6102,7 @@ namespace BridgedDeviceBasic {
 
 namespace Commands {
 namespace StartUp {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6133,7 +6133,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StartUp.
 namespace ShutDown {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6164,7 +6164,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ShutDown.
 namespace Leave {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6195,7 +6195,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Leave.
 namespace ReachableChanged {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6236,7 +6236,7 @@ namespace AdministratorCommissioning {
 
 namespace Commands {
 namespace OpenCommissioningWindow {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6292,7 +6292,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OpenCommissioningWindow.
 namespace OpenBasicCommissioningWindow {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6328,7 +6328,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OpenBasicCommissioningWindow.
 namespace RevokeCommissioning {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6362,7 +6362,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace AdministratorCommissioning
 namespace OperationalCredentials {
 namespace FabricDescriptor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6418,7 +6418,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace FabricDescriptor
 namespace NOCStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6460,7 +6460,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace AttestationRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6495,7 +6495,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AttestationRequest.
 namespace AttestationResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6535,7 +6535,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AttestationResponse.
 namespace CertificateChainRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6570,7 +6570,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CertificateChainRequest.
 namespace CertificateChainResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6605,7 +6605,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CertificateChainResponse.
 namespace OpCSRRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6640,7 +6640,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OpCSRRequest.
 namespace OpCSRResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6680,7 +6680,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OpCSRResponse.
 namespace AddNOC {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6731,7 +6731,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddNOC.
 namespace UpdateNOC {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6770,7 +6770,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpdateNOC.
 namespace NOCResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6813,7 +6813,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace NOCResponse.
 namespace UpdateFabricLabel {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6848,7 +6848,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpdateFabricLabel.
 namespace RemoveFabric {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6883,7 +6883,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RemoveFabric.
 namespace AddTrustedRootCertificate {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6918,7 +6918,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AddTrustedRootCertificate.
 namespace RemoveTrustedRootCertificate {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -6957,7 +6957,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace OperationalCredentials
 namespace FixedLabel {
 namespace LabelStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7009,7 +7009,7 @@ namespace DoorLock {
 
 namespace Commands {
 namespace LockDoor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7044,7 +7044,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LockDoor.
 namespace LockDoorResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7079,7 +7079,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LockDoorResponse.
 namespace UnlockDoor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7114,7 +7114,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UnlockDoor.
 namespace UnlockDoorResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7149,7 +7149,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UnlockDoorResponse.
 namespace Toggle {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7184,7 +7184,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Toggle.
 namespace ToggleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7219,7 +7219,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ToggleResponse.
 namespace UnlockWithTimeout {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7258,7 +7258,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UnlockWithTimeout.
 namespace UnlockWithTimeoutResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7293,7 +7293,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UnlockWithTimeoutResponse.
 namespace GetLogRecord {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7328,7 +7328,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetLogRecord.
 namespace GetLogRecordResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7388,7 +7388,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetLogRecordResponse.
 namespace SetPin {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7435,7 +7435,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetPin.
 namespace SetPinResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7470,7 +7470,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetPinResponse.
 namespace GetPin {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7505,7 +7505,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPin.
 namespace GetPinResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7552,7 +7552,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPinResponse.
 namespace ClearPin {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7587,7 +7587,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearPin.
 namespace ClearPinResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7622,7 +7622,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearPinResponse.
 namespace ClearAllPins {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7653,7 +7653,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearAllPins.
 namespace ClearAllPinsResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7688,7 +7688,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearAllPinsResponse.
 namespace SetUserStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7727,7 +7727,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetUserStatus.
 namespace SetUserStatusResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7762,7 +7762,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetUserStatusResponse.
 namespace GetUserStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7797,7 +7797,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetUserStatus.
 namespace GetUserStatusResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7836,7 +7836,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetUserStatusResponse.
 namespace SetWeekdaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7895,7 +7895,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetWeekdaySchedule.
 namespace SetWeekdayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7930,7 +7930,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetWeekdayScheduleResponse.
 namespace GetWeekdaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -7969,7 +7969,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetWeekdaySchedule.
 namespace GetWeekdayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8032,7 +8032,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetWeekdayScheduleResponse.
 namespace ClearWeekdaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8071,7 +8071,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearWeekdaySchedule.
 namespace ClearWeekdayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8106,7 +8106,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearWeekdayScheduleResponse.
 namespace SetYeardaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8153,7 +8153,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetYeardaySchedule.
 namespace SetYeardayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8188,7 +8188,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetYeardayScheduleResponse.
 namespace GetYeardaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8227,7 +8227,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetYeardaySchedule.
 namespace GetYeardayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8278,7 +8278,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetYeardayScheduleResponse.
 namespace ClearYeardaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8317,7 +8317,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearYeardaySchedule.
 namespace ClearYeardayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8352,7 +8352,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearYeardayScheduleResponse.
 namespace SetHolidaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8400,7 +8400,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetHolidaySchedule.
 namespace SetHolidayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8435,7 +8435,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetHolidayScheduleResponse.
 namespace GetHolidaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8470,7 +8470,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetHolidaySchedule.
 namespace GetHolidayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8522,7 +8522,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetHolidayScheduleResponse.
 namespace ClearHolidaySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8557,7 +8557,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearHolidaySchedule.
 namespace ClearHolidayScheduleResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8592,7 +8592,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearHolidayScheduleResponse.
 namespace SetUserType {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8631,7 +8631,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetUserType.
 namespace SetUserTypeResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8666,7 +8666,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetUserTypeResponse.
 namespace GetUserType {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8701,7 +8701,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetUserType.
 namespace GetUserTypeResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8740,7 +8740,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetUserTypeResponse.
 namespace SetRfid {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8787,7 +8787,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetRfid.
 namespace SetRfidResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8822,7 +8822,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetRfidResponse.
 namespace GetRfid {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8857,7 +8857,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetRfid.
 namespace GetRfidResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8904,7 +8904,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetRfidResponse.
 namespace ClearRfid {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8939,7 +8939,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearRfid.
 namespace ClearRfidResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -8974,7 +8974,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearRfidResponse.
 namespace ClearAllRfids {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9005,7 +9005,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearAllRfids.
 namespace ClearAllRfidsResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9040,7 +9040,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearAllRfidsResponse.
 namespace OperationEventNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9095,7 +9095,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace OperationEventNotification.
 namespace ProgrammingEventNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9163,7 +9163,7 @@ namespace WindowCovering {
 
 namespace Commands {
 namespace UpOrOpen {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9194,7 +9194,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace UpOrOpen.
 namespace DownOrClose {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9225,7 +9225,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace DownOrClose.
 namespace StopMotion {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9256,7 +9256,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StopMotion.
 namespace GoToLiftValue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9291,7 +9291,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GoToLiftValue.
 namespace GoToLiftPercentage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9332,7 +9332,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GoToLiftPercentage.
 namespace GoToTiltValue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9367,7 +9367,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GoToTiltValue.
 namespace GoToTiltPercentage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9413,7 +9413,7 @@ namespace BarrierControl {
 
 namespace Commands {
 namespace BarrierControlGoToPercent {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9448,7 +9448,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace BarrierControlGoToPercent.
 namespace BarrierControlStop {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9489,7 +9489,7 @@ namespace Thermostat {
 
 namespace Commands {
 namespace SetpointRaiseLower {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9528,7 +9528,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetpointRaiseLower.
 namespace CurrentWeeklySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9577,7 +9577,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CurrentWeeklySchedule.
 namespace SetWeeklySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9626,7 +9626,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetWeeklySchedule.
 namespace RelayStatusLog {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9682,7 +9682,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace RelayStatusLog.
 namespace GetWeeklySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9721,7 +9721,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetWeeklySchedule.
 namespace ClearWeeklySchedule {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9752,7 +9752,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ClearWeeklySchedule.
 namespace GetRelayStatusLog {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9803,7 +9803,7 @@ namespace ColorControl {
 
 namespace Commands {
 namespace MoveToHue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9854,7 +9854,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToHue.
 namespace MoveHue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9901,7 +9901,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveHue.
 namespace StepHue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9952,7 +9952,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StepHue.
 namespace MoveToSaturation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -9999,7 +9999,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToSaturation.
 namespace MoveSaturation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10046,7 +10046,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveSaturation.
 namespace StepSaturation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10097,7 +10097,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StepSaturation.
 namespace MoveToHueAndSaturation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10148,7 +10148,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToHueAndSaturation.
 namespace MoveToColor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10199,7 +10199,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToColor.
 namespace MoveColor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10246,7 +10246,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveColor.
 namespace StepColor {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10297,7 +10297,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StepColor.
 namespace MoveToColorTemperature {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10344,7 +10344,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveToColorTemperature.
 namespace EnhancedMoveToHue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10395,7 +10395,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedMoveToHue.
 namespace EnhancedMoveHue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10442,7 +10442,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedMoveHue.
 namespace EnhancedStepHue {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10493,7 +10493,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedStepHue.
 namespace EnhancedMoveToHueAndSaturation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10544,7 +10544,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace EnhancedMoveToHueAndSaturation.
 namespace ColorLoopSet {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10603,7 +10603,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ColorLoopSet.
 namespace StopMoveStep {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10642,7 +10642,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StopMoveStep.
 namespace MoveColorTemperature {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10699,7 +10699,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MoveColorTemperature.
 namespace StepColorTemperature {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10955,7 +10955,7 @@ namespace IasZone {
 
 namespace Commands {
 namespace ZoneEnrollResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -10995,7 +10995,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ZoneEnrollResponse.
 namespace ZoneStatusChangeNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11042,7 +11042,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ZoneStatusChangeNotification.
 namespace InitiateNormalOperationMode {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11073,7 +11073,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace InitiateNormalOperationMode.
 namespace ZoneEnrollRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11112,7 +11112,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ZoneEnrollRequest.
 namespace InitiateTestMode {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11152,7 +11152,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace InitiateTestMode.
 namespace InitiateNormalOperationModeResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11183,7 +11183,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace InitiateNormalOperationModeResponse.
 namespace InitiateTestModeResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11217,7 +11217,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace IasZone
 namespace IasAce {
 namespace IasAceZoneStatusResult {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11259,7 +11259,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace Arm {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11302,7 +11302,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Arm.
 namespace ArmResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11337,7 +11337,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ArmResponse.
 namespace Bypass {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11380,7 +11380,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Bypass.
 namespace GetZoneIdMapResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11475,7 +11475,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetZoneIdMapResponse.
 namespace Emergency {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11506,7 +11506,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Emergency.
 namespace GetZoneInformationResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11553,7 +11553,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetZoneInformationResponse.
 namespace Fire {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11584,7 +11584,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Fire.
 namespace ZoneStatusChanged {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11632,7 +11632,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ZoneStatusChanged.
 namespace Panic {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11663,7 +11663,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Panic.
 namespace PanelStatusChanged {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11711,7 +11711,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace PanelStatusChanged.
 namespace GetZoneIdMap {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11742,7 +11742,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetZoneIdMap.
 namespace GetPanelStatusResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11790,7 +11790,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPanelStatusResponse.
 namespace GetZoneInformation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11825,7 +11825,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetZoneInformation.
 namespace SetBypassedZoneList {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11864,7 +11864,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SetBypassedZoneList.
 namespace GetPanelStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11895,7 +11895,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetPanelStatus.
 namespace BypassResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11934,7 +11934,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace BypassResponse.
 namespace GetBypassedZoneList {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -11965,7 +11965,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetBypassedZoneList.
 namespace GetZoneStatusResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12009,7 +12009,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetZoneStatusResponse.
 namespace GetZoneStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12063,7 +12063,7 @@ namespace IasWd {
 
 namespace Commands {
 namespace StartWarning {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12110,7 +12110,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace StartWarning.
 namespace Squawk {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12153,7 +12153,7 @@ namespace Commands {
 } // namespace WakeOnLan
 namespace TvChannel {
 namespace TvChannelInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12205,7 +12205,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace TvChannelInfo
 namespace TvChannelLineupInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12255,7 +12255,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace ChangeChannel {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12290,7 +12290,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ChangeChannel.
 namespace ChangeChannelResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12329,7 +12329,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ChangeChannelResponse.
 namespace ChangeChannelByNumber {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12368,7 +12368,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ChangeChannelByNumber.
 namespace SkipChannel {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12406,7 +12406,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace TvChannel
 namespace TargetNavigator {
 namespace NavigateTargetTargetInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12448,7 +12448,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace NavigateTarget {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12487,7 +12487,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace NavigateTarget.
 namespace NavigateTargetResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12529,7 +12529,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace TargetNavigator
 namespace MediaPlayback {
 namespace MediaPlaybackPosition {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12571,7 +12571,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace MediaPlay {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12602,7 +12602,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaPlay.
 namespace MediaPlayResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12638,7 +12638,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaPlayResponse.
 namespace MediaPause {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12669,7 +12669,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaPause.
 namespace MediaPauseResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12705,7 +12705,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaPauseResponse.
 namespace MediaStop {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12736,7 +12736,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaStop.
 namespace MediaStopResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12772,7 +12772,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaStopResponse.
 namespace MediaStartOver {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12803,7 +12803,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaStartOver.
 namespace MediaStartOverResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12839,7 +12839,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaStartOverResponse.
 namespace MediaPrevious {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12870,7 +12870,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaPrevious.
 namespace MediaPreviousResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12906,7 +12906,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaPreviousResponse.
 namespace MediaNext {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12937,7 +12937,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaNext.
 namespace MediaNextResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -12973,7 +12973,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaNextResponse.
 namespace MediaRewind {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13004,7 +13004,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaRewind.
 namespace MediaRewindResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13040,7 +13040,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaRewindResponse.
 namespace MediaFastForward {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13071,7 +13071,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaFastForward.
 namespace MediaFastForwardResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13107,7 +13107,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaFastForwardResponse.
 namespace MediaSkipForward {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13143,7 +13143,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaSkipForward.
 namespace MediaSkipForwardResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13179,7 +13179,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaSkipForwardResponse.
 namespace MediaSkipBackward {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13215,7 +13215,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaSkipBackward.
 namespace MediaSkipBackwardResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13251,7 +13251,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaSkipBackwardResponse.
 namespace MediaSeek {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13286,7 +13286,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MediaSeek.
 namespace MediaSeekResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13325,7 +13325,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace MediaPlayback
 namespace MediaInput {
 namespace MediaInputInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13375,7 +13375,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace SelectInput {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13410,7 +13410,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SelectInput.
 namespace ShowInputStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13441,7 +13441,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace ShowInputStatus.
 namespace HideInputStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13472,7 +13472,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace HideInputStatus.
 namespace RenameInput {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13516,7 +13516,7 @@ namespace LowPower {
 
 namespace Commands {
 namespace Sleep {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13552,7 +13552,7 @@ namespace KeypadInput {
 
 namespace Commands {
 namespace SendKey {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13587,7 +13587,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SendKey.
 namespace SendKeyResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13625,7 +13625,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace KeypadInput
 namespace ContentLauncher {
 namespace ContentLaunchAdditionalInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13665,7 +13665,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace ContentLaunchAdditionalInfo
 namespace ContentLaunchParamater {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13709,7 +13709,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace ContentLaunchParamater
 namespace ContentLaunchBrandingInformation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13765,7 +13765,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace ContentLaunchBrandingInformation
 namespace ContentLaunchDimension {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13809,7 +13809,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace ContentLaunchDimension
 namespace ContentLaunchStyleInformation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13855,7 +13855,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace LaunchContent {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13894,7 +13894,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LaunchContent.
 namespace LaunchContentResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13934,7 +13934,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LaunchContentResponse.
 namespace LaunchURL {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -13973,7 +13973,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LaunchURL.
 namespace LaunchURLResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14016,7 +14016,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace ContentLauncher
 namespace AudioOutput {
 namespace AudioOutputInfo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14062,7 +14062,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace SelectOutput {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14097,7 +14097,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace SelectOutput.
 namespace RenameOutput {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14139,7 +14139,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace AudioOutput
 namespace ApplicationLauncher {
 namespace ApplicationLauncherApp {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14181,7 +14181,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace LaunchApp {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14224,7 +14224,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LaunchApp.
 namespace LaunchAppResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14268,7 +14268,7 @@ namespace ApplicationBasic {
 
 namespace Commands {
 namespace ChangeStatus {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14308,7 +14308,7 @@ namespace AccountLogin {
 
 namespace Commands {
 namespace GetSetupPIN {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14344,7 +14344,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetSetupPIN.
 namespace GetSetupPINResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14379,7 +14379,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetSetupPINResponse.
 namespace Login {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14422,7 +14422,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace AccountLogin
 namespace TestCluster {
 namespace SimpleStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14474,7 +14474,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace SimpleStruct
 namespace NestedStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14518,7 +14518,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace NestedStruct
 namespace NestedStructList {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14578,7 +14578,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace NestedStructList
 namespace DoubleNestedStructList {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14614,7 +14614,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace DoubleNestedStructList
 namespace TestListStructOctet {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14656,7 +14656,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 namespace Commands {
 namespace Test {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14687,7 +14687,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Test.
 namespace TestSpecificResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14722,7 +14722,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestSpecificResponse.
 namespace TestNotHandled {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14753,7 +14753,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestNotHandled.
 namespace TestAddArgumentsResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14788,7 +14788,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestAddArgumentsResponse.
 namespace TestSpecific {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14819,7 +14819,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestSpecific.
 namespace TestSimpleArgumentResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14854,7 +14854,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestSimpleArgumentResponse.
 namespace TestUnknownCommand {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14885,7 +14885,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestUnknownCommand.
 namespace TestStructArrayArgumentResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14940,7 +14940,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestStructArrayArgumentResponse.
 namespace TestAddArguments {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -14979,7 +14979,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestAddArguments.
 namespace TestSimpleArgumentRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15014,7 +15014,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace TestSimpleArgumentRequest.
 namespace TestStructArrayArgumentRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15074,7 +15074,7 @@ namespace Messaging {
 
 namespace Commands {
 namespace DisplayMessage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15130,7 +15130,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace DisplayMessage.
 namespace GetLastMessage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15161,7 +15161,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetLastMessage.
 namespace CancelMessage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15200,7 +15200,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace CancelMessage.
 namespace MessageConfirmation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15248,7 +15248,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace MessageConfirmation.
 namespace DisplayProtectedMessage {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15304,7 +15304,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace DisplayProtectedMessage.
 namespace GetMessageCancellation {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15340,7 +15340,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetMessageCancellation.
 namespace CancelAllMessages {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15391,7 +15391,7 @@ namespace ApplianceEventsAndAlert {
 
 namespace Commands {
 namespace GetAlerts {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15422,7 +15422,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetAlerts.
 namespace GetAlertsResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15457,7 +15457,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetAlertsResponse.
 namespace AlertsNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15492,7 +15492,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace AlertsNotification.
 namespace EventsNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15536,7 +15536,7 @@ namespace ApplianceStatistics {
 
 namespace Commands {
 namespace LogNotification {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15583,7 +15583,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LogNotification.
 namespace LogRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15618,7 +15618,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LogRequest.
 namespace LogResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15665,7 +15665,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LogResponse.
 namespace LogQueueRequest {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15696,7 +15696,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LogQueueRequest.
 namespace LogQueueResponse {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15735,7 +15735,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace LogQueueResponse.
 namespace StatisticsAvailable {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15779,7 +15779,7 @@ namespace ElectricalMeasurement {
 
 namespace Commands {
 namespace GetProfileInfoResponseCommand {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15828,7 +15828,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetProfileInfoResponseCommand.
 namespace GetProfileInfoCommand {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15859,7 +15859,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetProfileInfoCommand.
 namespace GetMeasurementProfileResponseCommand {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15916,7 +15916,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace GetMeasurementProfileResponseCommand.
 namespace GetMeasurementProfileCommand {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -15964,7 +15964,7 @@ namespace Binding {
 
 namespace Commands {
 namespace Bind {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -16011,7 +16011,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 }
 } // namespace Bind.
 namespace Unbind {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -16061,7 +16061,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace Binding
 namespace GroupKeyManagement {
 namespace GroupKey {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -16115,7 +16115,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 
 } // namespace GroupKey
 namespace GroupState {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -16166,7 +16166,7 @@ namespace SampleMfgSpecificCluster {
 
 namespace Commands {
 namespace CommandOne {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
@@ -16206,7 +16206,7 @@ namespace SampleMfgSpecificCluster2 {
 
 namespace Commands {
 namespace CommandTwo {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, uint64_t tag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -81,7 +81,7 @@ public:
 
     uint16_t identifyTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -109,7 +109,7 @@ public:
 
     uint16_t timeout;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -134,7 +134,7 @@ public:
     static constexpr CommandId GetCommandId() { return IdentifyQuery::Id; }
     static constexpr ClusterId GetClusterId() { return Identify::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -163,7 +163,7 @@ public:
     IdentifyEffectIdentifier effectIdentifier;
     IdentifyEffectVariant effectVariant;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -199,7 +199,7 @@ public:
     uint16_t groupId;
     Span<const char> groupName;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -230,7 +230,7 @@ public:
     uint8_t status;
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -259,7 +259,7 @@ public:
 
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -291,7 +291,7 @@ public:
     uint16_t groupId;
     Span<const char> groupName;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -323,7 +323,7 @@ public:
     uint8_t groupCount;
     DataModel::List<uint16_t> groupList;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -356,7 +356,7 @@ public:
     uint8_t groupCount;
     DataModel::List<uint16_t> groupList;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -386,7 +386,7 @@ public:
 
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -416,7 +416,7 @@ public:
     uint8_t status;
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -442,7 +442,7 @@ public:
     static constexpr CommandId GetCommandId() { return RemoveAllGroups::Id; }
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -471,7 +471,7 @@ public:
     uint16_t groupId;
     Span<const char> groupName;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -504,7 +504,7 @@ public:
     uint8_t length;
     uint8_t value;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -536,7 +536,7 @@ public:
     Span<const char> sceneName;
     DataModel::List<SceneExtensionFieldSet::Type> extensionFieldSets;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -572,7 +572,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -604,7 +604,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -643,7 +643,7 @@ public:
     Span<const char> sceneName;
     DataModel::List<SceneExtensionFieldSet::Type> extensionFieldSets;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -678,7 +678,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -711,7 +711,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -741,7 +741,7 @@ public:
 
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -771,7 +771,7 @@ public:
     uint8_t status;
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -802,7 +802,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -835,7 +835,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -869,7 +869,7 @@ public:
     uint8_t sceneId;
     uint16_t transitionTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -899,7 +899,7 @@ public:
 
     uint16_t groupId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -935,7 +935,7 @@ public:
     uint8_t sceneCount;
     DataModel::List<uint8_t> sceneList;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -975,7 +975,7 @@ public:
     Span<const char> sceneName;
     DataModel::List<SceneExtensionFieldSet::Type> extensionFieldSets;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1011,7 +1011,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1043,7 +1043,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1082,7 +1082,7 @@ public:
     Span<const char> sceneName;
     DataModel::List<SceneExtensionFieldSet::Type> extensionFieldSets;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1123,7 +1123,7 @@ public:
     uint16_t groupIdTo;
     uint8_t sceneIdTo;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1159,7 +1159,7 @@ public:
     uint16_t groupIdFrom;
     uint8_t sceneIdFrom;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1209,7 +1209,7 @@ public:
     static constexpr CommandId GetCommandId() { return Off::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1233,7 +1233,7 @@ public:
     static constexpr CommandId GetCommandId() { return SampleMfgSpecificOffWithTransition::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1257,7 +1257,7 @@ public:
     static constexpr CommandId GetCommandId() { return On::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1281,7 +1281,7 @@ public:
     static constexpr CommandId GetCommandId() { return SampleMfgSpecificOnWithTransition::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1305,7 +1305,7 @@ public:
     static constexpr CommandId GetCommandId() { return SampleMfgSpecificOnWithTransition2::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1329,7 +1329,7 @@ public:
     static constexpr CommandId GetCommandId() { return Toggle::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1353,7 +1353,7 @@ public:
     static constexpr CommandId GetCommandId() { return SampleMfgSpecificToggleWithTransition::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1377,7 +1377,7 @@ public:
     static constexpr CommandId GetCommandId() { return SampleMfgSpecificToggleWithTransition2::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1406,7 +1406,7 @@ public:
     OnOffEffectIdentifier effectId;
     OnOffDelayedAllOffEffectVariant effectVariant;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1432,7 +1432,7 @@ public:
     static constexpr CommandId GetCommandId() { return OnWithRecallGlobalScene::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1463,7 +1463,7 @@ public:
     uint16_t onTime;
     uint16_t offWaitTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1519,7 +1519,7 @@ public:
     uint8_t optionMask;
     uint8_t optionOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1556,7 +1556,7 @@ public:
     uint8_t optionMask;
     uint8_t optionOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1595,7 +1595,7 @@ public:
     uint8_t optionMask;
     uint8_t optionOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1629,7 +1629,7 @@ public:
     uint8_t optionMask;
     uint8_t optionOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1660,7 +1660,7 @@ public:
     uint8_t level;
     uint16_t transitionTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1691,7 +1691,7 @@ public:
     MoveMode moveMode;
     uint8_t rate;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1724,7 +1724,7 @@ public:
     uint8_t stepSize;
     uint16_t transitionTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1751,7 +1751,7 @@ public:
     static constexpr CommandId GetCommandId() { return StopWithOnOff::Id; }
     static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1785,7 +1785,7 @@ public:
     uint8_t alarmCode;
     chip::ClusterId clusterId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1816,7 +1816,7 @@ public:
     uint8_t alarmCode;
     chip::ClusterId clusterId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1842,7 +1842,7 @@ public:
     static constexpr CommandId GetCommandId() { return ResetAllAlarms::Id; }
     static constexpr ClusterId GetClusterId() { return Alarms::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1875,7 +1875,7 @@ public:
     chip::ClusterId clusterId;
     uint32_t timeStamp;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1903,7 +1903,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetAlarm::Id; }
     static constexpr ClusterId GetClusterId() { return Alarms::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1927,7 +1927,7 @@ public:
     static constexpr CommandId GetCommandId() { return ResetAlarmLog::Id; }
     static constexpr ClusterId GetClusterId() { return Alarms::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -1966,7 +1966,7 @@ public:
     bool powerProfileRemoteControl;
     uint8_t powerProfileState;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -1986,7 +1986,7 @@ public:
     uint8_t energyPhaseId;
     uint16_t scheduledTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -2014,7 +2014,7 @@ public:
     uint16_t energy;
     uint16_t maxActivationDelay;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -2038,7 +2038,7 @@ public:
 
     uint8_t powerProfileId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2072,7 +2072,7 @@ public:
     uint8_t numOfTransferredPhases;
     DataModel::List<TransferredPhase::Type> transferredPhases;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2100,7 +2100,7 @@ public:
     static constexpr CommandId GetCommandId() { return PowerProfileStateRequest::Id; }
     static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2133,7 +2133,7 @@ public:
     uint8_t numOfTransferredPhases;
     DataModel::List<TransferredPhase::Type> transferredPhases;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2170,7 +2170,7 @@ public:
     uint32_t price;
     uint8_t priceTrailingDigit;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2203,7 +2203,7 @@ public:
     uint8_t powerProfileCount;
     DataModel::List<PowerProfileRecord::Type> powerProfileRecords;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2236,7 +2236,7 @@ public:
     uint32_t price;
     uint8_t priceTrailingDigit;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2266,7 +2266,7 @@ public:
 
     uint8_t powerProfileId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2298,7 +2298,7 @@ public:
     uint8_t numOfScheduledPhases;
     DataModel::List<ScheduledPhase::Type> scheduledPhases;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2330,7 +2330,7 @@ public:
     uint8_t powerProfileCount;
     DataModel::List<PowerProfileRecord::Type> powerProfileRecords;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2363,7 +2363,7 @@ public:
     uint8_t numOfScheduledPhases;
     DataModel::List<ScheduledPhase::Type> scheduledPhases;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2390,7 +2390,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetOverallSchedulePrice::Id; }
     static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2417,7 +2417,7 @@ public:
 
     uint8_t powerProfileId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2445,7 +2445,7 @@ public:
 
     uint8_t powerProfileId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2473,7 +2473,7 @@ public:
 
     uint8_t powerProfileId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2505,7 +2505,7 @@ public:
     uint8_t numOfScheduledPhases;
     DataModel::List<ScheduledPhase::Type> scheduledPhases;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2541,7 +2541,7 @@ public:
     uint32_t price;
     uint8_t priceTrailingDigit;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2576,7 +2576,7 @@ public:
     uint8_t numOfScheduledPhases;
     DataModel::List<ScheduledPhase::Type> scheduledPhases;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2610,7 +2610,7 @@ public:
     uint16_t startAfter;
     uint16_t stopBefore;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2644,7 +2644,7 @@ public:
     uint16_t startAfter;
     uint16_t stopBefore;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2678,7 +2678,7 @@ public:
     uint8_t powerProfileId;
     uint16_t powerProfileStartTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2756,7 +2756,7 @@ public:
 
     CommandIdentification commandId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2788,7 +2788,7 @@ public:
     uint8_t remoteEnableFlagsAndDeviceStatus2;
     ApplianceStatus applianceStatus2;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2815,7 +2815,7 @@ public:
     static constexpr CommandId GetCommandId() { return SignalState::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2846,7 +2846,7 @@ public:
     uint8_t remoteEnableFlagsAndDeviceStatus2;
     ApplianceStatus applianceStatus2;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2880,7 +2880,7 @@ public:
     uint8_t functionDataType;
     DataModel::List<uint8_t> functionData;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2907,7 +2907,7 @@ public:
     static constexpr CommandId GetCommandId() { return OverloadPauseResume::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2931,7 +2931,7 @@ public:
     static constexpr CommandId GetCommandId() { return OverloadPause::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2958,7 +2958,7 @@ public:
 
     WarningEvent warningEvent;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -2988,7 +2988,7 @@ public:
     chip::DeviceTypeId type;
     uint16_t revision;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -3012,7 +3012,7 @@ public:
     static constexpr CommandId GetCommandId() { return CheckIn::Id; }
     static constexpr ClusterId GetClusterId() { return PollControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3041,7 +3041,7 @@ public:
     bool startFastPolling;
     uint16_t fastPollTimeout;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3067,7 +3067,7 @@ public:
     static constexpr CommandId GetCommandId() { return FastPollStop::Id; }
     static constexpr ClusterId GetClusterId() { return PollControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3094,7 +3094,7 @@ public:
 
     uint32_t newLongPollInterval;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3122,7 +3122,7 @@ public:
 
     uint16_t newShortPollInterval;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3152,7 +3152,7 @@ public:
     static constexpr CommandId GetCommandId() { return StartUp::Id; }
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3176,7 +3176,7 @@ public:
     static constexpr CommandId GetCommandId() { return MfgSpecificPing::Id; }
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3200,7 +3200,7 @@ public:
     static constexpr CommandId GetCommandId() { return ShutDown::Id; }
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3224,7 +3224,7 @@ public:
     static constexpr CommandId GetCommandId() { return Leave::Id; }
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3292,7 +3292,7 @@ public:
     bool requestorCanConsent;
     chip::ByteSpan metadataForProvider;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3329,7 +3329,7 @@ public:
     chip::ByteSpan updateToken;
     uint32_t newVersion;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3360,7 +3360,7 @@ public:
     chip::ByteSpan updateToken;
     uint32_t softwareVersion;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3403,7 +3403,7 @@ public:
     bool userConsentNeeded;
     chip::ByteSpan metadataForRequestor;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3440,7 +3440,7 @@ public:
     OTAApplyUpdateAction action;
     uint32_t delayedActionTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3487,7 +3487,7 @@ public:
     OTAAnnouncementReason announcementReason;
     chip::ByteSpan metadataForNode;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3535,7 +3535,7 @@ struct Type
 public:
     uint32_t failSafeExpiryLengthMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -3563,7 +3563,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3595,7 +3595,7 @@ public:
     GeneralCommissioningError errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3630,7 +3630,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3663,7 +3663,7 @@ public:
     GeneralCommissioningError errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3689,7 +3689,7 @@ public:
     static constexpr CommandId GetCommandId() { return CommissioningComplete::Id; }
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3718,7 +3718,7 @@ public:
     GeneralCommissioningError errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3771,7 +3771,7 @@ struct Type
 public:
     chip::ByteSpan discoveryResponse;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -3797,7 +3797,7 @@ public:
     uint8_t channel;
     uint32_t frequencyBand;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -3825,7 +3825,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3861,7 +3861,7 @@ public:
     DataModel::List<WiFiInterfaceScanResult::Type> wifiScanResults;
     DataModel::List<ThreadInterfaceScanResult::Type> threadScanResults;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3898,7 +3898,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3931,7 +3931,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3966,7 +3966,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -3999,7 +3999,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4032,7 +4032,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4064,7 +4064,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4097,7 +4097,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4129,7 +4129,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4162,7 +4162,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4194,7 +4194,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4227,7 +4227,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4259,7 +4259,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4292,7 +4292,7 @@ public:
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4324,7 +4324,7 @@ public:
     uint8_t errorCode;
     Span<const char> debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4353,7 +4353,7 @@ public:
 
     uint32_t timeoutMs;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4412,7 +4412,7 @@ public:
     LogsTransferProtocol requestedProtocol;
     chip::ByteSpan transferFileDesignator;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4448,7 +4448,7 @@ public:
     uint32_t timeStamp;
     uint32_t timeSinceBoot;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4543,7 +4543,7 @@ public:
     chip::ByteSpan hardwareAddress;
     InterfaceType type;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4573,7 +4573,7 @@ public:
     uint32_t stackFreeMinimum;
     uint32_t stackSize;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4594,7 +4594,7 @@ public:
     static constexpr CommandId GetCommandId() { return ResetWatermarks::Id; }
     static constexpr ClusterId GetClusterId() { return SoftwareDiagnostics::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4666,7 +4666,7 @@ public:
     bool fullNetworkData;
     bool isChild;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4706,7 +4706,7 @@ public:
     bool securityPolicyPresent;
     bool channelMaskPresent;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4742,7 +4742,7 @@ public:
     bool allocated;
     bool linkEstablished;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4762,7 +4762,7 @@ public:
     uint16_t rotationTime;
     uint16_t flags;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -4783,7 +4783,7 @@ public:
     static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
     static constexpr ClusterId GetClusterId() { return ThreadNetworkDiagnostics::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4832,7 +4832,7 @@ public:
     static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
     static constexpr ClusterId GetClusterId() { return WiFiNetworkDiagnostics::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4875,7 +4875,7 @@ public:
     static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
     static constexpr ClusterId GetClusterId() { return EthernetNetworkDiagnostics::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4904,7 +4904,7 @@ public:
     static constexpr CommandId GetCommandId() { return StartUp::Id; }
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4928,7 +4928,7 @@ public:
     static constexpr CommandId GetCommandId() { return ShutDown::Id; }
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4952,7 +4952,7 @@ public:
     static constexpr CommandId GetCommandId() { return Leave::Id; }
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -4976,7 +4976,7 @@ public:
     static constexpr CommandId GetCommandId() { return ReachableChanged::Id; }
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5028,7 +5028,7 @@ public:
     chip::ByteSpan salt;
     uint16_t passcodeID;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5061,7 +5061,7 @@ public:
 
     uint16_t commissioningTimeout;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5086,7 +5086,7 @@ public:
     static constexpr CommandId GetCommandId() { return RevokeCommissioning::Id; }
     static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5137,7 +5137,7 @@ public:
     chip::NodeId nodeId;
     chip::ByteSpan label;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -5157,7 +5157,7 @@ public:
     uint8_t fabricIndex;
     chip::ByteSpan noc;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -5181,7 +5181,7 @@ public:
 
     chip::ByteSpan attestationNonce;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5211,7 +5211,7 @@ public:
     chip::ByteSpan attestationElements;
     chip::ByteSpan signature;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5240,7 +5240,7 @@ public:
 
     uint8_t certificateType;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5268,7 +5268,7 @@ public:
 
     chip::ByteSpan certificate;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5296,7 +5296,7 @@ public:
 
     chip::ByteSpan CSRNonce;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5326,7 +5326,7 @@ public:
     chip::ByteSpan NOCSRElements;
     chip::ByteSpan attestationSignature;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5363,7 +5363,7 @@ public:
     chip::NodeId caseAdminNode;
     uint16_t adminVendorId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5397,7 +5397,7 @@ public:
     chip::ByteSpan NOCValue;
     chip::ByteSpan ICACValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5430,7 +5430,7 @@ public:
     uint8_t fabricIndex;
     chip::ByteSpan debugText;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5460,7 +5460,7 @@ public:
 
     Span<const char> label;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5488,7 +5488,7 @@ public:
 
     uint8_t fabricIndex;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5516,7 +5516,7 @@ public:
 
     chip::ByteSpan rootCertificate;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5544,7 +5544,7 @@ public:
 
     chip::ByteSpan trustedRootIdentifier;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5574,7 +5574,7 @@ public:
     chip::ByteSpan label;
     chip::ByteSpan value;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -5660,7 +5660,7 @@ public:
 
     chip::ByteSpan pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5688,7 +5688,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5716,7 +5716,7 @@ public:
 
     chip::ByteSpan pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5744,7 +5744,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5772,7 +5772,7 @@ public:
 
     Span<const char> pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5800,7 +5800,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5830,7 +5830,7 @@ public:
     uint16_t timeoutInSeconds;
     chip::ByteSpan pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5859,7 +5859,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5887,7 +5887,7 @@ public:
 
     uint16_t logIndex;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5927,7 +5927,7 @@ public:
     uint16_t userId;
     chip::ByteSpan pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5967,7 +5967,7 @@ public:
     DoorLockUserType userType;
     chip::ByteSpan pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -5998,7 +5998,7 @@ public:
 
     DoorLockSetPinOrIdStatus status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6026,7 +6026,7 @@ public:
 
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6060,7 +6060,7 @@ public:
     DoorLockUserType userType;
     chip::ByteSpan pin;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6091,7 +6091,7 @@ public:
 
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6119,7 +6119,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6144,7 +6144,7 @@ public:
     static constexpr CommandId GetCommandId() { return ClearAllPins::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6171,7 +6171,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6201,7 +6201,7 @@ public:
     uint16_t userId;
     uint8_t userStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6230,7 +6230,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6258,7 +6258,7 @@ public:
 
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6288,7 +6288,7 @@ public:
     uint16_t userId;
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6329,7 +6329,7 @@ public:
     uint8_t endHour;
     uint8_t endMinute;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6363,7 +6363,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6393,7 +6393,7 @@ public:
     uint8_t scheduleId;
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6436,7 +6436,7 @@ public:
     uint8_t endHour;
     uint8_t endMinute;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6473,7 +6473,7 @@ public:
     uint8_t scheduleId;
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6502,7 +6502,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6536,7 +6536,7 @@ public:
     uint32_t localStartTime;
     uint32_t localEndTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6567,7 +6567,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6597,7 +6597,7 @@ public:
     uint8_t scheduleId;
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6634,7 +6634,7 @@ public:
     uint32_t localStartTime;
     uint32_t localEndTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6668,7 +6668,7 @@ public:
     uint8_t scheduleId;
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6697,7 +6697,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6731,7 +6731,7 @@ public:
     uint32_t localEndTime;
     uint8_t operatingModeDuringHoliday;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6762,7 +6762,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6790,7 +6790,7 @@ public:
 
     uint8_t scheduleId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6826,7 +6826,7 @@ public:
     uint32_t localEndTime;
     uint8_t operatingModeDuringHoliday;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6858,7 +6858,7 @@ public:
 
     uint8_t scheduleId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6886,7 +6886,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6916,7 +6916,7 @@ public:
     uint16_t userId;
     DoorLockUserType userType;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6945,7 +6945,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -6973,7 +6973,7 @@ public:
 
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7003,7 +7003,7 @@ public:
     uint16_t userId;
     DoorLockUserType userType;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7038,7 +7038,7 @@ public:
     DoorLockUserType userType;
     chip::ByteSpan id;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7069,7 +7069,7 @@ public:
 
     DoorLockSetPinOrIdStatus status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7097,7 +7097,7 @@ public:
 
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7131,7 +7131,7 @@ public:
     DoorLockUserType userType;
     chip::ByteSpan rfid;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7162,7 +7162,7 @@ public:
 
     uint16_t userId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7190,7 +7190,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7215,7 +7215,7 @@ public:
     static constexpr CommandId GetCommandId() { return ClearAllRfids::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7242,7 +7242,7 @@ public:
 
     uint8_t status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7280,7 +7280,7 @@ public:
     uint32_t timeStamp;
     Span<const char> data;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7327,7 +7327,7 @@ public:
     uint32_t timeStamp;
     Span<const char> data;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7408,7 +7408,7 @@ public:
     static constexpr CommandId GetCommandId() { return UpOrOpen::Id; }
     static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7432,7 +7432,7 @@ public:
     static constexpr CommandId GetCommandId() { return DownOrClose::Id; }
     static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7456,7 +7456,7 @@ public:
     static constexpr CommandId GetCommandId() { return StopMotion::Id; }
     static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7483,7 +7483,7 @@ public:
 
     uint16_t liftValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7513,7 +7513,7 @@ public:
     uint8_t liftPercentageValue;
     uint16_t liftPercent100thsValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7542,7 +7542,7 @@ public:
 
     uint16_t tiltValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7572,7 +7572,7 @@ public:
     uint8_t tiltPercentageValue;
     uint16_t tiltPercent100thsValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7606,7 +7606,7 @@ public:
 
     uint8_t percentOpen;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7631,7 +7631,7 @@ public:
     static constexpr CommandId GetCommandId() { return BarrierControlStop::Id; }
     static constexpr ClusterId GetClusterId() { return BarrierControl::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7693,7 +7693,7 @@ public:
     SetpointAdjustMode mode;
     int8_t amount;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7728,7 +7728,7 @@ public:
     uint8_t modeForSequence;
     DataModel::List<uint8_t> payload;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7765,7 +7765,7 @@ public:
     uint8_t modeForSequence;
     DataModel::List<uint8_t> payload;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7806,7 +7806,7 @@ public:
     int16_t setpoint;
     uint16_t unreadEntries;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7841,7 +7841,7 @@ public:
     uint8_t daysToReturn;
     uint8_t modeToReturn;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7867,7 +7867,7 @@ public:
     static constexpr CommandId GetCommandId() { return ClearWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7891,7 +7891,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetRelayStatusLog::Id; }
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -7994,7 +7994,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8032,7 +8032,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8071,7 +8071,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8109,7 +8109,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8146,7 +8146,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8185,7 +8185,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8225,7 +8225,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8265,7 +8265,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8303,7 +8303,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8342,7 +8342,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8380,7 +8380,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8419,7 +8419,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8457,7 +8457,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8496,7 +8496,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8536,7 +8536,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8580,7 +8580,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8616,7 +8616,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8655,7 +8655,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8700,7 +8700,7 @@ public:
     uint8_t optionsMask;
     uint8_t optionsOverride;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8883,7 +8883,7 @@ public:
     IasEnrollResponseCode enrollResponseCode;
     uint8_t zoneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8918,7 +8918,7 @@ public:
     uint8_t zoneId;
     uint16_t delay;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8946,7 +8946,7 @@ public:
     static constexpr CommandId GetCommandId() { return InitiateNormalOperationMode::Id; }
     static constexpr ClusterId GetClusterId() { return IasZone::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -8975,7 +8975,7 @@ public:
     IasZoneType zoneType;
     uint16_t manufacturerCode;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9006,7 +9006,7 @@ public:
     uint8_t testModeDuration;
     uint8_t currentZoneSensitivityLevel;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9032,7 +9032,7 @@ public:
     static constexpr CommandId GetCommandId() { return InitiateNormalOperationModeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return IasZone::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9056,7 +9056,7 @@ public:
     static constexpr CommandId GetCommandId() { return InitiateTestModeResponse::Id; }
     static constexpr ClusterId GetClusterId() { return IasZone::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9166,7 +9166,7 @@ public:
     uint8_t zoneId;
     uint16_t zoneStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -9194,7 +9194,7 @@ public:
     Span<const char> armDisarmCode;
     uint8_t zoneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9224,7 +9224,7 @@ public:
 
     IasAceArmNotification armNotification;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9256,7 +9256,7 @@ public:
     DataModel::List<uint8_t> zoneIds;
     Span<const char> armDisarmCode;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9316,7 +9316,7 @@ public:
     uint16_t section14;
     uint16_t section15;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9356,7 +9356,7 @@ public:
     static constexpr CommandId GetCommandId() { return Emergency::Id; }
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9389,7 +9389,7 @@ public:
     chip::NodeId ieeeAddress;
     Span<const char> zoneLabel;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9417,7 +9417,7 @@ public:
     static constexpr CommandId GetCommandId() { return Fire::Id; }
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9450,7 +9450,7 @@ public:
     IasAceAudibleNotification audibleNotification;
     Span<const char> zoneLabel;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9478,7 +9478,7 @@ public:
     static constexpr CommandId GetCommandId() { return Panic::Id; }
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9511,7 +9511,7 @@ public:
     IasAceAudibleNotification audibleNotification;
     IasAceAlarmStatus alarmStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9539,7 +9539,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetZoneIdMap::Id; }
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9572,7 +9572,7 @@ public:
     IasAceAudibleNotification audibleNotification;
     IasAceAlarmStatus alarmStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9603,7 +9603,7 @@ public:
 
     uint8_t zoneId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9633,7 +9633,7 @@ public:
     uint8_t numberOfZones;
     DataModel::List<uint8_t> zoneIds;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9659,7 +9659,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetPanelStatus::Id; }
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9688,7 +9688,7 @@ public:
     uint8_t numberOfZones;
     DataModel::List<IasAceBypassResult> bypassResult;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9714,7 +9714,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetBypassedZoneList::Id; }
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9745,7 +9745,7 @@ public:
     uint8_t numberOfZones;
     DataModel::List<IasAceZoneStatusResult::Type> zoneStatusResult;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9781,7 +9781,7 @@ public:
     bool zoneStatusMaskFlag;
     uint16_t zoneStatusMask;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9823,7 +9823,7 @@ public:
     uint8_t strobeDutyCycle;
     uint8_t strobeLevel;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9854,7 +9854,7 @@ public:
 
     uint8_t squawkInfo;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9904,7 +9904,7 @@ public:
     chip::ByteSpan callSign;
     chip::ByteSpan affiliateCallSign;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -9928,7 +9928,7 @@ public:
     Span<const char> postalCode;
     TvChannelLineupInfoType lineupInfoType;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -9952,7 +9952,7 @@ public:
 
     Span<const char> match;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -9982,7 +9982,7 @@ public:
     DataModel::List<TvChannelInfo::Type> channelMatch;
     TvChannelErrorType errorType;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10013,7 +10013,7 @@ public:
     uint16_t majorNumber;
     uint16_t minorNumber;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10042,7 +10042,7 @@ public:
 
     uint16_t count;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10079,7 +10079,7 @@ public:
     uint8_t identifier;
     chip::ByteSpan name;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -10105,7 +10105,7 @@ public:
     uint8_t target;
     Span<const char> data;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10136,7 +10136,7 @@ public:
     NavigateTargetStatus status;
     Span<const char> data;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10185,7 +10185,7 @@ public:
     uint64_t updatedAt;
     uint64_t position;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -10206,7 +10206,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaPlay::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10233,7 +10233,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10258,7 +10258,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaPause::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10285,7 +10285,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10310,7 +10310,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaStop::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10337,7 +10337,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10362,7 +10362,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaStartOver::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10389,7 +10389,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10414,7 +10414,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaPrevious::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10441,7 +10441,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10466,7 +10466,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaNext::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10493,7 +10493,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10518,7 +10518,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaRewind::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10545,7 +10545,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10570,7 +10570,7 @@ public:
     static constexpr CommandId GetCommandId() { return MediaFastForward::Id; }
     static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10597,7 +10597,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10625,7 +10625,7 @@ public:
 
     uint64_t deltaPositionMilliseconds;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10653,7 +10653,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10681,7 +10681,7 @@ public:
 
     uint64_t deltaPositionMilliseconds;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10709,7 +10709,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10737,7 +10737,7 @@ public:
 
     uint64_t position;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10765,7 +10765,7 @@ public:
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10815,7 +10815,7 @@ public:
     chip::ByteSpan name;
     chip::ByteSpan description;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -10839,7 +10839,7 @@ public:
 
     uint8_t index;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10864,7 +10864,7 @@ public:
     static constexpr CommandId GetCommandId() { return ShowInputStatus::Id; }
     static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10888,7 +10888,7 @@ public:
     static constexpr CommandId GetCommandId() { return HideInputStatus::Id; }
     static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10917,7 +10917,7 @@ public:
     uint8_t index;
     Span<const char> name;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -10948,7 +10948,7 @@ public:
     static constexpr CommandId GetCommandId() { return Sleep::Id; }
     static constexpr ClusterId GetClusterId() { return LowPower::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11077,7 +11077,7 @@ public:
 
     KeypadInputCecKeyCode keyCode;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11105,7 +11105,7 @@ public:
 
     KeypadInputStatus status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11169,7 +11169,7 @@ public:
     Span<const char> name;
     Span<const char> value;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11191,7 +11191,7 @@ public:
     Span<const char> value;
     DataModel::List<ContentLaunchAdditionalInfo::Type> externalIDList;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11225,7 +11225,7 @@ public:
     uint8_t splash;
     uint8_t waterMark;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11247,7 +11247,7 @@ public:
     Span<const char> height;
     ContentLaunchMetricType metric;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11269,7 +11269,7 @@ public:
     Span<const char> color;
     uint8_t size;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11295,7 +11295,7 @@ public:
     bool autoPlay;
     Span<const char> data;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11326,7 +11326,7 @@ public:
     Span<const char> data;
     ContentLaunchStatus contentLaunchStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11357,7 +11357,7 @@ public:
     Span<const char> contentURL;
     Span<const char> displayString;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11388,7 +11388,7 @@ public:
     Span<const char> data;
     ContentLaunchStatus contentLaunchStatus;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11431,7 +11431,7 @@ public:
     AudioOutputType outputType;
     chip::ByteSpan name;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11455,7 +11455,7 @@ public:
 
     uint8_t index;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11485,7 +11485,7 @@ public:
     uint8_t index;
     Span<const char> name;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11523,7 +11523,7 @@ public:
     uint16_t catalogVendorId;
     Span<const char> applicationId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11551,7 +11551,7 @@ public:
     uint16_t catalogVendorId;
     Span<const char> applicationId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11583,7 +11583,7 @@ public:
     ApplicationLauncherStatus status;
     Span<const char> data;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11625,7 +11625,7 @@ public:
 
     ApplicationBasicStatus status;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11658,7 +11658,7 @@ public:
 
     Span<const char> tempAccountIdentifier;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11686,7 +11686,7 @@ public:
 
     Span<const char> setupPIN;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11716,7 +11716,7 @@ public:
     Span<const char> tempAccountIdentifier;
     Span<const char> setupPIN;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11761,7 +11761,7 @@ public:
     chip::ByteSpan d;
     Span<const char> e;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11783,7 +11783,7 @@ public:
     bool b;
     SimpleStruct::Type c;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11813,7 +11813,7 @@ public:
     DataModel::List<chip::ByteSpan> f;
     DataModel::List<uint8_t> g;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11841,7 +11841,7 @@ struct Type
 public:
     DataModel::List<NestedStructList::Type> a;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11865,7 +11865,7 @@ public:
     uint64_t fabricIndex;
     chip::ByteSpan operationalCert;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -11886,7 +11886,7 @@ public:
     static constexpr CommandId GetCommandId() { return Test::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11913,7 +11913,7 @@ public:
 
     uint8_t returnValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11938,7 +11938,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestNotHandled::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11965,7 +11965,7 @@ public:
 
     uint8_t returnValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -11990,7 +11990,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestSpecific::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12017,7 +12017,7 @@ public:
 
     bool returnValue;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12042,7 +12042,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestUnknownCommand::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12079,7 +12079,7 @@ public:
     SimpleEnum arg5;
     bool arg6;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12114,7 +12114,7 @@ public:
     uint8_t arg1;
     uint8_t arg2;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12143,7 +12143,7 @@ public:
 
     bool arg1;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12181,7 +12181,7 @@ public:
     SimpleEnum arg5;
     bool arg6;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12342,7 +12342,7 @@ public:
     Span<const char> message;
     uint8_t optionalExtendedMessageControl;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12372,7 +12372,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetLastMessage::Id; }
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12401,7 +12401,7 @@ public:
     uint32_t messageId;
     uint8_t messageControl;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12436,7 +12436,7 @@ public:
     uint8_t messageConfirmationControl;
     chip::ByteSpan messageResponse;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12477,7 +12477,7 @@ public:
     Span<const char> message;
     uint8_t optionalExtendedMessageControl;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12510,7 +12510,7 @@ public:
 
     uint32_t earliestImplementationTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12538,7 +12538,7 @@ public:
 
     uint32_t implementationDateTime;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12583,7 +12583,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetAlerts::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12610,7 +12610,7 @@ public:
 
     uint8_t alertsCount;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12638,7 +12638,7 @@ public:
 
     uint8_t alertsCount;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12668,7 +12668,7 @@ public:
     uint8_t eventHeader;
     EventIdentification eventId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12708,7 +12708,7 @@ public:
     uint32_t logLength;
     DataModel::List<uint8_t> logPayload;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12739,7 +12739,7 @@ public:
 
     uint32_t logId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12773,7 +12773,7 @@ public:
     uint32_t logLength;
     DataModel::List<uint8_t> logPayload;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12801,7 +12801,7 @@ public:
     static constexpr CommandId GetCommandId() { return LogQueueRequest::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12830,7 +12830,7 @@ public:
     uint8_t logQueueSize;
     DataModel::List<uint32_t> logIds;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12861,7 +12861,7 @@ public:
     uint8_t logQueueSize;
     DataModel::List<uint32_t> logIds;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12901,7 +12901,7 @@ public:
     uint8_t maxNumberOfIntervals;
     DataModel::List<uint16_t> listOfAttributes;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12929,7 +12929,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetProfileInfoCommand::Id; }
     static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -12966,7 +12966,7 @@ public:
     uint16_t attributeId;
     DataModel::List<uint8_t> intervals;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -13003,7 +13003,7 @@ public:
     uint32_t startTime;
     uint8_t numberOfIntervals;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -13044,7 +13044,7 @@ public:
     chip::EndpointId endpointId;
     chip::ClusterId clusterId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -13081,7 +13081,7 @@ public:
     chip::EndpointId endpointId;
     chip::ClusterId clusterId;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -13126,7 +13126,7 @@ public:
     uint64_t groupKeyEpochStartTime;
     GroupKeySecurityPolicy groupKeySecurityPolicy;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -13148,7 +13148,7 @@ public:
     uint16_t vendorGroupId;
     uint16_t groupKeySetIndex;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 
@@ -13175,7 +13175,7 @@ public:
 
     uint8_t argOne;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType
@@ -13208,7 +13208,7 @@ public:
 
     uint8_t argOne;
 
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, uint64_t tag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
 
 struct DecodableType


### PR DESCRIPTION
#### Problem
We have places where people do weird things with tags because they are actually integers.  We want to turn on tags-as-a-class to avoid those problems.

#### Change overview
Use TLV::Tag for tags.  No actual behavior changes to class yet.

#### Testing
Compiled and ran tests.  No intended behavior changes.