### PR TITLE
Properly shut down the exchange manager when shutting down system state.

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -235,11 +235,10 @@ CHIP_ERROR DeviceControllerSystemState::Shutdown()
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
 #endif
 
-    // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
-    // if (mExchangeMgr != nullptr)
-    // {
-    //     mExchangeMgr->Shutdown();
-    // }
+    if (mExchangeMgr != nullptr)
+    {
+        mExchangeMgr->Shutdown();
+    }
     if (mSessionMgr != nullptr)
     {
         mSessionMgr->Shutdown();


### PR DESCRIPTION
The leak that caused us to not do this before seems to be fixed with
the exchange lifetime work that has happened since.

Fixes https://github.com/project-chip/connectedhomeip/issues/6668

#### Problem
See above.

#### Change overview
See above.

#### Testing
Passes Darwin tests locally.