### PR TITLE
Fix cloudbuild: NCS version was updated, need to use new docker image version

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,6 +1,6 @@
 # NOTE: /workspace/ is the persistent directory across steps
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.11"
+    - name: "connectedhomeip/chip-build-vscode:0.5.13"
       id: "CompileAll"
       entrypoint: "./scripts/run_in_build_env.sh"
       args:


### PR DESCRIPTION
#### Problem
Cloudbuild failure as:

```
2021-10-11 16:53:22 INFO    Checking current nRF Connect SDK revision...
2021-10-11 16:53:22 INFO    ################################################################################
2021-10-11 16:53:22 INFO    # WARNING: Your current NCS revision (d29f1ddec99b81a66af93b7f0882a7bd0dfa30ee)#
2021-10-11 16:53:22 INFO    # differs from the recommended (ffcf07fe4586634a6793a48e5444a7196e7ebac6).     #
2021-10-11 16:53:22 INFO    #                                                                       …021-10-11 16:53:22 INFO    # Please be aware that it may lead to encountering unexpected problems.        #
2021-10-11 16:53:22 INFO    # Consider updating NCS to the recommended revision, by calling:               #
2021-10-11 16:53:22 INFO    # /workspace/scripts/setup/nrfconnect/update_ncs.py --update                   #
2021-10-11 16:53:22 INFO    ################################################################################
2021-10-11 16:53:22 ERROR   Failed to validate ZEPHYR_BASE status
```


#### Change overview
Use latest 0.5.13 image version for cloudbuild

#### Testing
Not tested - CI build integration.