### PR TITLE
[python] Support shutting down subscription (CLI)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -33,6 +33,7 @@ APIs
 apk
 AppConfig
 ApplicationBasic
+ApplicationIdentifier
 ApplicationLauncher
 approver
 appspot
@@ -46,6 +47,7 @@ armv
 ASYNC
 att
 attId
+attributeValue
 attrListName
 attrMask
 attSizeBytes
@@ -264,6 +266,7 @@ DISTRO
 Distutils
 DK
 DL
+DMG
 DNS
 Dnsmasq
 dnsmasqd
@@ -437,8 +440,8 @@ Infineon
 ini
 init
 inlined
-instantiation
 installDebug
+instantiation
 integrations
 IntelliSense
 InteractionModelVersion
@@ -533,6 +536,7 @@ matterc
 matterd
 MatterLock
 MaxInterval
+MaxIntervalCeilingSeconds
 MaxRtrAdvInterval
 mbedTLS
 mcu
@@ -562,6 +566,7 @@ MicroSD
 middleware
 Minicom
 MinInterval
+MinIntervalFloorSeconds
 MinRtrAdvInterval
 mkdir
 mlan
@@ -773,8 +778,8 @@ ScriptBinding
 SDC
 SDHC
 SDK
-sdkconfig
 SDK's
+sdkconfig
 SDKs
 SDKTARGETSYSROOT
 sdl
@@ -828,6 +833,8 @@ subdirectory
 submodule
 submodules
 subprocess
+SubscribeResponse
+SubscriptionId
 sudo
 svg
 SVR
@@ -959,12 +966,14 @@ wrover
 WS
 WSL
 WSTK
+xa
 xab
 xaver
 xbef
 xcd
 Xcode
 xd
+xdeadbeefcafe
 xds
 xdsdfu
 xef
@@ -991,6 +1000,7 @@ zaptool
 ZCL
 zclconfigure
 zclread
+zclsubscribe
 zclwrite
 ZephyrConfig
 zephyrproject

--- a/docs/guides/python_chip_controller_building.md
+++ b/docs/guides/python_chip_controller_building.md
@@ -584,20 +584,20 @@ chip-device-ctrl > zclsubscribe OccupancySensing Occupancy 1234 1 10 20
 
 ### `zclsubscribe -shutdown <subscription id>`
 
-Configure ZCL attribute reporting settings. For example:
+Shutdown an existing attribute subscription.
 
 ```
 chip-device-ctrl > zclsubscribe -shutdown 0xdeadbeefcafe
 ```
 
-The subscription id can be obtained by previous subscription messages:
+The subscription id can be obtained from previous subscription messages:
 
 ```
 chip-device-ctrl > zclsubscribe OnOff OnOff 1 1 10 20
 (omitted messages)
 [1633922898.965587][1117858:1117866] CHIP:DMG: SubscribeResponse =
 [1633922898.965599][1117858:1117866] CHIP:DMG: {
-[1633922898.965610][1117858:1117866] CHIP:DMG:  SubscriptionId = 0x11675bb9f688e4ad,
+[1633922898.965610][1117858:1117866] CHIP:DMG:  SubscriptionId = 0xdeadbeefcafe,
 [1633922898.965622][1117858:1117866] CHIP:DMG:  MinIntervalFloorSeconds = 0xa,
 [1633922898.965633][1117858:1117866] CHIP:DMG:  MaxIntervalCeilingSeconds = 0x14,
 [1633922898.965644][1117858:1117866] CHIP:DMG: }

--- a/docs/guides/python_chip_controller_building.md
+++ b/docs/guides/python_chip_controller_building.md
@@ -574,10 +574,39 @@ chip-device-ctrl > zclwrite TestCluster CharString 1 1 0 233233
 Note: The format of the value is the same as the format of argument values for
 ZCL cluster commands.
 
-### `zclconfigure <Cluster> <Attribute> <Nodeid> <Endpoint> <MinInterval> <MaxInterval> <Change>`
+### `zclsubscribe <Cluster> <Attribute> <Nodeid> <Endpoint> <MinInterval> <MaxInterval>`
 
 Configure ZCL attribute reporting settings. For example:
 
 ```
