### PR TITLE
[DNS-SD] Refresh services on RemoveFabric command

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -281,6 +281,8 @@ bool emberAfOperationalCredentialsClusterRemoveFabricCallback(app::CommandHandle
     CHIP_ERROR err       = Server::GetInstance().GetFabricTable().Delete(fabricBeingRemoved);
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
+    app::DnssdServer::Instance().StartServer();
+
 exit:
     writeFabricsIntoFabricsListAttribute();
     emberAfSendImmediateDefaultResponse(status);


### PR DESCRIPTION
#### Problem
AddNOC and UpdateNOC commands both cause refreshing DNS-SD services, but RemoveFabric does not remove the obsolete
operational node service.

#### Change overview
Refresh DNS-SD services on RemoveFabric command from OperationalCredentials cluster.

#### Testing
Tested manually using nRF Connect examples.

Fixes #10491 although not sure if it's still possible to cherry-pick patches to the TE6 branch...
