### PR TITLE
Surface a Java method to generate a PASE Verifier

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -309,6 +309,15 @@ void Device::OnOpenPairingWindowFailureResponse(void * context, uint8_t status)
     ChipLogError(Controller, "Failed to open pairing window on the device. Status %d", status);
 }
 
+CHIP_ERROR Device::ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt,
+                                       PASEVerifier & outVerifier, uint32_t & outPasscodeId)
+{
+    ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(outVerifier, iterations, salt, /* useRandomPIN= */ false, setupPincode));
+
+    outPasscodeId = mPAKEVerifierID++;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, CommissioningWindowOption option,
                                            const ByteSpan & salt, SetupPayload & setupPayload)
 {

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -316,6 +316,24 @@ public:
     CHIP_ERROR OpenPairingWindow(uint16_t timeout, CommissioningWindowOption option, SetupPayload & setupPayload);
 
     /**
+     * @brief
+     *   Compute a PASE verifier and passcode ID for the desired setup pincode.
+     *
+     *   This can be used to open a commissioning window on the device for
+     *   additional administrator commissioning.
+     *
+     * @param[in] iterations      The number of iterations to use when generating the verifier
+     * @param[in] setupPincode    The desired PIN code to use
+     * @param[in] salt            The 16-byte salt for verifier computation
+     * @param[out] outVerifier    The PASEVerifier to be populated on success
+     * @param[out] outPasscodeId  The passcode ID to be populated on success
+     *
+     * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
+     */
+    CHIP_ERROR ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt, PASEVerifier & outVerifier,
+                                   uint32_t & outPasscodeId);
+
+    /**
      *  In case there exists an open session to the device, mark it as expired.
      */
     CHIP_ERROR CloseSession();

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -63,6 +63,7 @@ android_library("java") {
     "src/chip/devicecontroller/ChipDeviceController.java",
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
     "src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java",
+    "src/chip/devicecontroller/PaseVerifierParams.java",
     "zap-generated/chip/devicecontroller/ChipClusters.java",
   ]
 

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -63,6 +63,8 @@ static void GetCHIPDevice(JNIEnv * env, long wrapperHandle, uint64_t deviceId, D
 static void ThrowError(JNIEnv * env, CHIP_ERROR errToThrow);
 static void * IOThreadMain(void * arg);
 static CHIP_ERROR N2J_Error(JNIEnv * env, CHIP_ERROR inErr, jthrowable & outEx);
+static CHIP_ERROR N2J_PaseVerifierParams(JNIEnv * env, jlong setupPincode, jint passcodeId, jbyteArray pakeVerifier,
+                                         jobject & outParams);
 
 namespace {
 
@@ -463,6 +465,44 @@ JNI_METHOD(void, deleteDeviceController)(JNIEnv * env, jobject self, jlong handl
     }
 }
 
+JNI_METHOD(jobject, computePaseVerifier)
+(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jlong setupPincode, jint iterations, jbyteArray salt)
+{
+    chip::DeviceLayer::StackLock lock;
+    Device * chipDevice = nullptr;
+
+    ChipLogProgress(Controller, "computePaseVerifier() called");
+    GetCHIPDevice(env, handle, deviceId, &chipDevice);
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    jobject params;
+    jbyteArray verifierBytes;
+    uint32_t passcodeId;
+    PASEVerifier verifier;
+
+    JniByteArray jniSalt(env, salt);
+
+    err = chipDevice->ComputePASEVerifier(iterations, setupPincode, jniSalt.byteSpan(), verifier, passcodeId);
+    SuccessOrExit(err);
+
+    uint8_t serializedVerifier[sizeof(verifier.mW0) + sizeof(verifier.mL)];
+    memcpy(serializedVerifier, verifier.mW0, kSpake2p_WS_Length);
+    memcpy(&serializedVerifier[sizeof(verifier.mW0)], verifier.mL, sizeof(verifier.mL));
+
+    err = JniReferences::GetInstance().N2J_ByteArray(env, serializedVerifier, sizeof(serializedVerifier), verifierBytes);
+    SuccessOrExit(err);
+
+    err = N2J_PaseVerifierParams(env, setupPincode, static_cast<jlong>(passcodeId), verifierBytes, params);
+    SuccessOrExit(err);
+    return params;
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ThrowError(env, err);
+    }
+    return nullptr;
+}
+
 void * IOThreadMain(void * arg)
 {
     JNIEnv * env;
@@ -499,6 +539,27 @@ void ThrowError(JNIEnv * env, CHIP_ERROR errToThrow)
     {
         env->Throw(ex);
     }
+}
+
+CHIP_ERROR N2J_PaseVerifierParams(JNIEnv * env, jlong setupPincode, jint passcodeId, jbyteArray paseVerifier, jobject & outParams)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    jmethodID constructor;
+    jclass paramsClass;
+
+    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/PaseVerifierParams", paramsClass);
+    JniClass paseVerifierParamsClass(paramsClass);
+    SuccessOrExit(err);
+
+    env->ExceptionClear();
+    constructor = env->GetMethodID(paramsClass, "<init>", "(JI[B)V");
+    VerifyOrExit(constructor != nullptr, err = CHIP_JNI_ERROR_METHOD_NOT_FOUND);
+
+    outParams = (jobject) env->NewObject(paramsClass, constructor, setupPincode, passcodeId, paseVerifier);
+
+    VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
+exit:
+    return err;
 }
 
 CHIP_ERROR N2J_Error(JNIEnv * env, CHIP_ERROR inErr, jthrowable & outEx)

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -220,6 +220,22 @@ public class ChipDeviceController {
     return isActive(deviceControllerPtr, deviceId);
   }
 
