### PR TITLE
Move some code within src/inet files

### DIFF
--- a/src/inet/DNSResolver.h
+++ b/src/inet/DNSResolver.h
@@ -103,6 +103,44 @@ private:
      */
     typedef void (*OnResolveCompleteFunct)(void * appState, CHIP_ERROR err, uint8_t addrCount, IPAddress * addrArray);
 
+    /**
+     *  This method revolves a host name into a list of IP addresses.
+     *
+     *  @note
+     *     Even if the operation completes successfully, the result might be a zero-length list of IP addresses.
+     *     Most of the error generated are returned via the application callback.
+     *
+     *  @param[in]  hostName    A pointer to a C string representing the host name
+     *                          to be queried.
+     *  @param[in]  hostNameLen The string length of host name.
+     *  @param[in]  maxAddrs    The maximum number of addresses to store in the DNS
+     *                          table.
+     *  @param[in]  options     An integer value controlling how host name address
+     *                          resolution is performed.  Values are from the #DNSOptions
+     *                          enumeration.
+     *  @param[in]  addrArray   A pointer to the DNS table.
+     *  @param[in]  onComplete  A pointer to the callback function when a DNS
+     *                          request is complete.
+     *  @param[in]  appState    A pointer to the application state to be passed to
+     *                          onComplete when a DNS request is complete.
+     *
+     *  @retval CHIP_NO_ERROR                   if a DNS request is handled
+     *                                          successfully.
+     *  @retval CHIP_ERROR_NOT_IMPLEMENTED      if DNS resolution is not enabled on
+     *                                          the underlying platform.
+     *  @retval _other_                         if other POSIX network or OS error
+     *                                          was returned by the underlying DNS
+     *                                          resolver implementation.
+     *
+     */
+    CHIP_ERROR Resolve(const char * hostName, uint16_t hostNameLen, uint8_t options, uint8_t maxAddrs, IPAddress * addrArray,
+                       OnResolveCompleteFunct onComplete, void * appState);
+
+    /**
+     *  This method cancels DNS requests that are in progress.
+     */
+    CHIP_ERROR Cancel();
+
     static chip::System::ObjectPool<DNSResolver, INET_CONFIG_NUM_DNS_RESOLVERS> sPool;
 
     /**
@@ -130,6 +168,8 @@ private:
      */
     uint8_t DNSOptions;
 
+    CHIP_ERROR ResolveImpl(char * hostNameBuf);
+
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     void InitAddrInfoHints(struct addrinfo & hints);
@@ -153,10 +193,6 @@ private:
 #endif // INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-    CHIP_ERROR Resolve(const char * hostName, uint16_t hostNameLen, uint8_t options, uint8_t maxAddrs, IPAddress * addrArray,
-                       OnResolveCompleteFunct onComplete, void * appState);
-    CHIP_ERROR Cancel();
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     void HandleResolveComplete(void);

