### PR TITLE
[cirque] Fix "No such file or directory" issue in CHIPCirqueDaemon

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/CHIPCirqueDaemon.py
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/CHIPCirqueDaemon.py
@@ -89,12 +89,12 @@ def ServerMain(args):
         "otbr-agent": ShellCommand(["otbr-agent", "-I", "wpan0", "spinel+hdlc+uart:///dev/ttyUSB0"])
     }
 
-    for extraOption in args:
-        cmd = extraOptions.get(extraOption, InvalidCommand())
-        cmd()
-
     with Listener(SERVER_ADDRESS) as listener:
         log.info("Server running on {}".format(SERVER_ADDRESS))
+        for extraOption in args:
+            cmd = extraOptions.get(extraOption, InvalidCommand())
+            cmd()
+
         while True:
             with listener.accept() as conn:
                 log.info("Received connection")


### PR DESCRIPTION
#### Problem

Recent updates exzposed timing related issues in `CHIPCirqueDaemon`. Sometimes client mode will throw exceptions like "No such file or directory",

```
raceback (most recent call last):
  File "/usr/bin/CHIPCirqueDaemon.py", line 127, in <module>
    main()
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/bin/CHIPCirqueDaemon.py", line 123, in main
    ClientMain(command)
  File "/usr/bin/CHIPCirqueDaemon.py", line 108, in ClientMain
    with Client(SERVER_ADDRESS) as conn:
  File "/usr/lib/python3.8/multiprocessing/connection.py", line 502, in Client
    c = SocketClient(address)
  File "/usr/lib/python3.8/multiprocessing/connection.py", line 630, in SocketClient
    s.connect(address)
FileNotFoundError: [Errno 2] No such file or directory
```

#### Change overview

After reviewing the code, this issue is caused by slow start up commands, and client sent requests before the listener is ready.

Reorder code so the listener will be ready eariler.

#### Testing

This issue does not occur on github actions although it is used by MobileDeviceTest under Cirque test. Local tests with updated script do not throw "No such file or directory" now.