### PR TITLE
[support] Add UniquePtr and MakeUnique to CHIPMem

### DIFF
--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -27,6 +27,7 @@
 #include <lib/core/CHIPError.h>
 #include <stdlib.h>
 
+#include <memory>
 #include <new>
 #include <utility>
 
@@ -161,6 +162,21 @@ inline void Delete(T * p)
 {
     p->~T();
     MemoryFree(p);
+}
+
+template <typename T>
+struct Deleter
+{
+    void operator()(T * p) { Delete(p); }
+};
+
+template <typename T>
+using UniquePtr = std::unique_ptr<T, Deleter<T>>;
+
+template <typename T, typename... Args>
+inline UniquePtr<T> MakeUnique(Args &&... args)
+{
+    return UniquePtr<T>(New<T>(std::forward<Args>(args)...));
 }
 
 // See MemoryDebugCheckPointer().

--- a/src/lib/support/tests/TestCHIPMem.cpp
+++ b/src/lib/support/tests/TestCHIPMem.cpp
@@ -114,6 +114,7 @@ static void TestMemAlloc_UniquePtr(nlTestSuite * inSuite, void * inContext)
     {
         auto ptr = MakeUnique<Cls>(&constructorCalled, &destructorCalled);
         NL_TEST_ASSERT(inSuite, constructorCalled == 1);
+        NL_TEST_ASSERT(inSuite, destructorCalled == 0);
         IgnoreUnusedVariable(ptr);
     }
 

--- a/src/lib/support/tests/TestCHIPMem.cpp
+++ b/src/lib/support/tests/TestCHIPMem.cpp
@@ -95,12 +95,38 @@ static void TestMemAlloc_Realloc(nlTestSuite * inSuite, void * inContext)
     chip::Platform::MemoryFree(pb);
 }
 
+static void TestMemAlloc_UniquePtr(nlTestSuite * inSuite, void * inContext)
+{
+    // UniquePtr is a wrapper of std::unique_ptr for platform allocators, we just check if we created a correct wrapper here.
+    int constructorCalled = 0;
+    int destructorCalled  = 0;
+
+    class Cls
+    {
+    public:
+        Cls(int * constructCtr, int * desctructorCtr) : mpDestructorCtr(desctructorCtr) { (*constructCtr)++; }
+        ~Cls() { (*mpDestructorCtr)++; }
+
+    private:
+        int * mpDestructorCtr;
+    };
+
+    {
+        auto ptr = MakeUnique<Cls>(&constructorCalled, &destructorCalled);
+        NL_TEST_ASSERT(inSuite, constructorCalled == 1);
+        IgnoreUnusedVariable(ptr);
+    }
+
+    NL_TEST_ASSERT(inSuite, destructorCalled == 1);
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
 static const nlTest sTests[] = { NL_TEST_DEF("Test MemAlloc::Malloc", TestMemAlloc_Malloc),
                                  NL_TEST_DEF("Test MemAlloc::Calloc", TestMemAlloc_Calloc),
-                                 NL_TEST_DEF("Test MemAlloc::Realloc", TestMemAlloc_Realloc), NL_TEST_SENTINEL() };
+                                 NL_TEST_DEF("Test MemAlloc::Realloc", TestMemAlloc_Realloc),
+                                 NL_TEST_DEF("Test MemAlloc::UniquePtr", TestMemAlloc_UniquePtr), NL_TEST_SENTINEL() };
 
 /**
  *  Set up the test suite.


### PR DESCRIPTION
#### Problem

We have our own allocator API, but we cannot use smart pointer from STL.

#### Change overview

- Introduce Platform::UniquePtr and Platform::MakeUnique

#### Testing
* Added a unit test to check if we have created correct wrapper for std::unique_ptr.