--- a/src/inet/EndPointBasis.cpp
+++ b/src/inet/EndPointBasis.cpp
@@ -30,20 +30,14 @@
 namespace chip {
 namespace Inet {
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+
 void EndPointBasis::InitEndPointBasis(InetLayer & aInetLayer, void * aAppState)
 {
     InitInetLayerBasis(aInetLayer, aAppState);
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
     mLwIPEndPointType = LwIPEndPointType::Unknown;
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    mSocket = kInvalidSocketFd;
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 }
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
 void EndPointBasis::DeferredFree(System::Object::ReleaseDeferralErrorTactic aTactic)
 {
     if (!CHIP_SYSTEM_CONFIG_USE_SOCKETS || (mVoid != nullptr))
@@ -55,7 +49,37 @@ void EndPointBasis::DeferredFree(System::Object::ReleaseDeferralErrorTactic aTac
         Release();
     }
 }
+
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+void EndPointBasis::InitEndPointBasis(InetLayer & aInetLayer, void * aAppState)
+{
+    InitInetLayerBasis(aInetLayer, aAppState);
+    mSocket = kInvalidSocketFd;
+}
+
+void EndPointBasis::DeferredFree(System::Object::ReleaseDeferralErrorTactic aTactic)
+{
+    Release();
+}
+
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+void EndPointBasis::InitEndPointBasis(InetLayer & aInetLayer, void * aAppState)
+{
+    InitInetLayerBasis(aInetLayer, aAppState);
+}
+
+void EndPointBasis::DeferredFree(System::Object::ReleaseDeferralErrorTactic aTactic)
+{
+    Release();
+}
+
+#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/EndPointBasis.h
+++ b/src/inet/EndPointBasis.h
@@ -54,6 +54,7 @@ class DLL_EXPORT EndPointBasis : public InetLayerBasis
 {
 protected:
     void InitEndPointBasis(InetLayer & aInetLayer, void * aAppState = nullptr);
+    void DeferredFree(System::Object::ReleaseDeferralErrorTactic aTactic);
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     nw_parameters_t mParameters;
@@ -88,8 +89,6 @@ protected:
         UCP     = 3,
         TCP     = 4
     } mLwIPEndPointType;
-
-    void DeferredFree(System::Object::ReleaseDeferralErrorTactic aTactic);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 };
 

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -49,6 +49,31 @@
 #include <lwip/netif.h>
 #include <lwip/raw.h>
 #include <lwip/udp.h>
+
+#if INET_CONFIG_ENABLE_IPV4
+#define LWIP_IPV4_ADDR_T ip4_addr_t
+#define IPV4_TO_LWIPADDR(aAddress) (aAddress).ToIPv4()
+#endif // INET_CONFIG_ENABLE_IPV4
+#define LWIP_IPV6_ADDR_T ip6_addr_t
+#define IPV6_TO_LWIPADDR(aAddress) (aAddress).ToIPv6()
+
+#if !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||                       \
+    !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
+#define HAVE_LWIP_MULTICAST_LOOP 0
+#else
+#define HAVE_LWIP_MULTICAST_LOOP 1
+#endif // !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||
+       // !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
+
+// unusual define check for LWIP_IPV6_ND is because espressif fork
+// of LWIP does not define the _ND constant.
+#if LWIP_IPV6_MLD && (!defined(LWIP_IPV6_ND) || LWIP_IPV6_ND) && LWIP_IPV6
+#define HAVE_IPV6_MULTICAST
+#else
+// Within Project CHIP multicast support is highly desirable: used for mDNS
+// as well as group communication.
+#undef HAVE_IPV6_MULTICAST
+#endif
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -86,49 +111,18 @@
 #error                                                                                                                             \
     "Neither IPV6_DROP_MEMBERSHIP nor IPV6_LEAVE_GROUP are defined which are required for generalized IPv6 multicast group support."
 #endif // IPV6_DROP_MEMBERSHIP
+
+#if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
+#include "ZephyrSocket.h"
+#endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 #define INET_PORTSTRLEN 6
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-#if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
-#include "ZephyrSocket.h"
-#endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
-
 namespace chip {
 namespace Inet {
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-union PeerSockAddr
-{
-    sockaddr any;
-    sockaddr_in in;
-    sockaddr_in6 in6;
-};
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-IPEndPointBasis::JoinMulticastGroupHandler IPEndPointBasis::sJoinMulticastGroupHandler;
-IPEndPointBasis::LeaveMulticastGroupHandler IPEndPointBasis::sLeaveMulticastGroupHandler;
-#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if INET_CONFIG_ENABLE_IPV4
-#define LWIP_IPV4_ADDR_T ip4_addr_t
-#define IPV4_TO_LWIPADDR(aAddress) (aAddress).ToIPv4()
-#endif // INET_CONFIG_ENABLE_IPV4
-#define LWIP_IPV6_ADDR_T ip6_addr_t
-#define IPV6_TO_LWIPADDR(aAddress) (aAddress).ToIPv6()
-
-#if !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||                       \
-    !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
-#define HAVE_LWIP_MULTICAST_LOOP 0
-#else
-#define HAVE_LWIP_MULTICAST_LOOP 1
-#endif // !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||
-       // !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 static CHIP_ERROR CheckMulticastGroupArgs(InterfaceId aInterfaceId, const IPAddress & aAddress)
@@ -142,6 +136,7 @@ static CHIP_ERROR CheckMulticastGroupArgs(InterfaceId aInterfaceId, const IPAddr
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+
 #if INET_CONFIG_ENABLE_IPV4
 #if LWIP_IPV4 && LWIP_IGMP
 static CHIP_ERROR LwIPIPv4JoinLeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress,
@@ -162,16 +157,6 @@ static CHIP_ERROR LwIPIPv4JoinLeaveMulticastGroup(InterfaceId aInterfaceId, cons
 #endif // LWIP_IPV4 && LWIP_IGMP
 #endif // INET_CONFIG_ENABLE_IPV4
 
-// unusual define check for LWIP_IPV6_ND is because espressif fork
-// of LWIP does not define the _ND constant.
-#if LWIP_IPV6_MLD && (!defined(LWIP_IPV6_ND) || LWIP_IPV6_ND) && LWIP_IPV6
-#define HAVE_IPV6_MULTICAST
-#else
-// Within Project CHIP multicast support is highly desirable: used for mDNS
-// as well as group communication.
-#undef HAVE_IPV6_MULTICAST
-#endif
-
 #ifdef HAVE_IPV6_MULTICAST
 static CHIP_ERROR LwIPIPv6JoinLeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress,
                                                   err_t (*aMethod)(struct netif *, const LWIP_IPV6_ADDR_T *))
@@ -189,9 +174,191 @@ static CHIP_ERROR LwIPIPv6JoinLeaveMulticastGroup(InterfaceId aInterfaceId, cons
     return chip::System::MapErrorLwIP(lStatus);
 }
 #endif // LWIP_IPV6_MLD && LWIP_IPV6_ND && LWIP_IPV6
+
+CHIP_ERROR IPEndPointBasis::SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback)
+{
+    CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
+
+#if !HAVE_LWIP_MULTICAST_LOOP
+    lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#else
+    if (aLoopback)
+    {
+        switch (mLwIPEndPointType)
+        {
+
+#if INET_CONFIG_ENABLE_UDP_ENDPOINT
+        case LwIPEndPointType::UDP:
+            udp_set_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP);
+            break;
+#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
+
+        default:
+            lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+            break;
+        }
+    }
+    else
+    {
+        switch (mLwIPEndPointType)
+        {
+
+#if INET_CONFIG_ENABLE_UDP_ENDPOINT
+        case LwIPEndPointType::UDP:
+            udp_clear_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP);
+            break;
+#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
+
+        default:
+            lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+            break;
+        }
+    }
+
+    lRetval = CHIP_NO_ERROR;
+#endif // !HAVE_LWIP_MULTICAST_LOOP
+    return (lRetval);
+}
+
+void IPEndPointBasis::InitImpl() {}
+
+#if INET_CONFIG_ENABLE_IPV4
+CHIP_ERROR IPEndPointBasis::IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
+{
+#if LWIP_IPV4 && LWIP_IGMP
+    const auto method = join ? igmp_joingroup_netif : igmp_leavegroup_netif;
+    return LwIPIPv4JoinLeaveMulticastGroup(aInterfaceId, aAddress, method);
+#else  // LWIP_IPV4 && LWIP_IGMP
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // LWIP_IPV4 && LWIP_IGMP
+}
+#endif // INET_CONFIG_ENABLE_IPV4
+
+CHIP_ERROR IPEndPointBasis::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
+{
+#ifdef HAVE_IPV6_MULTICAST
+    const auto method = join ? mld6_joingroup_netif : mld6_leavegroup_netif;
+    return LwIPIPv6JoinLeaveMulticastGroup(aInterfaceId, aAddress, method);
+#else  // HAVE_IPV6_MULTICAST
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // HAVE_IPV6_MULTICAST
+}
+
+void IPEndPointBasis::HandleDataReceived(System::PacketBufferHandle && aBuffer)
+{
+    if ((mState == kState_Listening) && (OnMessageReceived != NULL))
+    {
+        const IPPacketInfo * pktInfo = GetPacketInfo(aBuffer);
+
+        if (pktInfo != NULL)
+        {
+            const IPPacketInfo pktInfoCopy = *pktInfo; // copy the address info so that the app can free the
+                                                       // PacketBuffer without affecting access to address info.
+            OnMessageReceived(this, std::move(aBuffer), &pktInfoCopy);
+        }
+        else
+        {
+            if (OnReceiveError != NULL)
+                OnReceiveError(this, CHIP_ERROR_INBOUND_MESSAGE_TOO_BIG, NULL);
+        }
+    }
+}
+
+/**
+ *  @brief Get LwIP IP layer source and destination addressing information.
+ *
+ *  @param[in]   aBuffer       the packet buffer containing the IP message
+ *
+ *  @returns  a pointer to the address information on success; otherwise,
+ *            NULL if there is insufficient space in the packet for
+ *            the address information.
+ *
+ *  @details
+ *     When using LwIP information about the packet is 'hidden' in the
+ *     reserved space before the start of the data in the packet
+ *     buffer. This is necessary because the system layer events only
+ *     have two arguments, which in this case are used to convey the
+ *     pointer to the end point and the pointer to the buffer.
+ *
+ *     In most cases this trick of storing information before the data
+ *     works because the first buffer in an LwIP IP message contains
+ *     the space that was used for the Ethernet/IP/UDP headers. However,
+ *     given the current size of the IPPacketInfo structure (40 bytes),
+ *     it is possible for there to not be enough room to store the
+ *     structure along with the payload in a single packet buffer. In
+ *     practice, this should only happen for extremely large IPv4
+ *     packets that arrive without an Ethernet header.
+ *
+ */
+IPPacketInfo * IPEndPointBasis::GetPacketInfo(const System::PacketBufferHandle & aBuffer)
+{
+    uintptr_t lStart;
+    uintptr_t lPacketInfoStart;
+    IPPacketInfo * lPacketInfo = NULL;
+
+    if (!aBuffer->EnsureReservedSize(sizeof(IPPacketInfo) + 3))
+        goto done;
+
+    lStart           = (uintptr_t) aBuffer->Start();
+    lPacketInfoStart = lStart - sizeof(IPPacketInfo);
+
+    // Align to a 4-byte boundary
+
+    lPacketInfo = reinterpret_cast<IPPacketInfo *>(lPacketInfoStart & ~(sizeof(uint32_t) - 1));
+
+done:
+    return (lPacketInfo);
+}
+
+CHIP_ERROR IPEndPointBasis::PostPacketBufferEvent(chip::System::LayerLwIP * aLayer, System::Object & aTarget,
+                                                  System::EventType aEventType, System::PacketBufferHandle && aBuffer)
+{
+    VerifyOrReturnError(aLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const CHIP_ERROR error =
+        aLayer->PostEvent(aTarget, aEventType, (uintptr_t) System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(aBuffer));
+    if (error == CHIP_NO_ERROR)
+    {
+        // If PostEvent() succeeded, it has ownership of the buffer, so we need to release it (without freeing it).
+        static_cast<void>(std::move(aBuffer).UnsafeRelease());
+    }
+    return error;
+}
+
+struct netif * IPEndPointBasis::FindNetifFromInterfaceId(InterfaceId aInterfaceId)
+{
+    struct netif * lRetval = NULL;
+
+#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+    NETIF_FOREACH(lRetval)
+    {
+        if (lRetval == aInterfaceId)
+            break;
+    }
+#else  // LWIP_VERSION_MAJOR < 2 || !defined(NETIF_FOREACH)
+    for (lRetval = netif_list; lRetval != NULL && lRetval != aInterfaceId; lRetval = lRetval->next)
+        ;
+#endif // LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+
+    return (lRetval);
+}
+
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+union PeerSockAddr
+{
+    sockaddr any;
+    sockaddr_in in;
+    sockaddr_in6 in6;
+};
+
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+IPEndPointBasis::MulticastGroupHandler IPEndPointBasis::sJoinMulticastGroupHandler;
+IPEndPointBasis::MulticastGroupHandler IPEndPointBasis::sLeaveMulticastGroupHandler;
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 #if IP_MULTICAST_LOOP || IPV6_MULTICAST_LOOP
 static CHIP_ERROR SocketsSetMulticastLoopback(int aSocket, bool aLoopback, int aProtocol, int aOption)
 {
@@ -293,377 +460,46 @@ static CHIP_ERROR SocketsIPv6JoinLeaveMulticastGroup(int aSocket, InterfaceId aI
 }
 #endif // INET_IPV6_ADD_MEMBERSHIP || INET_IPV6_DROP_MEMBERSHIP
 
-static CHIP_ERROR SocketsIPv6JoinMulticastGroup(int aSocket, InterfaceId aInterfaceId, const IPAddress & aAddress)
-{
-#if INET_IPV6_ADD_MEMBERSHIP
-    return SocketsIPv6JoinLeaveMulticastGroup(aSocket, aInterfaceId, aAddress, INET_IPV6_ADD_MEMBERSHIP);
-#else
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif
-}
-
-static CHIP_ERROR SocketsIPv6LeaveMulticastGroup(int aSocket, InterfaceId aInterfaceId, const IPAddress & aAddress)
-{
-#if INET_IPV6_DROP_MEMBERSHIP
-    return SocketsIPv6JoinLeaveMulticastGroup(aSocket, aInterfaceId, aAddress, INET_IPV6_DROP_MEMBERSHIP);
-#else
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif
-}
-
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-/**
- *  @brief Set whether IP multicast traffic should be looped back.
- *
- *  @param[in]   aIPVersion
- *
- *  @param[in]   aLoopback
- *
- *  @retval  CHIP_NO_ERROR
- *       success: multicast loopback behavior set
- *  @retval  other
- *       another system or platform error
- *
- *  @details
- *     Set whether or not IP multicast traffic should be looped back
- *     to this endpoint.
- *
- */
 CHIP_ERROR IPEndPointBasis::SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback)
 {
     CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if !HAVE_LWIP_MULTICAST_LOOP
-    lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#else
-    if (aLoopback)
-    {
-        switch (mLwIPEndPointType)
-        {
-
-#if INET_CONFIG_ENABLE_UDP_ENDPOINT
-        case LwIPEndPointType::UDP:
-            udp_set_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP);
-            break;
-#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
-
-        default:
-            lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-            break;
-        }
-    }
-    else
-    {
-        switch (mLwIPEndPointType)
-        {
-
-#if INET_CONFIG_ENABLE_UDP_ENDPOINT
-        case LwIPEndPointType::UDP:
-            udp_clear_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP);
-            break;
-#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
-
-        default:
-            lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-            break;
-        }
-    }
-
-    lRetval = CHIP_NO_ERROR;
-#endif // !HAVE_LWIP_MULTICAST_LOOP
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     lRetval = SocketsSetMulticastLoopback(mSocket, aIPVersion, aLoopback);
     SuccessOrExit(lRetval);
 
 exit:
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
     return (lRetval);
 }
 
