### PR TITLE
[nrfconnect] Fixed an assert when trying to start DFU over BLE on nRF52

### DIFF
--- a/config/nrfconnect/app/overlay-single_image_dfu_support.conf
+++ b/config/nrfconnect/app/overlay-single_image_dfu_support.conf
@@ -40,5 +40,8 @@ CONFIG_MCUMGR_BUF_COUNT=6
 CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase MCUMGR_BUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
+CONFIG_MCUMGR_BUF_SIZE=1024
+
 # Increase system workqueue size, as SMP is processed within it
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2800


### PR DESCRIPTION
#### Problem
There is a bug that leads to assert when trying to start Device Firmware Upgrade over BLE on nRF52.

#### Change overview
* Increased MCUMGR_BUF_SIZE to 1024 B from default 384 B to fit the BT MAX MTU size + transport overhead

#### Testing
Tested manually on nrfconnect that DFU over BLE works for nRF52 platform