### PR TITLE
[esp32] Post server initialization to the scheduler in examples

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -23,6 +23,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
     "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${IDF_PATH}/examples/common_components"
 )
 if(${IDF_TARGET} STREQUAL "esp32")
     list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/tft"

--- a/examples/all-clusters-app/esp32/sdkconfig.defaults
+++ b/examples/all-clusters-app/esp32/sdkconfig.defaults
@@ -42,9 +42,5 @@ CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
 CONFIG_DEVICE_VENDOR_ID=0x235A
 CONFIG_DEVICE_PRODUCT_ID=0x4541
 
-# Main task needs a bit more stack than the default
-# default is 3584, bump this up to 5k.
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=5120
-
 #enable debug shell
 CONFIG_ENABLE_CHIP_SHELL=y

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -55,6 +55,12 @@ static EndpointId gCurrentEndpointId;
 static EndpointId gFirstDynamicEndpointId;
 static Device * gDevices[DYNAMIC_ENDPOINT_COUNT]; // number of dynamic endpoints count
 
+// 4 Bridged devices
+static Device gLight1("Light 1", "Office");
+static Device gLight2("Light 2", "Office");
+static Device gLight3("Light 3", "Kitchen");
+static Device gLight4("Light 4", "Den");
+
 // Descriptor attribute storage on dynamic endpoint
 static uint8_t gDescriptorAttrStorage[DYNAMIC_ENDPOINT_COUNT][kDescriptorAttributeCount][kDescriptorAttributeArraySize];
 
@@ -384,48 +390,8 @@ void HandleDeviceStatusChanged(Device * dev, Device::Changed_t itemChangedMask)
     }
 }
 
-extern "C" void app_main()
+static void InitServer(intptr_t context)
 {
-    // Initialize the ESP NVS layer.
-    esp_err_t err = nvs_flash_init();
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
-        return;
-    }
-
-    CHIP_ERROR chip_err = CHIP_NO_ERROR;
-
-    // bridge will have own database named gDevices.
-    // Clear database
-    memset(gDevices, 0, sizeof(gDevices));
-
-    // Bridged devices 4
-    static Device Light1("Light 1", "Office");
-    static Device Light2("Light 2", "Office");
-    static Device Light3("Light 3", "Kitchen");
-    static Device Light4("Light 4", "Den");
-
-    // Whenever bridged device changes its state
-    Light1.SetChangeCallback(&HandleDeviceStatusChanged);
-    Light2.SetChangeCallback(&HandleDeviceStatusChanged);
-    Light3.SetChangeCallback(&HandleDeviceStatusChanged);
-    Light4.SetChangeCallback(&HandleDeviceStatusChanged);
-
-    Light1.SetReachable(true);
-    Light2.SetReachable(true);
-    Light3.SetReachable(true);
-    Light4.SetReachable(true);
-
-    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
-
-    chip_err = deviceMgr.Init(&AppCallback);
-    if (chip_err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(chip_err));
-        return;
-    }
-
     chip::Server::GetInstance().Init();
 
     // Initialize device attestation config
@@ -442,16 +408,55 @@ extern "C" void app_main()
     emberAfEndpointEnableDisable(emberAfEndpointFromIndex(static_cast<uint16_t>(emberAfFixedEndpointCount() - 1)), false);
 
     // Add lights 1..3 --> will be mapped to ZCL endpoints 2, 3, 4