-/**
- *  @brief Join an IP multicast group.
- *
- *  @param[in]   aInterfaceId  the indicator of the network interface to
- *                             add to the multicast group
- *
- *  @param[in]   aAddress      the multicast group to add the
- *                             interface to
- *
- *  @retval  CHIP_NO_ERROR
- *       success: multicast group removed
- *
- *  @retval  INET_ERROR_UNKNOWN_INTERFACE
- *       unknown network interface, \c aInterfaceId
- *
- *  @retval  INET_ERROR_WRONG_ADDRESS_TYPE
- *       \c aAddress is not \c kIPAddressType_IPv4 or
- *       \c kIPAddressType_IPv6 or is not multicast
- *
- *  @retval  other
- *       another system or platform error
- *
- *  @details
- *     Join the endpoint to the supplied multicast group on the
- *     specified interface.
- *
- */
-CHIP_ERROR IPEndPointBasis::JoinMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress)
+void IPEndPointBasis::InitImpl()
 {
-    CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    const IPAddressType lAddrType = aAddress.Type();
-    lRetval                       = CheckMulticastGroupArgs(aInterfaceId, aAddress);
-    SuccessOrExit(lRetval);
-
-    switch (lAddrType)
-    {
-
-#if INET_CONFIG_ENABLE_IPV4
-    case kIPAddressType_IPv4: {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if LWIP_IPV4 && LWIP_IGMP
-        lRetval = LwIPIPv4JoinLeaveMulticastGroup(aInterfaceId, aAddress, igmp_joingroup_netif);
-#else  // LWIP_IPV4 && LWIP_IGMP
-        lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // LWIP_IPV4 && LWIP_IGMP
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-        lRetval = SocketsIPv4JoinLeaveMulticastGroup(mSocket, aInterfaceId, aAddress, IP_ADD_MEMBERSHIP);
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    }
-    break;
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    case kIPAddressType_IPv6: {
-#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-        if (sJoinMulticastGroupHandler != nullptr)
-        {
-            return sJoinMulticastGroupHandler(aInterfaceId, aAddress);
-        }
-#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#ifdef HAVE_IPV6_MULTICAST
-        lRetval = LwIPIPv6JoinLeaveMulticastGroup(aInterfaceId, aAddress, mld6_joingroup_netif);
-#else  // HAVE_IPV6_MULTICAST
-        lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // HAVE_IPV6_MULTICAST
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-        lRetval = SocketsIPv6JoinMulticastGroup(mSocket, aInterfaceId, aAddress);
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    }
-    break;
-
-    default:
-        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
-        break;
-    }
-
-exit:
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    return (lRetval);
-}
-
-/**
- *  @brief Leave an IP multicast group.
- *
- *  @param[in]   aInterfaceId  the indicator of the network interface to
- *                             remove from the multicast group
- *
- *  @param[in]   aAddress      the multicast group to remove the
- *                             interface from
- *
- *  @retval  CHIP_NO_ERROR
- *       success: multicast group removed
- *
- *  @retval  INET_ERROR_UNKNOWN_INTERFACE
- *       unknown network interface, \c aInterfaceId
- *
- *  @retval  INET_ERROR_WRONG_ADDRESS_TYPE
- *       \c aAddress is not \c kIPAddressType_IPv4 or
- *       \c kIPAddressType_IPv6 or is not multicast
- *
- *  @retval  other
- *       another system or platform error
- *
- *  @details
- *     Remove the endpoint from the supplied multicast group on the
- *     specified interface.
- *
- */
-CHIP_ERROR IPEndPointBasis::LeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress)
-{
-    CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    const IPAddressType lAddrType = aAddress.Type();
-    lRetval                       = CheckMulticastGroupArgs(aInterfaceId, aAddress);
-    SuccessOrExit(lRetval);
-
-    switch (lAddrType)
-    {
-
-#if INET_CONFIG_ENABLE_IPV4
-    case kIPAddressType_IPv4: {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if LWIP_IPV4 && LWIP_IGMP
-        lRetval = LwIPIPv4JoinLeaveMulticastGroup(aInterfaceId, aAddress, igmp_leavegroup_netif);
-#else  // LWIP_IPV4 && LWIP_IGMP
-        lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // LWIP_IPV4 && LWIP_IGMP
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-        lRetval = SocketsIPv4JoinLeaveMulticastGroup(mSocket, aInterfaceId, aAddress, IP_DROP_MEMBERSHIP);
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    }
-    break;
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    case kIPAddressType_IPv6: {
-#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-        if (sLeaveMulticastGroupHandler != nullptr)
-        {
-            return sLeaveMulticastGroupHandler(aInterfaceId, aAddress);
-        }
-#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if LWIP_IPV6_MLD && LWIP_IPV6_ND && LWIP_IPV6
-        lRetval = LwIPIPv6JoinLeaveMulticastGroup(aInterfaceId, aAddress, mld6_leavegroup_netif);
-#else  // LWIP_IPV6_MLD && LWIP_IPV6_ND && LWIP_IPV6
-        lRetval = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // LWIP_IPV6_MLD && LWIP_IPV6_ND && LWIP_IPV6
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-        lRetval = SocketsIPv6LeaveMulticastGroup(mSocket, aInterfaceId, aAddress);
-        SuccessOrExit(lRetval);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    }
-    break;
-
-    default:
-        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
-        break;
-    }
-
-exit:
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    return (lRetval);
-}
-
-void IPEndPointBasis::Init(InetLayer * aInetLayer)
-{
-    InitEndPointBasis(*aInetLayer);
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     mBoundIntfId = INET_NULL_INTERFACEID;
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 }
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-void IPEndPointBasis::HandleDataReceived(System::PacketBufferHandle && aBuffer)
+#if INET_CONFIG_ENABLE_IPV4
+CHIP_ERROR IPEndPointBasis::IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
 {
-    if ((mState == kState_Listening) && (OnMessageReceived != NULL))
+    return SocketsIPv4JoinLeaveMulticastGroup(mSocket, aInterfaceId, aAddress, join ? IP_ADD_MEMBERSHIP : IP_DROP_MEMBERSHIP);
+}
+#endif // INET_CONFIG_ENABLE_IPV4
+
+CHIP_ERROR IPEndPointBasis::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
+{
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+    MulticastGroupHandler handler = join ? sJoinMulticastGroupHandler : sLeaveMulticastGroupHandler;
+    if (handler != nullptr)
     {
-        const IPPacketInfo * pktInfo = GetPacketInfo(aBuffer);
-
-        if (pktInfo != NULL)
-        {
-            const IPPacketInfo pktInfoCopy = *pktInfo; // copy the address info so that the app can free the
-                                                       // PacketBuffer without affecting access to address info.
-            OnMessageReceived(this, std::move(aBuffer), &pktInfoCopy);
-        }
-        else
-        {
-            if (OnReceiveError != NULL)
-                OnReceiveError(this, CHIP_ERROR_INBOUND_MESSAGE_TOO_BIG, NULL);
-        }
+        return handler(aInterfaceId, aAddress);
     }
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+#if defined(INET_IPV6_ADD_MEMBERSHIP) && defined(INET_IPV6_DROP_MEMBERSHIP)
+    return SocketsIPv6JoinLeaveMulticastGroup(mSocket, aInterfaceId, aAddress,
+                                              join ? INET_IPV6_ADD_MEMBERSHIP : INET_IPV6_DROP_MEMBERSHIP);
+#else  // defined(INET_IPV6_ADD_MEMBERSHIP) && defined(INET_IPV6_DROP_MEMBERSHIP)
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // defined(INET_IPV6_ADD_MEMBERSHIP) && defined(INET_IPV6_DROP_MEMBERSHIP)
 }
 
