### PR TITLE
Miscellaneous src/inet cleanup

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -36,7 +36,7 @@ public:
         chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
-                                                               chip::Inet::kIPAddressType_Any);
+                                                               chip::Inet::IPAddressType::kAny);
     }
 
     void OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -48,7 +48,7 @@ void DiscoverCommissionablesCommand::OnDiscoveredDevice(const chip::Dnssd::Disco
     ChipLogProgress(Discovery, "\tPairing Hint\t\t0x%x", nodeData.pairingHint);
     for (int i = 0; i < nodeData.numIPs; i++)
     {
-        char buf[chip::Inet::kMaxIPAddressStringLength];
+        char buf[chip::Inet::IPAddress::kMaxStringLength];
         nodeData.ipAddress[i].ToString(buf);
 
         ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", i, buf);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -456,7 +456,7 @@ void PairingCommand::OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR err)
 void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
     const uint16_t port = nodeData.port;
-    char buf[chip::Inet::kMaxIPAddressStringLength];
+    char buf[chip::Inet::IPAddress::kMaxStringLength];
     nodeData.ipAddress[0].ToString(buf);
     ChipLogProgress(chipTool, "Discovered Device: %s:%u", buf, port);
 

--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -40,7 +40,7 @@ public:
         {
 #if INET_CONFIG_ENABLE_IPV4
             *id   = INET_NULL_INTERFACEID;
-            *type = chip::Inet::kIPAddressType_IPv4;
+            *type = chip::Inet::IPAddressType::kIPv4;
 #endif
             mState = State::kIpV6;
 
@@ -57,7 +57,7 @@ public:
         }
 
         *id   = mIterator.GetInterfaceId();
-        *type = chip::Inet::kIPAddressType_IPv6;
+        *type = chip::Inet::IPAddressType::kIPv6;
 
         for (mIterator.Next(); SkipCurrentInterface(); mIterator.Next())
         {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -95,19 +95,16 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     SuccessOrExit(err);
 
     // Init transport before operations with secure session mgr.
-    err = mTransports.Init(UdpListenParameters(&DeviceLayer::InetLayer)
-                               .SetAddressType(IPAddressType::kIPAddressType_IPv6)
-                               .SetListenPort(mSecuredServicePort)
+    err = mTransports.Init(
+        UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(IPAddressType::kIPv6).SetListenPort(mSecuredServicePort)
 
 #if INET_CONFIG_ENABLE_IPV4
-                               ,
-                           UdpListenParameters(&DeviceLayer::InetLayer)
-                               .SetAddressType(IPAddressType::kIPAddressType_IPv4)
-                               .SetListenPort(mSecuredServicePort)
+            ,
+        UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(IPAddressType::kIPv4).SetListenPort(mSecuredServicePort)
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
-                               ,
-                           BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
+            ,
+        BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
 #endif
     );
 

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -683,7 +683,7 @@ int main(int argc, char * argv[])
     InitializeChip();
 
     err = gTransportManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer)
-                                     .SetAddressType(chip::Inet::kIPAddressType_IPv6)
+                                     .SetAddressType(chip::Inet::IPAddressType::kIPv6)
                                      .SetListenPort(IM_CLIENT_PORT));
     SuccessOrExit(err);
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -213,7 +213,7 @@ int main(int argc, char * argv[])
     InitializeChip();
 
     err = gTransportManager.Init(
-        chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6));
+        chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::IPAddressType::kIPv6));
     SuccessOrExit(err);
 
     err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -328,7 +328,7 @@ CHIP_ERROR DeviceController::UpdateDevice(NodeId deviceId)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     return Dnssd::Resolver::Instance().ResolveNodeId(PeerId().SetCompressedFabricId(GetCompressedFabricId()).SetNodeId(deviceId),
-                                                     chip::Inet::kIPAddressType_Any);
+                                                     chip::Inet::IPAddressType::kAny);
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
@@ -622,12 +622,12 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     mUdcTransportMgr = chip::Platform::New<DeviceIPTransportMgr>();
     ReturnErrorOnFailure(mUdcTransportMgr->Init(Transport::UdpListenParameters(mSystemState->InetLayer())
-                                                    .SetAddressType(Inet::kIPAddressType_IPv6)
+                                                    .SetAddressType(Inet::IPAddressType::kIPv6)
                                                     .SetListenPort((uint16_t)(mUdcListenPort))
 #if INET_CONFIG_ENABLE_IPV4
                                                     ,
                                                 Transport::UdpListenParameters(mSystemState->InetLayer())
-                                                    .SetAddressType(Inet::kIPAddressType_IPv4)
+                                                    .SetAddressType(Inet::IPAddressType::kIPv4)
                                                     .SetListenPort((uint16_t)(mUdcListenPort))
 #endif // INET_CONFIG_ENABLE_IPV4
                                                     ));
@@ -1990,8 +1990,7 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
         ChipLogProgress(Controller, "Finding node on operational network");
         Dnssd::Resolver::Instance().ResolveNodeId(
-            PeerId().SetCompressedFabricId(GetCompressedFabricId()).SetNodeId(device->GetDeviceId()),
-            Inet::IPAddressType::kIPAddressType_Any);
+            PeerId().SetCompressedFabricId(GetCompressedFabricId()).SetNodeId(device->GetDeviceId()), Inet::IPAddressType::kAny);
 #endif
     }
     break;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -113,10 +113,10 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.transportMgr = chip::Platform::New<DeviceTransportMgr>();
 
     ReturnErrorOnFailure(stateParams.transportMgr->Init(
-        Transport::UdpListenParameters(stateParams.inetLayer).SetAddressType(Inet::kIPAddressType_IPv6).SetListenPort(mListenPort)
+        Transport::UdpListenParameters(stateParams.inetLayer).SetAddressType(Inet::IPAddressType::kIPv6).SetListenPort(mListenPort)
 #if INET_CONFIG_ENABLE_IPV4
             ,
-        Transport::UdpListenParameters(stateParams.inetLayer).SetAddressType(Inet::kIPAddressType_IPv4).SetListenPort(mListenPort)
+        Transport::UdpListenParameters(stateParams.inetLayer).SetAddressType(Inet::IPAddressType::kIPv4).SetListenPort(mListenPort)
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
             ,

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -116,7 +116,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->supportsTcp);
         for (int j = 0; j < dnsSdInfo->numIPs; ++j)
         {
-            char buf[chip::Inet::kMaxIPAddressStringLength];
+            char buf[chip::Inet::IPAddress::kMaxStringLength];
             dnsSdInfo->ipAddress[j].ToString(buf);
             ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", j, buf);
         }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -425,7 +425,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceComm
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->supportsTcp);
         for (int j = 0; j < dnsSdInfo->numIPs; ++j)
         {
-            char buf[chip::Inet::kMaxIPAddressStringLength];
+            char buf[chip::Inet::IPAddress::kMaxStringLength];
             dnsSdInfo->ipAddress[j].ToString(buf);
             ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", j, buf);
         }
@@ -472,7 +472,7 @@ void pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(
 ChipError::StorageType pychip_Resolver_ResolveNode(uint64_t fabricid, chip::NodeId nodeid)
 {
     return Dnssd::Resolver::Instance()
-        .ResolveNodeId(PeerId().SetNodeId(nodeid).SetCompressedFabricId(fabricid), Inet::kIPAddressType_Any)
+        .ResolveNodeId(PeerId().SetNodeId(nodeid).SetCompressedFabricId(fabricid), Inet::IPAddressType::kAny)
         .AsInteger();
 }
 

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -98,7 +98,7 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
         Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
 
         result = Resolver::Instance().ResolveNodeId(chip::PeerId().SetCompressedFabricId(fabricId).SetNodeId(nodeId),
-                                                    chip::Inet::IPAddressType::kIPAddressType_Any);
+                                                    chip::Inet::IPAddressType::kAny);
     });
 
     return result.AsInteger();

--- a/src/controller/tests/TestDevice.cpp
+++ b/src/controller/tests/TestDevice.cpp
@@ -60,15 +60,14 @@ void TestDevice_EstablishSessionDirectly(nlTestSuite * inSuite, void * inContext
 
     systemLayer.Init();
     inetLayer.Init(systemLayer, nullptr);
-    transportMgr.Init(
-        UdpListenParameters(&inetLayer).SetAddressType(Inet::IPAddressType::kIPAddressType_IPv6).SetListenPort(CHIP_PORT)
+    transportMgr.Init(UdpListenParameters(&inetLayer).SetAddressType(Inet::IPAddressType::kIPv6).SetListenPort(CHIP_PORT)
 #if INET_CONFIG_ENABLE_IPV4
-            ,
-        UdpListenParameters(&inetLayer).SetAddressType(Inet::kIPAddressType_IPv4).SetListenPort(CHIP_PORT)
+                          ,
+                      UdpListenParameters(&inetLayer).SetAddressType(Inet::IPAddressType::kIPv4).SetListenPort(CHIP_PORT)
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
-            ,
-        BleListenParameters(&blelayer)
+                          ,
+                      BleListenParameters(&blelayer)
 #endif
     );
     sessionManager.Init(&systemLayer, &transportMgr, &messageCounterManager);

--- a/src/inet/DNSResolver.cpp
+++ b/src/inet/DNSResolver.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR DNSResolver::Cancel()
     // application has called Cancel() we have to make sure to NOT call their mOnComplete function
     // when the request completes.
     //
-    // To ensure the right thing happens, we nullptr the mOnComplete pointer here, which signals the
+    // To ensure the right thing happens, we null out the mOnComplete pointer here, which signals the
     // code in HandleResolveComplete() and LwIPHandleResolveComplete() to not interact with the
     // application's state data (mAddrArray) and to not call the application's callback. This has
     // to happen with the LwIP lock held, since LwIPHandleResolveComplete() runs on LwIP's thread.
@@ -188,7 +188,7 @@ void DNSResolver::HandleResolveComplete()
  *  This method is called by LwIP network stack on success, failure, or timeout
  *  of a DNS request.
  *
- *  @param[in]  name            A pointer to a nullptr-terminated C string
+ *  @param[in]  name            A pointer to a null-terminated C string
  *                              representing the host name that is queried.
  *  @param[in]  ipaddr          A pointer to a list of resolved IP addresses.
  *  @param[in]  callback_arg    A pointer to the arguments that are passed to

--- a/src/inet/DNSResolver.h
+++ b/src/inet/DNSResolver.h
@@ -80,14 +80,14 @@ private:
     friend class AsyncDNSResolverSockets;
 
     /// States of the DNSResolver object with respect to hostname resolution.
-    typedef enum DNSResolverState{
-        kState_Unused   = 0, ///< Used to indicate that the DNSResolver object is not used.
-        kState_Active   = 2, ///< Used to indicate that a DNS resolution is being performed on the DNSResolver object.
-        kState_Complete = 3, ///< Used to indicate that the DNS resolution on the DNSResolver object is complete.
-        kState_Canceled = 4, ///< Used to indicate that the DNS resolution on the DNSResolver has been canceled.
-    } DNSResolverState;
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    enum class State : uint8_t{
+        kUnused   = 0, ///< Used to indicate that the DNSResolver object is not used.
+        kActive   = 2, ///< Used to indicate that a DNS resolution is being performed on the DNSResolver object.
+        kComplete = 3, ///< Used to indicate that the DNS resolution on the DNSResolver object is complete.
+        kCanceled = 4, ///< Used to indicate that the DNS resolution on the DNSResolver has been canceled.
+    };
 #endif // INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     /**
      * @brief   Type of event handling function called when a DNS request completes.
@@ -146,27 +146,27 @@ private:
     /**
      *  A pointer to the callback function when a DNS request is complete.
      */
-    OnResolveCompleteFunct OnComplete;
+    OnResolveCompleteFunct mOnComplete;
 
     /**
      *  A pointer to the DNS table that stores a list of resolved addresses.
      */
-    IPAddress * AddrArray;
+    IPAddress * mAddrArray;
 
     /**
      *  The maximum number of addresses that could be stored in the DNS table.
      */
-    uint8_t MaxAddrs;
+    uint8_t mMaxAddrs;
 
     /**
      *  The actual number of addresses that are stored in the DNS table.
      */
-    uint8_t NumAddrs;
+    uint8_t mNumAddrs;
 
     /**
      * DNS options for the current request.
      */
-    uint8_t DNSOptions;
+    uint8_t mDNSOptions;
 
     CHIP_ERROR ResolveImpl(char * hostNameBuf);
 
@@ -180,13 +180,13 @@ private:
 #if INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
 
     /* Hostname that requires resolution */
-    char asyncHostNameBuf[NL_DNS_HOSTNAME_MAX_LEN + 1]; // DNS limits hostnames to 253 max characters.
+    char mAsyncHostNameBuf[NL_DNS_HOSTNAME_MAX_LEN + 1]; // DNS limits hostnames to 253 max characters.
 
-    CHIP_ERROR asyncDNSResolveResult;
+    CHIP_ERROR mAsyncDNSResolveResult;
     /* The next DNSResolver object in the asynchronous DNS resolution queue. */
-    DNSResolver * pNextAsyncDNSResolver;
+    DNSResolver * mNextAsyncDNSResolver;
 
-    DNSResolverState mState;
+    State mState;
 
     void HandleAsyncResolveComplete();
 

--- a/src/inet/EndPointBasis.cpp
+++ b/src/inet/EndPointBasis.cpp
@@ -35,12 +35,12 @@ namespace Inet {
 void EndPointBasis::InitEndPointBasis(InetLayer & aInetLayer, void * aAppState)
 {
     InitInetLayerBasis(aInetLayer, aAppState);
-    mLwIPEndPointType = LwIPEndPointType::Unknown;
+    mLwIPEndPointType = LwIPEndPointType::kUnknown;
 }
 
 void EndPointBasis::DeferredFree(System::Object::ReleaseDeferralErrorTactic aTactic)
 {
-    if (!CHIP_SYSTEM_CONFIG_USE_SOCKETS || (mVoid != nullptr))
+    if (mVoid != nullptr)
     {
         DeferredRelease(static_cast<System::LayerLwIP *>(Layer().SystemLayer()), aTactic);
     }

--- a/src/inet/EndPointBasis.h
+++ b/src/inet/EndPointBasis.h
@@ -83,11 +83,11 @@ protected:
 
     enum class LwIPEndPointType : uint8_t
     {
-        Unknown = 0,
-        Raw     = 1,
-        UDP     = 2,
-        UCP     = 3,
-        TCP     = 4
+        kUnknown = 0,
+        kRaw     = 1,
+        kUDP     = 2,
+        kUCP     = 3,
+        kTCP     = 4
     } mLwIPEndPointType;
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 };

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -107,7 +107,7 @@ bool IPAddress::FromString(const char * str, IPAddress & output)
         if (inet_pton(AF_INET, str, &ipv4Addr) < 1)
             return false;
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
-        output = FromIPv4(ipv4Addr);
+        output = IPAddress(ipv4Addr);
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -121,7 +121,7 @@ bool IPAddress::FromString(const char * str, IPAddress & output)
         if (inet_pton(AF_INET6, str, &ipv6Addr) < 1)
             return false;
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
-        output = FromIPv6(ipv6Addr);
+        output = IPAddress(ipv6Addr);
     }
 
     return true;

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -23,7 +23,7 @@
  *      related enumerated constants. The CHIP Inet Layer uses objects
  *      of this class to represent Internet protocol addresses of both
  *      IPv4 and IPv6 address families. (IPv4 addresses are stored
- *      internally in the V4COMPAT format, reserved for that purpose.)
+ *      internally as IPv4-Mapped IPv6 addresses.)
  *
  */
 
@@ -70,6 +70,51 @@ IPAddress & IPAddress::operator=(const IPAddress & other)
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
+IPAddress::IPAddress(const ip6_addr_t & ipv6Addr)
+{
+    static_assert(sizeof(*this) == sizeof(Addr), "ip6_addr_t size mismatch");
+    memcpy(Addr, &ipv6Addr, sizeof(ipv6Addr));
+}
+
+#if INET_CONFIG_ENABLE_IPV4
+
+IPAddress::IPAddress(const ip4_addr_t & ipv4Addr)
+{
+    Addr[0] = 0;
+    Addr[1] = 0;
+    Addr[2] = htonl(0xFFFF);
+    Addr[3] = ipv4Addr.addr;
+}
+
+IPAddress::IPAddress(const ip_addr_t & addr)
+{
+    switch (IP_GET_TYPE(&addr))
+    {
+#if INET_CONFIG_ENABLE_IPV4
+    case IPADDR_TYPE_V4:
+        *this = IPAddress(*ip_2_ip4(&addr));
+        break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    case IPADDR_TYPE_V6:
+        *this = IPAddress(*ip_2_ip6(&addr));
+        break;
+
+    default:
+        *this = Any;
+        break;
+    }
+}
+
+ip4_addr_t IPAddress::ToIPv4() const
+{
+    ip4_addr_t ipAddr;
+    memcpy(&ipAddr, &Addr[3], sizeof(ipAddr));
+    return ipAddr;
+}
+
+#endif // INET_CONFIG_ENABLE_IPV4
+
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 ip_addr_t IPAddress::ToLwIPAddr(void) const
 {
@@ -78,43 +123,19 @@ ip_addr_t IPAddress::ToLwIPAddr(void) const
     switch (Type())
     {
 #if INET_CONFIG_ENABLE_IPV4
-    case kIPAddressType_IPv4:
+    case IPAddressType::kIPv4:
         IP_SET_TYPE_VAL(ret, IPADDR_TYPE_V4);
         *ip_2_ip4(&ret) = IPAddress::ToIPv4();
         break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
-    case kIPAddressType_IPv6:
+    case IPAddressType::kIPv6:
         IP_SET_TYPE_VAL(ret, IPADDR_TYPE_V6);
         *ip_2_ip6(&ret) = IPAddress::ToIPv6();
         break;
 
     default:
         ret = *IP_ADDR_ANY;
-        break;
-    }
-
-    return ret;
-}
-
-IPAddress IPAddress::FromLwIPAddr(const ip_addr_t & addr)
-{
-    IPAddress ret;
-
-    switch (IP_GET_TYPE(&addr))
-    {
-#if INET_CONFIG_ENABLE_IPV4
-    case IPADDR_TYPE_V4:
-        ret = IPAddress::FromIPv4(*ip_2_ip4(&addr));
-        break;
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    case IPADDR_TYPE_V6:
-        ret = IPAddress::FromIPv6(*ip_2_ip6(&addr));
-        break;
-
-    default:
-        ret = Any;
         break;
     }
 
@@ -128,12 +149,12 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
     switch (typ)
     {
 #if INET_CONFIG_ENABLE_IPV4
-    case kIPAddressType_IPv4:
+    case IPAddressType::kIPv4:
         ret = IPADDR_TYPE_V4;
         break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
-    case kIPAddressType_IPv6:
+    case IPAddressType::kIPv6:
         ret = IPADDR_TYPE_V6;
         break;
 
@@ -146,25 +167,6 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 }
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
-#if INET_CONFIG_ENABLE_IPV4
-ip4_addr_t IPAddress::ToIPv4() const
-{
-    ip4_addr_t ipAddr;
-    memcpy(&ipAddr, &Addr[3], sizeof(ipAddr));
-    return ipAddr;
-}
-
-IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
-{
-    IPAddress ipAddr;
-    ipAddr.Addr[0] = 0;
-    ipAddr.Addr[1] = 0;
-    ipAddr.Addr[2] = htonl(0xFFFF);
-    ipAddr.Addr[3] = ipv4Addr.addr;
-    return ipAddr;
-}
-#endif // INET_CONFIG_ENABLE_IPV4
-
 ip6_addr_t IPAddress::ToIPv6() const
 {
     ip6_addr_t ipAddr;
@@ -173,17 +175,23 @@ ip6_addr_t IPAddress::ToIPv6() const
     return ipAddr;
 }
 
-IPAddress IPAddress::FromIPv6(const ip6_addr_t & ipv6Addr)
-{
-    IPAddress ipAddr;
-    static_assert(sizeof(ipAddr) == sizeof(Addr), "ip6_addr_t size mismatch");
-    memcpy(ipAddr.Addr, &ipv6Addr, sizeof(ipv6Addr));
-    return ipAddr;
-}
-
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+IPAddress::IPAddress(const struct in_addr & ipv4Addr)
+{
+    Addr[0] = 0;
+    Addr[1] = 0;
+    Addr[2] = htonl(0xFFFF);
+    Addr[3] = ipv4Addr.s_addr;
+}
+
+IPAddress::IPAddress(const struct in6_addr & ipv6Addr)
+{
+    static_assert(sizeof(*this) == sizeof(ipv6Addr), "in6_addr size mismatch");
+    memcpy(Addr, &ipv6Addr, sizeof(ipv6Addr));
+}
 
 #if INET_CONFIG_ENABLE_IPV4
 struct in_addr IPAddress::ToIPv4() const
@@ -191,16 +199,6 @@ struct in_addr IPAddress::ToIPv4() const
     struct in_addr ipv4Addr;
     ipv4Addr.s_addr = Addr[3];
     return ipv4Addr;
-}
-
-IPAddress IPAddress::FromIPv4(const struct in_addr & ipv4Addr)
-{
-    IPAddress ipAddr;
-    ipAddr.Addr[0] = 0;
-    ipAddr.Addr[1] = 0;
-    ipAddr.Addr[2] = htonl(0xFFFF);
-    ipAddr.Addr[3] = ipv4Addr.s_addr;
-    return ipAddr;
 }
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -212,22 +210,14 @@ struct in6_addr IPAddress::ToIPv6() const
     return ipAddr;
 }
 
