### PR TITLE
Remove unused Send flags arguments

### DIFF
--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -616,7 +616,7 @@ CHIP_ERROR IPEndPointBasis::BindInterface(IPAddressType aAddressType, InterfaceI
     return (lRetval);
 }
 
-CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags)
+CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer)
 {
     // Ensure the destination address type is compatible with the endpoint address type.
     VerifyOrReturnError(mAddrType == aPktInfo->DestAddress.Type(), CHIP_ERROR_INVALID_ARGUMENT);
@@ -1063,7 +1063,7 @@ CHIP_ERROR IPEndPointBasis::Bind(IPAddressType aAddressType, const IPAddress & a
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags)
+CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer)
 {
     dispatch_data_t content;
 

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -167,7 +167,7 @@ protected:
 
     CHIP_ERROR Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort, InterfaceId aInterfaceId);
     CHIP_ERROR BindInterface(IPAddressType aAddressType, InterfaceId aInterfaceId);
-    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags);
+    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer);
     CHIP_ERROR GetSocket(IPAddressType aAddressType, int aType, int aProtocol);
     void HandlePendingIO(uint16_t aPort);
 
@@ -196,7 +196,7 @@ protected:
 
     CHIP_ERROR Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort, const nw_parameters_t & aParameters);
     CHIP_ERROR ConfigureProtocol(IPAddressType aAddressType, const nw_parameters_t & aParameters);
-    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags);
+    CHIP_ERROR SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer);
     CHIP_ERROR StartListener();
     CHIP_ERROR GetConnection(const IPPacketInfo * aPktInfo);
     CHIP_ERROR GetEndPoint(nw_endpoint_t & aEndpoint, const IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort);

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -222,7 +222,7 @@ CHIP_ERROR UDPEndPoint::ListenImpl()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
     CHIP_ERROR res             = CHIP_NO_ERROR;
     const IPAddress & destAddr = pktInfo->DestAddress;
@@ -579,18 +579,13 @@ CHIP_ERROR UDPEndPoint::ListenImpl()
     return layer->RequestCallbackOnPendingRead(mWatch);
 }
 
-CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
-    CHIP_ERROR res             = CHIP_NO_ERROR;
-    const IPAddress & destAddr = pktInfo->DestAddress;
-
     // Make sure we have the appropriate type of socket based on the
     // destination address.
+    ReturnErrorOnFailure(GetSocket(pktInfo->DestAddress.Type()));
 
-    res = GetSocket(destAddr.Type());
-    ReturnErrorOnFailure(res);
-
-    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg));
 }
 
 void UDPEndPoint::CloseImpl()
@@ -685,9 +680,9 @@ CHIP_ERROR UDPEndPoint::ListenImpl()
     return StartListener();
 }
 
-CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
-    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+    return IPEndPointBasis::SendMsg(pktInfo, std::move(msg));
 }
 
 void UDPEndPoint::CloseImpl()
@@ -759,35 +754,26 @@ CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnRecei
     return CHIP_NO_ERROR;
 }
 
-/**
- *  A synonym for <tt>SendTo(addr, port, INET_NULL_INTERFACEID, msg, sendFlags)</tt>.
- */
-CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
-{
-    return SendTo(addr, port, INET_NULL_INTERFACEID, std::move(msg), sendFlags);
-}
-
-CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
-                               uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, InterfaceId intfId)
 {
     IPPacketInfo pktInfo;
     pktInfo.Clear();
     pktInfo.DestAddress = addr;
     pktInfo.DestPort    = port;
     pktInfo.Interface   = intfId;
-    return SendMsg(&pktInfo, std::move(msg), sendFlags);
+    return SendMsg(&pktInfo, std::move(msg));
 }
 
-CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg, uint16_t sendFlags)
+CHIP_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
 {
     INET_FAULT_INJECT(FaultInjection::kFault_Send, return INET_ERROR_UNKNOWN_INTERFACE;);
     INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical, return CHIP_ERROR_NO_MEMORY;);
 
-    CHIP_ERROR res = SendMsgImpl(pktInfo, std::move(msg), sendFlags);
+    ReturnErrorOnFailure(SendMsgImpl(pktInfo, std::move(msg)));
 
     CHIP_SYSTEM_FAULT_INJECT_ASYNC_EVENT();
 
-    return res;
+    return CHIP_NO_ERROR;
 }
 
 void UDPEndPoint::Close()

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -136,7 +136,6 @@ public:
      * @param[in]   port        Destination UDP port.
      * @param[in]   msg         Packet buffer containing the UDP message.
      * @param[in]   intfId      Optional network interface indicator.
-     * @param[in]   sendFlags   Unused and will be removed.
      *
      * @retval  CHIP_NO_ERROR                       Success: \c msg is queued for transmit.
      * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE The system does not support the requested operation.
@@ -146,9 +145,8 @@ public:
      * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG Only a truncated portion of \c msg was queued for transmit.
      * @retval  other                               Another system or platform error.
      */
-    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
-                      uint16_t sendFlags = 0);
-    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+    CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg,
+                      InterfaceId intfId = INET_NULL_INTERFACEID);
 
     /**
      * Send a UDP message to a specified destination.
@@ -159,7 +157,6 @@ public:
      *
      * @param[in]   pktInfo     Source and destination information for the UDP message.
      * @param[in]   msg         Packet buffer containing the UDP message.
-     * @param[in]   sendFlags   Unused and will be removed.
      *
      * @retval  CHIP_NO_ERROR                       Success: \c msg is queued for transmit.
      * @retval  CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE The system does not support the requested operation.
@@ -169,7 +166,7 @@ public:
      * @retval  CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG Only a truncated portion of \c msg was queued for transmit.
      * @retval  other                               Another system or platform error.
      */
-    CHIP_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+    CHIP_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
 
     /**
      * Close the endpoint.
@@ -199,7 +196,7 @@ private:
     CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId);
     CHIP_ERROR BindInterfaceImpl(IPAddressType addrType, InterfaceId intfId);
     CHIP_ERROR ListenImpl();
-    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg, uint16_t sendFlags);
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
     void CloseImpl();
 
     void Init(InetLayer * inetLayer);

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -247,12 +247,12 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
 
         if (info->addressType == chip::Inet::kIPAddressType_IPv6)
         {
-            err = info->udp->SendTo(mIpv6BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv6BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if (info->addressType == chip::Inet::kIPAddressType_IPv4)
         {
-            err = info->udp->SendTo(mIpv4BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv4BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #endif
         else
@@ -300,12 +300,12 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
 
         if (info->addressType == chip::Inet::kIPAddressType_IPv6)
         {
-            err = info->udp->SendTo(mIpv6BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv6BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if (info->addressType == chip::Inet::kIPAddressType_IPv4)
         {
-            err = info->udp->SendTo(mIpv4BroadcastAddress, port, info->udp->GetBoundInterface(), std::move(copy));
+            err = info->udp->SendTo(mIpv4BroadcastAddress, port, std::move(copy), info->udp->GetBoundInterface());
         }
 #endif
         else


### PR DESCRIPTION
#### Problem

Some functions in Inet have arguments whose value is never used.

#### Change overview

Remove unused flags argument from:
- `IPEndPointBasis::SendMsg()`
- `UDPEndPoint::SendMsg()`
- `UDPEndPoint::SendMsgImpl()`
- `UDPEndPoint::SendTo()`

Reorder the arguments to `UDPEndPoint::SendTo()` to remove the need for an overload for the optional `InterfaceId`.

#### Testing

CI; no change to functionality.
