### PR TITLE
[OperationalCredentials]: Support read attribute with complex type via AttributeAccessInterface

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -123,7 +123,6 @@ CHIP_ERROR OperationalCredentialsAttrAccess::Read(ClusterInfo & aClusterInfo, At
 // As per specifications section 11.22.5.1. Constant RESP_MAX
 constexpr uint16_t kMaxRspLen = 900;
 
-#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 /*
  * Temporary flow for fabric management until addOptCert + fabric index are implemented:
  * 1) When Commissioner pairs with CHIP device, store device nodeId in Fabric table as NodeId
@@ -249,7 +248,6 @@ CHIP_ERROR writeFabricsIntoFabricsListAttribute()
 
     return err;
 }
-#endif // !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 
 static FabricInfo * retrieveCurrentFabric()
 {
@@ -263,7 +261,6 @@ static FabricInfo * retrieveCurrentFabric()
     return Server::GetInstance().GetFabricTable().FindFabricWithIndex(index);
 }
 
-#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 // TODO: The code currently has two sources of truths for fabrics, the fabricInfo table + the attributes. There should only be one,
 // the attributes list. Currently the attributes are not persisted so we are keeping the fabric table to have the
 // fabrics/admrins be persisted. Once attributes are persisted, there should only be one sorce of truth, the attributes list and
@@ -304,18 +301,17 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
 };
 
 OpCredsFabricTableDelegate gFabricDelegate;
-#endif // !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 
 void MatterOperationalCredentialsPluginServerInitCallback(void)
 {
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Initiating OpCreds cluster.");
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Initiating OpCreds cluster by writing fabrics list from fabric table.");
 
 #if CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
     registerAttributeAccessOverride(&gAttrAccess);
-#else
+#endif
+
     Server::GetInstance().GetFabricTable().SetFabricDelegate(&gFabricDelegate);
     writeFabricsIntoFabricsListAttribute();
-#endif
 }
 
 namespace {
@@ -352,9 +348,7 @@ bool emberAfOperationalCredentialsClusterRemoveFabricCallback(app::CommandHandle
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
 exit:
-#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
     writeFabricsIntoFabricsListAttribute();
-#endif
     emberAfSendImmediateDefaultResponse(status);
     if (err == CHIP_NO_ERROR)
     {
@@ -402,9 +396,7 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(app::CommandH
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
 exit:
-#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
     writeFabricsIntoFabricsListAttribute();
-#endif
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadFabricsList(EndpointId endpoint
             fabricDescriptor.vendorId    = fabricInfo.GetVendorId();
             fabricDescriptor.fabricId    = fabricInfo.GetFabricId();
 
-            // TODO: The type of 'label' should be 'CharSpan', need to fix the XML defination for broken member type.
+            // TODO: The type of 'label' should be 'CharSpan', need to fix the XML definition for broken member type.
             fabricDescriptor.label =
                 ByteSpan(Uint8::from_const_char(fabricInfo.GetFabricLabel().data()), fabricInfo.GetFabricLabel().size());
             fabricDescriptor.rootPublicKey = fabricInfo.GetRootPubkey();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, our SDK does not support read attribute with list type in OperationalCredentials cluster, we want to create and encode the list attributes in OperationalCredentials cluster on-the-fly using AttributeAccessInterface when read.

#### Change overview
Support read attribute with complex type via AttributeAccessInterface

#### Testing
How was this tested? (at least one bullet point required)
The client bits to read the list attribute with new encoding is not ready, the test is conducted with my private python device controller.

```
chip-device-ctrl > zclread OperationalCredentials FabricsList 12344321 0 0
[1634146520.207612][907267:907275] CHIP:IN: Prepared encrypted message 0x27feb00 to 0x0000000000BC5C01 of type 0x2 and protocolId (0, 1) on exchange 31635i with MessageCounter:0.
[1634146520.207709][907267:907275] CHIP:IN: Sending encrypted msg 0x27feb00 with MessageCounter:0 to 0x0000000000BC5C01 at monotonic time: 365205347 msec
[1634146520.210678][907267:907275] CHIP:EM: Received message of type 0x5 with protocolId (0, 1) and MessageCounter:1 on exchange 31635i
[1634146520.212128][907267:907275] CHIP:ZCL: ReadAttributesResponse:
[1634146520.212176][907267:907275] CHIP:ZCL:   ClusterId: 0x0000_003E
[1634146520.212211][907267:907275] CHIP:ZCL:   attributeId: 0x0000_0001
[1634146520.212239][907267:907275] CHIP:ZCL:   status: Success                (0x0000)
[1634146520.212275][907267:907275] CHIP:ZCL:   attribute TLV Type: 0x16
[1634146520.212668][907267:907275] CHIP:IN: Prepared encrypted message 0x27feb00 to 0x0000000000BC5C01 of type 0x1 and protocolId (0, 1) on exchange 31635i with MessageCounter:1.
AttributeReadResult(path=AttributePath(nodeId=12344321, endpointId=0, clusterId=62, attributeId=1), status=0, value=[{0: 1, 1: b'\x04\x8e!\xca>\xd6\x18]\x9b\xe6\xb7\xdc\x11\x7f\x9f\xb2\x9a\xd9Cv|_|\xb9ZoxE\xcda\xdclR:\x01\x04\x9f"\xbeJ]3\xf3\xa2\x90\x00gz\x14\x18\xf4z\xaa\xd3KJ\xd2\xa9e\xbb\x9b\x19\x06\x03Z', 2: 40896, 3: 0, 4: 12344321, 5: b''}, {0: 2, 1: b'\x04\x8e!\xca>\xd6\x18]\x9b\xe6\xb7\xdc\x11\x7f\x9f\xb2\x9a\xd9Cv|_|\xb9ZoxE\xcda\xdclR:\x01\x04\x9f"\xbeJ]3\xf3\xa2\x90\x00gz\x14\x18\xf4z\xaa\xd3KJ\xd2\xa9e\xbb\x9b\x19\x06\x03Z', 2: 40896, 3: 0, 4: 12344321, 5: b''}])
```