-IPAddress IPAddress::FromIPv6(const struct in6_addr & ipv6Addr)
-{
-    IPAddress ipAddr;
-    static_assert(sizeof(ipAddr) == sizeof(ipv6Addr), "in6_addr size mismatch");
-    memcpy(ipAddr.Addr, &ipv6Addr, sizeof(ipv6Addr));
-    return ipAddr;
-}
-
-IPAddress IPAddress::FromSockAddr(const struct sockaddr & sockaddr)
+IPAddress IPAddress::FromSockAddr(const SockAddr & sockaddr)
 {
 #if INET_CONFIG_ENABLE_IPV4
-    if (sockaddr.sa_family == AF_INET)
-        return FromIPv4(reinterpret_cast<const sockaddr_in *>(&sockaddr)->sin_addr);
+    if (sockaddr.any.sa_family == AF_INET)
+        return FromSockAddr(sockaddr.in);
 #endif // INET_CONFIG_ENABLE_IPV4
-    if (sockaddr.sa_family == AF_INET6)
-        return FromIPv6(reinterpret_cast<const sockaddr_in6 *>(&sockaddr)->sin6_addr);
+    if (sockaddr.any.sa_family == AF_INET6)
+        return FromSockAddr(sockaddr.in6);
     return Any;
 }
 
@@ -317,12 +307,12 @@ uint64_t IPAddress::GlobalId() const
 IPAddressType IPAddress::Type() const
 {
     if (Addr[0] == 0 && Addr[1] == 0 && Addr[2] == 0 && Addr[3] == 0)
-        return kIPAddressType_Any;
+        return IPAddressType::kAny;
 #if INET_CONFIG_ENABLE_IPV4
     if (Addr[0] == 0 && Addr[1] == 0 && Addr[2] == htonl(0xFFFF))
-        return kIPAddressType_IPv4;
+        return IPAddressType::kIPv4;
 #endif // INET_CONFIG_ENABLE_IPV4
-    return kIPAddressType_IPv6;
+    return IPAddressType::kIPv6;
 }
 
 // Encode IPAddress to buffer in network byte order. Buffer must have at least 128 bits of available space.
@@ -378,10 +368,11 @@ IPAddress IPAddress::MakeLLA(uint64_t interfaceId)
     return addr;
 }
 
