### PR TITLE
Fix global usage of GetRandU32

### DIFF
--- a/src/transport/MessageCounter.cpp
+++ b/src/transport/MessageCounter.cpp
@@ -27,7 +27,10 @@
 
 namespace chip {
 
-GlobalUnencryptedMessageCounter::GlobalUnencryptedMessageCounter() : value(Crypto::GetRandU32()) {}
+void GlobalUnencryptedMessageCounter::Init()
+{
+    value = Crypto::GetRandU32();
+}
 
 CHIP_ERROR GlobalEncryptedMessageCounter::Init()
 {

--- a/src/transport/MessageCounter.h
+++ b/src/transport/MessageCounter.h
@@ -45,7 +45,7 @@ public:
         Session,
     };
 
-    virtual ~MessageCounter() = 0;
+    virtual ~MessageCounter() = default;
 
     virtual Type GetType()                        = 0;
     virtual uint32_t Value()                      = 0; /** Get current value */
@@ -53,13 +53,12 @@ public:
     virtual CHIP_ERROR SetCounter(uint32_t count) = 0; /** Set the counter to the specified value */
 };
 
-inline MessageCounter::~MessageCounter() {}
-
 class GlobalUnencryptedMessageCounter : public MessageCounter
 {
 public:
-    GlobalUnencryptedMessageCounter();
-    ~GlobalUnencryptedMessageCounter() override {}
+    GlobalUnencryptedMessageCounter() : value(0) {}
+
+    void Init();
 
     Type GetType() override { return GlobalUnencrypted; }
     uint32_t Value() override { return value; }
@@ -82,7 +81,6 @@ class GlobalEncryptedMessageCounter : public MessageCounter
 {
 public:
     GlobalEncryptedMessageCounter() {}
-    ~GlobalEncryptedMessageCounter() override {}
 
     CHIP_ERROR Init();
     Type GetType() override { return GlobalEncrypted; }
@@ -117,7 +115,6 @@ class LocalSessionMessageCounter : public MessageCounter
 public:
     static constexpr uint32_t kInitialValue = 1;
     LocalSessionMessageCounter() : value(kInitialValue) {}
-    ~LocalSessionMessageCounter() override {}
 
     Type GetType() override { return Session; }
     uint32_t Value() override { return value; }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -79,7 +79,8 @@ CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * 
     mTransportMgr          = transportMgr;
     mMessageCounterManager = messageCounterManager;
 
-    mGlobalEncryptedMessageCounter.Init();
+    ReturnErrorOnFailure(mGlobalEncryptedMessageCounter.Init());
+    mGlobalUnencryptedMessageCounter.Init();
 
     ScheduleExpiryTimer();
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * 
     mMessageCounterManager = messageCounterManager;
 
     // TODO: Handle error from mGlobalEncryptedMessageCounter! Unit tests currently crash if you do!
-    (void)mGlobalEncryptedMessageCounter.Init();
+    (void) mGlobalEncryptedMessageCounter.Init();
     mGlobalUnencryptedMessageCounter.Init();
 
     ScheduleExpiryTimer();

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -79,7 +79,8 @@ CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * 
     mTransportMgr          = transportMgr;
     mMessageCounterManager = messageCounterManager;
 
-    ReturnErrorOnFailure(mGlobalEncryptedMessageCounter.Init());
+    // TODO: Handle error from mGlobalEncryptedMessageCounter! Unit tests currently crash if you do!
+    (void)mGlobalEncryptedMessageCounter.Init();
     mGlobalUnencryptedMessageCounter.Init();
 
     ScheduleExpiryTimer();

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -47,7 +47,10 @@ public:
 class UnauthenticatedSession : public ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter>
 {
 public:
-    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address) {}
+    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address)
+    {
+        mLocalMessageCounter.Init();
+    }
 
     UnauthenticatedSession(const UnauthenticatedSession &) = delete;
     UnauthenticatedSession & operator=(const UnauthenticatedSession &) = delete;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -47,10 +47,7 @@ public:
 class UnauthenticatedSession : public ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter>
 {
 public:
-    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address)
-    {
-        mLocalMessageCounter.Init();
-    }
+    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address) { mLocalMessageCounter.Init(); }
 
     UnauthenticatedSession(const UnauthenticatedSession &) = delete;
     UnauthenticatedSession & operator=(const UnauthenticatedSession &) = delete;


### PR DESCRIPTION
#### Problem
- GlobalUnencryptedMessageCounter called GetRandU32 in
  initializer list, which, under some linkage conditions,
  could occur before add_entropy_source.

Fixes #6997

#### Change overview
- Fix init of GlobalUnencryptedMessageCounter to
  be done at time of use

#### Testing
- Unit tests pass
- Cert tests pass
- TI platform no longer crashes at startup