-/**
- *  @brief Get LwIP IP layer source and destination addressing information.
- *
- *  @param[in]   aBuffer       the packet buffer containing the IP message
- *
- *  @returns  a pointer to the address information on success; otherwise,
- *            NULL if there is insufficient space in the packet for
- *            the address information.
- *
- *  @details
- *     When using LwIP information about the packet is 'hidden' in the
- *     reserved space before the start of the data in the packet
- *     buffer. This is necessary because the system layer events only
- *     have two arguments, which in this case are used to convey the
- *     pointer to the end point and the pointer to the buffer.
- *
- *     In most cases this trick of storing information before the data
- *     works because the first buffer in an LwIP IP message contains
- *     the space that was used for the Ethernet/IP/UDP headers. However,
- *     given the current size of the IPPacketInfo structure (40 bytes),
- *     it is possible for there to not be enough room to store the
- *     structure along with the payload in a single packet buffer. In
- *     practice, this should only happen for extremely large IPv4
- *     packets that arrive without an Ethernet header.
- *
- */
-IPPacketInfo * IPEndPointBasis::GetPacketInfo(const System::PacketBufferHandle & aBuffer)
-{
-    uintptr_t lStart;
-    uintptr_t lPacketInfoStart;
-    IPPacketInfo * lPacketInfo = NULL;
-
-    if (!aBuffer->EnsureReservedSize(sizeof(IPPacketInfo) + 3))
-        goto done;
-
-    lStart           = (uintptr_t) aBuffer->Start();
-    lPacketInfoStart = lStart - sizeof(IPPacketInfo);
-
-    // Align to a 4-byte boundary
-
-    lPacketInfo = reinterpret_cast<IPPacketInfo *>(lPacketInfoStart & ~(sizeof(uint32_t) - 1));
-
-done:
-    return (lPacketInfo);
-}
-
-CHIP_ERROR IPEndPointBasis::PostPacketBufferEvent(chip::System::LayerLwIP * aLayer, System::Object & aTarget,
-                                                  System::EventType aEventType, System::PacketBufferHandle && aBuffer)
-{
-    VerifyOrReturnError(aLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-    const CHIP_ERROR error =
-        aLayer->PostEvent(aTarget, aEventType, (uintptr_t) System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(aBuffer));
-    if (error == CHIP_NO_ERROR)
-    {
-        // If PostEvent() succeeded, it has ownership of the buffer, so we need to release it (without freeing it).
-        static_cast<void>(std::move(aBuffer).UnsafeRelease());
-    }
-    return error;
-}
-
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 CHIP_ERROR IPEndPointBasis::Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort, InterfaceId aInterfaceId)
 {
     CHIP_ERROR lRetval = CHIP_NO_ERROR;
@@ -1140,9 +976,31 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
         }
     }
 }
+
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+CHIP_ERROR IPEndPointBasis::SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback)
+{
+    CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
+    return (lRetval);
+}
+
+void IPEndPointBasis::InitImpl() {}
+
+#if INET_CONFIG_ENABLE_IPV4
+CHIP_ERROR IPEndPointBasis::IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+#endif // INET_CONFIG_ENABLE_IPV4
+
+CHIP_ERROR IPEndPointBasis::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR IPEndPointBasis::ConfigureProtocol(IPAddressType aAddressType, const nw_parameters_t & aParameters)
 {
     CHIP_ERROR res = CHIP_NO_ERROR;
@@ -1568,6 +1426,76 @@ CHIP_ERROR IPEndPointBasis::ReleaseConnection()
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+CHIP_ERROR IPEndPointBasis::JoinMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress)
+{
+    CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
+
+    const IPAddressType lAddrType = aAddress.Type();
+    lRetval                       = CheckMulticastGroupArgs(aInterfaceId, aAddress);
+    SuccessOrExit(lRetval);
+
+    switch (lAddrType)
+    {
+
+#if INET_CONFIG_ENABLE_IPV4
+    case kIPAddressType_IPv4: {
+        return IPv4JoinLeaveMulticastGroupImpl(aInterfaceId, aAddress, true);
+    }
+    break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    case kIPAddressType_IPv6: {
+        return IPv6JoinLeaveMulticastGroupImpl(aInterfaceId, aAddress, true);
+    }
+    break;
+
+    default:
+        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+        break;
+    }
+
+exit:
+    return (lRetval);
+}
+
+CHIP_ERROR IPEndPointBasis::LeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress)
+{
+    CHIP_ERROR lRetval = CHIP_ERROR_NOT_IMPLEMENTED;
+
+    const IPAddressType lAddrType = aAddress.Type();
+    lRetval                       = CheckMulticastGroupArgs(aInterfaceId, aAddress);
+    SuccessOrExit(lRetval);
+
+    switch (lAddrType)
+    {
+
+#if INET_CONFIG_ENABLE_IPV4
+    case kIPAddressType_IPv4: {
+        return IPv4JoinLeaveMulticastGroupImpl(aInterfaceId, aAddress, false);
+    }
+    break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    case kIPAddressType_IPv6: {
+        return IPv6JoinLeaveMulticastGroupImpl(aInterfaceId, aAddress, false);
+    }
+    break;
+
+    default:
+        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+        break;
+    }
+
+exit:
+    return (lRetval);
+}
+
+void IPEndPointBasis::Init(InetLayer * aInetLayer)
+{
+    InitEndPointBasis(*aInetLayer);
+    InitImpl();
+}
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -101,8 +101,36 @@ public:
     typedef void (*OnReceiveErrorFunct)(IPEndPointBasis * endPoint, CHIP_ERROR err, const IPPacketInfo * pktInfo);
 
     IPEndPointBasis() = default;
+
+    /**
+     * Set whether IP multicast traffic should be looped back.
+     */
     CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback);
+
+    /**
+     * Join an IP multicast group.
+     *
+     *  @param[in]   aInterfaceId   The indicator of the network interface to add to the multicast group.
+     *  @param[in]   aAddress       The multicast group to add the interface to.
+     *
+     *  @retval  CHIP_NO_ERROR                  Success: multicast group removed.
+     *  @retval  INET_ERROR_UNKNOWN_INTERFACE   Unknown network interface, \c aInterfaceId.
+     *  @retval  INET_ERROR_WRONG_ADDRESS_TYPE  \c aAddress is not \c kIPv4 or \c kIPv6 or is not multicast.
+     *  @retval  other                          Another system or platform error.
+     */
     CHIP_ERROR JoinMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress);
+
+    /**
+     * Leave an IP multicast group.
+     *
+     *  @param[in]   aInterfaceId   The indicator of the network interface to remove from the multicast group.
+     *  @param[in]   aAddress       The multicast group to remove the interface from.
+     *
+     *  @retval  CHIP_NO_ERROR                  Success: multicast group removed
+     *  @retval  INET_ERROR_UNKNOWN_INTERFACE   Unknown network interface, \c aInterfaceId
+     *  @retval  INET_ERROR_WRONG_ADDRESS_TYPE  \c aAddress is not \c kIPv4 or \c kIPv6 or is not multicast.
+     *  @retval  other                          Another system or platform error
+     */
     CHIP_ERROR LeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress);
 
 protected:
@@ -113,6 +141,13 @@ protected:
 
     /** The endpoint's receive error event handling function delegate. */
     OnReceiveErrorFunct OnReceiveError;
+
+private:
+    IPEndPointBasis(const IPEndPointBasis &) = delete;
+
+    void InitImpl();
+    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join);
+    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 public:
@@ -127,6 +162,7 @@ protected:
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+protected:
     InterfaceId mBoundIntfId;
 
     CHIP_ERROR Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort, InterfaceId aInterfaceId);
