### PR TITLE
Null out the delegate on an exchange when aborting it in Command.

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -214,6 +214,14 @@ void Command::Abort()
     //
     if (mpExchangeCtx != nullptr)
     {
+        // We (or more precisely our subclass) might be a delegate for this
+        // exchange, and we don't want the OnExchangeClosing notification in
+        // that case.  Null out the delegate to avoid that.
+        //
+        // TODO: This makes all sorts of assumptions about what the delegate is
+        // (notice the "might" above!) that might not hold in practice.  We
+        // really need a better solution here....
+        mpExchangeCtx->SetDelegate(nullptr);
         mpExchangeCtx->Abort();
         mpExchangeCtx = nullptr;
     }


### PR DESCRIPTION
Otherwise we might end up calling virtual functions on an object in
its destructor, which is not great.

Fixes https://github.com/project-chip/connectedhomeip/issues/10349

#### Problem
See above.

#### Change overview
See above.

#### Testing
Not sure how to exercise this codepath in a reasonable way.