### PR TITLE
removed unused dummy read/write for persisted storage

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2031,29 +2031,3 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
 
 } // namespace Controller
 } // namespace chip
-
-#if !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE // not needed with app/server is included
-namespace chip {
-namespace Platform {
-namespace PersistedStorage {
-
-/*
- * Dummy implementations of PersistedStorage platform methods. These aren't
- * used in the context of the Device Controller, but are required to satisfy
- * the linker.
- */
-
-CHIP_ERROR Read(const char * aKey, uint32_t & aValue)
-{
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR Write(const char * aKey, uint32_t aValue)
-{
-    return CHIP_NO_ERROR;
-}
-
-} // namespace PersistedStorage
-} // namespace Platform
-} // namespace chip
-#endif // !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE


### PR DESCRIPTION
#### Problem
Fix #9630, where there existing dummy implementation for read/write for persisted storage from 8ddfb87226f0eab9a9292f26b64a6e1cae2a9571, at that time, read/write in persistent storage has not yet implemented in most platform, and compiler would complain with error, currently it is all implemented via ConfigurationMgr().ReadPersistedStorageValue(key, value) and  ConfigurationMgr().WritePersistedStorageValue(key, value);

#### Change overview
Removed unused dummy read/write for persisted storage, 

#### Testing
Presubmit runs.

