### PR TITLE
Increase salt min/max from 8/16 to 16/32 to match specification

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -59,8 +59,8 @@ constexpr size_t kMAX_CSR_Length             = 512;
 
 constexpr size_t CHIP_CRYPTO_HASH_LEN_BYTES = kSHA256_Hash_Length;
 
-constexpr size_t kMin_Salt_Length = 8;
-constexpr size_t kMax_Salt_Length = 16;
+constexpr size_t kMin_Salt_Length = 16;
+constexpr size_t kMax_Salt_Length = 32;
 
 constexpr size_t kP256_PrivateKey_Length = CHIP_CRYPTO_GROUP_SIZE_BYTES;
 constexpr size_t kP256_PublicKey_Length  = CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES;

--- a/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
+++ b/src/crypto/tests/PBKDF2_SHA256_test_vectors.h
@@ -39,71 +39,72 @@ struct pbkdf2_test_vector
     CHIP_ERROR result;
 };
 
-static const uint8_t chiptest_key1[]                          = { 0x9a, 0x87, 0xd2, 0x5e, 0x37, 0x40, 0x8f, 0xd7, 0x2f, 0x42,
-                                         0x3d, 0x22, 0x85, 0xc7, 0x08, 0x6d, 0x3a, 0x64, 0x2a, 0x26 };
+static const uint8_t chiptest_key1[]                          = { 0xf2, 0xe3, 0x4b, 0xd9, 0x50, 0xe9, 0x1c, 0xf3, 0x7d, 0x22,
+                                         0xe1, 0x13, 0x5a, 0x39, 0x9b, 0x02, 0xa1, 0x7c, 0xb1, 0x93 };
 static const struct pbkdf2_test_vector chiptest_test_vector_1 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 8,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 1,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key1,
                                                                   .tcId     = 1,
                                                                   .result   = CHIP_NO_ERROR };
 
-static const uint8_t chiptest_key2[]                          = { 0xa0, 0xf3, 0x0e, 0x25, 0xe8, 0x65, 0x9c, 0x36, 0xa0, 0x95,
-                                         0x89, 0x49, 0x0d, 0x64, 0xa6, 0xb1, 0x2e, 0x0c, 0x38, 0x3c };
+static const uint8_t chiptest_key2[]                          = { 0x2b, 0x77, 0x27, 0x5c, 0xc3, 0x12, 0x0b, 0x15, 0x13, 0xf6,
+                                         0xf3, 0xe0, 0x36, 0x49, 0xfd, 0x49, 0x33, 0x76, 0x52, 0x60 };
 static const struct pbkdf2_test_vector chiptest_test_vector_2 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 8,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 2,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key2,
                                                                   .tcId     = 2,
                                                                   .result   = CHIP_NO_ERROR };
 
-static const uint8_t chiptest_key3[]                          = { 0x86, 0x16, 0x14, 0x28, 0x77, 0x14, 0xd4, 0x29, 0x75, 0x16,
-                                         0x5e, 0xb6, 0x3e, 0xa7, 0x8c, 0xce, 0x85, 0x50, 0x71, 0x3c };
+static const uint8_t chiptest_key3[]                          = { 0x82, 0xff, 0xaa, 0xfc, 0x0b, 0x04, 0x91, 0x80, 0xee, 0xa7,
+                                         0x9a, 0x04, 0x10, 0x31, 0x58, 0x87, 0xb6, 0x60, 0xac, 0x7e };
 static const struct pbkdf2_test_vector chiptest_test_vector_3 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 8,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 5,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key3,
                                                                   .tcId     = 3,
                                                                   .result   = CHIP_NO_ERROR };
 
