### PR TITLE
Remove unnecessary exchange manager from CommandHandler.

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -33,10 +33,7 @@
 namespace chip {
 namespace app {
 
-Command::Command(Messaging::ExchangeManager * apExchangeMgr)
-{
-    mpExchangeMgr = apExchangeMgr;
-}
+Command::Command() {}
 
 CHIP_ERROR Command::AllocateBuffer()
 {

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -36,7 +36,6 @@
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
-#include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
 #include <system/SystemPacketBuffer.h>
@@ -97,7 +96,7 @@ public:
     virtual CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) = 0;
 
 protected:
-    Command(Messaging::ExchangeManager * apExchangeMgr);
+    Command();
 
     /*
      * Allocates a packet buffer used for encoding an invoke request/response payload.
@@ -120,7 +119,6 @@ protected:
     const char * GetStateStr() const;
 
     InvokeCommand::Builder mInvokeCommandBuilder;
-    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     uint8_t mCommandIndex                      = 0;
     CommandState mState                        = CommandState::Idle;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -26,7 +26,7 @@
 #include "Command.h"
 #include "CommandSender.h"
 #include "InteractionModelEngine.h"
-#include "messaging/ExchangeMgr.h"
+#include "messaging/ExchangeContext.h"
 
 #include <lib/support/TypeTraits.h>
 #include <protocols/secure_channel/Constants.h>
@@ -36,9 +36,7 @@ using GeneralStatusCode = chip::Protocols::SecureChannel::GeneralStatusCode;
 namespace chip {
 namespace app {
 
-CommandHandler::CommandHandler(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback) :
-    Command(apExchangeMgr), mpCallback(apCallback)
-{}
+CommandHandler::CommandHandler(Callback * apCallback) : mpCallback(apCallback) {}
 
 CHIP_ERROR CommandHandler::OnInvokeCommandRequest(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                                   System::PacketBufferHandle && payload)

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -35,7 +35,6 @@
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
-#include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
 #include <system/SystemPacketBuffer.h>
@@ -63,7 +62,7 @@ public:
      *
      * The callback passed in has to outlive this CommandHandler object.
      */
-    CommandHandler(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback);
+    CommandHandler(Callback * apCallback);
 
     /*
      * Main entrypoint for this class to handle an invoke request.

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -37,7 +37,7 @@ namespace chip {
 namespace app {
 
 CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager * apExchangeMgr) :
-    Command(apExchangeMgr), mpCallback(apCallback)
+    mpCallback(apCallback), mpExchangeMgr(apExchangeMgr)
 {}
 
 CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> secureSession,

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -153,7 +153,8 @@ private:
 
     CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) override;
 
-    Callback * mpCallback = nullptr;
+    Callback * mpCallback                      = nullptr;
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
 };
 
 } // namespace app

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -191,7 +191,7 @@ CHIP_ERROR InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeCon
                                                           const PayloadHeader & aPayloadHeader,
                                                           System::PacketBufferHandle && aPayload)
 {
-    CommandHandler * commandHandler = mCommandHandlerObjs.CreateObject(mpExchangeMgr, this);
+    CommandHandler * commandHandler = mCommandHandlerObjs.CreateObject(this);
     if (commandHandler == nullptr)
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -310,7 +310,7 @@ void TestCommandInteraction::TestCommandHandlerWithWrongState(nlTestSuite * apSu
     CHIP_ERROR err         = CHIP_NO_ERROR;
     auto commandPathParams = MakeTestCommandPath();
 
-    app::CommandHandler commandHandler(gExchangeManager, &mockCommandHandlerDelegate);
+    app::CommandHandler commandHandler(&mockCommandHandlerDelegate);
 
     err = commandHandler.PrepareCommand(commandPathParams);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -346,7 +346,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite 
     CHIP_ERROR err         = CHIP_NO_ERROR;
     auto commandPathParams = MakeTestCommandPath();
 
-    app::CommandHandler commandHandler(gExchangeManager, &mockCommandHandlerDelegate);
+    app::CommandHandler commandHandler(&mockCommandHandlerDelegate);
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     auto exchangeCtx             = gExchangeManager->NewContext(SessionHandle(0, 0, 0, 0), nullptr);
@@ -378,7 +378,7 @@ void TestCommandInteraction::TestCommandSenderWithProcessReceivedMsg(nlTestSuite
 void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite * apSuite, void * apContext, bool aNeedStatusCode)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    app::CommandHandler commandHandler(gExchangeManager, &mockCommandHandlerDelegate);
+    app::CommandHandler commandHandler(&mockCommandHandlerDelegate);
     System::PacketBufferHandle commandPacket;
 
     auto exchangeCtx = gExchangeManager->NewContext(SessionHandle(0, 0, 0, 0), nullptr);
@@ -425,7 +425,7 @@ struct Fields
 void TestCommandInteraction::TestCommandHandlerCommandDataEncoding(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    app::CommandHandler commandHandler(gExchangeManager, nullptr);
+    app::CommandHandler commandHandler(nullptr);
     System::PacketBufferHandle commandPacket;
 
     commandHandler.mpExchangeCtx = gExchangeManager->NewContext(SessionHandle(0, 0, 0, 0), nullptr);
@@ -461,7 +461,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendSimpleStatusCode(nlTestSu
 void TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    app::CommandHandler commandHandler(gExchangeManager, &mockCommandHandlerDelegate);
+    app::CommandHandler commandHandler(&mockCommandHandlerDelegate);
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     GenerateReceivedCommand(apSuite, apContext, commandDatabuf, true /*aNeedCommandData*/);
@@ -472,7 +472,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg(nlTestSuit
 void TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    app::CommandHandler commandHandler(gExchangeManager, &mockCommandHandlerDelegate);
+    app::CommandHandler commandHandler(&mockCommandHandlerDelegate);
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     // Use some invalid endpoint / cluster / command.
@@ -489,7 +489,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistComman
 void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    app::CommandHandler commandHandler(gExchangeManager, &mockCommandHandlerDelegate);
+    app::CommandHandler commandHandler(&mockCommandHandlerDelegate);
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     chip::isCommandDispatched = false;


### PR DESCRIPTION
CommandHandler never needs to create exchanges.

Fixes https://github.com/project-chip/connectedhomeip/issues/10329

#### Problem
Unnecessary complications.

#### Change overview
Remove them.

#### Testing
Tree compiles.  No behavior changes.