### PR TITLE
Remove unnecessary includes of AttributeDataElement.h

### DIFF
--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -22,7 +22,6 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/MessageDef/AttributeDataElement.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -18,7 +18,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/MessageDef/AttributeDataElement.h>
 #include <app/util/attribute-storage.h>
 #include <platform/PlatformManager.h>
 

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -22,7 +22,6 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/MessageDef/AttributeDataElement.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>

--- a/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
+++ b/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
@@ -22,7 +22,6 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/MessageDef/AttributeDataElement.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPEncoding.h>

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -22,7 +22,6 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/MessageDef/AttributeDataElement.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>


### PR DESCRIPTION
We no longer need these, because the AttributeValueEncoder handles the
tagging for us.

#### Problem
Unnecessary includes.

#### Change overview
Remove them.

#### Testing
Grepping for "AttributeDataElement" in the relevant files shows no uses.