-static const uint8_t chiptest_key4[]                          = { 0x3f, 0x12, 0x78, 0x37, 0x88, 0x9c, 0x4a, 0x62, 0x3d, 0x6e,
-                                         0x8d, 0xc8, 0x8c, 0xa3, 0x3c, 0x01, 0x23, 0xa2, 0x9f, 0x07 };
+static const uint8_t chiptest_key4[]                          = { 0xf8, 0x8a, 0xfb, 0xb7, 0x9d, 0xda, 0x3f, 0x28, 0x2e, 0x21,
+                                         0xad, 0xf2, 0x53, 0xd0, 0xe9, 0xf1, 0x70, 0x82, 0x3a, 0x9f };
 static const struct pbkdf2_test_vector chiptest_test_vector_4 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 8,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 3,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key4,
                                                                   .tcId     = 4,
                                                                   .result   = CHIP_NO_ERROR };
 
-static const uint8_t chiptest_key5[] = { 0x28, 0x1a, 0xef, 0x26, 0xfa, 0x2d, 0xdf, 0x5b, 0x76, 0x82, 0x01, 0xff, 0x3a,
-                                         0xdd, 0xfc, 0x68, 0x0a, 0xda, 0x07, 0x87, 0xc9, 0xb4, 0x76, 0x55, 0x42 };
-static const struct pbkdf2_test_vector chiptest_test_vector_5 = { .password =
-                                                                      chip::Uint8::from_const_char("passwordPASSWORDpassword"),
-                                                                  .plen    = 24,
-                                                                  .salt    = chip::Uint8::from_const_char("saltSALTsaltSALT"),
-                                                                  .slen    = 16,
-                                                                  .iter    = 10,
-                                                                  .key_len = 25,
-                                                                  .key     = chiptest_key5,
-                                                                  .tcId    = 5,
-                                                                  .result  = CHIP_NO_ERROR };
+static const uint8_t chiptest_key5[] = { 0x0d, 0xbf, 0x87, 0x38, 0xd2, 0x30, 0xbf, 0x28, 0xba, 0xe0, 0xfb, 0x4d, 0x8f,
+                                         0x07, 0x34, 0x98, 0x24, 0xb5, 0xe0, 0xb1, 0xa7, 0x0b, 0xa2, 0x19, 0x3b };
+static const struct pbkdf2_test_vector chiptest_test_vector_5 = {
+    .password = chip::Uint8::from_const_char("passwordPASSWORDpassword"),
+    .plen     = 24,
+    .salt     = chip::Uint8::from_const_char("saltSALTsaltSALTsaltSALTsaltSALT"),
+    .slen     = 32,
+    .iter     = 10,
+    .key_len  = 25,
+    .key      = chiptest_key5,
+    .tcId     = 5,
+    .result   = CHIP_NO_ERROR
+};
 
 static const struct pbkdf2_test_vector chiptest_test_vector_6 = { .password = nullptr,
                                                                   .plen     = 8,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 1,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key4,
@@ -112,8 +113,8 @@ static const struct pbkdf2_test_vector chiptest_test_vector_6 = { .password = nu
 
 static const struct pbkdf2_test_vector chiptest_test_vector_7 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 0,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 1,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key4,
@@ -123,7 +124,7 @@ static const struct pbkdf2_test_vector chiptest_test_vector_7 = { .password = ch
 static const struct pbkdf2_test_vector chiptest_test_vector_8 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 8,
                                                                   .salt     = nullptr,
-                                                                  .slen     = 8,
+                                                                  .slen     = 16,
                                                                   .iter     = 1,
                                                                   .key_len  = 20,
                                                                   .key      = chiptest_key4,
@@ -132,8 +133,8 @@ static const struct pbkdf2_test_vector chiptest_test_vector_8 = { .password = ch
 
 static const struct pbkdf2_test_vector chiptest_test_vector_9 = { .password = chip::Uint8::from_const_char("password"),
                                                                   .plen     = 0,
-                                                                  .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                  .slen     = 8,
+                                                                  .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                  .slen     = 16,
                                                                   .iter     = 1,
                                                                   .key_len  = 0,
                                                                   .key      = chiptest_key4,
@@ -142,8 +143,8 @@ static const struct pbkdf2_test_vector chiptest_test_vector_9 = { .password = ch
 
 static const struct pbkdf2_test_vector chiptest_test_vector_10 = { .password = chip::Uint8::from_const_char("password"),
                                                                    .plen     = 0,
-                                                                   .salt     = chip::Uint8::from_const_char("saltSALT"),
-                                                                   .slen     = 8,
+                                                                   .salt     = chip::Uint8::from_const_char("saltSALTsaltSALT"),
+                                                                   .slen     = 16,
                                                                    .iter     = 1,
                                                                    .key_len  = 20,
                                                                    .key      = nullptr,
@@ -162,8 +163,8 @@ static const struct pbkdf2_test_vector chiptest_test_vector_11 = { .password = c
 
 static const struct pbkdf2_test_vector chiptest_test_vector_12 = { .password = chip::Uint8::from_const_char("password"),
                                                                    .plen     = 8,
-                                                                   .salt     = chip::Uint8::from_const_char("saltSAL"),
-                                                                   .slen     = 7,
+                                                                   .salt     = chip::Uint8::from_const_char("saltSALTsaltSAL"),
+                                                                   .slen     = 15,
                                                                    .iter     = 1,
                                                                    .key_len  = 20,
                                                                    .key      = chiptest_key4,
@@ -172,13 +173,14 @@ static const struct pbkdf2_test_vector chiptest_test_vector_12 = { .password = c
 
 static const struct pbkdf2_test_vector chiptest_test_vector_13 = { .password = chip::Uint8::from_const_char("password"),
                                                                    .plen     = 8,
-                                                                   .salt     = chip::Uint8::from_const_char("saltSALTsaltSALTs"),
-                                                                   .slen     = 17,
-                                                                   .iter     = 1,
-                                                                   .key_len  = 20,
-                                                                   .key      = chiptest_key4,
-                                                                   .tcId     = 13,
-                                                                   .result   = CHIP_ERROR_INVALID_ARGUMENT };
+                                                                   .salt     = chip::Uint8::from_const_char(
+                                                                       "saltSALTsaltSALTsaltSALTsaltSALTs"),
+                                                                   .slen    = 33,
+                                                                   .iter    = 1,
+                                                                   .key_len = 20,
+                                                                   .key     = chiptest_key4,
+                                                                   .tcId    = 13,
+                                                                   .result  = CHIP_ERROR_INVALID_ARGUMENT };
 
 static const struct pbkdf2_test_vector * pbkdf2_sha256_test_vectors[] = {
     &chiptest_test_vector_1, &chiptest_test_vector_2, &chiptest_test_vector_3,

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -186,8 +186,8 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
                        Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(1234, 500, ByteSpan((const uint8_t *) "saltSALT", 8), 0, &delegateAccessory) ==
-                       CHIP_NO_ERROR);
+                   pairingAccessory.WaitForPairing(1234, 500, ByteSpan((const uint8_t *) "saltSALTsaltSALT", 16), 0,
+                                                   &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, contextCommissioner,
                                             &delegateCommissioner) == CHIP_NO_ERROR);
@@ -255,8 +255,8 @@ void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
                        Protocols::SecureChannel::MsgType::PBKDFParamRequest, &pairingAccessory) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(1234, 500, ByteSpan((const uint8_t *) "saltSALT", 8), 0, &delegateAccessory) ==
-                       CHIP_NO_ERROR);
+                   pairingAccessory.WaitForPairing(1234, 500, ByteSpan((const uint8_t *) "saltSALTsaltSALT", 16), 0,
+                                                   &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 4321, 0, contextCommissioner,
                                             &delegateCommissioner) == CHIP_NO_ERROR);


### PR DESCRIPTION
Section 3.9 of the spec regarding PBKDF defines the min/max salt limits
as 16 and 32, respectively. This change increases the existing min from
8 to 16, and the max from 16 to 32.

Fixes #10531.

#### Problem

Section 3.9 of the spec regarding PBKDF defines the min/max salt limits
as 16 and 32, respectively, but the current values are limited to between 8
and 16 bytes.

* Fixes #10531 Increase salt min/max from 8/16 to 16/32 to match specification

#### Change overview

This change increases the existing min from 8 to 16, and the max from 16 to 32.

#### Testing
* Existing unit tests were modified, where existing boundary conditions were
  adjusted to match the new boundaries.