@@ -134,6 +170,18 @@ protected:
     CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags);
     CHIP_ERROR GetSocket(IPAddressType aAddressType, int aType, int aProtocol);
     void HandlePendingIO(uint16_t aPort);
+
+#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+public:
+    using MulticastGroupHandler = CHIP_ERROR (*)(InterfaceId, const IPAddress &);
+    static void SetJoinMulticastGroupHandler(MulticastGroupHandler handler) { sJoinMulticastGroupHandler = handler; }
+    static void SetLeaveMulticastGroupHandler(MulticastGroupHandler handler) { sLeaveMulticastGroupHandler = handler; }
+
+private:
+    static MulticastGroupHandler sJoinMulticastGroupHandler;
+    static MulticastGroupHandler sLeaveMulticastGroupHandler;
+#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
@@ -159,44 +207,7 @@ protected:
     CHIP_ERROR ReleaseConnection();
     void ReleaseAll();
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-#if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-public:
-    using JoinMulticastGroupHandler  = CHIP_ERROR (*)(InterfaceId, const IPAddress &);
-    using LeaveMulticastGroupHandler = CHIP_ERROR (*)(InterfaceId, const IPAddress &);
-    static void SetJoinMulticastGroupHandler(JoinMulticastGroupHandler handler) { sJoinMulticastGroupHandler = handler; }
-    static void SetLeaveMulticastGroupHandler(LeaveMulticastGroupHandler handler) { sLeaveMulticastGroupHandler = handler; }
-
-private:
-    static JoinMulticastGroupHandler sJoinMulticastGroupHandler;
-    static LeaveMulticastGroupHandler sLeaveMulticastGroupHandler;
-#endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-
-private:
-    IPEndPointBasis(const IPEndPointBasis &) = delete;
 };
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-
-inline struct netif * IPEndPointBasis::FindNetifFromInterfaceId(InterfaceId aInterfaceId)
-{
-    struct netif * lRetval = NULL;
-
-#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
-    NETIF_FOREACH(lRetval)
-    {
-        if (lRetval == aInterfaceId)
-            break;
-    }
-#else  // LWIP_VERSION_MAJOR < 2 || !defined(NETIF_FOREACH)
-    for (lRetval = netif_list; lRetval != NULL && lRetval != aInterfaceId; lRetval = lRetval->next)
-        ;
-#endif // LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
-
-    return (lRetval);
-}
-
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -54,16 +54,6 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <unistd.h>
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
-#include "ZephyrSocket.h"
-#endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
-
-#include "arpa-inet-compatibility.h"
-
-#include <string.h>
-#include <utility>
 
 // SOCK_CLOEXEC not defined on all platforms, e.g. iOS/macOS:
 #ifdef SOCK_CLOEXEC
@@ -72,12 +62,23 @@
 #define SOCK_FLAGS 0
 #endif
 
+#if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
+#include "ZephyrSocket.h"
+#endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#include "arpa-inet-compatibility.h"
+
+#include <string.h>
+#include <utility>
+
 namespace chip {
 namespace Inet {
 
 chip::System::ObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> UDPEndPoint::sPool;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+
 /*
  * Note that for LwIP InterfaceId is already defined to be 'struct
  * netif'; consequently, some of the checking performed here could
@@ -119,53 +120,9 @@ static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId)
 
     return res;
 }
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-/**
- * @brief   Bind the endpoint to an interface IP address.
- *
- * @param[in]   addrType    the protocol version of the IP address
- * @param[in]   addr        the IP address (must be an interface address)
- * @param[in]   port        the UDP port
- * @param[in]   intfId      an optional network interface indicator
- *
- * @retval  CHIP_NO_ERROR               success: endpoint bound to address
- * @retval  CHIP_ERROR_INCORRECT_STATE  endpoint has been bound previously
- * @retval  CHIP_ERROR_NO_MEMORY        insufficient memory for endpoint
- *
- * @retval  INET_ERROR_UNKNOWN_INTERFACE
- *      On some platforms, the optionally specified interface is not
- *      present.
- *
- * @retval  INET_ERROR_WRONG_PROTOCOL_TYPE
- *      \c addrType does not match \c IPVer.
- *
- * @retval  INET_ERROR_WRONG_ADDRESS_TYPE
- *      \c addrType is \c kIPAddressType_Any, or the type of \c addr is not
- *      equal to \c addrType.
- *
- * @retval  other                   another system or platform error
- *
- * @details
- *  Binds the endpoint to the specified network interface IP address.
- *
- *  On LwIP, this method must not be called with the LwIP stack lock
- *  already acquired.
- */
-CHIP_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
+CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
 {
-    if (mState != kState_Ready && mState != kState_Bound)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    if ((addr != IPAddress::Any) && (addr.Type() != kIPAddressType_Any) && (addr.Type() != addrType))
-    {
-        return INET_ERROR_WRONG_ADDRESS_TYPE;
-    }
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
@@ -208,122 +165,45 @@ CHIP_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
 
-    ReturnErrorOnFailure(res);
-
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-    // Make sure we have the appropriate type of socket.
-    ReturnErrorOnFailure(GetSocket(addrType));
-    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, intfId));
-
-    mBoundPort   = port;
-    mBoundIntfId = intfId;
-
-    // If an ephemeral port was requested, retrieve the actual bound port.
-    if (port == 0)
-    {
-        union
-        {
-            struct sockaddr any;
-            struct sockaddr_in in;
-            struct sockaddr_in6 in6;
-        } boundAddr;
-        socklen_t boundAddrLen = sizeof(boundAddr);
-
-        if (getsockname(mSocket, &boundAddr.any, &boundAddrLen) == 0)
-        {
-            if (boundAddr.any.sa_family == AF_INET)
-            {
-                mBoundPort = ntohs(boundAddr.in.sin_port);
-            }
-            else if (boundAddr.any.sa_family == AF_INET6)
-            {
-                mBoundPort = ntohs(boundAddr.in6.sin6_port);
-            }
-        }
-    }
-
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_queue_t dispatchQueue = static_cast<System::LayerSocketsLoop *>(Layer().SystemLayer())->GetDispatchQueue();
-    if (dispatchQueue != nullptr)
-    {
-        unsigned long fd = static_cast<unsigned long>(mSocket);
-
-        mReadableSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, dispatchQueue);
-        ReturnErrorCodeIf(mReadableSource == nullptr, CHIP_ERROR_NO_MEMORY);
-
-        dispatch_source_set_event_handler(mReadableSource, ^{
-            this->HandlePendingIO(System::SocketEventFlags::kRead);
-        });
-        dispatch_resume(mReadableSource);
-    }
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
-
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-    nw_parameters_configure_protocol_block_t configure_tls;
-    nw_parameters_t parameters;
-
-    if (intfId != INET_NULL_INTERFACEID)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
-    configure_tls = NW_PARAMETERS_DISABLE_PROTOCOL;
-    parameters    = nw_parameters_create_secure_udp(configure_tls, NW_PARAMETERS_DEFAULT_CONFIGURATION);
-
-    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, parameters));
-
-    mParameters = parameters;
-
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-    mState = kState_Bound;
-
-    return CHIP_NO_ERROR;
+    return res;
 }
 
-/**
- * @brief   Prepare the endpoint to receive UDP messages.
- *
- * @param[in]  onMessageReceived   The endpoint's message reception event handling function delegate.
- * @param[in]  onReceiveError      The endpoint's receive error event handling function delegate.
- * @param[in]  appState            Application state pointer.
- *
- * @retval  CHIP_NO_ERROR   success: endpoint ready to receive messages.
- * @retval  CHIP_ERROR_INCORRECT_STATE  endpoint is already listening.
- *
- * @details
- *  If \c State is already \c kState_Listening, then no operation is
- *  performed, otherwise the \c mState is set to \c kState_Listening and
- *  the endpoint is prepared to received UDP messages, according to the
- *  semantics of the platform.
- *
- *  On LwIP, this method must not be called with the LwIP stack lock
- *  already acquired
- */
-CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnReceiveErrorFunct onReceiveError, void * appState)
+CHIP_ERROR UDPEndPoint::BindInterfaceImpl(IPAddressType addrType, InterfaceId intfId)
 {
-    if (mState == kState_Listening)
+    // A lock is required because the LwIP thread may be referring to intf_filter,
+    // while this code running in the Inet application is potentially modifying it.
+    // NOTE: this only supports LwIP interfaces whose number is no bigger than 9.
+    LOCK_TCPIP_CORE();
+
+    // Make sure we have the appropriate type of PCB.
+    CHIP_ERROR err = GetPCB(addrType);
+
+    if (err == CHIP_NO_ERROR)
     {
-        return CHIP_NO_ERROR;
+        err = LwIPBindInterface(mUDP, intfId);
     }
 
-    if (mState != kState_Bound)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
+    UNLOCK_TCPIP_CORE();
 
-    OnMessageReceived = onMessageReceived;
-    OnReceiveError    = onReceiveError;
-    AppState          = appState;
+    return err;
+}
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
+InterfaceId UDPEndPoint::GetBoundInterface()
+{
+#if HAVE_LWIP_UDP_BIND_NETIF
+    return netif_get_by_index(mUDP->netif_idx);
+#else
+    return mUDP->intf_filter;
+#endif
+}
 
