### PR TITLE
Remove use of GetDevice() from Python controller

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -531,6 +531,15 @@ void DeviceController::PersistNextKeyId()
     }
 }
 
+CHIP_ERROR DeviceController::GetPeerAddressAndPort(PeerId peerId, Inet::IPAddress & addr, uint16_t & port)
+{
+    VerifyOrReturnError(GetCompressedFabricId() == peerId.GetCompressedFabricId(), CHIP_ERROR_INVALID_ARGUMENT);
+    uint16_t index = FindDeviceIndex(peerId.GetNodeId());
+    VerifyOrReturnError(index < kNumMaxActiveDevices, CHIP_ERROR_NOT_CONNECTED);
+    VerifyOrReturnError(mActiveDevices[index].GetAddress(addr, port), CHIP_ERROR_NOT_CONNECTED);
+    return CHIP_NO_ERROR;
+}
+
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 void DeviceController::OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData)
 {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -216,6 +216,8 @@ public:
      */
     CHIP_ERROR GetDevice(NodeId deviceId, Device ** device);
 
+    CHIP_ERROR GetPeerAddressAndPort(PeerId peerId, Inet::IPAddress & addr, uint16_t & port);
+
     /**
      *   This function returns true if the device corresponding to `deviceId` has previously been commissioned
      *   on the fabric.

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -329,7 +329,7 @@ void CloseSessionCallback(Device * device, ChipError::StorageType err)
     }
     if (!ChipError::IsSuccess(err))
     {
-        ChipLogError(Controller, "Close session was callback called with an error:  %d", err);
+        ChipLogError(Controller, "Close session callback was called with an error:  %d", err);
     }
 }
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -160,8 +160,6 @@ const char * pychip_Stack_ErrorToString(ChipError::StorageType err);
 const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t statusCode);
 void pychip_Stack_SetLogFunct(LogMessageFunct logFunct);
 
-ChipError::StorageType pychip_GetDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
-                                                chip::Controller::Device ** device);
 ChipError::StorageType pychip_GetConnectedDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
                                                          DeviceAvailableFunc callback);
 uint64_t pychip_GetCommandSenderHandle(chip::Controller::Device * device);
@@ -246,12 +244,12 @@ ChipError::StorageType pychip_DeviceController_GetAddressAndPort(chip::Controlle
                                                                  chip::NodeId nodeId, char * outAddress, uint64_t maxAddressLen,
                                                                  uint16_t * outPort)
 {
-    Device * device;
-    CHIP_ERROR err = devCtrl->GetDevice(nodeId, &device);
-    VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
-
     Inet::IPAddress address;
-    VerifyOrReturnError(device->GetAddress(address, *outPort), CHIP_ERROR_INCORRECT_STATE.AsInteger());
+    ReturnErrorOnFailure(
+        devCtrl
+            ->GetPeerAddressAndPort(PeerId().SetCompressedFabricId(devCtrl->GetCompressedFabricId()).SetNodeId(nodeId), address,
+                                    *outPort)
+            .AsInteger());
     VerifyOrReturnError(address.ToString(outAddress, maxAddressLen), CHIP_ERROR_BUFFER_TOO_SMALL.AsInteger());
 
     return CHIP_NO_ERROR.AsInteger();
@@ -323,13 +321,21 @@ ChipError::StorageType pychip_DeviceController_ConnectIP(chip::Controller::Devic
     return devCtrl->PairDevice(nodeid, params).AsInteger();
 }
 
+void CloseSessionCallback(Device * device, ChipError::StorageType err)
+{
+    if (device != nullptr)
+    {
+        device->CloseSession();
+    }
+    if (!ChipError::IsSuccess(err))
+    {
+        ChipLogError(Controller, "Close session was callback called with an error:  %d", err);
+    }
+}
+
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-    Device * device;
-    CHIP_ERROR err = devCtrl->GetDevice(nodeid, &device);
-    VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
-
-    return device->CloseSession().AsInteger();
+    return pychip_GetConnectedDeviceByNodeId(devCtrl, nodeid, CloseSessionCallback);
 }
 
 ChipError::StorageType pychip_DeviceController_DiscoverAllCommissionableNodes(chip::Controller::DeviceCommissioner * devCtrl)
@@ -512,13 +518,6 @@ const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t stat
 {
     // return chip::StatusReportStr(profileId, statusCode);
     return NULL;
-}
-
-ChipError::StorageType pychip_GetDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
-                                                chip::Controller::Device ** device)
-{
-    VerifyOrReturnError(devCtrl != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    return devCtrl->GetDevice(nodeId, device).AsInteger();
 }
 
 namespace {

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -33,6 +33,7 @@ from .clusters.CHIPClusters import *
 from .interaction_model import delegate as im
 from .exceptions import *
 import enum
+import threading
 
 
 __all__ = ["ChipDeviceController"]
@@ -95,6 +96,9 @@ class ChipDeviceController(object):
 
         self._Cluster = ChipClusters(self._ChipStack)
         self._Cluster.InitLib(self._dmLib)
+
+        self.device = c_void_p(None)
+        self.deviceAvailable = threading.Condition()
 
         def HandleKeyExchangeComplete(err):
             if err != 0:
@@ -304,65 +308,75 @@ class ChipDeviceController(object):
     def GetClusterHandler(self):
         return self._Cluster
 
-    def ZCLSend(self, cluster, command, nodeid, endpoint, groupid, args, blocking=False):
-        device = c_void_p(None)
-        # We should really use pychip_GetConnectedDeviceByNodeId and do the
-        # command off its callback....
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
-            self.devCtrl, nodeid, pointer(device)))
+    def GetConnectedDeviceSync(self, nodeid):
+        def DeviceAvailableCallback(device, err):
+            self.device = device
+            with self.deviceAvailable:
+                self.deviceAvailable.notify_all()
+            if err != 0:
+                print("Failed in getting the connected device: {}".format(err))
+                raise self._ChipStack.ErrorToException(err)
+
+        self.device = c_void_p(None)
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetConnectedDeviceByNodeId(
+            self.devCtrl, nodeid, _DeviceAvailableFunct(DeviceAvailableCallback)))
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
+
+        # The callback might have been received synchronously (during self._ChipStack.Call()).
+        # Check if the device is already set before waiting for the callback.
+        if self.device == c_void_p(None):
+            with self.deviceAvailable:
+                self.deviceAvailable.wait()
+
+        if self.device == c_void_p(None):
+            raise self._ChipStack.ErrorToException(CHIP_ERROR_INTERNAL)
+        return res
+
+    def ZCLSend(self, cluster, command, nodeid, endpoint, groupid, args, blocking=False):
+        res = self.GetConnectedDeviceSync(nodeid)
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
+
         im.ClearCommandStatus(im.PLACEHOLDER_COMMAND_HANDLE)
         self._Cluster.SendCommand(
-            device, cluster, command, endpoint, groupid, args, True)
+            self.device, cluster, command, endpoint, groupid, args, True)
         if blocking:
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(im.PLACEHOLDER_COMMAND_HANDLE, 1)
         return (0, None)
 
     def ZCLReadAttribute(self, cluster, attribute, nodeid, endpoint, groupid, blocking=True):
-        device = c_void_p(None)
-        # We should really use pychip_GetConnectedDeviceByNodeId and do the
-        # read off its callback....
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
-            self.devCtrl, nodeid, pointer(device)))
+        res = self.GetConnectedDeviceSync(nodeid)
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
         # We are not using IM for Attributes.
         res = self._Cluster.ReadAttribute(
-            device, cluster, attribute, endpoint, groupid, False)
+            self.device, cluster, attribute, endpoint, groupid, False)
         if blocking:
             return im.GetAttributeReadResponse(im.DEFAULT_ATTRIBUTEREAD_APPID)
 
     def ZCLWriteAttribute(self, cluster, attribute, nodeid, endpoint, groupid, value, blocking=True):
-        device = c_void_p(None)
-        # We should really use pychip_GetConnectedDeviceByNodeId and do the
-        # write off its callback....
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
-            self.devCtrl, nodeid, pointer(device)))
+        res = self.GetConnectedDeviceSync(nodeid)
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
         # We are not using IM for Attributes.
         res = self._Cluster.WriteAttribute(
-            device, cluster, attribute, endpoint, groupid, value, False)
+            self.device, cluster, attribute, endpoint, groupid, value, False)
         if blocking:
             return im.GetAttributeWriteResponse(im.DEFAULT_ATTRIBUTEWRITE_APPID)
 
     def ZCLSubscribeAttribute(self, cluster, attribute, nodeid, endpoint, minInterval, maxInterval, blocking=True):
-        device = c_void_p(None)
-        # We should really use pychip_GetConnectedDeviceByNodeId and do the
-        # SubscribeAttribute off its callback....
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
-            self.devCtrl, nodeid, pointer(device)))
+        res = self.GetConnectedDeviceSync(nodeid)
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
         commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(device)
         im.ClearCommandStatus(commandSenderHandle)
         res = self._Cluster.SubscribeAttribute(
-            device, cluster, attribute, endpoint, minInterval, maxInterval, commandSenderHandle != 0)
+            self.device, cluster, attribute, endpoint, minInterval, maxInterval, commandSenderHandle != 0)
         if blocking:
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(commandSenderHandle, 1)
@@ -473,13 +487,9 @@ class ChipDeviceController(object):
                 c_uint64, c_uint64]
             self._dmLib.pychip_Resolver_ResolveNode.restype = c_uint32
 
-            self._dmLib.pychip_GetDeviceByNodeId.argtypes = [
-                c_void_p, c_uint64, POINTER(c_void_p)]
-            self._dmLib.pychip_GetDeviceByNodeId.restype = c_uint32
-
             self._dmLib.pychip_GetConnectedDeviceByNodeId.argtypes = [
                 c_void_p, c_uint64, _DeviceAvailableFunct]
-            self._dmLib.pychip_GetDeviceByNodeId.restype = c_uint32
+            self._dmLib.pychip_GetConnectedDeviceByNodeId.restype = c_uint32
 
             self._dmLib.pychip_DeviceCommissioner_CloseBleConnection.argtypes = [
                 c_void_p]

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -373,7 +373,8 @@ class ChipDeviceController(object):
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-        commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(device)
+        commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(
+            self.device)
         im.ClearCommandStatus(commandSenderHandle)
         res = self._Cluster.SubscribeAttribute(
             self.device, cluster, attribute, endpoint, minInterval, maxInterval, commandSenderHandle != 0)


### PR DESCRIPTION
#### Problem
Python controller app is using `GetDevice()` API to retrieve device object. This API doesn't trigger a CASE session establishment and relies on existing session. The usage of this should be replaced with `GetConnectedDevice()` API call.

#### Change overview
Replaced most calls to `GetDevice()` with `GetConnectedDevice()`.
`GetAddressAndPort()` doesn't require an active secure session. Replaced it with a new controller API to retrieve the address. This should eventually be replaced with a call to DNS cache.

#### Testing
Tested commissioning flow using the Python controller. Tested network commissioning (which uses the updated ZCL APIs) and calls to read attributes.
