### PR TITLE
Fix bad "building android" link

### DIFF
--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -15,5 +15,5 @@ CHIPTool offers the following features:
 > pairing is implemented.
 
 For information about how to build the application, see the
-[Building Android CHIPTool](../../../docs/guides/android_chiptool_building.md)
+[Building Android CHIPTool](../../../docs/guides/android_building.md)
 guide.

--- a/src/android/CHIPTool/README.md
+++ b/src/android/CHIPTool/README.md
@@ -15,5 +15,4 @@ CHIPTool offers the following features:
 > pairing is implemented.
 
 For information about how to build the application, see the
-[Building Android CHIPTool](../../../docs/guides/android_building.md)
-guide.
+[Building Android CHIPTool](../../../docs/guides/android_building.md) guide.


### PR DESCRIPTION
#### Problem
Old filename was used for link.

#### Change overview
Use a correct file name.

#### Testing
Text typo only, no testing needed.