### PR TITLE
Use GetConnectedDevice in Darwin tests

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -68,7 +68,6 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
 - (BOOL)getConnectedDevice:(uint64_t)deviceID
                      queue:(dispatch_queue_t)queue
          completionHandler:(CHIPDeviceConnectionCallback)completionHandler;
-- (nullable CHIPDevice *)getPairedDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -451,31 +451,6 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     return YES;
 }
 
-- (CHIPDevice *)getPairedDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
-{
-    __block CHIPDevice * chipDevice = nil;
-    __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
-    if (![self isRunning]) {
-        [self checkForError:errorCode logMsg:kErrorNotRunning error:error];
-        return chipDevice;
-    }
-    dispatch_sync(_chipWorkQueue, ^{
-        chip::Controller::Device * device = nullptr;
-
-        if ([self isRunning]) {
-            errorCode = self.cppCommissioner->GetDevice(deviceID, &device);
-        }
-
-        if ([self checkForError:errorCode logMsg:kErrorGetPairedDevice error:error]) {
-            return;
-        }
-
-        chipDevice = [[CHIPDevice alloc] initWithDevice:device];
-    });
-
-    return chipDevice;
-}
-
 - (void)setListenPort:(uint16_t)port
 {
     _listenPort = port;

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -11,6 +11,8 @@
 #import <XCTest/XCTest.h>
 
 const uint16_t kPairingTimeoutInSeconds = 10;
+const uint16_t kAddressResolveTimeoutInSeconds = 10;
+const uint16_t kCASESetupTimeoutInSeconds = 30;
 const uint16_t kTimeoutInSeconds = 3;
 const uint64_t kDeviceId = 1;
 const uint16_t kDiscriminator = 3840;
@@ -18,6 +20,10 @@ const uint32_t kSetupPINCode = 20202021;
 const uint16_t kRemotePort = 5540;
 const uint16_t kLocalPort = 5541;
 NSString * kAddress = @"::1";
+
+// This test suite reuses a device object to speed up the test process for CI.
+// The following global variable holds the reference to the device object.
+static CHIPDevice * mConnectedDevice;
 
 // Test Util APIs
 void WaitForMs(XCTestExpectation * expectation, dispatch_queue_t queue, unsigned int ms)
@@ -27,17 +33,10 @@ void WaitForMs(XCTestExpectation * expectation, dispatch_queue_t queue, unsigned
     });
 }
 
-CHIPDevice * GetPairedDevice(uint64_t deviceId)
+CHIPDevice * GetConnectedDevice()
 {
-    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertNotNil(controller);
-
-    NSError * pairingError;
-    CHIPDevice * device = [controller getPairedDevice:deviceId error:&pairingError];
-    XCTAssertEqual(pairingError.code, 0);
-    XCTAssertNotNil(device);
-
-    return device;
+    XCTAssertNotNil(mConnectedDevice);
+    return mConnectedDevice;
 }
 
 @interface CHIPToolPairingDelegate : NSObject <CHIPDevicePairingDelegate>
@@ -55,6 +54,13 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 }
 
 - (void)onPairingComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+- (void)onAddressUpdated:(NSError *)error
 {
     XCTAssertEqual(error.code, 0);
     [_expectation fulfill];
@@ -98,6 +104,23 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     XCTAssertEqual(error.code, 0);
 
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
+
+    XCTestExpectation * addressExpectation = [self expectationWithDescription:@"Address Updated"];
+    pairing.expectation = addressExpectation;
+    [controller updateDevice:kDeviceId fabricId:0];
+
+    [self waitForExpectationsWithTimeout:kAddressResolveTimeoutInSeconds handler:nil];
+
+    __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
+    [controller getConnectedDevice:kDeviceId
+                             queue:dispatch_get_main_queue()
+                 completionHandler:^(CHIPDevice * _Nullable device, NSError * _Nullable error) {
+                     XCTAssertEqual(error.code, 0);
+                     [connectionExpectation fulfill];
+                     connectionExpectation = nil;
+                     mConnectedDevice = device;
+                 }];
+    [self waitForExpectationsWithTimeout:kCASESetupTimeoutInSeconds handler:nil];
 }
 
 - (void)testShutdownStack
@@ -117,7 +140,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"ReuseCHIPClusterObjectFirstCall"];
 
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
@@ -153,7 +176,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"{{asUpperCamelCase parent.name}}ReadAttribute{{asUpperCamelCase name}}WithResponseHandler"];
 
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asUpperCamelCase parent.name)}} queue:queue];
     XCTAssertNotNil(cluster);
@@ -172,7 +195,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"{{asUpperCamelCase parent.name}}WriteAttribute{{asUpperCamelCase name}}WithValue"];
 
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asUpperCamelCase parent.name)}} queue:queue];
     XCTAssertNotNil(cluster);

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -13,7 +13,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     dispatch_queue_t queue = dispatch_get_main_queue();
     {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{definedValue}}{{/chip_tests_item_parameters}});
 {{else}}
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTest{{asUpperCamelCase cluster}} * cluster = [[CHIPTest{{asUpperCamelCase cluster}} alloc] initWithDevice:device endpoint:{{endpoint}} queue:queue];
     XCTAssertNotNil(cluster);


### PR DESCRIPTION
#### Problem
Darwin tests were not using secure session established via CASE. The tests were instead using secure sessions established via initial PASE handshake.

#### Change overview
The SDK code relies on discovery of the device on operational network to trigger the CASE session with it. This PR adds address resolution and a call to `GetConnectedDevice` to establish the secure session using CASE.

Also removed the obsolete method to `getPairedDevice` from Darwin's controller API.

#### Testing
All the tests in Darwin framework will use the updated code. If the secure session setup fails, the tests will fail too.