### PR TITLE
Fixed #10439 - AdvertiseOperational returns CHIP_ERROR_BUFFER_TOO_SMALL

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -151,8 +151,8 @@ private:
                                                                 Dnssd::OperationalAdvertisingParameters::kTxtTotalValueSize);
 #else
         // Thread only supports operational discovery.
-        static constexpr size_t kSubTypeMaxNumber    = 0;
-        static constexpr size_t kSubTypeTotalLength  = 0;
+        static constexpr size_t kSubTypeMaxNumber    = 1;
+        static constexpr size_t kSubTypeTotalLength  = Dnssd::kSubTypeCompressedFabricIdMaxLength;
         static constexpr size_t kTxtMaxNumber        = Dnssd::OperationalAdvertisingParameters::kTxtMaxNumber;
         static constexpr size_t kTxtTotalValueLength = Dnssd::OperationalAdvertisingParameters::kTxtTotalValueSize;
 #endif


### PR DESCRIPTION
#### Problem
* Fix problem with Thread device not advertising the SRP correctly
* Fixes #10439 

#### Change overview
* Two-liner in the `GenericThreadStackManagerImpl_OpenThread.h` file which allows Thread devices to correctly start advertiments of SRP's, even when they are only Operational.

#### Testing
* Build, linked and flashed the TI device
* Tested that the TI device could be correctly commissioned and that the CASE session could finish using the `chip-device-ctrl`