### PR TITLE
Fix comment text on new size reports

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -540,7 +540,7 @@ def report_matching_commits(db: SizeDatabase) -> Dict[str, pd.DataFrame]:
             parent = df.attrs['parent']
             tdf.attrs['name'] = f'L,{commit},{parent}'
             tdf.attrs['title'] = (
-                f'Increases above {threshold:.1f}% from {commit} to {parent}')
+                f'Increases above {threshold:.1f}% from {parent} to {commit}')
             dfs[tdf.attrs['name']] = tdf
 
         if (pr and comment_enabled


### PR DESCRIPTION
#### Problem

The text for “Increases above _n_%” callouts has the parent and PR
commit hashes interchanged.

#### Change overview

Fix it.

#### Testing

Manual run.