-    AddDeviceEndpoint(&Light1, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
-    AddDeviceEndpoint(&Light2, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
-    AddDeviceEndpoint(&Light3, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
+    AddDeviceEndpoint(&gLight1, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
+    AddDeviceEndpoint(&gLight2, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
+    AddDeviceEndpoint(&gLight3, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
 
     // Remove Light 2 -- Lights 1 & 3 will remain mapped to endpoints 2 & 4
-    RemoveDeviceEndpoint(&Light2);
+    RemoveDeviceEndpoint(&gLight2);
 
     // Add Light 4 -- > will be mapped to ZCL endpoint 5
-    AddDeviceEndpoint(&Light4, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
+    AddDeviceEndpoint(&gLight4, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
 
     // Re-add Light 2 -- > will be mapped to ZCL endpoint 6
-    AddDeviceEndpoint(&Light2, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
+    AddDeviceEndpoint(&gLight2, &bridgedLightEndpoint, DEVICE_TYPE_LO_ON_OFF_LIGHT);
+}
+
+extern "C" void app_main()
+{
+    // Initialize the ESP NVS layer.
+    esp_err_t err = nvs_flash_init();
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
+        return;
+    }
+
+    CHIP_ERROR chip_err = CHIP_NO_ERROR;
+
+    // bridge will have own database named gDevices.
+    // Clear database
+    memset(gDevices, 0, sizeof(gDevices));
+
+    // Whenever bridged device changes its state
+    gLight1.SetChangeCallback(&HandleDeviceStatusChanged);
+    gLight2.SetChangeCallback(&HandleDeviceStatusChanged);
+    gLight3.SetChangeCallback(&HandleDeviceStatusChanged);
+    gLight4.SetChangeCallback(&HandleDeviceStatusChanged);
+
+    gLight1.SetReachable(true);
+    gLight2.SetReachable(true);
+    gLight3.SetReachable(true);
+    gLight4.SetReachable(true);
+
+    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+
+    chip_err = deviceMgr.Init(&AppCallback);
+    if (chip_err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(chip_err));
+        return;
+    }
+
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 }

--- a/examples/bridge-app/esp32/sdkconfig.defaults
+++ b/examples/bridge-app/esp32/sdkconfig.defaults
@@ -36,7 +36,3 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
-
-# Main task needs a bit more stack than the default
-# default is 3584, bump this up to 4k.
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096

--- a/examples/lock-app/esp32/main/main.cpp
+++ b/examples/lock-app/esp32/main/main.cpp
@@ -54,6 +54,21 @@ static const char * TAG = "lock-app";
 
 static DeviceCallbacks EchoCallbacks;
 
+static void InitServer(intptr_t context)
+{
+    chip::Server::GetInstance().Init();
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+
+    ESP_LOGI(TAG, "------------------------Starting App Task---------------------------");
+    CHIP_ERROR error = GetAppTask().StartAppTask();
+    if (error != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed: %s", ErrorStr(error));
+    }
+}
+
 extern "C" void app_main()
 {
     // Initialize the ESP NVS layer.
@@ -85,15 +100,5 @@ extern "C" void app_main()
         return;
     }
 
-    chip::Server::GetInstance().Init();
-
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-
-    ESP_LOGI(TAG, "------------------------Starting App Task---------------------------");
-    error = GetAppTask().StartAppTask();
-    if (error != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "GetAppTask().Init() failed: %s", ErrorStr(error));
-    }
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 }

--- a/examples/lock-app/esp32/sdkconfig.defaults
+++ b/examples/lock-app/esp32/sdkconfig.defaults
@@ -36,7 +36,3 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
-
-# Main task needs a bit more stack than the default
-# default is 3584, bump this up to 4k.
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096

--- a/examples/platform/esp32/shell_extension/launch.cpp
+++ b/examples/platform/esp32/shell_extension/launch.cpp
@@ -38,7 +38,7 @@ namespace chip {
 void LaunchShell()
 {
 #if CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
-    RegisterHeapTraceCommands();
+    idf::chip::RegisterHeapTraceCommands();
 #endif // CONFIG_HEAP_TRACING_STANDALONE || CONFIG_HEAP_TASK_TRACKING
     xTaskCreate(&MatterShellTask, "chip_cli", 2048, NULL, 5, NULL);
 }


### PR DESCRIPTION


#### Problem

Directly initializing the server in the main task causes potential data race and stack overflow. 

Fixes https://github.com/project-chip/connectedhomeip/issues/10430


#### Change overview

The initialization is now posted to the scheduler on ESP32 platforms.
 
#### Testing

* Manually built and run the modified apps.
* Github CI