-chip-device-ctrl > zclconfigure OccupancySensing Occupancy 1234 1 0 1000 2000 1
+chip-device-ctrl > zclsubscribe OccupancySensing Occupancy 1234 1 10 20
 ```
+
+### `zclsubscribe -shutdown <subscription id>`
+
+Configure ZCL attribute reporting settings. For example:
+
+```
+chip-device-ctrl > zclsubscribe -shutdown 0xdeadbeefcafe
+```
+
+The subscription id can be obtained by previous subscription messages:
+
+```
+chip-device-ctrl > zclsubscribe OnOff OnOff 1 1 10 20
+(omitted messages)
+[1633922898.965587][1117858:1117866] CHIP:DMG: SubscribeResponse =
+[1633922898.965599][1117858:1117866] CHIP:DMG: {
+[1633922898.965610][1117858:1117866] CHIP:DMG:  SubscriptionId = 0x11675bb9f688e4ad,
+[1633922898.965622][1117858:1117866] CHIP:DMG:  MinIntervalFloorSeconds = 0xa,
+[1633922898.965633][1117858:1117866] CHIP:DMG:  MaxIntervalCeilingSeconds = 0x14,
+[1633922898.965644][1117858:1117866] CHIP:DMG: }
+[1633922898.965662][1117858:1117866] CHIP:ZCL: SubscribeResponse:
+[1633922898.965673][1117858:1117866] CHIP:ZCL:   SubscriptionId:        0xdeadbeefcafe
+[1633922898.965683][1117858:1117866] CHIP:ZCL:   ApplicationIdentifier: 0
+[1633922898.965694][1117858:1117866] CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)
+[1633922898.965709][1117858:1117866] CHIP:ZCL:   attributeValue: false
+(omitted messages)
+```
+
+The subscription id is `0xdeadbeefcafe` in this case

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -144,13 +144,14 @@ CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClien
 
 CHIP_ERROR InteractionModelEngine::ShutdownSubscription(uint64_t aSubscriptionId)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_ERROR_KEY_NOT_FOUND;
 
     for (auto & readClient : mReadClients)
     {
         if (!readClient.IsFree() && readClient.IsSubscriptionType() && readClient.IsMatchingClient(aSubscriptionId))
         {
             readClient.Shutdown();
+            err = CHIP_NO_ERROR;
         }
     }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -142,6 +142,21 @@ CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClien
     return err;
 }
 
+CHIP_ERROR InteractionModelEngine::ShutdownSubscription(uint64_t aSubscriptionId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    for (auto & readClient : mReadClients)
+    {
+        if (!readClient.IsFree() && readClient.IsSubscriptionType() && readClient.IsMatchingClient(aSubscriptionId))
+        {
+            readClient.Shutdown();
+        }
+    }
+
+    return err;
+}
+
 CHIP_ERROR InteractionModelEngine::NewWriteClient(WriteClientHandle & apWriteClient, uint64_t aApplicationIdentifier)
 {
     apWriteClient.SetWriteClient(nullptr);

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -110,6 +110,13 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      */
     CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier = 0);
+
+    /**
+     * Tears down a active subscription. Will do nothing and return CHIP_NO_ERROR if no subscription found.
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR ShutdownSubscription(uint64_t aSubscriptionId);
     /**
      *  Retrieve a WriteClient that the SDK consumer can use to send a write.  If the call succeeds,
      *  see WriteClient documentation for lifetime handling.

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -112,8 +112,9 @@ public:
     CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier = 0);
 
     /**
-     * Tears down a active subscription. Will do nothing and return CHIP_NO_ERROR if no subscription found.
+     * Tears down an active subscription.
      *
+     * @retval #CHIP_ERROR_KEY_NOT_FOUND If the subscription is not found.
      * @retval #CHIP_NO_ERROR On success.
      */
     CHIP_ERROR ShutdownSubscription(uint64_t aSubscriptionId);

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -94,6 +94,12 @@ public:
     CHIP_ERROR OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
 
+    auto GetSubscriptionId() const
+    {
+        using returnType = Optional<decltype(mSubscriptionId)>;
+        return mInteractionType == InteractionType::Subscribe ? returnType(mSubscriptionId) : returnType::Missing();
+    }
+
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };

--- a/src/app/util/im-client-callbacks.cpp
+++ b/src/app/util/im-client-callbacks.cpp
@@ -427,7 +427,16 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
 
 bool IMSubscribeResponseCallback(const chip::app::ReadClient * apSubscribeClient, EmberAfStatus status)
 {
+    auto subscriptionId = apSubscribeClient->GetSubscriptionId();
     ChipLogProgress(Zcl, "SubscribeResponse:");
+    if (subscriptionId.HasValue())
+    {
+        ChipLogProgress(Zcl, "  SubscriptionId:        0x%" PRIx64, subscriptionId.Value());
+    }
+    else
+    {
+        ChipLogProgress(Zcl, "  SubscriptionId:        <missing>");
+    }
     ChipLogProgress(Zcl, "  ApplicationIdentifier: %" PRIx64, apSubscribeClient->GetAppIdentifier());
     LogStatus(status);
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -167,6 +167,8 @@ ChipError::StorageType pychip_GetConnectedDeviceByNodeId(chip::Controller::Devic
 uint64_t pychip_GetCommandSenderHandle(chip::Controller::Device * device);
 // CHIP Stack objects
 ChipError::StorageType pychip_BLEMgrImpl_ConfigureBle(uint32_t bluetoothAdapterId);
+
+chip::ChipError::StorageType pychip_InteractionModel_ShutdownSubscription(uint64_t subscriptionId);
 }
 
 ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Controller::DeviceCommissioner ** outDevCtrl,
@@ -587,4 +589,9 @@ ChipError::StorageType pychip_DeviceController_PostTaskOnChipThread(ChipThreadTa
     }
     PlatformMgr().ScheduleWork(callback, reinterpret_cast<intptr_t>(pythonContext));
     return CHIP_NO_ERROR.AsInteger();
+}
+
+chip::ChipError::StorageType pychip_InteractionModel_ShutdownSubscription(uint64_t subscriptionId)
+{
+    return chip::app::InteractionModelEngine::GetInstance()->ShutdownSubscription(subscriptionId).AsInteger();
 }

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -810,7 +810,7 @@ class DeviceMgrCmd(Cmd):
         To subscribe ZCL attribute reporting:
         zclsubscribe <cluster> <attribute> <nodeid> <endpoint> <minInterval> <maxInterval>
 
-        To shutdown a subscription:
+        To shut down a subscription:
         zclsubscribe -shutdown <subscriptionId>
         """
         try:

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -809,6 +809,9 @@ class DeviceMgrCmd(Cmd):
         """
         To subscribe ZCL attribute reporting:
         zclsubscribe <cluster> <attribute> <nodeid> <endpoint> <minInterval> <maxInterval>
+
+        To shutdown a subscription:
+        zclsubscribe -shutdown <subscriptionId>
         """
         try:
             args = shlex.split(line)
@@ -826,6 +829,9 @@ class DeviceMgrCmd(Cmd):
                     raise exceptions.UnknownCluster(args[0])
                 self.devCtrl.ZCLSubscribeAttribute(args[0], args[1], int(
                     args[2]), int(args[3]), int(args[4]), int(args[5]))
+            elif len(args) == 2 and args[0] == '-shutdown':
+                subscriptionId = int(args[1], base=0)
+                self.devCtrl.ZCLShutdownSubscription(subscriptionId)
             else:
                 self.do_help("zclsubscribe")
         except exceptions.ChipStackException as ex:

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -367,6 +367,12 @@ class ChipDeviceController(object):
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(commandSenderHandle, 1)
 
+    def ZCLShutdownSubscription(self, subscriptionId: int):
+        res = self._ChipStack.Call(
+            lambda: self._dmLib.pychip_InteractionModel_ShutdownSubscription(subscriptionId))
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
+
     def ZCLCommandList(self):
         return self._Cluster.ListClusterCommands()
 
@@ -489,3 +495,7 @@ class ChipDeviceController(object):
             self._dmLib.pychip_DeviceController_OpenCommissioningWindow.argtypes = [
                 c_void_p, c_uint64, c_uint16, c_uint16, c_uint16, c_uint8]
             self._dmLib.pychip_DeviceController_OpenCommissioningWindow.restype = c_uint32
+
+            self._dmLib.pychip_InteractionModel_ShutdownSubscription.argtypes = [
+                c_uint64]
+            self._dmLib.pychip_InteractionModel_ShutdownSubscription.restype = c_uint32


### PR DESCRIPTION
#### Problem

Fixes #9937

We do not support shutting down subscriptions now.

#### Change overview

Add a API for shutdown a subscription by subscription Id.

#### Testing

Since there is an ongoing callback changes on ReadClient for complex types, more tests will be added after final API decision.

Manaully tested:

```
zclsubscribe OnOff OnOff 1 1 10 20
(get subscription id from stdout)
zclsubscribe -shutdown <subscription id>
(no more subscription messages)
```

Also, can observe the following messages on server side:

```
[1633922918.967544][1117781:1117781] CHIP:DMG: <RE> Dumping report data...
[1633922918.967588][1117781:1117781] CHIP:DMG: ReportData =
[1633922918.967611][1117781:1117781] CHIP:DMG: {
[1633922918.967629][1117781:1117781] CHIP:DMG:  SubscriptionId = 0x11675bb9f688e4ad,
[1633922918.967649][1117781:1117781] CHIP:DMG: }
[1633922918.967667][1117781:1117781] CHIP:DMG: <RE> Sending report...
[1633922918.967692][1117781:1117781] CHIP:DMG: IM RH moving to [AwaitingReportResponse]
[1633922918.967766][1117781:1117781] CHIP:IN: Prepared encrypted message 0x55f22404b3f8 to 0x0000000000000000 of type 0x5 and protocolId (0, 1) on exchange 60309i with MessageCounter:11.
[1633922918.967799][1117781:1117781] CHIP:IN: Sending encrypted msg 0x55f22404b3f8 with MessageCounter:11 to 0x0000000000000000 at monotonic time: 264890964 msec
[1633922918.967910][1117781:1117781] CHIP:DMG: ReadHandler::Refresh Subscribe Sync Timer with 10 seconds
[1633922918.967935][1117781:1117781] CHIP:DMG: <RE> ReportsInFlight = 1 with readHandler 0, RE has no more messages
[1633922918.968454][1117781:1117781] CHIP:EM: Received message of type 0x10 with protocolId (0, 0) and MessageCounter:16 on exchange 60309i
[1633922918.968498][1117781:1117781] CHIP:EM: Rxd Ack; Removing MessageCounter:11 from Retrans Table on exchange 60309i
[1633922918.968517][1117781:1117781] CHIP:EM: Removed CHIP MessageCounter:11 from RetransTable on exchange 60309i
[1633922930.968470][1117781:1117781] CHIP:DMG: Time out! failed to receive status response from Exchange: 60309i
[1633922930.968523][1117781:1117781] CHIP:DMG: <RE> OnReportConfirm: NumReports = 0
[1633922930.968537][1117781:1117781] CHIP:DMG: IM RH moving to [Uninitialized]
```