+uint16_t UDPEndPoint::GetBoundPort()
+{
+    return mUDP->local_port;
+}
+
+CHIP_ERROR UDPEndPoint::ListenImpl()
+{
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
@@ -339,200 +219,13 @@ CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnRecei
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
 
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    ReturnErrorOnFailure(StartListener());
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-    mState = kState_Listening;
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    // Wait for ability to read on this endpoint.
-    auto layer = static_cast<System::LayerSockets *>(Layer().SystemLayer());
-    ReturnErrorOnFailure(layer->SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this)));
-    ReturnErrorOnFailure(layer->RequestCallbackOnPendingRead(mWatch));
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
     return CHIP_NO_ERROR;
 }
 
-/**
- * @brief   Close the endpoint.
- *
- * @details
- *  If <tt>mState != kState_Closed</tt>, then closes the endpoint, removing
- *  it from the set of endpoints eligible for communication events.
- *
- *  On LwIP systems, this method must not be called with the LwIP stack
- *  lock already acquired.
- */
-void UDPEndPoint::Close()
-{
-    if (mState != kState_Closed)
-    {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-
-        // Lock LwIP stack
-        LOCK_TCPIP_CORE();
-
-        // Since UDP PCB is released synchronously here, but UDP endpoint itself might have to wait
-        // for destruction asynchronously, there could be more allocated UDP endpoints than UDP PCBs.
-        if (mUDP != NULL)
-        {
-            udp_remove(mUDP);
-            mUDP              = NULL;
-            mLwIPEndPointType = LwIPEndPointType::Unknown;
-        }
-
-        // Unlock LwIP stack
-        UNLOCK_TCPIP_CORE();
-
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-        if (mSocket != kInvalidSocketFd)
-        {
-            static_cast<System::LayerSockets *>(Layer().SystemLayer())->StopWatchingSocket(&mWatch);
-            close(mSocket);
-            mSocket = kInvalidSocketFd;
-        }
-
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-        if (mReadableSource)
-        {
-            dispatch_source_cancel(mReadableSource);
-            dispatch_release(mReadableSource);
-        }
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-        IPEndPointBasis::ReleaseAll();
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-        mState = kState_Closed;
-    }
-}
-
-/**
- * @brief   Close the endpoint and recycle its memory.
- *
- * @details
- *  Invokes the \c Close method, then invokes the
- *  <tt>InetLayerBasis::Release</tt> method to return the object to its
- *  memory pool.
- *
- *  On LwIP systems, this method must not be called with the LwIP stack
- *  lock already acquired.
- */
-void UDPEndPoint::Free()
-{
-    Close();
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    DeferredFree(kReleaseDeferralErrorTactic_Die);
-#else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
-    Release();
-#endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
-}
-
-/**
- *  A synonym for <tt>SendTo(addr, port, INET_NULL_INTERFACEID, msg, sendFlags)</tt>.
- */
-CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
-{
-    return SendTo(addr, port, INET_NULL_INTERFACEID, std::move(msg), sendFlags);
-}
-
-/**
- * @brief   Send a UDP message to the specified destination address.
- *
- * @param[in]   addr        the destination IP address
- * @param[in]   port        the destination UDP port
- * @param[in]   intfId      an optional network interface indicator
- * @param[in]   msg         the packet buffer containing the UDP message
- * @param[in]   sendFlags   optional transmit option flags
- *
- * @retval  CHIP_NO_ERROR       success: \c msg is queued for transmit.
- *
- * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
- *      the system does not support the requested operation.
- *
- * @retval  INET_ERROR_WRONG_ADDRESS_TYPE
- *      the destination address and the bound interface address do not
- *      have matching protocol versions or address type.
- *
- * @retval  CHIP_ERROR_MESSAGE_TOO_LONG
- *      \c msg does not contain the whole UDP message.
- *
- * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG
- *      On some platforms, only a truncated portion of \c msg was queued
- *      for transmit.
- *
- * @retval  other
- *      another system or platform error
- *
- * @details
- *      If possible, then this method sends the UDP message \c msg to the
- *      destination \c addr (with \c intfId used as the scope
- *      identifier for IPv6 link-local destinations) and \c port with the
- *      transmit option flags encoded in \c sendFlags.
- */
-CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
-                               uint16_t sendFlags)
-{
-    IPPacketInfo pktInfo;
-    pktInfo.Clear();
-    pktInfo.DestAddress = addr;
-    pktInfo.DestPort    = port;
-    pktInfo.Interface   = intfId;
-    return SendMsg(&pktInfo, std::move(msg), sendFlags);
-}
-
-/**
- * @brief   Send a UDP message to a specified destination.
- *
- * @param[in]   pktInfo     source and destination information for the UDP message
- * @param[in]   msg         a packet buffer containing the UDP message
- * @param[in]   sendFlags   optional transmit option flags
- *
- * @retval  CHIP_NO_ERROR
- *      success: \c msg is queued for transmit.
- *
- * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
- *      the system does not support the requested operation.
- *
- * @retval  INET_ERROR_WRONG_ADDRESS_TYPE
- *      the destination address and the bound interface address do not
- *      have matching protocol versions or address type.
- *
- * @retval  CHIP_ERROR_MESSAGE_TOO_LONG
- *      \c msg does not contain the whole UDP message.
- *
- * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG
- *      On some platforms, only a truncated portion of \c msg was queued
- *      for transmit.
- *
- * @retval  other
- *      another system or platform error
- *
- * @details
- *      Send the UDP message in \c msg to the destination address and port given in
- *      \c pktInfo.  If \c pktInfo contains an interface id, the message will be sent
- *      over the specified interface.  If \c pktInfo contains a source address, the
- *      given address will be used as the source of the UDP message.
- */
-CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
 {
     CHIP_ERROR res             = CHIP_NO_ERROR;
     const IPAddress & destAddr = pktInfo->DestAddress;
-
-    INET_FAULT_INJECT(FaultInjection::kFault_Send, return INET_ERROR_UNKNOWN_INTERFACE;);
-    INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical, return CHIP_ERROR_NO_MEMORY;);
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
 
     if (!msg.HasSoleOwnership())
     {
@@ -542,7 +235,7 @@ CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBuff
         // msg into a fresh object in this case, and queues that for transmission, leaving
         // the original msg available after return.
         msg = msg.CloneData();
-        VerifyOrExit(!msg.IsNull(), res = CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
     }
 
     // Lock LwIP stack
@@ -550,7 +243,7 @@ CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBuff
 
     // Make sure we have the appropriate type of PCB based on the destination address.
     res = GetPCB(destAddr.Type());
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(res);
 
     // Send the message to the specified address/port.
     // If an outbound interface has been specified, call a specific version of the UDP sendto()
@@ -637,140 +330,33 @@ CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBuff
 
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-    // Make sure we have the appropriate type of socket based on the
-    // destination address.
-
-    res = GetSocket(destAddr.Type());
-    SuccessOrExit(res);
-
-    res = IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    res = IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-exit:
-    CHIP_SYSTEM_FAULT_INJECT_ASYNC_EVENT();
 
     return res;
 }
 