+  /**
+   * Generates a new PASE verifier and passcode ID for the given setup PIN code.
+   *
+   * @param deviceId the ID of the device for which to generate the PASE verifier
+   * @param setupPincode the PIN code to use
+   * @param iterations the number of iterations for computing the verifier
+   * @param salt the 16-byte salt
+   */
+  public PaseVerifierParams computePaseVerifier(
+      long deviceId, long setupPincode, int iterations, byte[] salt) {
+    return computePaseVerifier(deviceControllerPtr, deviceId, setupPincode, iterations, salt);
+  }
+
+  private native PaseVerifierParams computePaseVerifier(
+      long deviceControllerPtr, long deviceId, long setupPincode, int iterations, byte[] salt);
+
   private native long newDeviceController();
 
   private native void pairDevice(

--- a/src/controller/java/src/chip/devicecontroller/PaseVerifierParams.java
+++ b/src/controller/java/src/chip/devicecontroller/PaseVerifierParams.java
@@ -1,0 +1,69 @@
+package chip.devicecontroller;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Parameters representing a generated PASE verifier for a setup PIN code. */
+public final class PaseVerifierParams {
+
+  private final long setupPincode;
+  private final int passcodeId;
+  private final byte[] pakeVerifier;
+
+  /**
+   * Constructor
+   *
+   * @param setupPincode the PIN code associated with this verifier
+   * @param passcodeId the passcode ID for this generated verifier
+   * @param pakeVerifier the encoded verifier (concatenation of w0 and L)
+   */
+  public PaseVerifierParams(long setupPincode, int passcodeId, byte[] pakeVerifier) {
+    this.setupPincode = setupPincode;
+    this.passcodeId = passcodeId;
+    this.pakeVerifier = pakeVerifier.clone();
+  }
+
+  /** Returns the PIN code associated with this verifier. */
+  public long getSetupPincode() {
+    return setupPincode;
+  }
+
+  /** Returns the passcode ID for this generated verifier. */
+  public int getPasscodeId() {
+    return passcodeId;
+  }
+
+  /**
+   * Returns the encoded PAKE verifier (the concatenation of w0 and L, as described in section 3.10
+   * (PAKE) of the Matter specification).
+   */
+  public byte[] getPakeVerifier() {
+    return pakeVerifier.clone();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof PaseVerifierParams)) {
+      return false;
+    } else {
+      PaseVerifierParams that = (PaseVerifierParams) other;
+      return setupPincode == that.setupPincode
+          && passcodeId == that.passcodeId
+          && Arrays.equals(pakeVerifier, that.pakeVerifier);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(setupPincode, passcodeId);
+    result = 31 * result + Arrays.hashCode(pakeVerifier);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "PaseVerifierParams{ passcodeId=" + passcodeId + " }";
+  }
+}


### PR DESCRIPTION
#### Problem

Currently, ChipDeviceController does provide an openPairingWindow() API,
but this does not allow us to observe success or failure of the cluster
command to open the commissioning window. 

#### Change overview

This change introduces a Java wrapper class `PaseVerifierParams` which encapsulates
a generated PAKE verifier as well as the passcode ID, used for opening a commissioning
window on the device.

#### Testing

* Modified `DeviceProvisioningFragment` locally to verify the params were properly generated.
