### PR TITLE
Include Docker Build/Scan Github Workflow 

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) 2020-2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Docker CHIP images
+
+on:
+    push:
+        paths:
+            - 'integrations/docker/images/**'
+    pull_request:
+        paths:
+            - 'integrations/docker/images/**'
+    workflow_dispatch:
+
+jobs:
+    build_images:
+        name: Build Docker CHIP Build images
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+        strategy:
+            fail-fast: false
+            matrix:
+                # TODO: Enables "-crosscompile" and "-vscode" images
+                img: ["", "-android", "-cirque", "-efr32", "-esp32", "-esp32-qemu", "-infineon", "-k32w", "-mbed-os", "-nrf-platform", "-telink", "-tizen"]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Build All images using project bash script
+              run: |
+                  cd integrations/docker/images/chip-build${{ matrix.img }}
+                  ./build.sh --latest
+            - name: Scan for vulnerabilities
+              uses: crazy-max/docker-scan-action@master
+              with:
+                  image: connectedhomeip/chip-build${{ matrix.img }}:latest
+                  annotations: true
+

--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -44,6 +44,7 @@ VERSION=${DOCKER_BUILD_VERSION:-$(sed 's/ .*//' version)}
    --latest   update latest to the current built version (\"$VERSION\")
    --push     push image(s) to docker.io (requires docker login for \"$ORG\")
    --help     get this message
+   --squash   squash docker layers before push them to docker.io (requires docker-squash python module)
 
 "
     exit 0
@@ -73,6 +74,11 @@ docker build "${BUILD_ARGS[@]}" --build-arg VERSION="$VERSION" -t "$ORG/$IMAGE:$
 
 [[ ${*/--latest//} != "${*}" ]] && {
     docker tag "$ORG"/"$IMAGE":"$VERSION" "$ORG"/"$IMAGE":latest
+}
+
+[[ ${*/--squash//} != "${*}" ]] && {
+    command -v docker-squash >/dev/null &&
+        docker-squash "$ORG"/"$IMAGE":"$VERSION" -t "$ORG"/"$IMAGE":latest
 }
 
 [[ ${*/--push//} != "${*}" ]] && {

--- a/integrations/docker/images/build-all.sh
+++ b/integrations/docker/images/build-all.sh
@@ -26,3 +26,4 @@ find "$(git rev-parse --show-toplevel)"/integrations/docker/images/ -name Docker
     ./build.sh "$@"
     popd >/dev/null
 done
+docker image prune --force

--- a/integrations/docker/images/build-all.sh
+++ b/integrations/docker/images/build-all.sh
@@ -21,7 +21,8 @@
 #  https://github.com/project-chip/connectedhomeip/issues/710
 #
 set -e
-find . -name Dockerfile | while read -r dockerfile; do
-    dir=${dockerfile%/*}
-    (cd "$dir" && ./build.sh "$@") || exit $?
+find "$(git rev-parse --show-toplevel)"/integrations/docker/images/ -name Dockerfile | while read -r dockerfile; do
+    pushd "$(dirname "$dockerfile")" >/dev/null
+    ./build.sh "$@"
+    popd >/dev/null
 done


### PR DESCRIPTION
#### Problem
Changes on Dockerfiles are not tracked by any Workflow in the CI. These changes can affect the building process as well as being impacted by security vulnerabilities. 

#### Change overview
This change includes a Workflow which builds and scans CHIP Docker images. It was also included the `--squash` parameter to reduce the number of Docker layers and refactored the `build-all.sh` script to enable its execution from any folder and cleanup some leftovers.

#### Testing
It was tested using the GitHub actions on a personal branch.
