### PR TITLE
Use new command structs in operational credentials server.

### DIFF
--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -89,7 +89,7 @@ public:
     template <typename CommandData>
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
-        ReturnErrorOnFailure(PrepareResponse(aRequestCommandPath, CommandData::CommandId));
+        ReturnErrorOnFailure(PrepareResponse(aRequestCommandPath, CommandData::GetCommandId()));
         TLV::TLVWriter * writer = GetCommandDataElementTLVWriter();
         VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorOnFailure(DataModel::Encode(*writer, TLV::ContextTag(CommandDataElement::kCsTag_Data), aData));

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -412,7 +412,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendSimpleCommandData(nlTestS
 
 struct Fields
 {
-    static constexpr chip::CommandId CommandId = 4;
+    static constexpr chip::CommandId GetCommandId() { return 4; }
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
     {
         TLV::TLVType outerContainerType;


### PR DESCRIPTION
#### Problem
We are using the PrepareCommand/etc APIs in opcreds server.

#### Change overview
Use the cluster-objects structs for sending responses.

#### Testing
No behavior changes; existing tests pass.