-IPAddress IPAddress::MakeIPv6Multicast(uint8_t aFlags, uint8_t aScope,
+IPAddress IPAddress::MakeIPv6Multicast(IPv6MulticastFlags aFlags, uint8_t aScope,
                                        const uint8_t aGroupId[NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES])
 {
-    const uint32_t lFlagsAndScope = (((uint32_t(aFlags) & 0xF) << 20) | ((uint32_t(aScope) & 0xF) << 16));
+    const uint32_t lFlagsAndScope =
+        (((static_cast<uint32_t>(aFlags.Raw()) & 0xF) << 20) | ((static_cast<uint32_t>(aScope) & 0xF) << 16));
     IPAddress addr;
 
     addr.Addr[0] = htonl((0xFF000000U | lFlagsAndScope) | (uint32_t(aGroupId[0]) << 8) | (uint32_t(aGroupId[1]) << 0));
@@ -395,7 +386,7 @@ IPAddress IPAddress::MakeIPv6Multicast(uint8_t aFlags, uint8_t aScope,
     return addr;
 }
 
-IPAddress IPAddress::MakeIPv6Multicast(uint8_t aFlags, uint8_t aScope, uint32_t aGroupId)
+IPAddress IPAddress::MakeIPv6Multicast(IPv6MulticastFlags aFlags, uint8_t aScope, uint32_t aGroupId)
 {
     const uint8_t lGroupId[NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES] = { 0,
                                                                       0,
@@ -417,23 +408,22 @@ IPAddress IPAddress::MakeIPv6Multicast(uint8_t aFlags, uint8_t aScope, uint32_t 
 
 IPAddress IPAddress::MakeIPv6WellKnownMulticast(uint8_t aScope, uint32_t aGroupId)
 {
-    const uint8_t lFlags = 0;
+    constexpr IPv6MulticastFlags lFlags;
 
     return (MakeIPv6Multicast(lFlags, aScope, aGroupId));
 }
 
-IPAddress IPAddress::MakeIPv6TransientMulticast(uint8_t aFlags, uint8_t aScope,
+IPAddress IPAddress::MakeIPv6TransientMulticast(IPv6MulticastFlags aFlags, uint8_t aScope,
                                                 const uint8_t aGroupId[NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES])
 {
-    const uint8_t lFlags = (aFlags | kIPv6MulticastFlag_Transient);
-
-    return (MakeIPv6Multicast(lFlags, aScope, aGroupId));
+    aFlags.Set(IPv6MulticastFlag::kTransient);
+    return (MakeIPv6Multicast(aFlags, aScope, aGroupId));
 }
 
 IPAddress IPAddress::MakeIPv6PrefixMulticast(uint8_t aScope, uint8_t aPrefixLength, const uint64_t & aPrefix, uint32_t aGroupId)
 {
     const uint8_t lReserved                                       = 0;
-    const uint8_t lFlags                                          = kIPv6MulticastFlag_Prefix;
+    const IPv6MulticastFlags lFlags                               = IPv6MulticastFlag::kPrefix;
     const uint8_t lGroupId[NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES] = { lReserved,
                                                                       aPrefixLength,
                                                                       static_cast<uint8_t>((aPrefix & 0xFF00000000000000ULL) >> 56),

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -179,6 +179,7 @@ ip6_addr_t IPAddress::ToIPv6() const
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
+#if INET_CONFIG_ENABLE_IPV4
 IPAddress::IPAddress(const struct in_addr & ipv4Addr)
 {
     Addr[0] = 0;
@@ -186,6 +187,7 @@ IPAddress::IPAddress(const struct in_addr & ipv4Addr)
     Addr[2] = htonl(0xFFFF);
     Addr[3] = ipv4Addr.s_addr;
 }
+#endif // INET_CONFIG_ENABLE_IPV4
 
 IPAddress::IPAddress(const struct in6_addr & ipv6Addr)
 {

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -23,14 +23,17 @@
  *      related enumerated constants. The CHIP Inet Layer uses objects
  *      of this class to represent Internet protocol addresses of both
  *      IPv4 and IPv6 address families. (IPv4 addresses are stored
- *      internally in the V4COMPAT format, reserved for that purpose.)
+ *      internally as IPv4-Mapped IPv6 addresses.)
  */
 
 #pragma once
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+#include <type_traits>
 
+#include <lib/support/BitFlags.h>
 #include <lib/support/DLLUtil.h>
 
 #include <inet/InetConfig.h>
@@ -80,56 +83,40 @@ namespace chip {
 namespace Inet {
 
 /**
- * @brief   Internet protocol address family
- *
- * @details
- *  Values of the \c IPAddressType type are returned by the
- *  <tt>IPAddress::Type()</tt> method. They indicate the address family
- *  entailed by the use of the address.
+ * Internet protocol address family
  */
-typedef enum
+enum class IPAddressType : uint8_t
 {
-    /** Not used. */
-    kIPAddressType_Unknown = 0,
-
-#if INET_CONFIG_ENABLE_IPV4
-    /** Internet protocol version 4. */
-    kIPAddressType_IPv4 = 1,
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    /** Internet protocol version 6. */
-    kIPAddressType_IPv6 = 2,
-
-    /** The unspecified internet address (independent of protocol version) */
-    kIPAddressType_Any = 3
-} IPAddressType;
+    kUnknown = 0, ///< Not used.
+    kIPv4    = 1, ///< Internet protocol version 4.
+    kIPv6    = 2, ///< Internet protocol version 6.
+    kAny     = 3  ///< The unspecified internet address (independent of protocol version).
+};
 
 /**
- * @brief   Internet protocol v6 multicast flags
+ * Internet protocol v6 multicast flags
  *
- * @details
- *  Values of the \c IPv6MulticastFlag type are used to call the
- *  <tt>IPAddress::MakeIPv6Multicast()</tt> methods. They indicate the
- *  type of IPv6 multicast address to create. These numbers are
- *  registered by IETF with IANA.
+ *  Values of the \c IPv6MulticastFlag type are used to call the <tt>IPAddress::MakeIPv6Multicast()</tt> methods.
+ *  They indicate the type of IPv6 multicast address to create. These numbers are registered by IETF with IANA.
  */
-typedef enum
+enum class IPv6MulticastFlag : uint8_t
 {
     /** The multicast address is (1) transient (i.e., dynamically-assigned) rather than (0) well-known (i.e, IANA-assigned). */
-    kIPv6MulticastFlag_Transient = 0x01,
+    kTransient = 0x01,
 
     /** The multicast address is (1) based on a network prefix. */
-    kIPv6MulticastFlag_Prefix = 0x02
-} IPv6MulticastFlag;
+    kPrefix = 0x02
+};
+using IPv6MulticastFlags = BitFlags<IPv6MulticastFlag>;
 
-/**
- * @brief   Maximum length of the string representation of an IP address.
- */
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-constexpr uint16_t kMaxIPAddressStringLength = IP6ADDR_STRLEN_MAX;
-#else
-constexpr uint16_t kMaxIPAddressStringLength = INET6_ADDRSTRLEN;
-#endif
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+union SockAddr
+{
+    sockaddr any;
+    sockaddr_in in;
+    sockaddr_in6 in6;
+};
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 /**
  * @brief   Internet protocol address
@@ -141,21 +128,43 @@ constexpr uint16_t kMaxIPAddressStringLength = INET6_ADDRSTRLEN;
 class DLL_EXPORT IPAddress
 {
 public:
-    IPAddress() = default;
+/**
+ * Maximum length of the string representation of an IP address.
+ */
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    static constexpr uint16_t kMaxStringLength = IP6ADDR_STRLEN_MAX;
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+    static constexpr uint16_t kMaxStringLength = INET6_ADDRSTRLEN;
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-    /**
-     *  Copy constructor for the IPAddress class.
-     *
-     */
+public:
+    IPAddress()                        = default;
     IPAddress(const IPAddress & other) = default;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    explicit IPAddress(const ip6_addr_t & ipv6Addr);
+#if INET_CONFIG_ENABLE_IPV4
+    explicit IPAddress(const ip4_addr_t & ipv4Addr);
+    explicit IPAddress(const ip_addr_t & addr);
+#endif // INET_CONFIG_ENABLE_IPV4
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+    explicit IPAddress(const struct in6_addr & ipv6Addr);
+#if INET_CONFIG_ENABLE_IPV4
+    explicit IPAddress(const struct in_addr & ipv4Addr);
+#endif // INET_CONFIG_ENABLE_IPV4
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     /**
      * @brief   Opaque word array to contain IP addresses (independent of protocol version)
      *
      * @details
      *  IPv6 address use all 128-bits split into four 32-bit network byte
-     *  ordered unsigned integers. IPv4 addresses are V4COMPAT, i.e. the
-     *  first three words are zero, and the fourth word contains the IPv4
+     *  ordered unsigned integers. IPv4 addresses are IPv4-Mapped IPv6 addresses,
+     *  i.e. the first two words are zero, the third word contains 0xFFFF in
+     *  network byte order, and the fourth word contains the IPv4
      *  address in network byte order.
      */
     uint32_t Addr[4];
@@ -283,9 +292,9 @@ public:
      *  Use this method to return an value of the enumerated type \c
      *  IPAddressType to indicate the type of the IP address.
      *
-     * @retval  kIPAddressType_IPv4 The address is IPv4.
-     * @retval  kIPAddressType_IPv6 The address is IPv6.
-     * @retval  kIPAddressType_Any  The address is the unspecified address.
+     * @retval  IPAddressType::kIPv4 The address is IPv4.
+     * @retval  IPAddressType::kIPv6 The address is IPv6.
+     * @retval  IPAddressType::kAny  The address is the unspecified address.
      */
     IPAddressType Type() const;
 
@@ -388,8 +397,8 @@ public:
      * @details
      *  Use <tt>WriteAddress(uint8_t *&p)</tt> to encode the IP address in
      *  the binary format defined by RFC 4291 for IPv6 addresses.  IPv4
-     *  addresses are encoded according to section 2.5.5.1 "IPv4-Compatible
-     *  IPv6 Address" (V4COMPAT).
+     *  addresses are encoded according to section 2.5.5.2 "IPv4-Mapped
+     *  IPv6 Address".
      */
     void WriteAddress(uint8_t *& p) const;
 
@@ -475,42 +484,6 @@ public:
      *      either unspecified or not an IPv4 address.
      */
 
-    /**
-     * @fn      static IPAddress FromIPv4(const struct in_addr & addr)
-     *
-     * @brief   Inject the IPv4 address from a platform data structure.
-     *
-     * @details
-     *  Use <tt>FromIPv4(const ip4_addr_t &addr)</tt> to inject \c addr as an
-     *  IPv4 address.
-     *
-     *  The argument \c addr is either of type <tt>const struct in_addr&</tt>
-     *  (on POSIX) or <tt>const ip4_addr_t&</tt> (on LwIP).
-     *
-     * @return  The constructed IP address.
-     */
-    /**
-     * @overload static IPAddress FromIPv4(const ip4_addr_t &addr)
-     */
-
-    /**
-     * @fn      static IPAddress FromIPv6(const struct in6_addr& addr)
-     *
-     * @brief   Inject the IPv6 address from a platform data structure.
-     *
-     * @details
-     *  Use <tt>FromIPv6(const ip6_addr_t &addr)</tt> to inject \c addr as an
-     *  IPv6 address.
-     *
-     *  The argument \c addr is either of type <tt>const struct in6_addr&</tt>
-     *  (on POSIX) or <tt>const ip6_addr_t&</tt> (on LwIP).
-     *
-     * @return  The constructed IP address.
-     */
-    /**
-     * @overload     static IPAddress FromIPv6(const ip6_addr_t &addr)
-     */
-
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
@@ -528,21 +501,6 @@ public:
     ip_addr_t ToLwIPAddr(void) const;
 
     /**
-     * @fn      static IPAddress FromLwIPAddr(const ip_addr_t& addr)
-     *
-     * @brief   Inject the IP address from an LwIP ip_addr_t structure.
-     *
-     * @details
-     *  Use <tt>FromLwIPAddr(const ip_addr_t &addr)</tt> to inject \c addr as an
-     *  Inet layer IP address.
-     *
-     *  The argument \c addr is of type <tt>const ip_addr_t&</tt> (on LwIP).
-     *
-     * @return  The constructed IP address.
-     */
-    static IPAddress FromLwIPAddr(const ip_addr_t & addr);
-
-    /**
      * @brief   Convert the INET layer address type to its underlying LwIP type.
      *
      * @details
@@ -553,11 +511,9 @@ public:
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
     ip6_addr_t ToIPv6(void) const;
-    static IPAddress FromIPv6(const ip6_addr_t & addr);
 
 #if INET_CONFIG_ENABLE_IPV4
     ip4_addr_t ToIPv4(void) const;
-    static IPAddress FromIPv4(const ip4_addr_t & addr);
 #endif // INET_CONFIG_ENABLE_IPV4
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -565,23 +521,18 @@ public:
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     struct in6_addr ToIPv6() const;
-    static IPAddress FromIPv6(const struct in6_addr & addr);
 
 #if INET_CONFIG_ENABLE_IPV4
     struct in_addr ToIPv4() const;
-    static IPAddress FromIPv4(const struct in_addr & addr);
 #endif // INET_CONFIG_ENABLE_IPV4
 
     /**
-     * @brief   Inject the IPv6 address from a POSIX <tt>struct sockaddr&</tt>
-     *
-     * @details
-     *  Use <tt>FromSockAddr(const struct sockaddr& sockaddr)</tt> to inject
-     *  <tt>sockaddr.sa_addr</tt> as an IPv6 address.
-     *
-     * @return  The constructed IP address.
+     * Get the IP address from a SockAddr.
      */
-    static IPAddress FromSockAddr(const struct sockaddr & sockaddr);
+    static IPAddress FromSockAddr(const SockAddr & sockaddr);
+    static IPAddress FromSockAddr(const sockaddr & sockaddr) { return FromSockAddr(reinterpret_cast<const SockAddr &>(sockaddr)); }
+    static IPAddress FromSockAddr(const sockaddr_in & sockaddr) { return IPAddress(sockaddr.sin_addr); }
+    static IPAddress FromSockAddr(const sockaddr_in6 & sockaddr) { return IPAddress(sockaddr.sin6_addr); }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_USE_NETWORK_FRAMEWORK
 
@@ -620,7 +571,7 @@ public:
      *
      * @return  The constructed IP address.
      */
-    static IPAddress MakeIPv6Multicast(uint8_t aFlags, uint8_t aScope,
+    static IPAddress MakeIPv6Multicast(IPv6MulticastFlags aFlags, uint8_t aScope,
                                        const uint8_t aGroupId[NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES]);
 
     /**
@@ -634,7 +585,7 @@ public:
      *
      * @return  The constructed IP address.
      */
-    static IPAddress MakeIPv6Multicast(uint8_t aFlags, uint8_t aScope, uint32_t aGroupId);
+    static IPAddress MakeIPv6Multicast(IPv6MulticastFlags aFlags, uint8_t aScope, uint32_t aGroupId);
 
     /**
      * @brief   Construct a well-known IPv6 multicast address from its parts.
@@ -659,7 +610,7 @@ public:
      *
      * @return  The constructed IP address.
      */
-    static IPAddress MakeIPv6TransientMulticast(uint8_t aFlags, uint8_t aScope,
+    static IPAddress MakeIPv6TransientMulticast(IPv6MulticastFlags aFlags, uint8_t aScope,
                                                 const uint8_t aGroupId[NL_INET_IPV6_MCAST_GROUP_LEN_IN_BYTES]);
 
     /**

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -531,8 +531,10 @@ public:
      */
     static IPAddress FromSockAddr(const SockAddr & sockaddr);
     static IPAddress FromSockAddr(const sockaddr & sockaddr) { return FromSockAddr(reinterpret_cast<const SockAddr &>(sockaddr)); }
-    static IPAddress FromSockAddr(const sockaddr_in & sockaddr) { return IPAddress(sockaddr.sin_addr); }
     static IPAddress FromSockAddr(const sockaddr_in6 & sockaddr) { return IPAddress(sockaddr.sin6_addr); }
+#if INET_CONFIG_ENABLE_IPV4
+    static IPAddress FromSockAddr(const sockaddr_in & sockaddr) { return IPAddress(sockaddr.sin_addr); }
+#endif // INET_CONFIG_ENABLE_IPV4
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_USE_NETWORK_FRAMEWORK
 

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -128,9 +128,9 @@ union SockAddr
 class DLL_EXPORT IPAddress
 {
 public:
-/**
- * Maximum length of the string representation of an IP address.
- */
+    /**
+     * Maximum length of the string representation of an IP address, including a terminating NUL.
+     */
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     static constexpr uint16_t kMaxStringLength = IP6ADDR_STRLEN_MAX;
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -52,26 +52,7 @@ class IPPacketInfo;
  */
 class DLL_EXPORT IPEndPointBasis : public EndPointBasis
 {
-    friend class InetLayer;
-
 public:
-    /**
-     * @brief   Basic dynamic state of the underlying endpoint.
-     *
-     * @details
-     *  Objects are initialized in the "ready" state, proceed to the "bound"
-     *  state after binding to a local interface address, then proceed to the
-     *  "listening" state when they have continuations registered for handling
-     *  events for reception of ICMP messages.
-     */
-    enum
-    {
-        kState_Ready     = 0, /**< Endpoint initialized, but not open. */
-        kState_Bound     = 1, /**< Endpoint bound, but not listening. */
-        kState_Listening = 2, /**< Endpoint receiving datagrams. */
-        kState_Closed    = 3  /**< Endpoint closed, ready for release. */
-    } mState;
-
     /**
      * @brief   Type of message text reception event handling function.
      *
@@ -134,6 +115,24 @@ public:
     CHIP_ERROR LeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress);
 
 protected:
+    friend class InetLayer;
+
+    /**
+     * Basic dynamic state of the underlying endpoint.
+     *
+     *  Objects are initialized in the "ready" state, proceed to the "bound"
+     *  state after binding to a local interface address, then proceed to the
+     *  "listening" state when they have continuations registered for handling
+     *  events for reception of ICMP messages.
+     */
+    enum class State : uint8_t
+    {
+        kReady     = 0, /**< Endpoint initialized, but not open. */
+        kBound     = 1, /**< Endpoint bound, but not listening. */
+        kListening = 2, /**< Endpoint receiving datagrams. */
+        kClosed    = 3  /**< Endpoint closed, ready for release. */
+    } mState;
+
     void Init(InetLayer * aInetLayer);
 
     /** The endpoint's message reception event handling function delegate. */
@@ -152,12 +151,36 @@ private:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 public:
     static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
-    static CHIP_ERROR PostPacketBufferEvent(chip::System::LayerLwIP * aLayer, System::Object & aTarget,
-                                            System::EventType aEventType, System::PacketBufferHandle && aBuffer);
 
 protected:
     void HandleDataReceived(chip::System::PacketBufferHandle && aBuffer);
 
+    /**
+     *  @brief Get LwIP IP layer source and destination addressing information.
+     *
+     *  @param[in]   aBuffer       the packet buffer containing the IP message
+     *
+     *  @returns  a pointer to the address information on success; otherwise,
+     *            nullptr if there is insufficient space in the packet for
+     *            the address information.
+     *
+     *  @details
+     *     When using LwIP information about the packet is 'hidden' in the
+     *     reserved space before the start of the data in the packet
+     *     buffer. This is necessary because the system layer events only
+     *     have two arguments, which in this case are used to convey the
+     *     pointer to the end point and the pointer to the buffer.
+     *
+     *     In most cases this trick of storing information before the data
+     *     works because the first buffer in an LwIP IP message contains
+     *     the space that was used for the Ethernet/IP/UDP headers. However,
+     *     given the current size of the IPPacketInfo structure (40 bytes),
+     *     it is possible for there to not be enough room to store the
+     *     structure along with the payload in a single packet buffer. In
+     *     practice, this should only happen for extremely large IPv4
+     *     packets that arrive without an Ethernet header.
+     *
+     */
     static IPPacketInfo * GetPacketInfo(const chip::System::PacketBufferHandle & aBuffer);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
@@ -167,7 +190,7 @@ protected:
 
     CHIP_ERROR Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort, InterfaceId aInterfaceId);
     CHIP_ERROR BindInterface(IPAddressType aAddressType, InterfaceId aInterfaceId);
-    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags);
+    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer);
     CHIP_ERROR GetSocket(IPAddressType aAddressType, int aType, int aProtocol);
     void HandlePendingIO(uint16_t aPort);
 
@@ -181,7 +204,6 @@ private:
     static MulticastGroupHandler sJoinMulticastGroupHandler;
     static MulticastGroupHandler sLeaveMulticastGroupHandler;
 #endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
@@ -196,7 +218,7 @@ protected:
 
     CHIP_ERROR Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort, const nw_parameters_t & aParameters);
     CHIP_ERROR ConfigureProtocol(IPAddressType aAddressType, const nw_parameters_t & aParameters);
-    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags);
+    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer);
     CHIP_ERROR StartListener();
     CHIP_ERROR GetConnection(const IPPacketInfo * aPktInfo);
     CHIP_ERROR GetEndPoint(nw_endpoint_t & aEndpoint, const IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort);

--- a/src/inet/IPPrefix.h
+++ b/src/inet/IPPrefix.h
@@ -62,14 +62,14 @@ public:
      * @details
      *  Note well: this field is public, and it is an invariant of this class
      *  that <tt>Length <= 32</tt> where the type of \c IPAddr is
-     *  \c kIPAddressType_IPv4 and <tt>Length <= 128</tt> where the type of
-     *  \c IPAddr is \c kIPAddressType_IPv6.
+     *  \c IPAddressType::kIPv4 and <tt>Length <= 128</tt> where the type of
+     *  \c IPAddr is \c IPAddressType::kIPv6.
      */
     uint8_t Length;
 
     /**
      * A distinguished object where the type of \c IPAddr is
-     * \c kIPAddressType_Any and <tt>Length == 0</tt>.
+     * \c IPAddressType::kAny and <tt>Length == 0</tt>.
      */
     static IPPrefix Zero;
 
@@ -78,7 +78,7 @@ public:
      *
      * @details
      *  Note well: a prefix is not equivalent to \c Zero if the type of
-     *  \c IPAddr is not \c kIPAddressType_Any.
+     *  \c IPAddr is not \c IPAddressType::kAny.
      *
      * @return  \c true if equivalent to \c Zero, else \c false.
      */

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -877,7 +877,7 @@ IPAddress InterfaceAddressIterator::GetAddress()
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-        return IPAddress::FromIPv6(mIpv6->unicast[mCurAddrIndex].address.in6_addr);
+        return IPAddress(mIpv6->unicast[mCurAddrIndex].address.in6_addr);
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -885,12 +885,12 @@ IPAddress InterfaceAddressIterator::GetAddress()
 
         if (mCurAddrIndex < LWIP_IPV6_NUM_ADDRESSES)
         {
-            return IPAddress::FromIPv6(*netif_ip6_addr(curIntf, mCurAddrIndex));
+            return IPAddress(*netif_ip6_addr(curIntf, mCurAddrIndex));
         }
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
         else
         {
-            return IPAddress::FromIPv4(*netif_ip4_addr(curIntf));
+            return IPAddress(*netif_ip4_addr(curIntf));
         }
 #endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -241,7 +241,7 @@ void InetLayer::DroppableEventDequeued(void)
 CHIP_ERROR InetLayer::Init(chip::System::Layer & aSystemLayer, void * aContext)
 {
     Inet::RegisterLayerErrorFormatter();
-    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitializing(), CHIP_ERROR_INCORRECT_STATE);
 
     // Platform-specific initialization may elect to set this data
     // member. Ensure it is set to a sane default value before
@@ -258,7 +258,7 @@ CHIP_ERROR InetLayer::Init(chip::System::Layer & aSystemLayer, void * aContext)
     static_cast<System::LayerLwIP *>(mSystemLayer)->AddEventHandlerDelegate(sInetEventHandlerDelegate);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    mLayerState.Initialized();
+    mLayerState.SetInitialized();
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && INET_CONFIG_ENABLE_DNS_RESOLVER && INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
     ReturnErrorOnFailure(mAsyncDNSResolver.Init(this));
@@ -277,7 +277,7 @@ CHIP_ERROR InetLayer::Init(chip::System::Layer & aSystemLayer, void * aContext)
  */
 CHIP_ERROR InetLayer::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -320,7 +320,7 @@ CHIP_ERROR InetLayer::Shutdown()
     });
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
 
-    mLayerState.Shutdown();
+    mLayerState.SetShutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return err;
 }

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -81,6 +81,7 @@
 #include <system/SystemStats.h>
 
 #include <lib/support/DLLUtil.h>
+#include <lib/support/ObjectLifeCycle.h>
 
 #if INET_CONFIG_MAX_DROPPABLE_EVENTS
 
@@ -143,16 +144,6 @@ class DLL_EXPORT InetLayer
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
 
 public:
-    /**
-     *  The current state of the InetLayer object.
-     *
-     */
-    volatile enum {
-        kState_NotInitialized     = 0, /**< Not initialized state. */
-        kState_Initialized        = 1, /**< Initialized state. */
-        kState_ShutdownInProgress = 2, /**< State where Shutdown has been triggered. */
-    } State;                           /**< [READ-ONLY] Current state. */
-
     InetLayer();
 
     CHIP_ERROR Init(chip::System::Layer & aSystemLayer, void * aContext);
@@ -257,6 +248,7 @@ public:
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL > 0
 
 private:
+    ObjectLifeCycle mLayerState;
     void * mContext;
     void * mPlatformData;
     chip::System::Layer * mSystemLayer;

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -48,6 +48,7 @@ class TCPTest;
 namespace Inet {
 
 class InetLayer;
+class TCPTest;
 
 /**
  * @brief   Objects of this class represent TCP transport endpoints.
@@ -61,32 +62,9 @@ class DLL_EXPORT TCPEndPoint : public EndPointBasis
 {
     friend class InetLayer;
     friend class ::chip::Transport::TCPTest;
+    friend class TCPTest;
 
 public:
-    /** Control switch indicating whether the application is receiving data. */
-    bool ReceiveEnabled;
-
-    /**
-     * @brief   Basic dynamic state of the underlying endpoint.
-     *
-     * @details
-     *  Objects are initialized in the "ready" state, proceed to subsequent
-     *  states corresponding to a simplification of the states of the TCP
-     *  transport state machine.
-     */
-    enum
-    {
-        kState_Ready           = 0, /**< Endpoint initialized, but not bound. */
-        kState_Bound           = 1, /**< Endpoint bound, but not listening. */
-        kState_Listening       = 2, /**< Endpoint receiving connections. */
-        kState_Connecting      = 3, /**< Endpoint attempting to connect. */
-        kState_Connected       = 4, /**< Endpoint connected, ready for tx/rx. */
-        kState_SendShutdown    = 5, /**< Endpoint initiated its half-close. */
-        kState_ReceiveShutdown = 6, /**< Endpoint responded to half-close. */
-        kState_Closing         = 7, /**< Endpoint closing bidirectionally. */
-        kState_Closed          = 8  /**< Endpoint closed, ready for release. */
-    } State;
-
     TCPEndPoint() = default;
 
     /**
@@ -105,7 +83,7 @@ public:
      *      \c addrType does not match \c IPVer.
      *
      * @retval  INET_ERROR_WRONG_ADDRESS_TYPE
-     *      \c addrType is \c kIPAddressType_Any, or the type of \c addr is not
+     *      \c addrType is \c IPAddressType::kAny, or the type of \c addr is not
      *      equal to \c addrType.
      *
      * @retval  other                   another system or platform error
@@ -127,8 +105,8 @@ public:
      * @retval  CHIP_ERROR_INCORRECT_STATE  endpoint is already listening.
      *
      * @details
-     *  If \c State is already \c kState_Listening, then no operation is
-     *  performed, otherwise the \c State is set to \c kState_Listening and
+     *  If \c mState is already \c State::kListening, then no operation is
+     *  performed, otherwise the \c mState is set to \c State::kListening and
      *  the endpoint is prepared to received TCP messages, according to the
      *  semantics of the platform.
      *
@@ -175,7 +153,7 @@ public:
      * @retval  CHIP_ERROR_CONNECTION_ABORTED   TCP connection no longer open.
      *
      * @details
-     *  Do not use \c NULL pointer values for either argument.
+     *  Do not use \c nullptr pointer values for either argument.
      */
     CHIP_ERROR GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const;
 
@@ -190,9 +168,9 @@ public:
      * @retval  CHIP_ERROR_CONNECTION_ABORTED   TCP connection no longer open.
      *
      * @details
-     *  Do not use \c NULL pointer values for either argument.
+     *  Do not use \c nullptr pointer values for either argument.
      */
-    CHIP_ERROR GetLocalInfo(IPAddress * retAddr, uint16_t * retPort);
+    CHIP_ERROR GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const;
 
     /**
      * @brief   Extract the interface id of the TCP endpoint.
@@ -217,32 +195,27 @@ public:
     CHIP_ERROR Send(chip::System::PacketBufferHandle && data, bool push = true);
 
     /**
-     * @brief   Disable reception.
+     * Disable reception.
      *
-     * @details
      *  Disable all event handlers. Data sent to an endpoint that disables
      *  reception will be acknowledged until the receive window is exhausted.
      */
-    void DisableReceive() { ReceiveEnabled = false; }
+    void DisableReceive() { mReceiveEnabled = false; }
 
     /**
-     * @brief   Enable reception.
+     * Enable reception.
      *
-     * @details
      *  Enable all event handlers. Data sent to an endpoint that disables
      *  reception will be acknowledged until the receive window is exhausted.
      */
     void EnableReceive()
     {
-        ReceiveEnabled = true;
+        mReceiveEnabled = true;
         DriveReceiving();
     }
 
     /**
-     *  @brief EnableNoDelay
-     *
-     *    Switch off nagle buffering algorithm in TCP by setting the
-     *    TCP_NODELAY socket options.
+     * Switch off Nagle buffering algorithm.
      */
     CHIP_ERROR EnableNoDelay();
 
@@ -380,7 +353,7 @@ public:
     /**
      * @brief   Extract whether TCP connection is established.
      */
-    bool IsConnected() const { return IsConnected(State); }
+    bool IsConnected() const { return IsConnected(mState); }
 
     /**
      * Set timeout for Connect to succeed or return an error.
@@ -600,6 +573,29 @@ public:
 private:
     static chip::System::ObjectPool<TCPEndPoint, INET_CONFIG_NUM_TCP_ENDPOINTS> sPool;
 
+    /**
+     * Basic dynamic state of the underlying endpoint.
+     *
+     *  Objects are initialized in the "ready" state, proceed to subsequent
+     *  states corresponding to a simplification of the states of the TCP
+     *  transport state machine.
+     */
+    enum class State : uint8_t
+    {
+        kReady           = 0, /**< Endpoint initialized, but not bound. */
+        kBound           = 1, /**< Endpoint bound, but not listening. */
+        kListening       = 2, /**< Endpoint receiving connections. */
+        kConnecting      = 3, /**< Endpoint attempting to connect. */
+        kConnected       = 4, /**< Endpoint connected, ready for tx/rx. */
+        kSendShutdown    = 5, /**< Endpoint initiated its half-close. */
+        kReceiveShutdown = 6, /**< Endpoint responded to half-close. */
+        kClosing         = 7, /**< Endpoint closing bidirectionally. */
+        kClosed          = 8  /**< Endpoint closed, ready for release. */
+    } mState;
+
+    /** Control switch indicating whether the application is receiving data. */
+    bool mReceiveEnabled;
+
     chip::System::PacketBufferHandle mRcvQueue;
     chip::System::PacketBufferHandle mSendQueue;
 #if INET_TCP_IDLE_CHECK_INTERVAL > 0
@@ -658,7 +654,7 @@ private:
 
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
-    TCPEndPoint(const TCPEndPoint &); // not defined
+    TCPEndPoint(const TCPEndPoint &) = delete;
 
     void Init(InetLayer * inetLayer);
     CHIP_ERROR DriveSending();
@@ -666,7 +662,7 @@ private:
     void HandleConnectComplete(CHIP_ERROR err);
     void HandleAcceptError(CHIP_ERROR err);
     CHIP_ERROR DoClose(CHIP_ERROR err, bool suppressCallback);
-    static bool IsConnected(int state);
+    static bool IsConnected(State state);
 
     static void TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState);
 
@@ -682,7 +678,7 @@ private:
     void InitImpl();
     CHIP_ERROR DriveSendingImpl();
     void HandleConnectCompleteImpl();
-    void DoCloseImpl(CHIP_ERROR err, int oldState);
+    void DoCloseImpl(CHIP_ERROR err, State oldState);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     struct BufferOffset
@@ -717,6 +713,7 @@ private:
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    CHIP_ERROR GetSocketInfo(int getname(int, sockaddr *, socklen_t *), IPAddress * retAddr, uint16_t * retPort) const;
     CHIP_ERROR GetSocket(IPAddressType addrType);
     void HandlePendingIO(System::SocketEvents events);
     void ReceiveData();

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -56,10 +56,8 @@
 #include <unistd.h>
 
 // SOCK_CLOEXEC not defined on all platforms, e.g. iOS/macOS:
-#ifdef SOCK_CLOEXEC
-#define SOCK_FLAGS SOCK_CLOEXEC
-#else
-#define SOCK_FLAGS 0
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
 #endif
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS
@@ -79,6 +77,8 @@ chip::System::ObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> UDPEndPoint
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
+namespace {
+
 /*
  * Note that for LwIP InterfaceId is already defined to be 'struct
  * netif'; consequently, some of the checking performed here could
@@ -88,7 +88,7 @@ chip::System::ObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> UDPEndPoint
  *   udp_bind_netif(aUDP, intfId);
  *
  */
-static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId)
+CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId)
 {
     CHIP_ERROR res = CHIP_NO_ERROR;
 
@@ -121,6 +121,8 @@ static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId)
     return res;
 }
 
+} // anonymous namespace
+
 CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
 {
     // Lock LwIP stack
@@ -140,13 +142,13 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
 #endif // INET_CONFIG_ENABLE_IPV4
         res = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipAddr, port));
 #else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-        if (addrType == kIPAddressType_IPv6)
