### PR TITLE
[ChipTool] Add CharString argument support

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -98,10 +98,17 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
         break;
     }
 
-    case ArgumentType::CharString: {
+    case ArgumentType::String: {
         const char ** value = reinterpret_cast<const char **>(arg.value);
         *value              = argValue;
         isValidArgument     = true;
+        break;
+    }
+
+    case ArgumentType::CharString: {
+        auto * value    = static_cast<chip::Span<const char> *>(arg.value);
+        *value          = chip::Span<const char>(argValue, strlen(argValue));
+        isValidArgument = true;
         break;
     }
 
@@ -304,6 +311,17 @@ size_t Command::AddArgument(const char * name, const char * value)
 }
 
 size_t Command::AddArgument(const char * name, char ** value)
+{
+    Argument arg;
+    arg.type  = ArgumentType::CharString;
+    arg.name  = name;
+    arg.value = reinterpret_cast<void *>(value);
+
+    mArgs.emplace_back(arg);
+    return mArgs.size();
+}
+
+size_t Command::AddArgument(const char * name, chip::CharSpan * value)
 {
     Argument arg;
     arg.type  = ArgumentType::CharString;

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -58,8 +58,9 @@ enum ArgumentType
     Number_int16,
     Number_int32,
     Number_int64,
-    CharString,
     Boolean,
+    String,
+    CharString,
     OctetString,
     Attribute,
     Address
@@ -131,6 +132,7 @@ public:
      * Add an octet string command argument
      */
     size_t AddArgument(const char * name, chip::ByteSpan * value);
+    size_t AddArgument(const char * name, chip::Span<const char> * value);
     size_t AddArgument(const char * name, AddressWithInterface * out);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out)
     {

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -207,7 +207,7 @@ public:
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asUpperCamelCase label}}), strlen(m{{asUpperCamelCase label}})){{else}}m{{asUpperCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
+        return cluster.{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments}}, m{{asUpperCamelCase label}}{{/chip_cluster_command_arguments}});
     }
 
 private:
@@ -218,11 +218,7 @@ private:
     {{/if}}
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     {{#chip_cluster_command_arguments}}
-    {{#if (isCharString type)}}
-    char * m{{asUpperCamelCase label}};
-    {{else}}
-    {{chipType}} m{{asUpperCamelCase label}};
-    {{/if}}
+    {{#if (isCharString type)}}chip::ByteSpan{{else}}{{chipType}}{{/if}} m{{asUpperCamelCase label}};
     {{/chip_cluster_command_arguments}}
 };
 
@@ -292,17 +288,13 @@ public:
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)){{else}}mValue{{/if}});
+        return cluster.WriteAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
     chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback = new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    {{#if (isCharString type)}}
-    char * mValue;
-    {{else}}
-    {{chipType}} mValue;
-    {{/if}}
+    {{#if (isCharString type)}}chip::ByteSpan{{else}}{{chipType}}{{/if}} mValue;
 };
 
 {{/if}}

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -1247,8 +1247,7 @@ public:
 
         chip::Controller::AccountLoginCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.GetSetupPIN(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                   chip::ByteSpan(chip::Uint8::from_char(mTempAccountIdentifier), strlen(mTempAccountIdentifier)));
+        return cluster.GetSetupPIN(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mTempAccountIdentifier);
     }
 
 private:
@@ -1257,7 +1256,7 @@ private:
                                                                                      this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mTempAccountIdentifier;
+    chip::ByteSpan mTempAccountIdentifier;
 };
 
 /*
@@ -1284,9 +1283,7 @@ public:
 
         chip::Controller::AccountLoginCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.Login(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                             chip::ByteSpan(chip::Uint8::from_char(mTempAccountIdentifier), strlen(mTempAccountIdentifier)),
-                             chip::ByteSpan(chip::Uint8::from_char(mSetupPIN), strlen(mSetupPIN)));
+        return cluster.Login(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mTempAccountIdentifier, mSetupPIN);
     }
 
 private:
@@ -1294,8 +1291,8 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mTempAccountIdentifier;
-    char * mSetupPIN;
+    chip::ByteSpan mTempAccountIdentifier;
+    chip::ByteSpan mSetupPIN;
 };
 
 /*
@@ -1848,9 +1845,7 @@ public:
 
         chip::Controller::ApplicationLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.LaunchApp(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                 chip::ByteSpan(chip::Uint8::from_char(mData), strlen(mData)), mCatalogVendorId,
-                                 chip::ByteSpan(chip::Uint8::from_char(mApplicationId), strlen(mApplicationId)));
+        return cluster.LaunchApp(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mData, mCatalogVendorId, mApplicationId);
     }
 
 private:
@@ -1859,9 +1854,9 @@ private:
             OnApplicationLauncherClusterLaunchAppResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mData;
+    chip::ByteSpan mData;
     uint16_t mCatalogVendorId;
-    char * mApplicationId;
+    chip::ByteSpan mApplicationId;
 };
 
 /*
@@ -2038,8 +2033,7 @@ public:
 
         chip::Controller::AudioOutputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.RenameOutput(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mIndex,
-                                    chip::ByteSpan(chip::Uint8::from_char(mName), strlen(mName)));
+        return cluster.RenameOutput(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mIndex, mName);
     }
 
 private:
@@ -2048,7 +2042,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint8_t mIndex;
-    char * mName;
+    chip::ByteSpan mName;
 };
 
 /*
@@ -2719,8 +2713,7 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttributeUserLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                               chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)));
+        return cluster.WriteAttributeUserLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
@@ -2728,7 +2721,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mValue;
+    chip::ByteSpan mValue;
 };
 
 /*
@@ -2787,8 +2780,7 @@ public:
 
         chip::Controller::BasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttributeLocation(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                              chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)));
+        return cluster.WriteAttributeLocation(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
@@ -2796,7 +2788,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mValue;
+    chip::ByteSpan mValue;
 };
 
 /*
@@ -3852,8 +3844,7 @@ public:
 
         chip::Controller::BridgedDeviceBasicCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttributeUserLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                               chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)));
+        return cluster.WriteAttributeUserLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
@@ -3861,7 +3852,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mValue;
+    chip::ByteSpan mValue;
 };
 
 /*
@@ -7626,8 +7617,7 @@ public:
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.LaunchContent(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mAutoPlay,
-                                     chip::ByteSpan(chip::Uint8::from_char(mData), strlen(mData)));
+        return cluster.LaunchContent(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mAutoPlay, mData);
     }
 
 private:
@@ -7637,7 +7627,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     bool mAutoPlay;
-    char * mData;
+    chip::ByteSpan mData;
 };
 
 /*
@@ -7664,9 +7654,7 @@ public:
 
         chip::Controller::ContentLauncherCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.LaunchURL(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                 chip::ByteSpan(chip::Uint8::from_char(mContentURL), strlen(mContentURL)),
-                                 chip::ByteSpan(chip::Uint8::from_char(mDisplayString), strlen(mDisplayString)));
+        return cluster.LaunchURL(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mContentURL, mDisplayString);
     }
 
 private:
@@ -7675,8 +7663,8 @@ private:
                                                                                       this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mContentURL;
-    char * mDisplayString;
+    chip::ByteSpan mContentURL;
+    chip::ByteSpan mDisplayString;
 };
 
 /*
@@ -10216,9 +10204,8 @@ public:
 
         chip::Controller::GeneralCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.SetRegulatoryConfig(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mLocation,
-                                           chip::ByteSpan(chip::Uint8::from_char(mCountryCode), strlen(mCountryCode)), mBreadcrumb,
-                                           mTimeoutMs);
+        return cluster.SetRegulatoryConfig(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mLocation, mCountryCode,
+                                           mBreadcrumb, mTimeoutMs);
     }
 
 private:
@@ -10228,7 +10215,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint8_t mLocation;
-    char * mCountryCode;
+    chip::ByteSpan mCountryCode;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -10743,8 +10730,7 @@ public:
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.AddGroup(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mGroupId,
-                                chip::ByteSpan(chip::Uint8::from_char(mGroupName), strlen(mGroupName)));
+        return cluster.AddGroup(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mGroupId, mGroupName);
     }
 
 private:
@@ -10753,7 +10739,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint16_t mGroupId;
-    char * mGroupName;
+    chip::ByteSpan mGroupName;
 };
 
 /*
@@ -10780,8 +10766,7 @@ public:
 
         chip::Controller::GroupsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.AddGroupIfIdentifying(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mGroupId,
-                                             chip::ByteSpan(chip::Uint8::from_char(mGroupName), strlen(mGroupName)));
+        return cluster.AddGroupIfIdentifying(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mGroupId, mGroupName);
     }
 
 private:
@@ -10790,7 +10775,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint16_t mGroupId;
-    char * mGroupName;
+    chip::ByteSpan mGroupName;
 };
 
 /*
@@ -11895,8 +11880,7 @@ public:
 
         chip::Controller::MediaInputCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.RenameInput(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mIndex,
-                                   chip::ByteSpan(chip::Uint8::from_char(mName), strlen(mName)));
+        return cluster.RenameInput(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mIndex, mName);
     }
 
 private:
@@ -11905,7 +11889,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint8_t mIndex;
-    char * mName;
+    chip::ByteSpan mName;
 };
 
 /*
@@ -13308,9 +13292,7 @@ public:
         chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
         cluster.Associate(device, endpointId);
         return cluster.QueryImage(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mVendorId, mProductId, mHardwareVersion,
-                                  mSoftwareVersion, mProtocolsSupported,
-                                  chip::ByteSpan(chip::Uint8::from_char(mLocation), strlen(mLocation)), mRequestorCanConsent,
-                                  mMetadataForProvider);
+                                  mSoftwareVersion, mProtocolsSupported, mLocation, mRequestorCanConsent, mMetadataForProvider);
     }
 
 private:
@@ -13324,7 +13306,7 @@ private:
     uint16_t mHardwareVersion;
     uint32_t mSoftwareVersion;
     uint8_t mProtocolsSupported;
-    char * mLocation;
+    chip::ByteSpan mLocation;
     bool mRequestorCanConsent;
     chip::ByteSpan mMetadataForProvider;
 };
@@ -14783,8 +14765,7 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.UpdateFabricLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                         chip::ByteSpan(chip::Uint8::from_char(mLabel), strlen(mLabel)));
+        return cluster.UpdateFabricLabel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mLabel);
     }
 
 private:
@@ -14793,7 +14774,7 @@ private:
                                                                                        this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mLabel;
+    chip::ByteSpan mLabel;
 };
 
 /*
@@ -16170,8 +16151,7 @@ public:
         chip::Controller::ScenesCluster cluster;
         cluster.Associate(device, endpointId);
         return cluster.AddScene(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mGroupId, mSceneId, mTransitionTime,
-                                chip::ByteSpan(chip::Uint8::from_char(mSceneName), strlen(mSceneName)), mClusterId, mLength,
-                                mValue);
+                                mSceneName, mClusterId, mLength, mValue);
     }
 
 private:
@@ -16182,7 +16162,7 @@ private:
     uint16_t mGroupId;
     uint8_t mSceneId;
     uint16_t mTransitionTime;
-    char * mSceneName;
+    chip::ByteSpan mSceneName;
     chip::ClusterId mClusterId;
     uint8_t mLength;
     uint8_t mValue;
@@ -16982,8 +16962,7 @@ public:
 
         chip::Controller::TvChannelCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ChangeChannel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                     chip::ByteSpan(chip::Uint8::from_char(mMatch), strlen(mMatch)));
+        return cluster.ChangeChannel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMatch);
     }
 
 private:
@@ -16991,7 +16970,7 @@ private:
         new chip::Callback::Callback<TvChannelClusterChangeChannelResponseCallback>(OnTvChannelClusterChangeChannelResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mMatch;
+    chip::ByteSpan mMatch;
 };
 
 /*
@@ -17236,8 +17215,7 @@ public:
 
         chip::Controller::TargetNavigatorCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.NavigateTarget(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mTarget,
-                                      chip::ByteSpan(chip::Uint8::from_char(mData), strlen(mData)));
+        return cluster.NavigateTarget(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mTarget, mData);
     }
 
 private:
@@ -17247,7 +17225,7 @@ private:
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     uint8_t mTarget;
-    char * mData;
+    chip::ByteSpan mData;
 };
 
 /*
@@ -19005,8 +18983,7 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttributeCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)));
+        return cluster.WriteAttributeCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
@@ -19014,7 +18991,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mValue;
+    chip::ByteSpan mValue;
 };
 
 /*
@@ -19073,8 +19050,7 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttributeLongCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                    chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)));
+        return cluster.WriteAttributeLongCharString(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
@@ -19082,7 +19058,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mValue;
+    chip::ByteSpan mValue;
 };
 
 /*


### PR DESCRIPTION
#### Problem

This PR adds some code to support `CharString` parameter as `chip::Span<const char>` inside `chip-tool`. Currently the code still uses a `chip::ByteSpan` but once `chip-tool` support the new API for sending complex types it will be over.

#### Change overview
 * Add some argument parsing code for `chip::Span<const char>`
 * Update the template to have a `ByteSpan` instead of `uint8_t *` for some strings.

#### Testing
I have tested it locally mostly, since this part of `chip-tool` does not have real tests.