-/**
- * @brief   Bind the endpoint to a network interface.
- *
- * @param[in]   addrType    the protocol version of the IP address.
- *
- * @param[in]   intfId      indicator of the network interface.
- *
- * @retval  CHIP_NO_ERROR               success: endpoint bound to address
- * @retval  CHIP_ERROR_NO_MEMORY        insufficient memory for endpoint
- * @retval  CHIP_ERROR_NOT_IMPLEMENTED  system implementation not complete.
- *
- * @retval  INET_ERROR_UNKNOWN_INTERFACE
- *      On some platforms, the interface is not present.
- *
- * @retval  other                   another system or platform error
- *
- * @details
- *  Binds the endpoint to the specified network interface IP address.
- *
- *  On LwIP, this method must not be called with the LwIP stack lock
- *  already acquired.
- */
-CHIP_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
+void UDPEndPoint::CloseImpl()
 {
-    if (mState != kState_Ready && mState != kState_Bound)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-
-    // A lock is required because the LwIP thread may be referring to intf_filter,
-    // while this code running in the Inet application is potentially modifying it.
-    // NOTE: this only supports LwIP interfaces whose number is no bigger than 9.
+    // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
-    // Make sure we have the appropriate type of PCB.
-    CHIP_ERROR err = GetPCB(addrType);
-
-    if (err == CHIP_NO_ERROR)
+    // Since UDP PCB is released synchronously here, but UDP endpoint itself might have to wait
+    // for destruction asynchronously, there could be more allocated UDP endpoints than UDP PCBs.
+    if (mUDP != NULL)
     {
-        err = LwIPBindInterface(mUDP, intfId);
+        udp_remove(mUDP);
+        mUDP              = NULL;
+        mLwIPEndPointType = LwIPEndPointType::Unknown;
     }
 
+    // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
-
-    ReturnErrorOnFailure(err);
-
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    // Make sure we have the appropriate type of socket.
-    ReturnErrorOnFailure(GetSocket(addrType));
-    ReturnErrorOnFailure(IPEndPointBasis::BindInterface(addrType, intfId));
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    return INET_ERROR_UNKNOWN_INTERFACE;
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-    mState = kState_Bound;
-
-    return CHIP_NO_ERROR;
 }
 
-void UDPEndPoint::Init(InetLayer * inetLayer)
+void UDPEndPoint::Free()
 {
-    IPEndPointBasis::Init(inetLayer);
+    Close();
+    DeferredFree(kReleaseDeferralErrorTactic_Die);
 }
-
-/**
- * Get the bound interface on this endpoint.
- *
- * @return InterfaceId   The bound interface id.
- */
-InterfaceId UDPEndPoint::GetBoundInterface()
-{
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if HAVE_LWIP_UDP_BIND_NETIF
-    return netif_get_by_index(mUDP->netif_idx);
-#else
-    return mUDP->intf_filter;
-#endif
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    return mBoundIntfId;
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    return INET_NULL_INTERFACEID;
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-}
-
-uint16_t UDPEndPoint::GetBoundPort()
-{
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    return mUDP->local_port;
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    return mBoundPort;
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    nw_endpoint_t endpoint = nw_parameters_copy_local_endpoint(mParameters);
-    return nw_endpoint_get_port(endpoint);
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-}
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 void UDPEndPoint::HandleDataReceived(System::PacketBufferHandle && msg)
 {
@@ -915,6 +501,122 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
+{
+    // Make sure we have the appropriate type of socket.
+    ReturnErrorOnFailure(GetSocket(addrType));
+    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, intfId));
+
+    mBoundPort   = port;
+    mBoundIntfId = intfId;
+
+    // If an ephemeral port was requested, retrieve the actual bound port.
+    if (port == 0)
+    {
+        union
+        {
+            struct sockaddr any;
+            struct sockaddr_in in;
+            struct sockaddr_in6 in6;
+        } boundAddr;
+        socklen_t boundAddrLen = sizeof(boundAddr);
+
+        if (getsockname(mSocket, &boundAddr.any, &boundAddrLen) == 0)
+        {
+            if (boundAddr.any.sa_family == AF_INET)
+            {
+                mBoundPort = ntohs(boundAddr.in.sin_port);
+            }
+            else if (boundAddr.any.sa_family == AF_INET6)
+            {
+                mBoundPort = ntohs(boundAddr.in6.sin6_port);
+            }
+        }
+    }
+
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    dispatch_queue_t dispatchQueue = static_cast<System::LayerSocketsLoop *>(Layer().SystemLayer())->GetDispatchQueue();
+    if (dispatchQueue != nullptr)
+    {
+        unsigned long fd = static_cast<unsigned long>(mSocket);
+
+        mReadableSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, dispatchQueue);
+        ReturnErrorCodeIf(mReadableSource == nullptr, CHIP_ERROR_NO_MEMORY);
+
+        dispatch_source_set_event_handler(mReadableSource, ^{
+            this->HandlePendingIO(System::SocketEventFlags::kRead);
+        });
+        dispatch_resume(mReadableSource);
+    }
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR UDPEndPoint::BindInterfaceImpl(IPAddressType addrType, InterfaceId intfId)
+{
+    // Make sure we have the appropriate type of socket.
+    ReturnErrorOnFailure(GetSocket(addrType));
+    return IPEndPointBasis::BindInterface(addrType, intfId);
+}
+
+InterfaceId UDPEndPoint::GetBoundInterface()
+{
+    return mBoundIntfId;
+}
+
+uint16_t UDPEndPoint::GetBoundPort()
+{
+    return mBoundPort;
+}
+
+CHIP_ERROR UDPEndPoint::ListenImpl()
+{
+    // Wait for ability to read on this endpoint.
+    auto layer = static_cast<System::LayerSockets *>(Layer().SystemLayer());
+    ReturnErrorOnFailure(layer->SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this)));
+    return layer->RequestCallbackOnPendingRead(mWatch);
+}
+
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+{
+    CHIP_ERROR res             = CHIP_NO_ERROR;
+    const IPAddress & destAddr = pktInfo->DestAddress;
+
+    // Make sure we have the appropriate type of socket based on the
+    // destination address.
+
+    res = GetSocket(destAddr.Type());
+    ReturnErrorOnFailure(res);
+
+    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+}
+
+void UDPEndPoint::CloseImpl()
+{
+    if (mSocket != kInvalidSocketFd)
+    {
+        static_cast<System::LayerSockets *>(Layer().SystemLayer())->StopWatchingSocket(&mWatch);
+        close(mSocket);
+        mSocket = kInvalidSocketFd;
+    }
+
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    if (mReadableSource)
+    {
+        dispatch_source_cancel(mReadableSource);
+        dispatch_release(mReadableSource);
+    }
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+}
+
+void UDPEndPoint::Free()
+{
+    Close();
+    Release();
+}
+
 CHIP_ERROR UDPEndPoint::GetSocket(IPAddressType aAddressType)
 {
     constexpr int lType     = (SOCK_DGRAM | SOCK_FLAGS);
@@ -940,6 +642,167 @@ void UDPEndPoint::HandlePendingIO(System::SocketEvents events)
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
+{
+    nw_parameters_configure_protocol_block_t configure_tls;
+    nw_parameters_t parameters;
+
+    if (intfId != INET_NULL_INTERFACEID)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    configure_tls = NW_PARAMETERS_DISABLE_PROTOCOL;
+    parameters    = nw_parameters_create_secure_udp(configure_tls, NW_PARAMETERS_DEFAULT_CONFIGURATION);
+
+    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, parameters));
+
+    mParameters = parameters;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR UDPEndPoint::BindInterfaceImpl(IPAddressType addrType, InterfaceId intfId)
+{
+    return INET_ERROR_UNKNOWN_INTERFACE;
+}
+
+InterfaceId UDPEndPoint::GetBoundInterface()
+{
+    return INET_NULL_INTERFACEID;
+}
+
+uint16_t UDPEndPoint::GetBoundPort()
+{
+    nw_endpoint_t endpoint = nw_parameters_copy_local_endpoint(mParameters);
+    return nw_endpoint_get_port(endpoint);
+}
+
+CHIP_ERROR UDPEndPoint::ListenImpl()
+{
+    return StartListener();
+}
+
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+{
+    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+}
+
+void UDPEndPoint::CloseImpl()
+{
+    IPEndPointBasis::ReleaseAll();
+}
+
+void UDPEndPoint::Free()
+{
+    Close();
+    Release();
+}
+
+#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+CHIP_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
+{
+    if (mState != kState_Ready && mState != kState_Bound)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    if ((addr != IPAddress::Any) && (addr.Type() != kIPAddressType_Any) && (addr.Type() != addrType))
+    {
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
+    }
+
+    ReturnErrorOnFailure(BindImpl(addrType, addr, port, intfId));
+
+    mState = kState_Bound;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
+{
+    if (mState != kState_Ready && mState != kState_Bound)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    ReturnErrorOnFailure(BindInterfaceImpl(addrType, intfId));
+
+    mState = kState_Bound;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnReceiveErrorFunct onReceiveError, void * appState)
+{
+    if (mState == kState_Listening)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (mState != kState_Bound)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    OnMessageReceived = onMessageReceived;
+    OnReceiveError    = onReceiveError;
+    AppState          = appState;
+
+    ReturnErrorOnFailure(ListenImpl());
+
+    mState = kState_Listening;
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ *  A synonym for <tt>SendTo(addr, port, INET_NULL_INTERFACEID, msg, sendFlags)</tt>.
+ */
+CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
+{
+    return SendTo(addr, port, INET_NULL_INTERFACEID, std::move(msg), sendFlags);
+}
+
+CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
+                               uint16_t sendFlags)
+{
+    IPPacketInfo pktInfo;
+    pktInfo.Clear();
+    pktInfo.DestAddress = addr;
+    pktInfo.DestPort    = port;
+    pktInfo.Interface   = intfId;
+    return SendMsg(&pktInfo, std::move(msg), sendFlags);
+}
+
+CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+{
+    INET_FAULT_INJECT(FaultInjection::kFault_Send, return INET_ERROR_UNKNOWN_INTERFACE;);
+    INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical, return CHIP_ERROR_NO_MEMORY;);
+
+    CHIP_ERROR res = SendMsgImpl(pktInfo, std::move(msg), sendFlags);
+
+    CHIP_SYSTEM_FAULT_INJECT_ASYNC_EVENT();
+
+    return res;
+}
+
+void UDPEndPoint::Close()
+{
+    if (mState != kState_Closed)
+    {
+        CloseImpl();
+        mState = kState_Closed;
+    }
+}
+
+void UDPEndPoint::Init(InetLayer * inetLayer)
+{
+    IPEndPointBasis::Init(inetLayer);
+}
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -58,22 +58,149 @@ class DLL_EXPORT UDPEndPoint : public IPEndPointBasis
 public:
     UDPEndPoint() = default;
 