+        if (addrType == IPAddressType::kIPv6)
         {
             ip6_addr_t ipv6Addr = addr.ToIPv6();
             res                 = chip::System::MapErrorLwIP(udp_bind_ip6(mUDP, &ipv6Addr, port));
         }
 #if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == kIPAddressType_IPv4)
+        else if (addrType == IPAddressType::kIPv4)
         {
             ip4_addr_t ipv4Addr = addr.ToIPv4();
             res                 = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipv4Addr, port));
@@ -222,9 +224,8 @@ CHIP_ERROR UDPEndPoint::ListenImpl()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
-    CHIP_ERROR res             = CHIP_NO_ERROR;
     const IPAddress & destAddr = pktInfo->DestAddress;
 
     if (!msg.HasSoleOwnership())
@@ -242,8 +243,12 @@ CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::Packet
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB based on the destination address.
-    res = GetPCB(destAddr.Type());
-    ReturnErrorOnFailure(res);
+    CHIP_ERROR res = GetPCB(destAddr.Type());
+    if (res != CHIP_NO_ERROR)
+    {
+        UNLOCK_TCPIP_CORE();
+        return res;
+    }
 
     // Send the message to the specified address/port.
     // If an outbound interface has been specified, call a specific version of the UDP sendto()
@@ -251,91 +256,89 @@ CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::Packet
     // If a source address has been specified, temporarily override the local_ip of the PCB.
     // This results in LwIP using the given address being as the source address for the generated
     // packet, as if the PCB had been bound to that address.
-    {
-        err_t lwipErr              = ERR_VAL;
-        const IPAddress & srcAddr  = pktInfo->SrcAddress;
-        const uint16_t & destPort  = pktInfo->DestPort;
-        const InterfaceId & intfId = pktInfo->Interface;
+    err_t lwipErr              = ERR_VAL;
+    const IPAddress & srcAddr  = pktInfo->SrcAddress;
+    const uint16_t & destPort  = pktInfo->DestPort;
+    const InterfaceId & intfId = pktInfo->Interface;
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
-        ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
-        ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
+    ip_addr_t lwipSrcAddr  = srcAddr.ToLwIPAddr();
+    ip_addr_t lwipDestAddr = destAddr.ToLwIPAddr();
 
-        ip_addr_t boundAddr;
-        ip_addr_copy(boundAddr, mUDP->local_ip);
+    ip_addr_t boundAddr;
+    ip_addr_copy(boundAddr, mUDP->local_ip);
+
+    if (!ip_addr_isany(&lwipSrcAddr))
+    {
+        ip_addr_copy(mUDP->local_ip, lwipSrcAddr);
+    }
+
+    if (intfId != INET_NULL_INTERFACEID)
+        lwipErr = udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
+    else
+        lwipErr = udp_sendto(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
+
+    ip_addr_copy(mUDP->local_ip, boundAddr);
+
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
+
+    ipX_addr_t boundAddr;
+    ipX_addr_copy(boundAddr, mUDP->local_ip);
+
+    if (PCB_ISIPV6(mUDP))
+    {
+        ip6_addr_t lwipSrcAddr  = srcAddr.ToIPv6();
+        ip6_addr_t lwipDestAddr = destAddr.ToIPv6();
+
+        if (!ip6_addr_isany(&lwipSrcAddr))
+        {
+            ipX_addr_copy(mUDP->local_ip, *ip6_2_ipX(&lwipSrcAddr));
+        }
+
+        if (intfId != INET_NULL_INTERFACEID)
+            lwipErr =
+                udp_sendto_if_ip6(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
+        else
+            lwipErr = udp_sendto_ip6(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
+    }
+
+#if INET_CONFIG_ENABLE_IPV4
+
+    else
+    {
+        ip4_addr_t lwipSrcAddr  = srcAddr.ToIPv4();
+        ip4_addr_t lwipDestAddr = destAddr.ToIPv4();
+        ipX_addr_t boundAddr;
 
         if (!ip_addr_isany(&lwipSrcAddr))
         {
-            ip_addr_copy(mUDP->local_ip, lwipSrcAddr);
+            ipX_addr_copy(mUDP->local_ip, *ip_2_ipX(&lwipSrcAddr));
         }
 
         if (intfId != INET_NULL_INTERFACEID)
             lwipErr = udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
         else
             lwipErr = udp_sendto(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
+    }
 
-        ip_addr_copy(mUDP->local_ip, boundAddr);
-
-#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
-
-        ipX_addr_t boundAddr;
-        ipX_addr_copy(boundAddr, mUDP->local_ip);
-
-        if (PCB_ISIPV6(mUDP))
-        {
-            ip6_addr_t lwipSrcAddr  = srcAddr.ToIPv6();
-            ip6_addr_t lwipDestAddr = destAddr.ToIPv6();
-
-            if (!ip6_addr_isany(&lwipSrcAddr))
-            {
-                ipX_addr_copy(mUDP->local_ip, *ip6_2_ipX(&lwipSrcAddr));
-            }
-
-            if (intfId != INET_NULL_INTERFACEID)
-                lwipErr =
-                    udp_sendto_if_ip6(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
-            else
-                lwipErr = udp_sendto_ip6(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
-        }
-
-#if INET_CONFIG_ENABLE_IPV4
-
-        else
-        {
-            ip4_addr_t lwipSrcAddr  = srcAddr.ToIPv4();
-            ip4_addr_t lwipDestAddr = destAddr.ToIPv4();
-            ipX_addr_t boundAddr;
-
-            if (!ip_addr_isany(&lwipSrcAddr))
-            {
-                ipX_addr_copy(mUDP->local_ip, *ip_2_ipX(&lwipSrcAddr));
-            }
-
-            if (intfId != INET_NULL_INTERFACEID)
-                lwipErr =
-                    udp_sendto_if(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort, intfId);
-            else
-                lwipErr = udp_sendto(mUDP, System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(msg), &lwipDestAddr, destPort);
-        }
-
-        ipX_addr_copy(mUDP->local_ip, boundAddr);
+    ipX_addr_copy(mUDP->local_ip, boundAddr);
 
 #endif // INET_CONFIG_ENABLE_IPV4
 #endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 
-        if (lwipErr != ERR_OK)
-            res = chip::System::MapErrorLwIP(lwipErr);
-    }
-
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
+
+    if (lwipErr != ERR_OK)
+        res = chip::System::MapErrorLwIP(lwipErr);
 
     return res;
 }
 
 void UDPEndPoint::CloseImpl()
 {
+
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
@@ -345,7 +348,7 @@ void UDPEndPoint::CloseImpl()
     {
         udp_remove(mUDP);
         mUDP              = NULL;
-        mLwIPEndPointType = LwIPEndPointType::Unknown;
+        mLwIPEndPointType = LwIPEndPointType::kUnknown;
     }
 
     // Unlock LwIP stack
@@ -371,7 +374,7 @@ CHIP_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
     if (mUDP == NULL)
     {
         // Allocate a PCB of the appropriate type.
-        if (addrType == kIPAddressType_IPv6)
+        if (addrType == IPAddressType::kIPv6)
         {
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
             mUDP = udp_new_ip_type(IPADDR_TYPE_V6);
@@ -380,7 +383,7 @@ CHIP_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
 #endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
         }
 #if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == kIPAddressType_IPv4)
+        else if (addrType == IPAddressType::kIPv4)
         {
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
             mUDP = udp_new_ip_type(IPADDR_TYPE_V4);
@@ -415,11 +418,11 @@ CHIP_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
         switch (static_cast<lwip_ip_addr_type>(IP_GET_TYPE(&mUDP->local_ip)))
         {
         case IPADDR_TYPE_V6:
-            pcbAddrType = kIPAddressType_IPv6;
+            pcbAddrType = IPAddressType::kIPv6;
             break;
 #if INET_CONFIG_ENABLE_IPV4
         case IPADDR_TYPE_V4:
-            pcbAddrType = kIPAddressType_IPv4;
+            pcbAddrType = IPAddressType::kIPv4;
             break;
 #endif // INET_CONFIG_ENABLE_IPV4
         default:
@@ -427,9 +430,9 @@ CHIP_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
         }
 #else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
 #if INET_CONFIG_ENABLE_IPV4
-        pcbAddrType = PCB_ISIPV6(mUDP) ? kIPAddressType_IPv6 : kIPAddressType_IPv4;
+        pcbAddrType = PCB_ISIPV6(mUDP) ? IPAddressType::kIPv6 : IPAddressType::kIPv4;
 #else  // !INET_CONFIG_ENABLE_IPV4
-        pcbAddrType = kIPAddressType_IPv6;
+        pcbAddrType = IPAddressType::kIPv6;
 #endif // !INET_CONFIG_ENABLE_IPV4
 #endif // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
 
@@ -473,19 +476,19 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
     if (pktInfo != NULL)
     {
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        pktInfo->SrcAddress  = IPAddress::FromLwIPAddr(*addr);
-        pktInfo->DestAddress = IPAddress::FromLwIPAddr(*ip_current_dest_addr());
+        pktInfo->SrcAddress  = IPAddress(*addr);
+        pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
 #else // LWIP_VERSION_MAJOR <= 1
         if (PCB_ISIPV6(pcb))
         {
-            pktInfo->SrcAddress = IPAddress::FromIPv6(*(ip6_addr_t *) addr);
-            pktInfo->DestAddress = IPAddress::FromIPv6(*ip6_current_dest_addr());
+            pktInfo->SrcAddress = IPAddress(*(ip6_addr_t *) addr);
+            pktInfo->DestAddress = IPAddress(*ip6_current_dest_addr());
         }
 #if INET_CONFIG_ENABLE_IPV4
         else
         {
-            pktInfo->SrcAddress = IPAddress::FromIPv4(*addr);
-            pktInfo->DestAddress = IPAddress::FromIPv4(*ip_current_dest_addr());
+            pktInfo->SrcAddress = IPAddress(*addr);
+            pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 #endif // LWIP_VERSION_MAJOR <= 1
@@ -495,7 +498,13 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
         pktInfo->DestPort  = pcb->local_port;
     }
 
-    PostPacketBufferEvent(lSystemLayer, *ep, kInetEvent_UDPDataReceived, std::move(buf));
+    const CHIP_ERROR error =
+        lSystemLayer->PostEvent(*ep, kInetEvent_UDPDataReceived, (uintptr_t) System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(buf));
+    if (error == CHIP_NO_ERROR)
+    {
+        // If PostEvent() succeeded, it has ownership of the buffer, so we need to release it (without freeing it).
+        static_cast<void>(std::move(buf).UnsafeRelease());
+    }
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -514,12 +523,7 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
     // If an ephemeral port was requested, retrieve the actual bound port.
     if (port == 0)
     {
-        union
-        {
-            struct sockaddr any;
-            struct sockaddr_in in;
-            struct sockaddr_in6 in6;
-        } boundAddr;
+        SockAddr boundAddr;
         socklen_t boundAddrLen = sizeof(boundAddr);
 
         if (getsockname(mSocket, &boundAddr.any, &boundAddrLen) == 0)
@@ -579,22 +583,18 @@ CHIP_ERROR UDPEndPoint::ListenImpl()
     return layer->RequestCallbackOnPendingRead(mWatch);
 }
 
-CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
-    CHIP_ERROR res             = CHIP_NO_ERROR;
-    const IPAddress & destAddr = pktInfo->DestAddress;
-
     // Make sure we have the appropriate type of socket based on the
     // destination address.
+    ReturnErrorOnFailure(GetSocket(pktInfo->DestAddress.Type()));
 
-    res = GetSocket(destAddr.Type());
-    ReturnErrorOnFailure(res);
-
-    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg));
 }
 
 void UDPEndPoint::CloseImpl()
 {
+
     if (mSocket != kInvalidSocketFd)
     {
         static_cast<System::LayerSockets *>(Layer().SystemLayer())->StopWatchingSocket(&mWatch);
@@ -619,7 +619,7 @@ void UDPEndPoint::Free()
 
 CHIP_ERROR UDPEndPoint::GetSocket(IPAddressType aAddressType)
 {
-    constexpr int lType     = (SOCK_DGRAM | SOCK_FLAGS);
+    constexpr int lType     = (SOCK_DGRAM | SOCK_CLOEXEC);
     constexpr int lProtocol = 0;
 
     return IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol);
@@ -633,7 +633,7 @@ void UDPEndPoint::HandlePendingIO(System::SocketEvents events, intptr_t data)
 
 void UDPEndPoint::HandlePendingIO(System::SocketEvents events)
 {
-    if (mState == kState_Listening && OnMessageReceived != nullptr && events.Has(System::SocketEventFlags::kRead))
+    if (mState == State::kListening && OnMessageReceived != nullptr && events.Has(System::SocketEventFlags::kRead))
     {
         const uint16_t lPort = mBoundPort;
 
@@ -661,6 +661,7 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
     ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, parameters));
 
     mParameters = parameters;
+
     return CHIP_NO_ERROR;
 }
 
@@ -685,9 +686,9 @@ CHIP_ERROR UDPEndPoint::ListenImpl()
     return StartListener();
 }
 
-CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
-    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg));
 }
 
 void UDPEndPoint::CloseImpl()
@@ -705,45 +706,43 @@ void UDPEndPoint::Free()
 
 CHIP_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
 {
-    if (mState != kState_Ready && mState != kState_Bound)
+    if (mState != State::kReady && mState != State::kBound)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    if ((addr != IPAddress::Any) && (addr.Type() != kIPAddressType_Any) && (addr.Type() != addrType))
+    if ((addr != IPAddress::Any) && (addr.Type() != IPAddressType::kAny) && (addr.Type() != addrType))
     {
         return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
     ReturnErrorOnFailure(BindImpl(addrType, addr, port, intfId));
 
-    mState = kState_Bound;
-
+    mState = State::kBound;
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
 {
-    if (mState != kState_Ready && mState != kState_Bound)
+    if (mState != State::kReady && mState != State::kBound)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
     ReturnErrorOnFailure(BindInterfaceImpl(addrType, intfId));
 
-    mState = kState_Bound;
-
+    mState = State::kBound;
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnReceiveErrorFunct onReceiveError, void * appState)
 {
-    if (mState == kState_Listening)
+    if (mState == State::kListening)
     {
         return CHIP_NO_ERROR;
     }
 
-    if (mState != kState_Bound)
+    if (mState != State::kBound)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
@@ -754,48 +753,37 @@ CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnRecei
 
     ReturnErrorOnFailure(ListenImpl());
 
-    mState = kState_Listening;
-
+    mState = State::kListening;
     return CHIP_NO_ERROR;
 }
 
-/**
- *  A synonym for <tt>SendTo(addr, port, INET_NULL_INTERFACEID, msg, sendFlags)</tt>.
- */
-CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
-{
-    return SendTo(addr, port, INET_NULL_INTERFACEID, std::move(msg), sendFlags);
-}
-
-CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
-                               uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, InterfaceId intfId)
 {
     IPPacketInfo pktInfo;
     pktInfo.Clear();
     pktInfo.DestAddress = addr;
     pktInfo.DestPort    = port;
     pktInfo.Interface   = intfId;
-    return SendMsg(&pktInfo, std::move(msg), sendFlags);
+    return SendMsg(&pktInfo, std::move(msg));
 }
 
-CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
     INET_FAULT_INJECT(FaultInjection::kFault_Send, return INET_ERROR_UNKNOWN_INTERFACE;);
     INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical, return CHIP_ERROR_NO_MEMORY;);
 
-    CHIP_ERROR res = SendMsgImpl(pktInfo, std::move(msg), sendFlags);
+    ReturnErrorOnFailure(SendMsgImpl(pktInfo, std::move(msg)));
 
     CHIP_SYSTEM_FAULT_INJECT_ASYNC_EVENT();
-
-    return res;
+    return CHIP_NO_ERROR;
 }
 
 void UDPEndPoint::Close()
 {
-    if (mState != kState_Closed)
+    if (mState != State::kClosed)
     {
         CloseImpl();
-        mState = kState_Closed;
+        mState = State::kClosed;
     }
 }
 

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -136,7 +136,6 @@ public:
      * @param[in]   port        Destination UDP port.
      * @param[in]   msg         Packet buffer containing the UDP message.
      * @param[in]   intfId      Optional network interface indicator.
-     * @param[in]   sendFlags   Unused and will be removed.
      *
      * @retval  CHIP_NO_ERROR                       Success: \c msg is queued for transmit.
      * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE The system does not support the requested operation.
@@ -146,9 +145,8 @@ public:
      * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG Only a truncated portion of \c msg was queued for transmit.
      * @retval  other                               Another system or platform error.
      */
-    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
-                      uint16_t sendFlags = 0);
-    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg,
+                      InterfaceId intfId = INET_NULL_INTERFACEID);
 
     /**
      * Send a UDP message to a specified destination.
@@ -159,7 +157,6 @@ public:
      *
      * @param[in]   pktInfo     Source and destination information for the UDP message.
      * @param[in]   msg         Packet buffer containing the UDP message.
-     * @param[in]   sendFlags   Unused and will be removed.
      *
      * @retval  CHIP_NO_ERROR                       Success: \c msg is queued for transmit.
      * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE The system does not support the requested operation.
@@ -169,7 +166,7 @@ public:
      * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG Only a truncated portion of \c msg was queued for transmit.
      * @retval  other                               Another system or platform error.
      */
