### PR TITLE
[CI] Add TestLogCommands.yaml and an helper to log a custom message

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -52,6 +52,13 @@ CHIP_ERROR TestCommand::WaitForMs(uint32_t ms)
     return chip::DeviceLayer::SystemLayer().StartTimer(ms, OnWaitForMsFn, this);
 }
 
+CHIP_ERROR TestCommand::Log(const char * message)
+{
+    ChipLogDetail(chipTool, "%s", message);
+    WaitForMs(0);
+    return CHIP_NO_ERROR;
+}
+
 void TestCommand::Exit(std::string message)
 {
     ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -44,6 +44,7 @@ public:
 
     /////////// GlobalCommands Interface /////////
     CHIP_ERROR WaitForMs(uint32_t ms);
+    CHIP_ERROR Log(const char * message);
 
 protected:
     ChipDevice * mDevice;

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -96,7 +96,7 @@ class {{filename}}: public TestCommand
     {{#if (isTestOnlyCluster cluster)}}
     CHIP_ERROR {{>testCommand}}()
     {
-        return {{command}}({{#chip_tests_item_parameters}}{{#not_first}}, {{/not_first}}{{definedValue}}{{/chip_tests_item_parameters}});
+        return {{command}}({{#chip_tests_item_parameters}}{{#not_first}}, {{/not_first}}{{#if (isString type)}}"{{/if}}{{definedValue}}{{#if (isString type)}}"{{/if}}{{/chip_tests_item_parameters}});
     }
     {{else}}
     {{#*inline "failureResponse"}}OnFailureResponse_{{index}}{{/inline}}

--- a/examples/chip-tool/templates/tests.js
+++ b/examples/chip-tool/templates/tests.js
@@ -126,6 +126,7 @@ function getTests()
     'TestClusterComplexTypes',
     'TestConstraints',
     'TestDelayCommands',
+    'TestLogCommands',
     'TestDescriptorCluster',
     'TestOperationalCredentialsCluster',
   ];

--- a/src/app/tests/suites/TestLogCommands.yaml
+++ b/src/app/tests/suites/TestLogCommands.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Log Commands Tests
+
+config:
+    cluster: "Test Cluster"
+    endpoint: 1
+
+tests:
+    - label: "Log a simple message"
+      cluster: "LogCommands"
+      command: "Log"
+      arguments:
+          values:
+              - name: "message"
+                value: "This is a simple message"

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -27,6 +27,7 @@ const path              = require('path');
 const templateUtil = require(zapPath + 'dist/src-electron/generator/template-util.js')
 
 const { DelayCommands }                 = require('./simulated-clusters/TestDelayCommands.js');
+const { LogCommands }                   = require('./simulated-clusters/TestLogCommands.js');
 const { Clusters, asBlocks, asPromise } = require('./ClustersHelper.js');
 const { asUpperCamelCase }              = require(basePath + 'src/app/zap-templates/templates/app/helper.js');
 
@@ -263,18 +264,31 @@ function getClusters()
 {
   // Create a new array to merge the configured clusters list and test
   // simulated clusters.
-  return Clusters.getClusters().then(clusters => clusters.concat(DelayCommands));
+  return Clusters.getClusters().then(clusters => clusters.concat(DelayCommands, LogCommands));
 }
 
 function getCommands(clusterName)
 {
-  return (clusterName == DelayCommands.name) ? Promise.resolve(DelayCommands.commands) : Clusters.getClientCommands(clusterName);
+  switch (clusterName) {
+  case DelayCommands.name:
+    return Promise.resolve(DelayCommands.commands);
+  case LogCommands.name:
+    return Promise.resolve(LogCommands.commands);
+  default:
+    return Clusters.getClientCommands(clusterName);
+  }
 }
 
 function getAttributes(clusterName)
 {
-  return (clusterName == DelayCommands.name) ? Promise.resolve(DelayCommands.attributes)
-                                             : Clusters.getServerAttributes(clusterName);
+  switch (clusterName) {
+  case DelayCommands.name:
+    return Promise.resolve(DelayCommands.attributes);
+  case LogCommands.name:
+    return Promise.resolve(LogCommands.attributes);
+  default:
+    return Clusters.getServerAttributes(clusterName);
+  }
 }
 
 function assertCommandOrAttribute(context)
@@ -341,7 +355,11 @@ function chip_tests_items(options)
 
 function isTestOnlyCluster(name)
 {
-  return name == DelayCommands.name;
+  const testOnlyClusters = [
+    DelayCommands.name,
+    LogCommands.name,
+  ];
+  return testOnlyClusters.includes(name);
 }
 
 function chip_tests_item_response_type(options)

--- a/src/app/zap-templates/common/simulated-clusters/TestLogCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/TestLogCommands.js
@@ -16,26 +16,26 @@
  */
 
 /*
- * This file declare test suites utilities methods for delayed commands.
+ * This file declares test suite utility methods for logging.
  *
  * Each method declared in this file needs to be implemented on a per-language
- * basis and permits to exposes methods to the test suites that are not part
+ * basis and allows exposing  methods to the test suites that are not part
  * of the regular cluster set of APIs.
  *
  */
 
-const WaitForMs = {
-  name : 'WaitForMs',
-  arguments : [ { type : 'INT32U', name : 'ms' } ],
+const Log = {
+  name : 'Log',
+  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
   response : { arguments : [] }
 };
 
-const DelayCommands = {
-  name : 'DelayCommands',
-  commands : [ WaitForMs ],
+const LogCommands = {
+  name : 'LogCommands',
+  commands : [ Log ],
 };
 
 //
 // Module exports
 //
-exports.DelayCommands = DelayCommands;
+exports.LogCommands = LogCommands;

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -16568,6 +16568,60 @@ private:
     CHIP_ERROR TestWait100ms_0() { return WaitForMs(100); }
 };
 
+class TestLogCommands : public TestCommand
+{
+public:
+    TestLogCommands() : TestCommand("TestLogCommands"), mTestIndex(0) {}
+
+    /////////// TestCommand Interface /////////
+    void NextTest() override
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        if (0 == mTestIndex)
+        {
+            ChipLogProgress(chipTool, " **** Test Start: TestLogCommands\n");
+        }
+
+        if (mTestCount == mTestIndex)
+        {
+            ChipLogProgress(chipTool, " **** Test Complete: TestLogCommands\n");
+            SetCommandExitStatus(CHIP_NO_ERROR);
+            return;
+        }
+
+        Wait();
+
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++)
+        {
+        case 0:
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Log a simple message\n");
+            err = TestLogASimpleMessage_0();
+            break;
+        }
+
+        if (CHIP_NO_ERROR != err)
+        {
+            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
+            SetCommandExitStatus(err);
+        }
+    }
+
+private:
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 1;
+
+    //
+    // Tests methods
+    //
+
+    CHIP_ERROR TestLogASimpleMessage_0() { return Log("This is a simple message"); }
+};
+
 class TestDescriptorCluster : public TestCommand
 {
 public:
@@ -17216,6 +17270,7 @@ void registerCommandsTests(Commands & commands)
         make_unique<TestClusterComplexTypes>(),
         make_unique<TestConstraints>(),
         make_unique<TestDelayCommands>(),
+        make_unique<TestLogCommands>(),
         make_unique<TestDescriptorCluster>(),
         make_unique<TestOperationalCredentialsCluster>(),
         make_unique<TestSubscribe_OnOff>(),


### PR DESCRIPTION
#### Problem

Sometimes when writing YAML tests, one needs to add some custom logs.
This PR adds a command for that.

#### Change overview
 * Add `LogCommands` simulated cluster
 * Add `TestLogCommands.yaml` for testing it...

#### Testing
I have added a test for it.