+    /**
+     * Bind the endpoint to an interface IP address.
+     *
+     *  Binds the endpoint to the specified network interface IP address.
+     *
+     *  On LwIP, this method must not be called with the LwIP stack lock already acquired.
+     *
+     * @param[in]   addrType    Protocol version of the IP address.
+     * @param[in]   addr        IP address (must be an interface address).
+     * @param[in]   port        UDP port.
+     * @param[in]   intfId      An optional network interface indicator.
+     *
+     * @retval  CHIP_NO_ERROR                   Success: endpoint bound to address.
+     * @retval  CHIP_ERROR_INCORRECT_STATE      Endpoint has been bound previously.
+     * @retval  CHIP_ERROR_NO_MEMORY            Insufficient memory for endpoint.
+     * @retval  INET_ERROR_UNKNOWN_INTERFACE    The optionally specified interface is not present.
+     * @retval  INET_ERROR_WRONG_PROTOCOL_TYPE  \c addrType does not match \c IPVer.
+     * @retval  INET_ERROR_WRONG_ADDRESS_TYPE   \c addrType is \c IPAddressType::kAny, or not equal to the type of \c addr.
+     * @retval  other                           Another system or platform error
+     */
     CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId = INET_NULL_INTERFACEID);
+
+    /**
+     * Bind the endpoint to a network interface.
+     *
+     *  Binds the endpoint to the specified network interface IP address.
+     *
+     *  On LwIP, this method must not be called with the LwIP stack lock already acquired.
+     *
+     * @param[in]   addrType    Protocol version of the IP address.
+     * @param[in]   intfId      Network interface.
+     *
+     * @retval  CHIP_NO_ERROR                   Success: endpoint bound to address.
+     * @retval  CHIP_ERROR_NO_MEMORY            Insufficient memory for endpoint.
+     * @retval  CHIP_ERROR_NOT_IMPLEMENTED      System implementation not complete.
+     * @retval  INET_ERROR_UNKNOWN_INTERFACE    The interface is not present.
+     * @retval  other                           Another system or platform error.
+     */
     CHIP_ERROR BindInterface(IPAddressType addrType, InterfaceId intfId);
+
+    /**
+     * Get the bound interface on this endpoint.
+     *
+     * @return InterfaceId   The bound interface id.
+     */
     InterfaceId GetBoundInterface();
+
     uint16_t GetBoundPort();
+
+    /**
+     * Prepare the endpoint to receive UDP messages.
+     *
+     *  If \c mState is already \c State::kListening, then no operation is
+     *  performed, otherwise the \c mState is set to \c State::kListening and
+     *  the endpoint is prepared to received UDP messages, according to the
+     *  semantics of the platform.
+     *
+     *  On LwIP, this method must not be called with the LwIP stack lock already acquired.
+     *
+     * @param[in]  onMessageReceived   The endpoint's message reception event handling function delegate.
+     * @param[in]  onReceiveError      The endpoint's receive error event handling function delegate.
+     * @param[in]  appState            Application state pointer.
+     *
+     * @retval  CHIP_NO_ERROR               Success: endpoint ready to receive messages.
+     * @retval  CHIP_ERROR_INCORRECT_STATE  Endpoint is already listening.
+     */
     CHIP_ERROR Listen(OnMessageReceivedFunct onMessageReceived, OnReceiveErrorFunct onReceiveError, void * appState = nullptr);
-    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+
+    /**
+     * Send a UDP message to the specified destination address.
+     *
+     *  If possible, then this method sends the UDP message \c msg to the destination \c addr
+     *  (with \c intfId used as the scope identifier for IPv6 link-local destinations) and \c port.
+     *
+     * @param[in]   addr        Destination IP address.
+     * @param[in]   port        Destination UDP port.
+     * @param[in]   msg         Packet buffer containing the UDP message.
+     * @param[in]   intfId      Optional network interface indicator.
+     * @param[in]   sendFlags   Unused and will be removed.
+     *
+     * @retval  CHIP_NO_ERROR                       Success: \c msg is queued for transmit.
+     * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE The system does not support the requested operation.
+     * @retval  INET_ERROR_WRONG_ADDRESS_TYPE       The destination address and the bound interface address do not have
+     *                                              matching protocol versions or address type.
+     * @retval  CHIP_ERROR_MESSAGE_TOO_LONG         \c msg does not contain the whole UDP message.
+     * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG Only a truncated portion of \c msg was queued for transmit.
+     * @retval  other                               Another system or platform error.
+     */
     CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
                       uint16_t sendFlags = 0);
+    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+
+    /**
+     * Send a UDP message to a specified destination.
+     *
+     *  Send the UDP message in \c msg to the destination address and port given in \c pktInfo.
+     *  If \c pktInfo contains an interface id, the message will be sent over the specified interface.
+     *  If \c pktInfo contains a source address, the given address will be used as the source of the UDP message.
+     *
+     * @param[in]   pktInfo     Source and destination information for the UDP message.
+     * @param[in]   msg         Packet buffer containing the UDP message.
+     * @param[in]   sendFlags   Unused and will be removed.
+     *
+     * @retval  CHIP_NO_ERROR                       Success: \c msg is queued for transmit.
+     * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE The system does not support the requested operation.
+     * @retval  INET_ERROR_WRONG_ADDRESS_TYPE       The destination address and the bound interface address do not have
+     *                                              matching protocol versions or address type.
+     * @retval  CHIP_ERROR_MESSAGE_TOO_LONG         \c msg does not contain the whole UDP message.
+     * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG Only a truncated portion of \c msg was queued for transmit.
+     * @retval  other                               Another system or platform error.
+     */
     CHIP_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+
+    /**
+     * Close the endpoint.
+     *
+     *  If <tt>mState != State::kClosed</tt>, then closes the endpoint, removing
+     *  it from the set of endpoints eligible for communication events.
+     *
+     *  On LwIP systems, this method must not be called with the LwIP stack lock already acquired.
+     */
     void Close();
+
+    /**
+     * Close the endpoint and recycle its memory.
+     *
+     *  Invokes the \c Close method, then invokes the <tt>InetLayerBasis::Release</tt> method to return the object to its
+     *  memory pool.
+     *
+     *  On LwIP systems, this method must not be called with the LwIP stack lock already acquired.
+     */
     void Free();
 
 private:
     UDPEndPoint(const UDPEndPoint &) = delete;
 
     static chip::System::ObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
+
+    CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId);
+    CHIP_ERROR BindInterfaceImpl(IPAddressType addrType, InterfaceId intfId);
+    CHIP_ERROR ListenImpl();
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg, uint16_t sendFlags);
+    void CloseImpl();
 
     void Init(InetLayer * inetLayer);
 


### PR DESCRIPTION
#### Problem

Code for different Inet implementations is scattered across many `#if`s.

#### Change overview

This is a step toward #7715 _Virtualize System and Inet interfaces_.

- For the affected `.cpp` files, code is moved to a single `#if` section
  for each of the three implementations (LwIP, sockets, and Network
  Framework.) Some methods have internals split off into separate `…Impl`
  methods.

- Method implementations are reordered to match their declarations.

- Doxygen comments move to headers.

Since comparing moved code in diff format is difficult, this change
explicitly does NOT make any changes to function bodies, beyond any
necessary arguments and returns when splitting.

#### Testing

CI; no change to functionality.