-    CHIP_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+    CHIP_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 
     /**
      * Close the endpoint.
@@ -199,7 +196,7 @@ private:
     CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId);
     CHIP_ERROR BindInterfaceImpl(IPAddressType addrType, InterfaceId intfId);
     CHIP_ERROR ListenImpl();
-    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg, uint16_t sendFlags);
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
     void CloseImpl();
 
     void Init(InetLayer * inetLayer);

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -174,43 +174,43 @@ const IPV6MulticastGroup sIPv6WellKnownMulticastGroups[NUM_MCAST_GROUPS] = {
 const struct IPAddressExpandedContext sIPAddressContext[] =
 {
     {
-         { { 0x00000000, 0x00000000, 0x00000000, 0x00000000 }, kIPAddressType_Any,
+         { { 0x00000000, 0x00000000, 0x00000000, 0x00000000 }, IPAddressType::kAny,
         "::" },
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-        { { 0x26200001, 0x10e70400, 0xe83fb28f, 0x9c3a1941 }, kIPAddressType_IPv6,
+        { { 0x26200001, 0x10e70400, 0xe83fb28f, 0x9c3a1941 }, IPAddressType::kIPv6,
                                                                   "2620:1:10e7:400:e83f:b28f:9c3a:1941" } ,
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0xfe800000, 0x00000000, 0x8edcd4ff, 0xfe3aebfb }, kIPAddressType_IPv6,
+         { { 0xfe800000, 0x00000000, 0x8edcd4ff, 0xfe3aebfb }, IPAddressType::kIPv6,
         "fe80::8edc:d4ff:fe3a:ebfb" },
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0xff010000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6,
+         { { 0xff010000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6,
         "ff01::1" },
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0xfd000000, 0x00010001, 0x00000000, 0x00000001 }, kIPAddressType_IPv6,
+         { { 0xfd000000, 0x00010001, 0x00000000, 0x00000001 }, IPAddressType::kIPv6,
         "fd00:0:1:1::1" },
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsIPv6ULA, kTestIsNotIPv6LLA,
         0x1, 1, 1
     },
     {
-         { { 0xfd123456, 0x0001abcd, 0xabcdef00, 0xfedcba09 }, kIPAddressType_IPv6,
+         { { 0xfd123456, 0x0001abcd, 0xabcdef00, 0xfedcba09 }, IPAddressType::kIPv6,
         "fd12:3456:1:abcd:abcd:ef00:fedc:ba09" },
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsIPv6ULA, kTestIsNotIPv6LLA,
         0x1234560001, 0xabcd, 0xabcdef00fedcba09
     },
     {
-         { { 0xfdffffff, 0xffffffff, 0xffffffff, 0xffffffff }, kIPAddressType_IPv6,
+         { { 0xfdffffff, 0xffffffff, 0xffffffff, 0xffffffff }, IPAddressType::kIPv6,
         "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" },
         kTestIsIPv6, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsIPv6ULA, kTestIsNotIPv6LLA,
         0xffffffffff, 0xffff, 0xffffffffffffffff
@@ -218,13 +218,13 @@ const struct IPAddressExpandedContext sIPAddressContext[] =
 #if INET_CONFIG_ENABLE_IPV4
     // IPv4-only
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xffffff00 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xffffff00 }, IPAddressType::kIPv4,
         "255.255.255.0" },
         kTestIsIPv4, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0x7f000001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0x7f000001 }, IPAddressType::kIPv4,
         "127.0.0.1" },
         kTestIsIPv4, kTestIsNotIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
@@ -233,286 +233,286 @@ const struct IPAddressExpandedContext sIPAddressContext[] =
 
     // IPv4 Local subnetwork multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000000 }, IPAddressType::kIPv4,
         "224.0.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000001 }, IPAddressType::kIPv4,
         "224.0.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000080 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000080 }, IPAddressType::kIPv4,
         "224.0.0.128" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00000fe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00000fe }, IPAddressType::kIPv4,
         "224.0.0.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00000ff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00000ff }, IPAddressType::kIPv4,
         "224.0.0.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 Internetwork control multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000100 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000100 }, IPAddressType::kIPv4,
         "224.0.1.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000101 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000101 }, IPAddressType::kIPv4,
         "224.0.1.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000180 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000180 }, IPAddressType::kIPv4,
         "224.0.1.128" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00001fe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00001fe }, IPAddressType::kIPv4,
         "224.0.1.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00001ff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe00001ff }, IPAddressType::kIPv4,
         "224.0.1.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 AD-HOC block 1 multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000200 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000200 }, IPAddressType::kIPv4,
         "224.0.2.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000201 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0000201 }, IPAddressType::kIPv4,
         "224.0.2.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0008100 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0008100 }, IPAddressType::kIPv4,
         "224.0.129.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe000fffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe000fffe }, IPAddressType::kIPv4,
         "224.0.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe000ffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe000ffff }, IPAddressType::kIPv4,
         "224.0.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 AD-HOC block 2 multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0030000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0030000 }, IPAddressType::kIPv4,
         "224.3.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0030001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0030001 }, IPAddressType::kIPv4,
         "224.3.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0040000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe0040000 }, IPAddressType::kIPv4,
         "224.4.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe004fffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe004fffe }, IPAddressType::kIPv4,
         "224.4.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe004ffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe004ffff }, IPAddressType::kIPv4,
         "224.4.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 source-specific multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8000000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8000000 }, IPAddressType::kIPv4,
         "232.0.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8000001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8000001 }, IPAddressType::kIPv4,
         "232.0.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8800000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8800000 }, IPAddressType::kIPv4,
         "232.128.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8fffffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8fffffe }, IPAddressType::kIPv4,
         "232.255.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8ffffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe8ffffff }, IPAddressType::kIPv4,
         "232.255.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 GLOP addressing multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9000000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9000000 }, IPAddressType::kIPv4,
         "233.0.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9000001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9000001 }, IPAddressType::kIPv4,
         "233.0.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe97e0000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe97e0000 }, IPAddressType::kIPv4,
         "233.126.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fbfffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fbfffe }, IPAddressType::kIPv4,
         "233.251.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fbffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fbffff }, IPAddressType::kIPv4,
         "233.251.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 AD-HOC block 3 multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fc0000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fc0000 }, IPAddressType::kIPv4,
         "233.252.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fc0001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fc0001 }, IPAddressType::kIPv4,
         "233.252.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fe0000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fe0000 }, IPAddressType::kIPv4,
         "233.254.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fffffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9fffffe }, IPAddressType::kIPv4,
         "233.255.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9ffffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xe9ffffff }, IPAddressType::kIPv4,
         "233.255.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 unicast-prefix-based multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xea000000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xea000000 }, IPAddressType::kIPv4,
         "234.0.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xea000001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xea000001 }, IPAddressType::kIPv4,
         "234.0.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xea800000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xea800000 }, IPAddressType::kIPv4,
         "234.128.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xeafffffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xeafffffe }, IPAddressType::kIPv4,
         "234.255.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xeaffffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xeaffffff }, IPAddressType::kIPv4,
         "234.255.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IPv4 administratively scoped multicast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xef000000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xef000000 }, IPAddressType::kIPv4,
         "239.0.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xef000001 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xef000001 }, IPAddressType::kIPv4,
         "239.0.0.1" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xef800000 }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xef800000 }, IPAddressType::kIPv4,
         "239.128.0.0" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xeffffffe }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xeffffffe }, IPAddressType::kIPv4,
         "239.255.255.254" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xefffffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xefffffff }, IPAddressType::kIPv4,
         "239.255.255.255" },
         kTestIsIPv4, kTestIsIPv4Multicast, kTestIsNotIPv4Broadcast, kTestIsMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
     },
     // IP4 and IPv4 broadcast
     {
-         { { 0x00000000, 0x00000000, 0x0000ffff, 0xffffffff }, kIPAddressType_IPv4,
+         { { 0x00000000, 0x00000000, 0x0000ffff, 0xffffffff }, IPAddressType::kIPv4,
         "255.255.255.255" },
         kTestIsIPv4, kTestIsNotIPv4Multicast, kTestIsIPv4Broadcast, kTestIsNotMulticast, kTestIsNotIPv6Multicast, kTestIsNotIPv6ULA, kTestIsNotIPv6LLA,
         0x0, 0x0, 0x0
@@ -526,23 +526,23 @@ const IPAddressContext sIPv6WellKnownMulticastContext[] = {
 
     // All-nodes in Various Scopes
 
-    { { 0xff010000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff01::1" },
-    { { 0xff020000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff02::1" },
-    { { 0xff030000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff03::1" },
-    { { 0xff040000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff04::1" },
-    { { 0xff050000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff05::1" },
-    { { 0xff080000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff08::1" },
-    { { 0xff0e0000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff0e::1" },
+    { { 0xff010000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff01::1" },
+    { { 0xff020000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff02::1" },
+    { { 0xff030000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff03::1" },
+    { { 0xff040000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff04::1" },
+    { { 0xff050000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff05::1" },
+    { { 0xff080000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff08::1" },
+    { { 0xff0e0000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff0e::1" },
 
     // All-routers in Various Scopes
 
-    { { 0xff010000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff01::2" },
-    { { 0xff020000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff02::2" },
-    { { 0xff030000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff03::2" },
-    { { 0xff040000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff04::2" },
-    { { 0xff050000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff05::2" },
-    { { 0xff080000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff08::2" },
-    { { 0xff0e0000, 0x00000000, 0x00000000, 0x00000002 }, kIPAddressType_IPv6, "ff0e::2" }
+    { { 0xff010000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff01::2" },
+    { { 0xff020000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff02::2" },
+    { { 0xff030000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff03::2" },
+    { { 0xff040000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff04::2" },
+    { { 0xff050000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff05::2" },
+    { { 0xff080000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff08::2" },
+    { { 0xff0e0000, 0x00000000, 0x00000000, 0x00000002 }, IPAddressType::kIPv6, "ff0e::2" }
 };
 
 const IPAddressContext sIPv6TransientMulticastContext[] = {
@@ -550,23 +550,23 @@ const IPAddressContext sIPv6TransientMulticastContext[] = {
 
     // Short Transient Group in Various Scopes
 
-    { { 0xff110000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff11::1" },
-    { { 0xff120000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff12::1" },
-    { { 0xff130000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff13::1" },
-    { { 0xff140000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff14::1" },
-    { { 0xff150000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff15::1" },
-    { { 0xff180000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff18::1" },
-    { { 0xff1e0000, 0x00000000, 0x00000000, 0x00000001 }, kIPAddressType_IPv6, "ff1e::1" },
+    { { 0xff110000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff11::1" },
+    { { 0xff120000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff12::1" },
+    { { 0xff130000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff13::1" },
+    { { 0xff140000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff14::1" },
+    { { 0xff150000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff15::1" },
+    { { 0xff180000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff18::1" },
+    { { 0xff1e0000, 0x00000000, 0x00000000, 0x00000001 }, IPAddressType::kIPv6, "ff1e::1" },
 
     // Long Transient Group in Various Scopes
 
-    { { 0xff11d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff11:d5d6:2ba2:7847:6452:587a:c955:b5a" },
-    { { 0xff12d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff12:d5d6:2ba2:7847:6452:587a:c955:b5a" },
-    { { 0xff13d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff13:d5d6:2ba2:7847:6452:587a:c955:b5a" },
-    { { 0xff14d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff14:d5d6:2ba2:7847:6452:587a:c955:b5a" },
-    { { 0xff15d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff15:d5d6:2ba2:7847:6452:587a:c955:b5a" },
-    { { 0xff18d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff18:d5d6:2ba2:7847:6452:587a:c955:b5a" },
-    { { 0xff1ed5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, kIPAddressType_IPv6, "ff1e:d5d6:2ba2:7847:6452:587a:c955:b5a" }
+    { { 0xff11d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff11:d5d6:2ba2:7847:6452:587a:c955:b5a" },
+    { { 0xff12d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff12:d5d6:2ba2:7847:6452:587a:c955:b5a" },
+    { { 0xff13d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff13:d5d6:2ba2:7847:6452:587a:c955:b5a" },
+    { { 0xff14d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff14:d5d6:2ba2:7847:6452:587a:c955:b5a" },
+    { { 0xff15d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff15:d5d6:2ba2:7847:6452:587a:c955:b5a" },
+    { { 0xff18d5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff18:d5d6:2ba2:7847:6452:587a:c955:b5a" },
+    { { 0xff1ed5d6, 0x2ba27847, 0x6452587a, 0xc9550b5a }, IPAddressType::kIPv6, "ff1e:d5d6:2ba2:7847:6452:587a:c955:b5a" }
 };
 
 const IPAddressContext sIPv6PrefixMulticastContext[] = {
@@ -574,43 +574,43 @@ const IPAddressContext sIPv6PrefixMulticastContext[] = {
 
     // 56-bit Prefix with Short Group in Various Scopes
 
-    { { 0xff310038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff31:38:373a:cba4:d2ad:8d00:1:1" },
-    { { 0xff320038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff32:38:373a:cba4:d2ad:8d00:1:1" },
-    { { 0xff330038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff33:38:373a:cba4:d2ad:8d00:1:1" },
-    { { 0xff340038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff34:38:373a:cba4:d2ad:8d00:1:1" },
-    { { 0xff350038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff35:38:373a:cba4:d2ad:8d00:1:1" },
-    { { 0xff380038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff38:38:373a:cba4:d2ad:8d00:1:1" },
-    { { 0xff3e0038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, kIPAddressType_IPv6, "ff3e:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff310038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff31:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff320038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff32:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff330038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff33:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff340038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff34:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff350038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff35:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff380038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff38:38:373a:cba4:d2ad:8d00:1:1" },
+    { { 0xff3e0038, 0x373acba4, 0xd2ad8d00, 0x00010001 }, IPAddressType::kIPv6, "ff3e:38:373a:cba4:d2ad:8d00:1:1" },
 
     // 56-bit Prefix with Long Group in Various Scopes
 
-    { { 0xff310038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff31:38:373a:cba4:d2ad:8d00:afff:5258" },
-    { { 0xff320038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff32:38:373a:cba4:d2ad:8d00:afff:5258" },
-    { { 0xff330038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff33:38:373a:cba4:d2ad:8d00:afff:5258" },
-    { { 0xff340038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff34:38:373a:cba4:d2ad:8d00:afff:5258" },
-    { { 0xff350038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff35:38:373a:cba4:d2ad:8d00:afff:5258" },
-    { { 0xff380038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff38:38:373a:cba4:d2ad:8d00:afff:5258" },
-    { { 0xff3e0038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, kIPAddressType_IPv6, "ff3e:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff310038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff31:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff320038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff32:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff330038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff33:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff340038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff34:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff350038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff35:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff380038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff38:38:373a:cba4:d2ad:8d00:afff:5258" },
+    { { 0xff3e0038, 0x373acba4, 0xd2ad8d00, 0xafff5258 }, IPAddressType::kIPv6, "ff3e:38:373a:cba4:d2ad:8d00:afff:5258" },
 
     // 64-bit Prefix with Short Group in Various Scopes
 
-    { { 0xff310040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff31:40:6664:3dfb:afa4:385b:1:1" },
-    { { 0xff320040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff32:40:6664:3dfb:afa4:385b:1:1" },
-    { { 0xff330040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff33:40:6664:3dfb:afa4:385b:1:1" },
-    { { 0xff340040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff34:40:6664:3dfb:afa4:385b:1:1" },
-    { { 0xff350040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff35:40:6664:3dfb:afa4:385b:1:1" },
-    { { 0xff380040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff38:40:6664:3dfb:afa4:385b:1:1" },
-    { { 0xff3e0040, 0x66643dfb, 0xafa4385b, 0x00010001 }, kIPAddressType_IPv6, "ff3e:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff310040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff31:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff320040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff32:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff330040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff33:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff340040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff34:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff350040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff35:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff380040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff38:40:6664:3dfb:afa4:385b:1:1" },
+    { { 0xff3e0040, 0x66643dfb, 0xafa4385b, 0x00010001 }, IPAddressType::kIPv6, "ff3e:40:6664:3dfb:afa4:385b:1:1" },
 
     // 64-bit Prefix with Long Group in Various Scopes
 
-    { { 0xff310040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff31:40:6664:3dfb:afa4:385b:afff:5258" },
-    { { 0xff320040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff32:40:6664:3dfb:afa4:385b:afff:5258" },
-    { { 0xff330040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff33:40:6664:3dfb:afa4:385b:afff:5258" },
-    { { 0xff340040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff34:40:6664:3dfb:afa4:385b:afff:5258" },
-    { { 0xff350040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff35:40:6664:3dfb:afa4:385b:afff:5258" },
-    { { 0xff380040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff38:40:6664:3dfb:afa4:385b:afff:5258" },
-    { { 0xff3e0040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, kIPAddressType_IPv6, "ff3e:40:6664:3dfb:afa4:385b:afff:5258" }
+    { { 0xff310040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff31:40:6664:3dfb:afa4:385b:afff:5258" },
+    { { 0xff320040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff32:40:6664:3dfb:afa4:385b:afff:5258" },
+    { { 0xff330040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff33:40:6664:3dfb:afa4:385b:afff:5258" },
+    { { 0xff340040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff34:40:6664:3dfb:afa4:385b:afff:5258" },
+    { { 0xff350040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff35:40:6664:3dfb:afa4:385b:afff:5258" },
+    { { 0xff380040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff38:40:6664:3dfb:afa4:385b:afff:5258" },
+    { { 0xff3e0040, 0x66643dfb, 0xafa4385b, 0xafff5258 }, IPAddressType::kIPv6, "ff3e:40:6664:3dfb:afa4:385b:afff:5258" }
 };
 
 const size_t kIPv6WellKnownMulticastTestElements = sizeof(sIPv6WellKnownMulticastContext) / sizeof(struct IPAddressContext);
@@ -1053,7 +1053,7 @@ void CheckFromIPv6(nlTestSuite * inSuite, void * inContext)
         struct in6_addr ip_addr;
         ip_addr = *reinterpret_cast<struct in6_addr *>(addr);
 #endif
-        test_addr_2 = IPAddress::FromIPv6(ip_addr);
+        test_addr_2 = IPAddress(ip_addr);
 
         CheckAddressQuartets(inSuite, test_addr_1, test_addr_2);
 
@@ -1186,7 +1186,7 @@ void CheckFromIPv4(nlTestSuite * inSuite, void * inContext)
         ip_addr.s_addr      = htonl(lCurrent->mAddr.mAddrQuartets[3]);
         test_addr_1.Addr[2] = htonl(0xffff);
 #endif
-        test_addr_2 = IPAddress::FromIPv4(ip_addr);
+        test_addr_2 = IPAddress(ip_addr);
 
         CheckAddressQuartets(inSuite, test_addr_1, test_addr_2);
 
@@ -1228,26 +1228,26 @@ void CheckFromSocket(nlTestSuite * inSuite, void * inContext)
         switch (lCurrent->mAddr.mAddrType)
         {
 #if INET_CONFIG_ENABLE_IPV4
-        case kIPAddressType_IPv4:
+        case IPAddressType::kIPv4:
             memset(&sock_v4, 0, sizeof(struct sockaddr_in));
             sock_v4.sin_family = AF_INET;
             memcpy(&sock_v4.sin_addr.s_addr, &addr[3], sizeof(struct in_addr));
-            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v4));
+            test_addr_2 = IPAddress::FromSockAddr(sock_v4);
             break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
-        case kIPAddressType_IPv6:
+        case IPAddressType::kIPv6:
             memset(&sock_v6, 0, sizeof(struct sockaddr_in6));
             sock_v6.sin6_family = AF_INET6;
             memcpy(&sock_v6.sin6_addr.s6_addr, addr, sizeof(struct in6_addr));
-            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v6));
+            test_addr_2 = IPAddress::FromSockAddr(sock_v6);
             break;
 
-        case kIPAddressType_Any:
+        case IPAddressType::kAny:
             memset(&sock_v6, 0, sizeof(struct sockaddr_in6));
             sock_v6.sin6_family = 0;
             memcpy(&sock_v6.sin6_addr.s6_addr, addr, sizeof(struct in6_addr));
-            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v6));
+            test_addr_2 = IPAddress::FromSockAddr(sock_v6);
             break;
 
         default:
@@ -1290,7 +1290,7 @@ void CheckAnyAddress(nlTestSuite * inSuite, void * inContext)
     const IPAddress test_addr = IPAddress::Any;
     IPAddressType test_type   = test_addr.Type();
 
-    NL_TEST_ASSERT(inSuite, test_type == kIPAddressType_Any);
+    NL_TEST_ASSERT(inSuite, test_type == IPAddressType::kAny);
 }
 
 /**
@@ -1557,7 +1557,7 @@ void CheckMakeIPv6TransientMulticast(nlTestSuite * inSuite, void * inContext)
     const struct TestContext * lContext = static_cast<const struct TestContext *>(inContext);
     IPAddressContextIterator lCurrent   = lContext->mIPv6TransientMulticastContextRange.mBegin;
     IPAddressContextIterator lEnd       = lContext->mIPv6TransientMulticastContextRange.mEnd;
-    const uint8_t lFlags                = 0;
+    constexpr IPv6MulticastFlags lFlags;
     size_t lScopeIndex;
     IPAddress lAddress;
 

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -308,32 +308,32 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     // UdpEndPoint special cases to cover the error branch
     err = testUDPEP->Listen(nullptr /*OnMessageReceived*/, nullptr /*OnReceiveError*/);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    err = testUDPEP->Bind(kIPAddressType_Unknown, addr_any, 3000);
