### PR TITLE
disable android studio build in build_examples

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -133,8 +133,13 @@ def AndroidTargets():
     yield target.Extend('arm64-chip-tool', board=AndroidBoard.ARM64, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('x64-chip-tool', board=AndroidBoard.X64, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('x86-chip-tool', board=AndroidBoard.X86, app=AndroidApp.CHIP_TOOL)
-    yield target.Extend('androidstudio-chip-tool', board=AndroidBoard.AndroidStudio, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('arm64-chip-test', board=AndroidBoard.ARM64, app=AndroidApp.CHIP_TEST)
+    # TODO: android studio build is broken:
+    #   - When compile succeeds, build artifact copy fails with "No such file or 
+    #     directory: '<out_prefix>/android-androidstudio-chip-tool/outputs/apk/debug/app-debug.apk'
+    #   - Compiling locally in the vscode image fails with 
+    #     "2 files found with path 'lib/armeabi-v7a/libCHIPController.so'"
+    # yield target.Extend('androidstudio-chip-tool', board=AndroidBoard.AndroidStudio, app=AndroidApp.CHIP_TOOL)
 
 
 ALL = []

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -135,9 +135,9 @@ def AndroidTargets():
     yield target.Extend('x86-chip-tool', board=AndroidBoard.X86, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('arm64-chip-test', board=AndroidBoard.ARM64, app=AndroidApp.CHIP_TEST)
     # TODO: android studio build is broken:
-    #   - When compile succeeds, build artifact copy fails with "No such file or 
+    #   - When compile succeeds, build artifact copy fails with "No such file or
     #     directory: '<out_prefix>/android-androidstudio-chip-tool/outputs/apk/debug/app-debug.apk'
-    #   - Compiling locally in the vscode image fails with 
+    #   - Compiling locally in the vscode image fails with
     #     "2 files found with path 'lib/armeabi-v7a/libCHIPController.so'"
     # yield target.Extend('androidstudio-chip-tool', board=AndroidBoard.AndroidStudio, app=AndroidApp.CHIP_TOOL)
 

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -1,4 +1,3 @@
-android-androidstudio-chip-tool
 android-arm-chip-tool
 android-arm64-chip-test
 android-arm64-chip-tool

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -4,18 +4,6 @@ python3 build/chip/java/tests/generate_jars_for_test.py
 # Setting up Android deps through Gradle
 python3 third_party/android_deps/set_up_android_deps.py
 
-# Generating android-androidstudio-chip-tool
-gn gen --check --fail-on-unused-args {out}/android-androidstudio-chip-tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
-
-# Accepting NDK licenses
-bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
-
-# Generating JARs for Java build rules test
-python3 build/chip/java/tests/generate_jars_for_test.py
-
-# Setting up Android deps through Gradle
-python3 third_party/android_deps/set_up_android_deps.py
-
 # Generating android-arm-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-arm-chip-tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
 
@@ -182,9 +170,6 @@ west build --cmake-only -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {
 
 # Generating tizen-arm-light
 gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/linux '--args=target_os="tizen" target_cpu="arm" sysroot="TEST_TIZEN_HOME"' {out}/tizen-arm-light
-
-# Building APP android-androidstudio-chip-tool
-{root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-androidstudio-chip-tool -PmatterSdkSourceBuild=true assembleDebug
 
 # Building JNI android-arm-chip-tool
 ninja -C {out}/android-arm-chip-tool


### PR DESCRIPTION
#### Problem
Android studio build is broken:

Cloudbuild artifact generation fails with:

```
2021-10-12 18:10:46 INFO    Adding /workspace/out/android-androidstudio-chip-tool/outputs/apk/debug/app-debug.apk into /workspace/artifacts/android-androidstudio-chip-tool.tar.gz/CHIPTool-debug.apk
Traceback (most recent call last):
  File "/workspace/./scripts/build/build_examples.py", line 213, in <module>
    main()
...
  File "/usr/lib/python3.9/tarfile.py", line 1842, in gettarinfo
    statres = os.lstat(name)
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/out/android-androidstudio-chip-tool/outputs/apk/debug/app-debug.apk'
ERROR
```

VSCode build image fails with:

```
2021-10-12 18:25:01 WARNING > A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
2021-10-12 18:25:01 WARNING    > 2 files found with path 'lib/armeabi-v7a/libCHIPController.so' from inputs:
2021-10-12 18:25:01 WARNING       - /workspaces/connectedhomeip/src/android/CHIPTool/app/build/intermediates/merged_jni_libs/debug/out
2021-10-12 18:25:01 WARNING       - /workspaces/connectedhomeip/src/android/CHIPTool/app/build/intermediates/cmake/debug/obj
2021-10-12 18:25:01 WARNING      If you are using jniLibs and CMake IMPORTED targets, see
2021-10-12 18:25:01 WARNING      https://developer.android.com/r/tools/jniLibs-vs-imported-targets
2021-10-12 18:25:01 WARNING 
2021-10-12 18:25:01 WARNING * Try:
2021-10-12 18:25:01 WARNING Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```

Further more the build seems to pollute the source directory and generates output into `src/android/CHIPTool/build` and `src/android/CHIPTool/app/build` even though  the build_examples script is supposed to only generate files into its output directory.

#### Change overview
Disable the studio build version for android in build_examples.py.

#### Testing
Removal only. CI updated.
