### PR TITLE
Ramp up new bloat reports

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -49,8 +49,8 @@ jobs:
                     --report-increases 1 \
                     --report-pr \
                     --github-comment \
-                    --github-limit-artifact-pages 5 \
-                    --github-limit-artifacts 50 \
-                    --github-limit-comments 2 \
+                    --github-limit-artifact-pages 50 \
+                    --github-limit-artifacts 500 \
+                    --github-limit-comments 20 \
                     --github-repository project-chip/connectedhomeip \
                     --github-api-token "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### Problem

`gh_report.py` now runs in CI but is severely rate-limited.

#### Change overview

Increase limits.

#### Testing

Offline run.
