### PR TITLE
Add a version bump reason to our docker version.

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -31,7 +31,7 @@ ORG=${DOCKER_BUILD_ORG:-connectedhomeip}
 IMAGE=${DOCKER_BUILD_IMAGE:-$(basename "$(pwd)")}
 
 # version
-VERSION=${DOCKER_BUILD_VERSION:-$(cat version)}
+VERSION=${DOCKER_BUILD_VERSION:-$(sed 's/ .*//' version)}
 
 [[ ${*/--help//} != "${*}" ]] && {
     set +x

--- a/integrations/docker/ci-only-images/chip-cirque-device-base/build.sh
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/build.sh
@@ -31,7 +31,7 @@ ORG=${DOCKER_BUILD_ORG:-connectedhomeip}
 IMAGE=${DOCKER_BUILD_IMAGE:-$(basename "$(pwd)")}
 
 # version
-VERSION=${DOCKER_BUILD_VERSION:-$(cat version)}
+VERSION=${DOCKER_BUILD_VERSION:-$(sed 's/ .*//' version)}
 
 GITHUB_ACTION_RUN=${GITHUB_ACTION_RUN:-"0"}
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.13
+0.5.14 Version bump reason: Added reasons.

--- a/integrations/docker/run.sh
+++ b/integrations/docker/run.sh
@@ -35,7 +35,7 @@ ORG=${DOCKER_RUN_ORG:-connectedhomeip}
 IMAGE=${DOCKER_RUN_IMAGE:-$(basename "$here")}
 
 # version
-VERSION=${DOCKER_RUN_VERSION:-$(cat "$here/version")} ||
+VERSION=${DOCKER_RUN_VERSION:-$(sed 's/ .*//' "$here/version")} ||
     die "please run me from an image directory or set environment variables:
           DOCKER_RUN_ORG
           DOCKER_RUN_IMAGE


### PR DESCRIPTION
Without this, two independent version bumps can happen that only bump
the version once, because git's conflict detection will not perceive
two independent PRs changing the version to the same thing as a merge
conflict.

Adding a version bump reason handles this, because the reasons will be
different and cause a merge conflict.

#### Problem
See above.

#### Change overview
See above.

I considered using bash string functions to strip off the bits after vesion, but it would have complicated the logic in the script (because I think I would have needed to store the shell command output in a variable and then manipulate that variable), hence the use of sed instead.

#### Testing
Verified that the version extracted by `build.sh` is the right substring.