### PR TITLE
Sanitize CryptoContext keys on destructor call

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -153,6 +153,12 @@ enum class SupportedECPKeyTypes : uint8_t
     ECP256R1 = 0,
 };
 
+/** @brief Safely clears the first `len` bytes of memory area `buf`.
+ * @param buf Pointer to a memory buffer holding secret data that must be cleared.
+ * @param len Specifies secret data size in bytes.
+ **/
+void ClearSecretData(uint8_t * buf, size_t len);
+
 template <typename Sig>
 class ECPKey
 {
@@ -175,6 +181,12 @@ template <size_t Cap>
 class CapacityBoundBuffer
 {
 public:
+    ~CapacityBoundBuffer()
+    {
+        // Sanitize after use
+        ClearSecretData(&bytes[0], Cap);
+    }
+
     /** @brief Set current length of the buffer that's being used
      * @return Returns error if new length is > capacity
      **/
@@ -337,7 +349,7 @@ class P256Keypair : public P256KeypairBase
 {
 public:
     P256Keypair() {}
-    ~P256Keypair();
+    virtual ~P256Keypair();
 
     /**
      * @brief Initialize the keypair.
@@ -1178,12 +1190,6 @@ private:
  */
 CHIP_ERROR GenerateCompressedFabricId(const Crypto::P256PublicKey & root_public_key, uint64_t fabric_id,
                                       MutableByteSpan & out_compressed_fabric_id);
-
-/** @brief Safely clears the first `len` bytes of memory area `buf`.
- * @param buf Pointer to a memory buffer holding secret data that must be cleared.
- * @param len Specifies secret data size in bytes.
- **/
-void ClearSecretData(uint8_t * buf, size_t len);
 
 typedef CapacityBoundBuffer<kMax_x509_Certificate_Length> X509DerCertificate;
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1004,7 +1004,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     }
 
 exit:
-    memset(privkey, 0, sizeof(privkey));
+    ClearSecretData(privkey, sizeof(privkey));
     _logSSLError();
     return error;
 }
@@ -1062,7 +1062,6 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
     ec_key       = nullptr;
 
 exit:
-
     if (ec_key != nullptr)
     {
         EC_KEY_free(ec_key);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -706,7 +706,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     output.SetLength(bbuf.Needed());
 
 exit:
-    memset(privkey, 0, sizeof(privkey));
+    ClearSecretData(privkey, sizeof(privkey));
     _log_mbedTLS_error(result);
     return error;
 }

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -22,11 +22,14 @@
  *
  */
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CodeUtils.h>
 #include <transport/CryptoContext.h>
 #include <transport/raw/MessageHeader.h>
+
+#include <lib/support/BytesToHex.h>
 
 #include <string.h>
 
@@ -54,6 +57,14 @@ using HKDF_sha_crypto = HKDF_sha;
 #endif
 
 CryptoContext::CryptoContext() : mKeyAvailable(false) {}
+
+CryptoContext::~CryptoContext()
+{
+    for (auto & key : mKeys)
+    {
+        ClearSecretData(key, sizeof(CryptoKey));
+    }
+}
 
 CHIP_ERROR CryptoContext::InitFromSecret(const ByteSpan & secret, const ByteSpan & salt, SessionInfoType infoType, SessionRole role)
 {

--- a/src/transport/CryptoContext.h
+++ b/src/transport/CryptoContext.h
@@ -36,6 +36,7 @@ class DLL_EXPORT CryptoContext
 {
 public:
     CryptoContext();
+    ~CryptoContext();
     CryptoContext(CryptoContext &&)      = default;
     CryptoContext(const CryptoContext &) = default;
     CryptoContext & operator=(const CryptoContext &) = default;


### PR DESCRIPTION
#### Problem

- Key material is not sanitized in CryptoContext which may lead to more opportunities to recover session keys from stale pool/stack data.

Fixes #10512 

#### Change overview

- Sanitize keys on CryptoContext destructor

#### Testing

- Manually added logs and validated the keys are clear after destructor
- Manually ran in debugger and validated the keys are clear after destructor
- Current unit tests pass
- Current cert tests pass