### PR TITLE
Introduce a RNG determinism audit

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -33,13 +33,6 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-// Temporary includes for TemporaryAuditRandomPerformance()
-// TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
-#if 1
-#include <crypto/CHIPCryptoPAL.h>
-#include <lib/support/BytesToHex.h>
-#endif
-
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CHIPFaultInjection.h>
@@ -56,49 +49,6 @@ using namespace chip::System;
 
 namespace chip {
 namespace Messaging {
-
-namespace {
-
-// Audit random number generator proper initialization with prints.
-// TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
-void TemporaryAuditRandomNumberGenerator()
-{
-    uint8_t buf1[16];
-    uint8_t buf2[16];
-
-    memset(&buf1[0], 0, sizeof(buf1));
-    memset(&buf2[0], 0, sizeof(buf2));
-
-    VerifyOrDie(chip::Crypto::DRBG_get_bytes(&buf1[0], sizeof(buf1)) == CHIP_NO_ERROR);
-    VerifyOrDie(chip::Crypto::DRBG_get_bytes(&buf2[0], sizeof(buf2)) == CHIP_NO_ERROR);
-
-    char hex_buf[sizeof(buf1) * 2 + 1];
-
-    ChipLogProgress(ExchangeManager, "AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====");
-    ChipLogProgress(ExchangeManager, "AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>");
-    ChipLogProgress(ExchangeManager, "AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>");
-
-    memset(&hex_buf[0], 0, sizeof(hex_buf));
-    VerifyOrDie(Encoding::BytesToUppercaseHexString(&buf1[0], sizeof(buf1), &hex_buf[0], sizeof(hex_buf)) == CHIP_NO_ERROR);
-    ChipLogProgress(ExchangeManager, "AUDIT: * buf1: %s", &hex_buf[0]);
-
-    memset(&hex_buf[0], 0, sizeof(hex_buf));
-    VerifyOrDie(Encoding::BytesToUppercaseHexString(&buf2[0], sizeof(buf2), &hex_buf[0], sizeof(hex_buf)) == CHIP_NO_ERROR);
-    ChipLogProgress(ExchangeManager, "AUDIT: * buf2: %s", &hex_buf[0]);
-
-    VerifyOrDieWithMsg(memcmp(&buf1[0], &buf2[0], sizeof(buf1)) != 0, ExchangeManager,
-                       "AUDIT: FAILED: buf1, buf2 are equal: DRBG_get_bytes() does not function!");
-
-    uint32_t r1 = GetRandU32();
-    uint32_t r2 = GetRandU32();
-
-    ChipLogProgress(ExchangeManager, "AUDIT: * r1: 0x%08" PRIX32 " r2: 0x%08" PRIX32, r1, r2);
-    VerifyOrDieWithMsg(r1 != r2, ExchangeManager,
-                       "AUDIT: FAILED: buf1, buf2 are equal: random number generator does not function!");
-    ChipLogProgress(ExchangeManager, "AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====");
-}
-
-} // namespace
 
 /**
  *  Constructor for the ExchangeManager class.
@@ -121,11 +71,6 @@ CHIP_ERROR ExchangeManager::Init(SessionManager * sessionManager)
     VerifyOrReturnError(mState == State::kState_NotInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
     mSessionManager = sessionManager;
-
-    {
-        // TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
-        TemporaryAuditRandomNumberGenerator();
-    }
 
     mNextExchangeId = GetRandU16();
     mNextKeyId      = 0;

--- a/src/platform/Entropy.cpp
+++ b/src/platform/Entropy.cpp
@@ -70,8 +70,7 @@ void TemporaryAuditRandomNumberGenerator()
     uint32_t r2 = GetRandU32();
 
     ChipLogProgress(DeviceLayer, "AUDIT: * r1: 0x%08" PRIX32 " r2: 0x%08" PRIX32, r1, r2);
-    VerifyOrDieWithMsg(r1 != r2, DeviceLayer,
-                       "AUDIT: FAILED: buf1, buf2 are equal: random number generator does not function!");
+    VerifyOrDieWithMsg(r1 != r2, DeviceLayer, "AUDIT: FAILED: buf1, buf2 are equal: random number generator does not function!");
     ChipLogProgress(DeviceLayer, "AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====");
 }
 

--- a/src/platform/Entropy.cpp
+++ b/src/platform/Entropy.cpp
@@ -28,9 +28,7 @@
 
 // Temporary includes for TemporaryAuditRandomPerformance()
 // TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
-#if 1
 #include <lib/support/BytesToHex.h>
-#endif
 
 namespace chip {
 
@@ -40,11 +38,8 @@ namespace {
 // TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
 void TemporaryAuditRandomNumberGenerator()
 {
-    uint8_t buf1[16];
-    uint8_t buf2[16];
-
-    memset(&buf1[0], 0, sizeof(buf1));
-    memset(&buf2[0], 0, sizeof(buf2));
+    uint8_t buf1[16] = { 0 };
+    uint8_t buf2[16] = { 0 };
 
     VerifyOrDie(chip::Crypto::DRBG_get_bytes(&buf1[0], sizeof(buf1)) == CHIP_NO_ERROR);
     VerifyOrDie(chip::Crypto::DRBG_get_bytes(&buf2[0], sizeof(buf2)) == CHIP_NO_ERROR);
@@ -70,7 +65,7 @@ void TemporaryAuditRandomNumberGenerator()
     uint32_t r2 = GetRandU32();
 
     ChipLogProgress(DeviceLayer, "AUDIT: * r1: 0x%08" PRIX32 " r2: 0x%08" PRIX32, r1, r2);
-    VerifyOrDieWithMsg(r1 != r2, DeviceLayer, "AUDIT: FAILED: buf1, buf2 are equal: random number generator does not function!");
+    VerifyOrDieWithMsg(r1 != r2, DeviceLayer, "AUDIT: FAILED: r1, r2 are equal: random number generator does not function!");
     ChipLogProgress(DeviceLayer, "AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====");
 }
 
@@ -85,10 +80,8 @@ CHIP_ERROR InitEntropy()
     ReturnErrorOnFailure(chip::Crypto::DRBG_get_bytes((uint8_t *) &seed, sizeof(seed)));
     srand(seed);
 
-    {
-        // TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
-        TemporaryAuditRandomNumberGenerator();
-    }
+    // TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
+    TemporaryAuditRandomNumberGenerator();
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Entropy.cpp
+++ b/src/platform/Entropy.cpp
@@ -23,8 +23,60 @@
  */
 
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/RandUtils.h>
+
+// Temporary includes for TemporaryAuditRandomPerformance()
+// TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
+#if 1
+#include <lib/support/BytesToHex.h>
+#endif
 
 namespace chip {
+
+namespace {
+
+// Audit random number generator proper initialization with prints.
+// TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
+void TemporaryAuditRandomNumberGenerator()
+{
+    uint8_t buf1[16];
+    uint8_t buf2[16];
+
+    memset(&buf1[0], 0, sizeof(buf1));
+    memset(&buf2[0], 0, sizeof(buf2));
+
+    VerifyOrDie(chip::Crypto::DRBG_get_bytes(&buf1[0], sizeof(buf1)) == CHIP_NO_ERROR);
+    VerifyOrDie(chip::Crypto::DRBG_get_bytes(&buf2[0], sizeof(buf2)) == CHIP_NO_ERROR);
+
+    char hex_buf[sizeof(buf1) * 2 + 1];
+
+    ChipLogProgress(DeviceLayer, "AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====");
+    ChipLogProgress(DeviceLayer, "AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>");
+    ChipLogProgress(DeviceLayer, "AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>");
+
+    memset(&hex_buf[0], 0, sizeof(hex_buf));
+    VerifyOrDie(Encoding::BytesToUppercaseHexString(&buf1[0], sizeof(buf1), &hex_buf[0], sizeof(hex_buf)) == CHIP_NO_ERROR);
+    ChipLogProgress(DeviceLayer, "AUDIT: * buf1: %s", &hex_buf[0]);
+
+    memset(&hex_buf[0], 0, sizeof(hex_buf));
+    VerifyOrDie(Encoding::BytesToUppercaseHexString(&buf2[0], sizeof(buf2), &hex_buf[0], sizeof(hex_buf)) == CHIP_NO_ERROR);
+    ChipLogProgress(DeviceLayer, "AUDIT: * buf2: %s", &hex_buf[0]);
+
+    VerifyOrDieWithMsg(memcmp(&buf1[0], &buf2[0], sizeof(buf1)) != 0, DeviceLayer,
+                       "AUDIT: FAILED: buf1, buf2 are equal: DRBG_get_bytes() does not function!");
+
+    uint32_t r1 = GetRandU32();
+    uint32_t r2 = GetRandU32();
+
+    ChipLogProgress(DeviceLayer, "AUDIT: * r1: 0x%08" PRIX32 " r2: 0x%08" PRIX32, r1, r2);
+    VerifyOrDieWithMsg(r1 != r2, DeviceLayer,
+                       "AUDIT: FAILED: buf1, buf2 are equal: random number generator does not function!");
+    ChipLogProgress(DeviceLayer, "AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====");
+}
+
+} // namespace
+
 namespace DeviceLayer {
 namespace Internal {
 
@@ -33,6 +85,11 @@ CHIP_ERROR InitEntropy()
     unsigned int seed;
     ReturnErrorOnFailure(chip::Crypto::DRBG_get_bytes((uint8_t *) &seed, sizeof(seed)));
     srand(seed);
+
+    {
+        // TODO: remove once https://github.com/project-chip/connectedhomeip/issues/10454 is done.
+        TemporaryAuditRandomNumberGenerator();
+    }
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem
Entropy initialization for DRBG_get_bytes() and random number generation (rand() from C++ standard library, GetRandU*()) is done per platform, often in *PlatformManagerImpl<ImplClass>::_InitChipStack().

It was found that the methods are varied and there are no tests (and no easy test, given the methods used) to ensure entropy sources are initialized properly and across the board.

This PR introduces a runnable audit to validate the behavior.

Issue #10454

#### Change overview

- Add a temporary audit function in Entropy.cpp.
- Entropy.cpp is used because it is used by both
  `DeviceController` and `Server` (i.e. by all modalities)
  and it is already expected to be called.
- Audit must be validated manually since it needs to be done on targets
  and comparisons across reboot.
- Audit validates `GetRandU*` and `Crypto::DRBG_get_bytes()`,
  which may both use different underlying impl.

#### Testing
- Unit tests pass
- Manually tested on Linux by commenting-out `srand(seed);` in
  Entropy.cpp, which forces `GetRandU*` to give the same values
  across calls.
- If you are testing this, search for lines starting with `AUDIT:`
  in the log.

##### First run
- This is the control run

> tennessee@tennessee1:~/repos/connectedhomeip-tcv/examples/all-clusters-app/linux$ cat roboto1.txt | grep AUDIT
> [1634143013.837761][3590257:3590257] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====
> [1634143013.837774][3590257:3590257] CHIP:DL: AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>
> [1634143013.837786][3590257:3590257] CHIP:DL: AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>
> [1634143013.837799][3590257:3590257] CHIP:DL: AUDIT: * buf1: 888C916478174820774FF68F28E7954D
> [1634143013.837811][3590257:3590257] CHIP:DL: AUDIT: * buf2: 52B95621E48B11BA1A5B352263895784
> [1634143013.837824][3590257:3590257] CHIP:DL: AUDIT: * **r1: 0xA9B9AE24 r2: 0x7FAB624E**
> [1634143013.837838][3590257:3590257] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====
> 

##### Second run (good)
- This is a good second run: `buf1`, `buf2` different to first run, `r1`, `r2` different from first run

> tennessee@tennessee1:~/repos/connectedhomeip-tcv/examples/all-clusters-app/linux$ cat roboto2.txt | grep AUDIT
> [1634143017.573763][3590265:3590265] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====
> [1634143017.573777][3590265:3590265] CHIP:DL: AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>
> [1634143017.573787][3590265:3590265] CHIP:DL: AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>
> [1634143017.573798][3590265:3590265] CHIP:DL: AUDIT: * buf1: 983898695607FBBBCD3C4EE5F16DE785
> [1634143017.573809][3590265:3590265] CHIP:DL: AUDIT: * buf2: 3F26419B8903D830E70BD18CEF886976
> [1634143017.573822][3590265:3590265] CHIP:DL: AUDIT: * r1: 0x60415904 r2: 0x7D43202D
> [1634143017.573832][3590265:3590265] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====
> 

##### Second run (bad)
- This is a good second run: `buf1`, `buf2` different to first run, `r1`, `r2` *same* from first run (i.e. same random numbers generated on a second run)

> tennessee@tennessee1:~/repos/connectedhomeip-tcv/examples/all-clusters-app/linux$ cat roboto2.txt | grep AUDIT
> [1634143017.573763][3590265:3590265] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====
> [1634143017.573777][3590265:3590265] CHIP:DL: AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>
> [1634143017.573787][3590265:3590265] CHIP:DL: AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>
> [1634143017.573798][3590265:3590265] CHIP:DL: AUDIT: * buf1: 983898695607FBBBCD3C4EE5F16DE785
> [1634143017.573809][3590265:3590265] CHIP:DL: AUDIT: * buf2: 3F26419B8903D830E70BD18CEF886976
> [1634143017.573822][3590265:3590265] CHIP:DL: AUDIT: * **r1: 0xA9B9AE24 r2: 0x7FAB624E**
> [1634143017.573832][3590265:3590265] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====
> 
