### PR TITLE
Add attribute accessor for test cluster list attributes.

### DIFF
--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -26,7 +26,9 @@
 #include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/command-id.h>
+#include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Commands.h>
+#include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
@@ -37,12 +39,53 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::TestCluster;
 using namespace chip::app::Clusters::TestCluster::Commands;
+using namespace chip::app::Clusters::TestCluster::Attributes;
 
 constexpr const char * kErrorStr = "Test Cluster: List Octet cluster (0x%02x) Error setting '%s' attribute: 0x%02x";
 
 namespace {
+
+class TestAttrAccess : public AttributeAccessInterface
+{
+public:
+    // Register for the Test Cluster cluster on all endpoints.
+    TestAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), TestCluster::Id) {}
+
+    CHIP_ERROR Read(ClusterInfo & aClusterInfo, AttributeValueEncoder & aEncoder) override;
+
+private:
+    CHIP_ERROR ReadListInt8uAttribute(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadListOctetStringAttribute(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadListStructOctetStringAttribute(AttributeValueEncoder & aEncoder);
+};
+
+TestAttrAccess gAttrAccess;
+
+CHIP_ERROR TestAttrAccess::Read(ClusterInfo & aClusterInfo, AttributeValueEncoder & aEncoder)
+{
+    switch (aClusterInfo.mFieldId)
+    {
+    case ListInt8u::Id: {
+        return ReadListInt8uAttribute(aEncoder);
+    }
+    case ListOctetString::Id: {
+        return ReadListOctetStringAttribute(aEncoder);
+    }
+    case ListStructOctetString::Id: {
+        return ReadListStructOctetStringAttribute(aEncoder);
+    }
+    default: {
+        break;
+    }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 EmberAfStatus writeAttribute(EndpointId endpoint, AttributeId attributeId, uint8_t * buffer, int32_t index = -1)
 {
     EmberAfAttributeSearchRecord record;
@@ -79,7 +122,21 @@ EmberAfStatus writeTestListInt8uAttribute(EndpointId endpoint)
     VerifyOrReturnError(status == EMBER_ZCL_STATUS_SUCCESS, status);
     return status;
 }
+#endif // !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 
+CHIP_ERROR TestAttrAccess::ReadListInt8uAttribute(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([](const TagBoundEncoder & encoder) -> CHIP_ERROR {
+        constexpr uint16_t attributeCount = 4;
+        for (uint8_t index = 0; index < attributeCount; index++)
+        {
+            ReturnErrorOnFailure(encoder.Encode(index));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 EmberAfStatus writeTestListOctetAttribute(EndpointId endpoint)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
@@ -101,7 +158,25 @@ EmberAfStatus writeTestListOctetAttribute(EndpointId endpoint)
     VerifyOrReturnError(status == EMBER_ZCL_STATUS_SUCCESS, status);
     return status;
 }
+#endif // !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 
+CHIP_ERROR TestAttrAccess::ReadListOctetStringAttribute(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([](const TagBoundEncoder & encoder) -> CHIP_ERROR {
+        constexpr uint16_t attributeCount = 4;
+        char data[6]                      = { 'T', 'e', 's', 't', 'N', '\0' };
+
+        for (uint8_t index = 0; index < attributeCount; index++)
+        {
+            snprintf(data + strlen(data) - 1, 2, "%d", index);
+            ByteSpan span(Uint8::from_char(data), strlen(data));
+            ReturnErrorOnFailure(encoder.Encode(span));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+#if !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 EmberAfStatus writeTestListStructOctetAttribute(EndpointId endpoint)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
@@ -126,6 +201,27 @@ EmberAfStatus writeTestListStructOctetAttribute(EndpointId endpoint)
     status = writeAttribute(endpoint, attributeId, (uint8_t *) &attributeCount);
     VerifyOrReturnError(status == EMBER_ZCL_STATUS_SUCCESS, status);
     return status;
+}
+#endif // !CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
+
+CHIP_ERROR TestAttrAccess::ReadListStructOctetStringAttribute(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([](const TagBoundEncoder & encoder) -> CHIP_ERROR {
+        constexpr uint16_t attributeCount = 4;
+        char data[6]                      = { 'T', 'e', 's', 't', 'N', '\0' };
+
+        for (uint8_t index = 0; index < attributeCount; index++)
+        {
+            snprintf(data + strlen(data) - 1, 2, "%d", index);
+            ByteSpan span(Uint8::from_char(data), strlen(data));
+
+            Structs::TestListStructOctet::Type structOctet;
+            structOctet.fabricIndex     = index;
+            structOctet.operationalCert = span;
+            ReturnErrorOnFailure(encoder.Encode(structOctet));
+        }
+        return CHIP_NO_ERROR;
+    });
 }
 } // namespace
 
@@ -178,6 +274,9 @@ bool emberAfTestClusterClusterTestAddArgumentsCallback(CommandHandler * apComman
 
 void MatterTestClusterPluginServerInitCallback(void)
 {
+#if CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
+    registerAttributeAccessOverride(&gAttrAccess);
+#else  // CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
     for (uint8_t index = 0; index < emberAfEndpointCount(); index++)
@@ -198,4 +297,5 @@ void MatterTestClusterPluginServerInitCallback(void)
         VerifyOrReturn(status == EMBER_ZCL_STATUS_SUCCESS,
                        ChipLogError(Zcl, kErrorStr, endpoint, "test list struct octet", status));
     }
+#endif // CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
 }


### PR DESCRIPTION
#### Problem
Need attribute access interface for Test Cluster so we can move it to the new list/struct infra.

#### Change overview
Add that.

#### Testing
No way to test this yet until we have the client side working.  Then will be tested in CI.