+    err = testUDPEP->Bind(IPAddressType::kUnknown, addr_any, 3000);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
-    err = testUDPEP->Bind(kIPAddressType_Unknown, addr, 3000);
+    err = testUDPEP->Bind(IPAddressType::kUnknown, addr, 3000);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
 #if INET_CONFIG_ENABLE_IPV4
-    err = testUDPEP->Bind(kIPAddressType_IPv4, addr, 3000);
+    err = testUDPEP->Bind(IPAddressType::kIPv4, addr, 3000);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
 #endif // INET_CONFIG_ENABLE_IPV4
 
-    err            = testUDPEP->Bind(kIPAddressType_IPv6, addr, 3000, intId);
-    err            = testUDPEP->BindInterface(kIPAddressType_IPv6, intId);
+    err            = testUDPEP->Bind(IPAddressType::kIPv6, addr, 3000, intId);
+    err            = testUDPEP->BindInterface(IPAddressType::kIPv6, intId);
     InterfaceId id = testUDPEP->GetBoundInterface();
     NL_TEST_ASSERT(inSuite, id == intId);
 
     err = testUDPEP->Listen(nullptr /*OnMessageReceived*/, nullptr /*OnReceiveError*/);
     err = testUDPEP->Listen(nullptr /*OnMessageReceived*/, nullptr /*OnReceiveError*/);
-    err = testUDPEP->Bind(kIPAddressType_IPv6, addr, 3000, intId);
+    err = testUDPEP->Bind(IPAddressType::kIPv6, addr, 3000, intId);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    err = testUDPEP->BindInterface(kIPAddressType_IPv6, intId);
+    err = testUDPEP->BindInterface(IPAddressType::kIPv6, intId);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
     testUDPEP->Free();
 
     err = gInet.NewUDPEndPoint(&testUDPEP);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 #if INET_CONFIG_ENABLE_IPV4
-    err = testUDPEP->Bind(kIPAddressType_IPv4, addr_v4, 3000, intId);
+    err = testUDPEP->Bind(IPAddressType::kIPv4, addr_v4, 3000, intId);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
     buf = PacketBufferHandle::New(PacketBuffer::kMaxSize);
     err = testUDPEP->SendTo(addr_v4, 3000, std::move(buf));
@@ -358,17 +358,17 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     err = testTCPEP1->GetLocalInfo(nullptr, nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
-    err = testTCPEP1->Bind(kIPAddressType_Unknown, addr_any, 3000, true);
+    err = testTCPEP1->Bind(IPAddressType::kUnknown, addr_any, 3000, true);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
 #if INET_CONFIG_ENABLE_IPV4
-    err = testTCPEP1->Bind(kIPAddressType_IPv4, addr, 3000, true);
+    err = testTCPEP1->Bind(IPAddressType::kIPv4, addr, 3000, true);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
 #endif // INET_CONFIG_ENABLE_IPV4
-    err = testTCPEP1->Bind(kIPAddressType_Unknown, addr, 3000, true);
+    err = testTCPEP1->Bind(IPAddressType::kUnknown, addr, 3000, true);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
 
-    err = testTCPEP1->Bind(kIPAddressType_IPv6, addr_any, 3000, true);
-    err = testTCPEP1->Bind(kIPAddressType_IPv6, addr_any, 3000, true);
+    err = testTCPEP1->Bind(IPAddressType::kIPv6, addr_any, 3000, true);
+    err = testTCPEP1->Bind(IPAddressType::kIPv6, addr_any, 3000, true);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
     err = testTCPEP1->Listen(4);
 #if INET_CONFIG_ENABLE_IPV4

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -185,6 +185,22 @@ static OptionSet *       sToolOptionSets[] =
 };
 // clang-format on
 
+namespace chip {
+namespace Inet {
+
+class TCPTest
+{
+public:
+    static bool StateIsConnected(const TCPEndPoint * endPoint) { return endPoint->mState == TCPEndPoint::State::kConnected; }
+    static bool StateIsConnectedOrReceiveShutdown(const TCPEndPoint * endPoint)
+    {
+        return endPoint->mState == TCPEndPoint::State::kConnected || endPoint->mState == TCPEndPoint::State::kReceiveShutdown;
+    }
+};
+
+} // namespace Inet
+} // namespace chip
+
 static void CheckSucceededOrFailed(TestState & aTestState, bool & aOutSucceeded, bool & aOutFailed)
 {
     const TransferStats & lStats = aTestState.mStats;
@@ -570,7 +586,7 @@ static CHIP_ERROR HandleTCPDataReceived(TCPEndPoint * aEndPoint, PacketBufferHan
     VerifyOrExit(aEndPoint != nullptr, lStatus = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(!aBuffer.IsNull(), lStatus = CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (aEndPoint->State != TCPEndPoint::kState_Connected)
+    if (!TCPTest::StateIsConnected(aEndPoint))
     {
         lStatus = aEndPoint->SetReceivedDataForTesting(std::move(aBuffer));
         INET_FAIL_ERROR(lStatus, "TCPEndPoint::PutBackReceivedData failed");
@@ -654,33 +670,18 @@ static void HandleUDPReceiveError(IPEndPointBasis * aEndPoint, CHIP_ERROR aError
 
 static bool IsTransportReadyForSend()
 {
-    bool lStatus = false;
-
     if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
     {
-        lStatus = (sUDPIPEndPoint != nullptr);
+        return (sUDPIPEndPoint != nullptr);
     }
-    else if ((gOptFlags & kOptFlagUseTCPIP) == kOptFlagUseTCPIP)
+
+    if ((gOptFlags & kOptFlagUseTCPIP) == kOptFlagUseTCPIP)
     {
-        if (sTCPIPEndPoint != nullptr)
-        {
-            if (sTCPIPEndPoint->PendingSendLength() == 0)
-            {
-                switch (sTCPIPEndPoint->State)
-                {
-                case TCPEndPoint::kState_Connected:
-                case TCPEndPoint::kState_ReceiveShutdown:
-                    lStatus = true;
-                    break;
-
-                default:
-                    break;
-                }
-            }
-        }
+        return (sTCPIPEndPoint != nullptr) && (sTCPIPEndPoint->PendingSendLength() == 0) &&
+            TCPTest::StateIsConnectedOrReceiveShutdown(sTCPIPEndPoint);
     }
 
-    return (lStatus);
+    return false;
 }
 
 static CHIP_ERROR PrepareTransportForSend()
@@ -789,7 +790,7 @@ exit:
 
 static void StartTest()
 {
-    IPAddressType lIPAddressType = kIPAddressType_IPv6;
+    IPAddressType lIPAddressType = IPAddressType::kIPv6;
     IPAddress lAddress           = chip::Inet::IPAddress::Any;
     CHIP_ERROR lStatus;
 
@@ -799,7 +800,7 @@ static void StartTest()
 #if INET_CONFIG_ENABLE_IPV4
     if (gOptFlags & kOptFlagUseIPv4)
     {
-        lIPAddressType = kIPAddressType_IPv4;
+        lIPAddressType = IPAddressType::kIPv4;
         if (!gNetworkOptions.LocalIPv6Addr.empty())
             lAddress = gNetworkOptions.LocalIPv4Addr[0];
         else

--- a/src/inet/tests/TestInetLayerDNS.cpp
+++ b/src/inet/tests/TestInetLayerDNS.cpp
@@ -596,9 +596,9 @@ static void HandleResolutionComplete(void * appState, CHIP_ERROR err, uint8_t ad
         for (uint8_t i = 0; i < addrCount; i++)
         {
 #if INET_CONFIG_ENABLE_IPV4
-            respContainsIPv4Addrs = respContainsIPv4Addrs || (addrArray[i].Type() == kIPAddressType_IPv4);
+            respContainsIPv4Addrs = respContainsIPv4Addrs || (addrArray[i].Type() == IPAddressType::kIPv4);
 #endif
-            respContainsIPv6Addrs = respContainsIPv6Addrs || (addrArray[i].Type() == kIPAddressType_IPv6);
+            respContainsIPv6Addrs = respContainsIPv6Addrs || (addrArray[i].Type() == IPAddressType::kIPv6);
         }
 
         // Verify the expected address types were returned.
@@ -641,7 +641,7 @@ static void HandleResolutionComplete(void * appState, CHIP_ERROR err, uint8_t ad
         case kDNSOption_AddrFamily_IPv4Preferred:
             if (respContainsIPv4Addrs)
             {
-                NL_TEST_ASSERT(testSuite, addrArray[0].Type() == kIPAddressType_IPv4);
+                NL_TEST_ASSERT(testSuite, addrArray[0].Type() == IPAddressType::kIPv4);
             }
             break;
 #endif
@@ -651,7 +651,7 @@ static void HandleResolutionComplete(void * appState, CHIP_ERROR err, uint8_t ad
         case kDNSOption_AddrFamily_IPv6Preferred:
             if (respContainsIPv6Addrs)
             {
-                NL_TEST_ASSERT(testSuite, addrArray[0].Type() == kIPAddressType_IPv6);
+                NL_TEST_ASSERT(testSuite, addrArray[0].Type() == IPAddressType::kIPv6);
             }
             break;
         default:

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -489,7 +489,7 @@ static IPAddress MakeIPv4Multicast(uint32_t aGroupIdentifier)
 
 static IPAddress MakeIPv6Multicast(uint32_t aGroupIdentifier)
 {
-    const uint8_t lFlags = kIPv6MulticastFlag_Transient;
+    const uint8_t lFlags = IPv6MulticastFlag::kTransient;
 
     return (IPAddress::MakeIPv6Multicast(lFlags, kIPv6MulticastScope_Site, aGroupIdentifier));
 }
@@ -718,7 +718,7 @@ exit:
 
 static void StartTest()
 {
-    IPAddressType lIPAddressType = kIPAddressType_IPv6;
+    IPAddressType lIPAddressType = IPAddressType::kIPv6;
     IPVersion lIPVersion         = kIPVersion_6;
     IPAddress lAddress           = IPAddress::Any;
     IPEndPointBasis * lEndPoint  = nullptr;
@@ -728,7 +728,7 @@ static void StartTest()
 #if INET_CONFIG_ENABLE_IPV4
     if (gOptFlags & kOptFlagUseIPv4)
     {
-        lIPAddressType = kIPAddressType_IPv4;
+        lIPAddressType = IPAddressType::kIPv4;
         lIPVersion     = kIPVersion_4;
     }
 #endif // INET_CONFIG_ENABLE_IPV4

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -480,7 +480,7 @@ static IPAddress MakeIPv4Multicast(uint32_t aGroupIdentifier)
     lAddress.Addr[0] = 0;
     lAddress.Addr[1] = 0;
     lAddress.Addr[2] = nlByteOrderSwap32HostToBig(0xFFFF);
-    lAddress.Addr[3] = nlByteOrderSwap32HostToBig((239 << 24) | (aGroupIdentifier & 0xFFFFFF));
+    lAddress.Addr[3] = nlByteOrderSwap32HostToBig((239u << 24) | (aGroupIdentifier & 0xFFFFFF));
 
     return (lAddress);
 }
@@ -489,9 +489,7 @@ static IPAddress MakeIPv4Multicast(uint32_t aGroupIdentifier)
 
 static IPAddress MakeIPv6Multicast(uint32_t aGroupIdentifier)
 {
-    const uint8_t lFlags = IPv6MulticastFlag::kTransient;
-
-    return (IPAddress::MakeIPv6Multicast(lFlags, kIPv6MulticastScope_Site, aGroupIdentifier));
+    return (IPAddress::MakeIPv6Multicast(IPv6MulticastFlag::kTransient, kIPv6MulticastScope_Site, aGroupIdentifier));
 }
 
 static void SetGroup(GroupAddress & aGroupAddress, uint32_t aGroupIdentifier, uint32_t aExpectedRx, uint32_t aExpectedTx)

--- a/src/inet/tests/TestLwIPDNS.cpp
+++ b/src/inet/tests/TestLwIPDNS.cpp
@@ -88,7 +88,7 @@ static void found_multi(const char * aName, ip_addr_t * aIpAddrs, uint8_t aNumIp
     {
         char addrStr[INET6_ADDRSTRLEN];
 
-        IPAddress::FromIPv4(aIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+        IPAddress(aIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
 
         printf("\t(%d) IPv4: %s\n", i, addrStr);
     }
@@ -145,7 +145,7 @@ static void TestLwIPDNS(void)
         for (uint8_t i = 0; i < sNumIpAddrs; ++i)
         {
             char addrStr[64];
-            IPAddress::FromIPv4(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+            IPAddress(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
             printf("\t(%d) IPv4: %s\n", i, addrStr);
         }
     }
@@ -171,7 +171,7 @@ static void TestLwIPDNS(void)
         for (i = 0; i < sNumIpAddrs; ++i)
         {
             char addrStr[64];
-            IPAddress::FromIPv4(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+            IPAddress(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
             printf("\t(%d) IPv4: %s\n", i, addrStr);
         }
     }
@@ -197,7 +197,7 @@ static void TestLwIPDNS(void)
         for (i = 0; i < sNumIpAddrs; ++i)
         {
             char addrStr[64];
-            IPAddress::FromIPv4(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+            IPAddress(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
             printf("\t(%d) IPv4: %s\n", i, addrStr);
         }
     }

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -42,13 +42,6 @@
 #include <ble/BleConfig.h>
 #include <system/SystemConfig.h>
 
-/* COMING SOON: making the INET Layer optional entails making this inclusion optional. */
-//#include "InetConfig.h"
-/*
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL <= 0
-#error "chip SDK requires INET_TCP_IDLE_CHECK_INTERVAL > 0"
-#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL <= 0
-*/
 /* Include a project-specific configuration file, if defined.
  *
  * An application or module that incorporates chip can define a project configuration

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -246,7 +246,7 @@ private:
 void AdvertiserMinMdns::OnMdnsPacketData(const BytesRange & data, const chip::Inet::IPPacketInfo * info)
 {
 #ifdef DETAIL_LOGGING
-    char srcAddressString[chip::Inet::kMaxIPAddressStringLength];
+    char srcAddressString[chip::Inet::IPAddress::kMaxStringLength];
     VerifyOrDie(info->SrcAddress.ToString(srcAddressString) != nullptr);
     ChipLogDetail(Discovery, "Received an mDNS query from %s", srcAddressString);
 #endif

--- a/src/lib/dnssd/AllInterfacesListenIterator.h
+++ b/src/lib/dnssd/AllInterfacesListenIterator.h
@@ -73,14 +73,14 @@ public:
         if (mState == State::kIpV4)
         {
             *id    = mIterator.GetInterfaceId();
-            *type  = chip::Inet::kIPAddressType_IPv4;
+            *type  = chip::Inet::IPAddressType::kIPv4;
             mState = State::kIpV6;
             return true;
         }
 #endif
 
         *id   = mIterator.GetInterfaceId();
-        *type = chip::Inet::kIPAddressType_IPv6;
+        *type = chip::Inet::IPAddressType::kIPv6;
 #if INET_CONFIG_ENABLE_IPV4
         mState = State::kIpV4;
 #endif

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -350,7 +350,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     service.mInterface     = INET_NULL_INTERFACEID;
     service.mSubTypes      = subTypes;
     service.mSubTypeSize   = subTypeSize;
-    service.mAddressType   = Inet::kIPAddressType_Any;
+    service.mAddressType   = Inet::IPAddressType::kAny;
     error                  = ChipDnssdPublishService(&service);
 
     if (error == CHIP_NO_ERROR)
@@ -430,7 +430,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     service.mTextEntries   = txtEntries;
     service.mTextEntrySize = textEntrySize;
     service.mInterface     = INET_NULL_INTERFACEID;
-    service.mAddressType   = Inet::kIPAddressType_Any;
+    service.mAddressType   = Inet::IPAddressType::kAny;
     service.mSubTypes      = subTypes;
     service.mSubTypeSize   = subTypeSize;
     error                  = ChipDnssdPublishService(&service);
@@ -544,7 +544,7 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter
     char serviceName[kMaxCommisisonableServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionableNode));
 
-    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::kIPAddressType_Any, INET_NULL_INTERFACEID,
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, INET_NULL_INTERFACEID,
                            HandleNodeBrowse, this);
 }
 
@@ -554,7 +554,7 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
     char serviceName[kMaxCommisisonerServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionerNode));
 
-    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::kIPAddressType_Any, INET_NULL_INTERFACEID,
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, INET_NULL_INTERFACEID,
                            HandleNodeBrowse, this);
 }
 

--- a/src/lib/dnssd/MinimalMdnsServer.cpp
+++ b/src/lib/dnssd/MinimalMdnsServer.cpp
@@ -39,14 +39,14 @@ public:
         if (mState == State::kIpV4)
         {
             *id    = mIterator.GetInterfaceId();
-            *type  = chip::Inet::kIPAddressType_IPv4;
+            *type  = chip::Inet::IPAddressType::kIPv4;
             mState = State::kIpV6;
             return true;
         }
 #endif
 
         *id   = mIterator.GetInterfaceId();
-        *type = chip::Inet::kIPAddressType_IPv6;
+        *type = chip::Inet::IPAddressType::kIPv6;
 #if INET_CONFIG_ENABLE_IPV4
         mState = State::kIpV4;
 #endif

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -41,7 +41,7 @@ struct ResolvedNodeData
     void LogNodeIdResolved()
     {
 #if CHIP_PROGRESS_LOGGING
-        char addrBuffer[Inet::IPAddress::kMaxStringLength + 1];
+        char addrBuffer[Inet::IPAddress::kMaxStringLength];
         mAddress.ToString(addrBuffer);
         // Would be nice to log the interface id, but sorting out how to do so
         // across our differnet InterfaceId implementations is a pain.

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -41,7 +41,7 @@ struct ResolvedNodeData
     void LogNodeIdResolved()
     {
 #if CHIP_PROGRESS_LOGGING
-        char addrBuffer[Inet::kMaxIPAddressStringLength + 1];
+        char addrBuffer[Inet::IPAddress::kMaxStringLength + 1];
         mAddress.ToString(addrBuffer);
         // Would be nice to log the interface id, but sorting out how to do so
         // across our differnet InterfaceId implementations is a pain.
@@ -185,7 +185,7 @@ struct DiscoveredNodeData
         for (int j = 0; j < numIPs; j++)
         {
 #if CHIP_DETAIL_LOGGING
-            char buf[Inet::kMaxIPAddressStringLength];
+            char buf[Inet::IPAddress::kMaxStringLength];
             char * ipAddressOut = ipAddress[j].ToString(buf);
             ChipLogDetail(Discovery, "\tIP Address #%d: %s", j + 1, ipAddressOut);
             (void) ipAddressOut;

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -161,7 +161,7 @@ CHIP_ERROR ResponseSender::FlushReply()
 
     if (mResponseBuilder.HasResponseRecords())
     {
-        char srcAddressString[chip::Inet::kMaxIPAddressStringLength];
+        char srcAddressString[chip::Inet::IPAddress::kMaxStringLength];
         VerifyOrDie(mSendState.GetSourceAddress().ToString(srcAddressString) != nullptr);
 
         if (mSendState.SendUnicast())

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -80,12 +80,12 @@ CHIP_ERROR JoinMulticastGroup(chip::Inet::InterfaceId interfaceId, chip::Inet::U
 
     chip::Inet::IPAddress address;
 
-    if (addressType == chip::Inet::IPAddressType::kIPAddressType_IPv6)
+    if (addressType == chip::Inet::IPAddressType::kIPv6)
     {
         BroadcastIpAddresses::GetIpv6Into(address);
 #if INET_CONFIG_ENABLE_IPV4
     }
-    else if (addressType == chip::Inet::IPAddressType::kIPAddressType_IPv4)
+    else if (addressType == chip::Inet::IPAddressType::kIPv4)
     {
         BroadcastIpAddresses::GetIpv4Into(address);
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -102,10 +102,10 @@ const char * AddressTypeStr(chip::Inet::IPAddressType addressType)
 {
     switch (addressType)
     {
-    case chip::Inet::IPAddressType::kIPAddressType_IPv6:
+    case chip::Inet::IPAddressType::kIPv6:
         return "IPv6";
 #if INET_CONFIG_ENABLE_IPV4
-    case chip::Inet::IPAddressType::kIPAddressType_IPv4:
+    case chip::Inet::IPAddressType::kIPv4:
         return "IPv4";
 #endif // INET_CONFIG_ENABLE_IPV4
     default:
@@ -245,14 +245,14 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
         /// TODO: this wastes one copy of the data and that could be optimized away
         chip::System::PacketBufferHandle copy = data.CloneData();
 
-        if (info->addressType == chip::Inet::kIPAddressType_IPv6)
+        if (info->addressType == chip::Inet::IPAddressType::kIPv6)
         {
-            err = info->udp->SendTo(mIpv6BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv6BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #if INET_CONFIG_ENABLE_IPV4
-        else if (info->addressType == chip::Inet::kIPAddressType_IPv4)
+        else if (info->addressType == chip::Inet::IPAddressType::kIPv4)
         {
-            err = info->udp->SendTo(mIpv4BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv4BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #endif
         else
@@ -298,14 +298,14 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
         /// TODO: this wastes one copy of the data and that could be optimized away
         chip::System::PacketBufferHandle copy = data.CloneData();
 
-        if (info->addressType == chip::Inet::kIPAddressType_IPv6)
+        if (info->addressType == chip::Inet::IPAddressType::kIPv6)
         {
-            err = info->udp->SendTo(mIpv6BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv6BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #if INET_CONFIG_ENABLE_IPV4
-        else if (info->addressType == chip::Inet::kIPAddressType_IPv4)
+        else if (info->addressType == chip::Inet::IPAddressType::kIPv4)
         {
-            err = info->udp->SendTo(mIpv4BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv4BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #endif
         else

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -106,7 +106,7 @@ public:
     }
 
 private:
-    char ipAddressBuf[Inet::kMaxIPAddressStringLength];
+    char ipAddressBuf[Inet::IPAddress::kMaxStringLength];
 };
 
 DnsShellResolverDelegate sDnsShellResolverDelegate;
@@ -121,7 +121,7 @@ CHIP_ERROR ResolveHandler(int argc, char ** argv)
     peerId.SetCompressedFabricId(strtoull(argv[0], NULL, 10));
     peerId.SetNodeId(strtoull(argv[1], NULL, 10));
 
-    return Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::kIPAddressType_Any);
+    return Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::IPAddressType::kAny);
 }
 
 bool ParseSubType(int argc, char ** argv, Dnssd::DiscoveryFilter & filter)

--- a/src/lib/support/ObjectLifeCycle.h
+++ b/src/lib/support/ObjectLifeCycle.h
@@ -67,13 +67,13 @@ public:
     /*
      * State transitions.
      *
-     * Typical use is `VerifyOrReturnError(state.Initializing(), CHIP_ERROR_INCORRECT_STATE)`; these functions return `bool`
+     * Typical use is `VerifyOrReturnError(state.SetInitializing(), CHIP_ERROR_INCORRECT_STATE)`; these functions return `bool`
      * rather than a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
      */
-    bool Initializing() { return Transition<State::Uninitialized, State::Initializing>(); }
-    bool Initialized() { return Transition<State::Initializing, State::Initialized>(); }
-    bool ShuttingDown() { return Transition<State::Initialized, State::ShuttingDown>(); }
-    bool Shutdown() { return Transition<State::ShuttingDown, State::Shutdown>(); }
+    bool SetInitializing() { return Transition<State::Uninitialized, State::Initializing>(); }
+    bool SetInitialized() { return Transition<State::Initializing, State::Initialized>(); }
+    bool SetShuttingDown() { return Transition<State::Initialized, State::ShuttingDown>(); }
+    bool SetShutdown() { return Transition<State::ShuttingDown, State::Shutdown>(); }
 
     /**
      * Transition from Shutdown back to Uninitialized, or remain Uninitialized.

--- a/src/lib/support/ObjectLifeCycle.h
+++ b/src/lib/support/ObjectLifeCycle.h
@@ -26,57 +26,54 @@ namespace chip {
  * Track the life cycle of an object.
  *
  * <pre>
- *                  ┌───────────────┐  Init  ┌─────────────┐  Shutdown  ┌──────────┐  Destroy  ┌───────────┐
- * Construction ───>│ Uninitialized ├───────>│ Initialized ├───────────>│ Shutdown ├──────────>│ Destroyed │
- *                  └──────────┬────┘        └─────────────┘            └─────┬────┘           └───────────┘
- *                      ^      │                               Reset          │
- *                      └──────┴<─────────────────────────────────────────────┘
+ *
+ *      Construction
+ *          ↓
+ *      Uninitialized ‹─┐
+ *          ↓           │
+ *      Initializing    │
+ *          ↓           │
+ *      Initialized     │
+ *          ↓           │
+ *      ShuttingDown    │
+ *          ↓           │
+ *      Shutdown ───────┘
+ *          ↓
+ *      Destroyed
+ *
  * </pre>
  */
-struct ObjectLifeCycle
+class ObjectLifeCycle
 {
+public:
+    enum class State : uint8_t
+    {
+        Uninitialized = 0, ///< Pre-initialized state.
+        Initializing  = 1, ///< State during intialization.
+        Initialized   = 2, ///< Initialized (active) state.
+        ShuttingDown  = 3, ///< State during shutdown.
+        Shutdown      = 4, ///< Post-shutdown state.
+        Destroyed     = 5, ///< Post-destructor state.
+    };
+
+    ObjectLifeCycle() : mState(State::Uninitialized) {}
+    ~ObjectLifeCycle() { mState = State::Destroyed; }
+
     /**
      * @returns true if and only if the object is in the Initialized state.
      */
     bool IsInitialized() const { return mState == State::Initialized; }
 
-    /**
-     * Transition from Uninitialized to Initialized.
+    /*
+     * State transitions.
      *
-     * Typical use is `VerifyOrReturnError(state.Init(), CHIP_ERROR_INCORRECT_STATE)`; this function returns `bool` rather than
-     * a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
-     *
-     * @return true     if the state was Uninitialized and is now Initialized.
-     * @return false    otherwise.
+     * Typical use is `VerifyOrReturnError(state.Initializing(), CHIP_ERROR_INCORRECT_STATE)`; these functions return `bool`
+     * rather than a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
      */
-    bool Init()
-    {
-        if (mState == State::Uninitialized)
-        {
-            mState = State::Initialized;
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Transition from Initialized to Shutdown.
-     *
-     * Typical use is `VerifyOrReturnError(state.Shutdown(), CHIP_ERROR_INCORRECT_STATE)`; this function returns `bool` rather than
-     * a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
-     *
-     * @return true     if the state was Initialized and is now Shutdown.
-     * @return false    otherwise.
-     */
-    bool Shutdown()
-    {
-        if (mState == State::Initialized)
-        {
-            mState = State::Shutdown;
-            return true;
-        }
-        return false;
-    }
+    bool Initializing() { return Transition<State::Uninitialized, State::Initializing>(); }
+    bool Initialized() { return Transition<State::Initializing, State::Initialized>(); }
+    bool ShuttingDown() { return Transition<State::Initialized, State::ShuttingDown>(); }
+    bool Shutdown() { return Transition<State::ShuttingDown, State::Shutdown>(); }
 
     /**
      * Transition from Shutdown back to Uninitialized, or remain Uninitialized.
@@ -115,21 +112,21 @@ struct ObjectLifeCycle
         return false;
     }
 
-    /**
-     * Return the current state as an integer. This is intended for troubleshooting or logging, since there is no code access to
-     * the meaning of the integer value.
-     */
-    explicit operator int() const { return static_cast<int>(mState); }
+    State GetState() const { return mState; }
 
 private:
-    enum class State : uint8_t
+    template <State FROM, State TO>
+    bool Transition()
     {
-        Uninitialized = 0, /**< Pre-initialized state; */
-        Initialized   = 1, /**< Initialized state. */
-        Shutdown      = 2, /**< Post-Shutdown state. */
-        Destroyed     = 3, /**< Post-destructor state. */
-    };
-    State mState = State::Uninitialized;
+        if (mState == FROM)
+        {
+            mState = TO;
+            return true;
+        }
+        return false;
+    }
+
+    State mState;
 };
 
 } // namespace chip

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -228,7 +228,7 @@ int main(int argc, char * argv[])
     if (gUseTCP)
     {
         err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer)
-                                   .SetAddressType(chip::Inet::kIPAddressType_IPv6)
+                                   .SetAddressType(chip::Inet::IPAddressType::kIPv6)
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
@@ -238,7 +238,7 @@ int main(int argc, char * argv[])
     else
     {
         err = gUDPManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer)
-                                   .SetAddressType(chip::Inet::kIPAddressType_IPv6)
+                                   .SetAddressType(chip::Inet::IPAddressType::kIPv6)
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -85,9 +85,9 @@ int main(int argc, char * argv[])
     {
         err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer)
 #if INET_CONFIG_ENABLE_IPV4
-                                   .SetAddressType(chip::Inet::kIPAddressType_IPv4)
+                                   .SetAddressType(chip::Inet::IPAddressType::kIPv4)
 #else
-                                   .SetAddressType(chip::Inet::kIPAddressType_IPv6)
+                                   .SetAddressType(chip::Inet::IPAddressType::kIPv6)
 #endif
         );
         SuccessOrExit(err);
@@ -98,7 +98,7 @@ int main(int argc, char * argv[])
     else
     {
         err = gUDPManager.Init(
-            chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6));
+            chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::IPAddressType::kIPv6));
         SuccessOrExit(err);
 
         err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -433,11 +433,11 @@ static CHIP_ERROR GetAddrInfo(void * context, DnssdResolveCallback callback, uin
     DNSServiceProtocol protocol;
 
 #if INET_CONFIG_ENABLE_IPV4
-    if (addressType == chip::Inet::kIPAddressType_IPv4)
+    if (addressType == chip::Inet::IPAddressType::kIPv4)
     {
         protocol = kDNSServiceProtocol_IPv4;
     }
-    else if (addressType == chip::Inet::kIPAddressType_IPv6)
+    else if (addressType == chip::Inet::IPAddressType::kIPv6)
     {
         protocol = kDNSServiceProtocol_IPv6;
     }

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -49,11 +49,11 @@ AvahiProtocol ToAvahiProtocol(chip::Inet::IPAddressType addressType)
     switch (addressType)
     {
 #if INET_CONFIG_ENABLE_IPV4
-    case chip::Inet::IPAddressType::kIPAddressType_IPv4:
+    case chip::Inet::IPAddressType::kIPv4:
         protocol = AVAHI_PROTO_INET;
         break;
 #endif
-    case chip::Inet::IPAddressType::kIPAddressType_IPv6:
+    case chip::Inet::IPAddressType::kIPv6:
         protocol = AVAHI_PROTO_INET6;
         break;
     default:
@@ -72,14 +72,14 @@ chip::Inet::IPAddressType ToAddressType(AvahiProtocol protocol)
     {
 #if INET_CONFIG_ENABLE_IPV4
     case AVAHI_PROTO_INET:
-        type = chip::Inet::IPAddressType::kIPAddressType_IPv4;
+        type = chip::Inet::IPAddressType::kIPv4;
         break;
 #endif
     case AVAHI_PROTO_INET6:
-        type = chip::Inet::IPAddressType::kIPAddressType_IPv6;
+        type = chip::Inet::IPAddressType::kIPv6;
         break;
     default:
-        type = chip::Inet::IPAddressType::kIPAddressType_Unknown;
+        type = chip::Inet::IPAddressType::kUnknown;
         break;
     }
 
@@ -722,7 +722,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
                 struct in_addr addr4;
 
                 memcpy(&addr4, &(address->data.ipv4), sizeof(addr4));
-                result.mAddress.SetValue(chip::Inet::IPAddress::FromIPv4(addr4));
+                result.mAddress.SetValue(chip::Inet::IPAddress(addr4));
 #else
                 result_err = CHIP_ERROR_INVALID_ADDRESS;
                 ChipLogError(Discovery, "Ignoring IPv4 mDNS address.");
@@ -732,7 +732,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
                 struct in6_addr addr6;
 
                 memcpy(&addr6, &(address->data.ipv6), sizeof(addr6));
-                result.mAddress.SetValue(chip::Inet::IPAddress::FromIPv6(addr6));
+                result.mAddress.SetValue(chip::Inet::IPAddress(addr6));
                 break;
             default:
                 break;

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -181,7 +181,7 @@ bool ThreadStackManagerImpl::_HaveRouteToAddress(const Inet::IPAddress & destAdd
                 continue;
 
             Inet::IPPrefix p;
-            p.IPAddr = Inet::IPAddress::FromIPv6(*reinterpret_cast<const struct in6_addr *>(data));
+            p.IPAddr = Inet::IPAddress(*reinterpret_cast<const struct in6_addr *>(data));
             p.Length = prefixLength;
 
             if (p.MatchAddress(destAddr))

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1917,7 +1917,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::FromOtDnsRespons
     }
     mdnsService.mPort        = serviceInfo.mPort;
     mdnsService.mInterface   = INET_NULL_INTERFACEID;
-    mdnsService.mAddressType = Inet::kIPAddressType_IPv6;
+    mdnsService.mAddressType = Inet::IPAddressType::kIPv6;
     mdnsService.mAddress     = chip::Optional<chip::Inet::IPAddress>(ToIPAddress(serviceInfo.mHostAddress));
 
     otDnsTxtEntryIterator iterator;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -247,7 +247,7 @@ void GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::UpdateThreadInter
                 uint8_t state = netif_ip6_addr_state(mNetIf, addrIdx);
                 if (state != IP6_ADDR_INVALID)
                 {
-                    IPAddress addr = IPAddress::FromIPv6(*netif_ip6_addr(mNetIf, addrIdx));
+                    IPAddress addr = IPAddress(*netif_ip6_addr(mNetIf, addrIdx));
                     char addrStr[50];
                     addr.ToString(addrStr, sizeof(addrStr));
                     const char * typeStr;

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -60,7 +60,7 @@ static void InitCallback(void * context, CHIP_ERROR error)
     service.mPort      = 80;
     strcpy(service.mName, "test");
     strcpy(service.mType, "_mock");
-    service.mAddressType   = chip::Inet::kIPAddressType_Any;
+    service.mAddressType   = chip::Inet::IPAddressType::kAny;
     service.mProtocol      = DnssdServiceProtocol::kDnssdProtocolTcp;
     entry.mKey             = key;
     entry.mData            = reinterpret_cast<const uint8_t *>(val);
@@ -71,7 +71,7 @@ static void InitCallback(void * context, CHIP_ERROR error)
     service.mSubTypeSize   = 0;
 
     NL_TEST_ASSERT(suite, ChipDnssdPublishService(&service) == CHIP_NO_ERROR);
-    ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::kIPAddressType_Any, INET_NULL_INTERFACEID,
+    ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny, INET_NULL_INTERFACEID,
                     HandleBrowse, suite);
 }
 

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -611,7 +611,8 @@ struct LwIPEvent;
  *  or sockets, this setting allows the platform layer to inject handlers
  *  which achieve the goal by other means.
  *
- *  Defaults to enabled on Zephyr platforms using sockets
+ *  Defaults to enabled on Zephyr platforms using sockets.
+ *  Only supported for CHIP_SYSTEM_CONFIG_USE_SOCKETS.
  */
 #ifndef CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && __ZEPHYR__

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -32,7 +32,6 @@
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
-#include <lib/support/ObjectLifeCycle.h>
 #include <system/SystemError.h>
 #include <system/SystemEvent.h>
 #include <system/SystemObject.h>

--- a/src/system/SystemLayerImplLibevent.cpp
+++ b/src/system/SystemLayerImplLibevent.cpp
@@ -55,7 +55,7 @@ System::SocketEvents SocketEventsFromLibeventFlags(short eventFlags)
 
 CHIP_ERROR LayerImplLibevent::Init(System::Layer & systemLayer)
 {
-    VerifyOrReturnError(!mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
 
     RegisterPOSIXErrorFormatter();
 
@@ -83,7 +83,7 @@ CHIP_ERROR LayerImplLibevent::Init(System::Layer & systemLayer)
 
     Mutex::Init(mTimerListMutex);
 
-    VerifyOrReturnError(mLayerState.Init(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Initialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
@@ -111,7 +111,7 @@ void LayerImplLibevent::MdnsTimeoutCallbackHandler()
 
 CHIP_ERROR LayerImplLibevent::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.Shutdown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
 
     event_base_loopbreak(mEventBase);
 
@@ -133,6 +133,7 @@ CHIP_ERROR LayerImplLibevent::Shutdown()
     mEventBase   = nullptr;
     mSystemLayer = nullptr;
 
+    mLayerState.Shutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/system/SystemLayerImplLibevent.cpp
+++ b/src/system/SystemLayerImplLibevent.cpp
@@ -55,7 +55,7 @@ System::SocketEvents SocketEventsFromLibeventFlags(short eventFlags)
 
 CHIP_ERROR LayerImplLibevent::Init(System::Layer & systemLayer)
 {
-    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitializing(), CHIP_ERROR_INCORRECT_STATE);
 
     RegisterPOSIXErrorFormatter();
 
@@ -83,7 +83,7 @@ CHIP_ERROR LayerImplLibevent::Init(System::Layer & systemLayer)
 
     Mutex::Init(mTimerListMutex);
 
-    VerifyOrReturnError(mLayerState.Initialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
@@ -111,7 +111,7 @@ void LayerImplLibevent::MdnsTimeoutCallbackHandler()
 
 CHIP_ERROR LayerImplLibevent::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
 
     event_base_loopbreak(mEventBase);
 
@@ -133,7 +133,7 @@ CHIP_ERROR LayerImplLibevent::Shutdown()
     mEventBase   = nullptr;
     mSystemLayer = nullptr;
 
-    mLayerState.Shutdown();
+    mLayerState.SetShutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/system/SystemLayerImplLibevent.h
+++ b/src/system/SystemLayerImplLibevent.h
@@ -44,7 +44,7 @@ class LayerImplLibevent : public LayerSocketsLoop
 {
 public:
     LayerImplLibevent() : mEventBase(nullptr), mMdnsTimeoutEvent(nullptr) {}
-    ~LayerImplLibevent() { mLayerState.Destroy(); }
+    ~LayerImplLibevent() = default;
 
     // Layer overrides.
     CHIP_ERROR Init() override;

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -34,19 +34,20 @@ LayerImplLwIP::LayerImplLwIP() : mHandlingTimerComplete(false), mEventDelegateLi
 
 CHIP_ERROR LayerImplLwIP::Init()
 {
-    VerifyOrReturnError(!mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
 
     RegisterLwIPErrorFormatter();
 
     ReturnErrorOnFailure(mTimerList.Init());
 
-    VerifyOrReturnError(mLayerState.Init(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Initialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LayerImplLwIP::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.Shutdown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
+    mLayerState.Shutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -34,20 +34,20 @@ LayerImplLwIP::LayerImplLwIP() : mHandlingTimerComplete(false), mEventDelegateLi
 
 CHIP_ERROR LayerImplLwIP::Init()
 {
-    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitializing(), CHIP_ERROR_INCORRECT_STATE);
 
     RegisterLwIPErrorFormatter();
 
     ReturnErrorOnFailure(mTimerList.Init());
 
-    VerifyOrReturnError(mLayerState.Initialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LayerImplLwIP::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
-    mLayerState.Shutdown();
+    VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
+    mLayerState.SetShutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/system/SystemLayerImplLwIP.h
+++ b/src/system/SystemLayerImplLwIP.h
@@ -32,7 +32,7 @@ class LayerImplLwIP : public LayerLwIP
 {
 public:
     LayerImplLwIP();
-    ~LayerImplLwIP() { mLayerState.Destroy(); }
+    ~LayerImplLwIP() = default;
 
     // Layer overrides.
     CHIP_ERROR Init() override;

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -42,7 +42,7 @@ namespace System {
 
 CHIP_ERROR LayerImplSelect::Init()
 {
-    VerifyOrReturnError(!mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
 
     RegisterPOSIXErrorFormatter();
 
@@ -60,13 +60,13 @@ CHIP_ERROR LayerImplSelect::Init()
     // Create an event to allow an arbitrary thread to wake the thread in the select loop.
     ReturnErrorOnFailure(mWakeEvent.Open(*this));
 
-    VerifyOrReturnError(mLayerState.Init(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Initialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LayerImplSelect::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.Shutdown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
 
     Timer * timer;
     while ((timer = mTimerList.PopEarliest()) != nullptr)
@@ -84,6 +84,8 @@ CHIP_ERROR LayerImplSelect::Shutdown()
         timer->Release();
     }
     mWakeEvent.Close(*this);
+
+    mLayerState.Shutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -42,7 +42,7 @@ namespace System {
 
 CHIP_ERROR LayerImplSelect::Init()
 {
-    VerifyOrReturnError(mLayerState.Initializing(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitializing(), CHIP_ERROR_INCORRECT_STATE);
 
     RegisterPOSIXErrorFormatter();
 
@@ -60,13 +60,13 @@ CHIP_ERROR LayerImplSelect::Init()
     // Create an event to allow an arbitrary thread to wake the thread in the select loop.
     ReturnErrorOnFailure(mWakeEvent.Open(*this));
 
-    VerifyOrReturnError(mLayerState.Initialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LayerImplSelect::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.ShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
 
     Timer * timer;
     while ((timer = mTimerList.PopEarliest()) != nullptr)
@@ -85,7 +85,7 @@ CHIP_ERROR LayerImplSelect::Shutdown()
     }
     mWakeEvent.Close(*this);
 
-    mLayerState.Shutdown();
+    mLayerState.SetShutdown();
     mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -39,8 +39,8 @@ namespace System {
 class LayerImplSelect : public LayerSocketsLoop
 {
 public:
-    LayerImplSelect() = default;
-    ~LayerImplSelect() { mLayerState.Destroy(); }
+    LayerImplSelect()  = default;
+    ~LayerImplSelect() = default;
 
     // Layer overrides.
     CHIP_ERROR Init() override;

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -74,10 +74,10 @@ public:
     }
 
 private:
-    Inet::InetLayer * mLayer         = nullptr;                   ///< Associated inet layer
-    Inet::IPAddressType mAddressType = Inet::kIPAddressType_IPv6; ///< type of listening socket
-    uint16_t mListenPort             = CHIP_PORT;                 ///< TCP listen port
-    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;     ///< Interface to listen on
+    Inet::InetLayer * mLayer         = nullptr;                    ///< Associated inet layer
+    Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
+    uint16_t mListenPort             = CHIP_PORT;                  ///< TCP listen port
+    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;      ///< Interface to listen on
 };
 
 /**
@@ -255,9 +255,9 @@ private:
     // @see TCPEndpoint::OnAcceptErrorFunct
     static void OnAcceptError(Inet::TCPEndPoint * endPoint, CHIP_ERROR err);
 
-    Inet::TCPEndPoint * mListenSocket = nullptr;                                     ///< TCP socket used by the transport
-    Inet::IPAddressType mEndpointType = Inet::IPAddressType::kIPAddressType_Unknown; ///< Socket listening type
-    State mState                      = State::kNotReady;                            ///< State of the TCP transport
+    Inet::TCPEndPoint * mListenSocket = nullptr;                       ///< TCP socket used by the transport
+    Inet::IPAddressType mEndpointType = Inet::IPAddressType::kUnknown; ///< Socket listening type
+    State mState                      = State::kNotReady;              ///< State of the TCP transport
 
     // Number of active and 'pending connection' endpoints
     size_t mUsedEndPointCount = 0;

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -71,10 +71,10 @@ public:
     }
 
 private:
-    Inet::InetLayer * mLayer         = nullptr;                   ///< Associated inet layer
-    Inet::IPAddressType mAddressType = Inet::kIPAddressType_IPv6; ///< type of listening socket
-    uint16_t mListenPort             = CHIP_PORT;                 ///< UDP listen port
-    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;     ///< Interface to listen on
+    Inet::InetLayer * mLayer         = nullptr;                    ///< Associated inet layer
+    Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
+    uint16_t mListenPort             = CHIP_PORT;                  ///< UDP listen port
+    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;      ///< Interface to listen on
 };
 
 /** Implements a transport using UDP. */
@@ -125,9 +125,9 @@ private:
     static void OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBufferHandle && buffer,
                              const Inet::IPPacketInfo * pktInfo);
 
-    Inet::UDPEndPoint * mUDPEndPoint     = nullptr;                                     ///< UDP socket used by the transport
-    Inet::IPAddressType mUDPEndpointType = Inet::IPAddressType::kIPAddressType_Unknown; ///< Socket listening type
-    State mState                         = State::kNotReady;                            ///< State of the UDP transport
+    Inet::UDPEndPoint * mUDPEndPoint     = nullptr;                       ///< UDP socket used by the transport
+    Inet::IPAddressType mUDPEndpointType = Inet::IPAddressType::kUnknown; ///< Socket listening type
+    State mState                         = State::kNotReady;              ///< State of the UDP transport
 };
 
 } // namespace Transport

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -181,13 +181,13 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext, Inet::IPAddres
 #if INET_CONFIG_ENABLE_IPV4
 void CheckSimpleInitTest4(nlTestSuite * inSuite, void * inContext)
 {
-    CheckSimpleInitTest(inSuite, inContext, kIPAddressType_IPv4);
+    CheckSimpleInitTest(inSuite, inContext, IPAddressType::kIPv4);
 }
 #endif
 
 void CheckSimpleInitTest6(nlTestSuite * inSuite, void * inContext)
 {
-    CheckSimpleInitTest(inSuite, inContext, kIPAddressType_IPv6);
+    CheckSimpleInitTest(inSuite, inContext, IPAddressType::kIPv6);
 }
 
 /////////////////////////// Messaging test

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -98,13 +98,13 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext, Inet::IPAddres
 #if INET_CONFIG_ENABLE_IPV4
 void CheckSimpleInitTest4(nlTestSuite * inSuite, void * inContext)
 {
-    CheckSimpleInitTest(inSuite, inContext, kIPAddressType_IPv4);
+    CheckSimpleInitTest(inSuite, inContext, IPAddressType::kIPv4);
 }
 #endif
 
 void CheckSimpleInitTest6(nlTestSuite * inSuite, void * inContext)
 {
-    CheckSimpleInitTest(inSuite, inContext, kIPAddressType_IPv6);
+    CheckSimpleInitTest(inSuite, inContext, IPAddressType::kIPv6);
 }
 
 /////////////////////////// Messaging test


### PR DESCRIPTION
#### Problem

Working toward #7715 Virtualize System and Inet interfaces

#### Change overview

- Convert some `enum` to `enum class`, and use `BitFlags` for flag sets.
- Rename some class members with `m` preifx for consistency within `src/inet`.
- Revise `IPAddress` construction.
- Fix outdated `IPAddress` documentation.
- Convert file-local functions from `static` to anonymous `namespace`.
- Revise `IPEndPointBasis` to reduce duplication and remove dead code.
- Remove unused flags argument from `SendTo()` and `SendMsg()`.
- Replace various `sockaddr` unions with `SockAddr`.
- Remove some `exit: return` and use `ReturnError…` more.
- Move some comments from definition (.cpp) to declaration (.h).
- Use `ObjectLifeCycle` for `InetLayer`.
- Make some `TCPEndPoint` members `private` with `TCPTest` for tests.

#### Testing

CI; no changes to functionality intended.
