### PR TITLE
[DNS-SD] Clean up common constants

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -205,7 +205,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
     ChipLogDetail(AppServer, "SendUserDirectedCommissioningRequest2");
 
     CHIP_ERROR err;
-    char nameBuffer[chip::Dnssd::kMaxInstanceNameSize + 1];
+    char nameBuffer[chip::Dnssd::Commissionable::kInstanceNameMaxLength + 1];
     err = app::DnssdServer::Instance().GetCommissionableInstanceName(nameBuffer, sizeof(nameBuffer));
     if (err != CHIP_NO_ERROR)
     {

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -36,20 +36,6 @@ static constexpr uint16_t kMdnsPort = 5353;
 // Need 8 bytes to fit a thread mac.
 static constexpr size_t kMaxMacSize = 8;
 
-// Commissionable/commissioner node subtypes
-static constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4;  // _S<dd>
-static constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6;  // _L<dddd>
-static constexpr size_t kSubTypeVendorMaxLength                  = 7;  // _V<ddddd>
-static constexpr size_t kSubTypeDeviceTypeMaxLength              = 5;  // _T<ddd>
-static constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _C<d>
-static constexpr size_t kSubTypeAdditionalCommissioningMaxLength = 3;  // _A<d>
-static constexpr size_t kSubTypeCompressedFabricIdMaxLength      = 18; //_I<16-hex-digits>
-// These are the max vals for comissioning adverts
-static constexpr size_t kSubTypeMaxNumber   = 6;
-static constexpr size_t kSubTypeTotalLength = kSubTypeShortDiscriminatorMaxLength + kSubTypeLongDiscriminatorMaxLength +
-    kSubTypeVendorMaxLength + kSubTypeDeviceTypeMaxLength + kSubTypeCommissioningModeMaxLength +
-    kSubTypeAdditionalCommissioningMaxLength;
-
 enum class CommssionAdvertiseMode : uint8_t
 {
     kCommissionableNode,

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -339,7 +339,7 @@ QueryResponderAllocator<AdvertiserMinMdns::kMaxOperationalRecords> * AdvertiserM
 
 CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters & params)
 {
-    char nameBuffer[kOperationalServiceNamePrefix + 1] = "";
+    char nameBuffer[Operational::kInstanceNameMaxLength + 1] = "";
 
     /// need to set server name
     ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), params.GetPeerId()));
@@ -439,7 +439,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
 
 CHIP_ERROR AdvertiserMinMdns::GetCommissionableInstanceName(char * instanceName, size_t maxLength)
 {
-    if (maxLength < (kMaxInstanceNameSize + 1))
+    if (maxLength < (Commissionable::kInstanceNameMaxLength + 1))
     {
         return CHIP_ERROR_NO_MEMORY;
     }

--- a/src/lib/dnssd/Constants.h
+++ b/src/lib/dnssd/Constants.h
@@ -49,11 +49,14 @@ constexpr size_t kSubTypeCompressedFabricIdMaxLength      = 18; // _I<16-hex-dig
 
 namespace Operational {
 
-constexpr auto kSubTypeLengths          = { kSubTypeCompressedFabricIdMaxLength };
+#define SUBTYPES (std::initializer_list<size_t>{ kSubTypeCompressedFabricIdMaxLength })
+
 constexpr size_t kInstanceNameMaxLength = 33; // <NodeId>-<FabricId> in hex (16 + 1 + 16)
-constexpr size_t kSubTypeMaxNumber      = kSubTypeLengths.size();
-constexpr size_t kSubTypeMaxLength      = std::max(kSubTypeLengths);
-constexpr size_t kSubTypeTotalLength    = chip::Sum(kSubTypeLengths);
+constexpr size_t kSubTypeMaxNumber      = SUBTYPES.size();
+constexpr size_t kSubTypeMaxLength      = std::max(SUBTYPES);
+constexpr size_t kSubTypeTotalLength    = chip::Sum(SUBTYPES);
+
+#undef SUBTYPES
 
 } // namespace Operational
 
@@ -63,14 +66,17 @@ constexpr size_t kSubTypeTotalLength    = chip::Sum(kSubTypeLengths);
 
 namespace Commissionable {
 
-constexpr auto kSubTypeLengths = {
-    kSubTypeShortDiscriminatorMaxLength, kSubTypeLongDiscriminatorMaxLength, kSubTypeVendorMaxLength,
-    kSubTypeDeviceTypeMaxLength,         kSubTypeCommissioningModeMaxLength, kSubTypeAdditionalCommissioningMaxLength
-};
+#define SUBTYPES                                                                                                                   \
+    (std::initializer_list<size_t>{ kSubTypeShortDiscriminatorMaxLength, kSubTypeLongDiscriminatorMaxLength,                       \
+                                    kSubTypeVendorMaxLength, kSubTypeDeviceTypeMaxLength, kSubTypeCommissioningModeMaxLength,      \
+                                    kSubTypeAdditionalCommissioningMaxLength })
+
 constexpr size_t kInstanceNameMaxLength = 16; // 64-bit random number in hex
-constexpr size_t kSubTypeMaxNumber      = kSubTypeLengths.size();
-constexpr size_t kSubTypeMaxLength      = std::max(kSubTypeLengths);
-constexpr size_t kSubTypeTotalLength    = chip::Sum(kSubTypeLengths);
+constexpr size_t kSubTypeMaxNumber      = SUBTYPES.size();
+constexpr size_t kSubTypeMaxLength      = std::max(SUBTYPES);
+constexpr size_t kSubTypeTotalLength    = chip::Sum(SUBTYPES);
+
+#undef SUBTYPES
 
 } // namespace Commissionable
 

--- a/src/lib/dnssd/Constants.h
+++ b/src/lib/dnssd/Constants.h
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/support/Fold.h>
+
+#include <algorithm>
+#include <initializer_list>
+
+namespace chip {
+namespace Dnssd {
+
+/*
+ * Matter DNS host settings
+ */
+
+constexpr size_t kHostNameMaxLength = 16; // MAC or 802.15.4 Extended Address in hex
+
+/*
+ * Matter DNS service subtypes
+ */
+
+constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4;  // _S<dd>
+constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6;  // _L<dddd>
+constexpr size_t kSubTypeVendorMaxLength                  = 7;  // _V<ddddd>
+constexpr size_t kSubTypeDeviceTypeMaxLength              = 5;  // _T<ddd>
+constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _C<d>
+constexpr size_t kSubTypeAdditionalCommissioningMaxLength = 3;  // _A<d>
+constexpr size_t kSubTypeCompressedFabricIdMaxLength      = 18; // _I<16-hex-digits>
+
+/*
+ * Matter operational node service settings
+ */
+
+namespace Operational {
+
+constexpr auto kSubTypeLengths          = { kSubTypeCompressedFabricIdMaxLength };
+constexpr size_t kInstanceNameMaxLength = 33; // <NodeId>-<FabricId> in hex (16 + 1 + 16)
+constexpr size_t kSubTypeMaxNumber      = kSubTypeLengths.size();
+constexpr size_t kSubTypeMaxLength      = std::max(kSubTypeLengths);
+constexpr size_t kSubTypeTotalLength    = chip::Sum(kSubTypeLengths);
+
+} // namespace Operational
+
+/*
+ * Matter commissionable/commissioner node service constants.
+ */
+
+namespace Commissionable {
+
+constexpr auto kSubTypeLengths = {
+    kSubTypeShortDiscriminatorMaxLength, kSubTypeLongDiscriminatorMaxLength, kSubTypeVendorMaxLength,
+    kSubTypeDeviceTypeMaxLength,         kSubTypeCommissioningModeMaxLength, kSubTypeAdditionalCommissioningMaxLength
+};
+constexpr size_t kInstanceNameMaxLength = 16; // 64-bit random number in hex
+constexpr size_t kSubTypeMaxNumber      = kSubTypeLengths.size();
+constexpr size_t kSubTypeMaxLength      = std::max(kSubTypeLengths);
+constexpr size_t kSubTypeTotalLength    = chip::Sum(kSubTypeLengths);
+
+} // namespace Commissionable
+
+/*
+ * Constants for any Matter service.
+ */
+
+namespace Common {
+
+constexpr size_t kInstanceNameMaxLength = std::max(Operational::kInstanceNameMaxLength, Commissionable::kInstanceNameMaxLength);
+constexpr size_t kSubTypeMaxNumber      = std::max(Operational::kSubTypeMaxNumber, Commissionable::kSubTypeMaxNumber);
+constexpr size_t kSubTypeMaxLength      = std::max(Operational::kSubTypeMaxLength, Commissionable::kSubTypeMaxLength);
+constexpr size_t kSubTypeTotalLength    = std::max(Operational::kSubTypeTotalLength, Commissionable::kSubTypeTotalLength);
+
+} // namespace Common
+
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -114,7 +114,7 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
 
 CHIP_ERROR DiscoveryImplPlatform::GetCommissionableInstanceName(char * instanceName, size_t maxLength)
 {
-    if (maxLength < (chip::Dnssd::kMaxInstanceNameSize + 1))
+    if (maxLength < (chip::Dnssd::Commissionable::kInstanceNameMaxLength + 1))
     {
         return CHIP_ERROR_NO_MEMORY;
     }
@@ -217,7 +217,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     char commissioningModeSubType[kSubTypeCommissioningModeMaxLength + 1];
     char deviceTypeSubType[kSubTypeDeviceTypeMaxLength + 1];
     // size of subTypes array should be count of SubTypes above
-    const char * subTypes[kSubTypeMaxNumber];
+    const char * subTypes[Commissionable::kSubTypeMaxNumber];
     size_t subTypeSize = 0;
 
     if (!mDnssdInitialized)
@@ -394,7 +394,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     char compressedFabricIdSub[kSubTypeCompressedFabricIdMaxLength + 1];
-    const char * subTypes[1];
+    const char * subTypes[Operational::kSubTypeMaxNumber];
     size_t subTypeSize = 0;
 
     mOperationalAdvertisingParams = params;

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -27,13 +27,12 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
 #include <lib/core/PeerId.h>
+#include <lib/dnssd/Constants.h>
 #include <lib/support/BytesToHex.h>
 
 namespace chip {
 namespace Dnssd {
 
-// Largest host name is 64-bits in hex.
-static constexpr int kMaxHostNameSize      = 16;
 constexpr uint32_t kUndefinedRetryInterval = std::numeric_limits<uint32_t>::max();
 
 struct ResolvedNodeData
@@ -63,26 +62,25 @@ struct ResolvedNodeData
     }
 
     PeerId mPeerId;
-    Inet::IPAddress mAddress             = Inet::IPAddress::Any;
-    Inet::InterfaceId mInterfaceId       = INET_NULL_INTERFACEID;
-    uint16_t mPort                       = 0;
-    char mHostName[kMaxHostNameSize + 1] = {};
-    bool mSupportsTcp                    = false;
-    uint32_t mMrpRetryIntervalIdle       = kUndefinedRetryInterval;
-    uint32_t mMrpRetryIntervalActive     = kUndefinedRetryInterval;
+    Inet::IPAddress mAddress               = Inet::IPAddress::Any;
+    Inet::InterfaceId mInterfaceId         = INET_NULL_INTERFACEID;
+    uint16_t mPort                         = 0;
+    char mHostName[kHostNameMaxLength + 1] = {};
+    bool mSupportsTcp                      = false;
+    uint32_t mMrpRetryIntervalIdle         = kUndefinedRetryInterval;
+    uint32_t mMrpRetryIntervalActive       = kUndefinedRetryInterval;
 };
 
 constexpr size_t kMaxDeviceNameLen         = 32;
 constexpr size_t kMaxRotatingIdLen         = 50;
 constexpr size_t kMaxPairingInstructionLen = 128;
 
-static constexpr int kMaxInstanceNameSize = 16;
 struct DiscoveredNodeData
 {
     // TODO(cecille): is 4 OK? IPv6 LL, GUA, ULA, IPv4?
     static constexpr int kMaxIPAddresses = 5;
-    char hostName[kMaxHostNameSize + 1];
-    char instanceName[kMaxInstanceNameSize + 1];
+    char hostName[kHostNameMaxLength + 1];
+    char instanceName[Commissionable::kInstanceNameMaxLength + 1];
     uint16_t longDiscriminator;
     uint16_t vendorId;
     uint16_t productId;

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -470,7 +470,7 @@ CHIP_ERROR MinMdnsResolver::BrowseNodes(DiscoveryType type, DiscoveryFilter filt
         }
         else
         {
-            char subtypeStr[kMaxSubtypeDescSize];
+            char subtypeStr[Common::kSubTypeMaxLength + 1];
             ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), filter));
             qname = CheckAndAllocateQName(subtypeStr, kSubtypeServiceNamePart, kCommissionableServiceName, kCommissionProtocol,
                                           kLocalDomain);
@@ -483,7 +483,7 @@ CHIP_ERROR MinMdnsResolver::BrowseNodes(DiscoveryType type, DiscoveryFilter filt
         }
         else
         {
-            char subtypeStr[kMaxSubtypeDescSize];
+            char subtypeStr[Common::kSubTypeMaxLength + 1];
             ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), filter));
             qname = CheckAndAllocateQName(subtypeStr, kSubtypeServiceNamePart, kCommissionerServiceName, kCommissionProtocol,
                                           kLocalDomain);

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -30,7 +30,7 @@ namespace Dnssd {
 
 CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peerId)
 {
-    ReturnErrorCodeIf(bufferLen <= kOperationalServiceNamePrefix, CHIP_ERROR_BUFFER_TOO_SMALL);
+    ReturnErrorCodeIf(bufferLen <= Operational::kInstanceNameMaxLength, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     NodeId nodeId               = peerId.GetNodeId();
     CompressedFabricId fabricId = peerId.GetCompressedFabricId();

--- a/src/lib/dnssd/ServiceNaming.h
+++ b/src/lib/dnssd/ServiceNaming.h
@@ -19,6 +19,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/PeerId.h>
+#include <lib/dnssd/Constants.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/Span.h>
 
@@ -27,28 +28,25 @@
 
 namespace chip {
 namespace Dnssd {
-constexpr size_t kMaxSubtypeDescSize           = 19; // _I service subtype = 16 chars for 64-bit id, + 2 for "_I" + nullchar
-constexpr char kSubtypeServiceNamePart[]       = "_sub";
-constexpr char kCommissionableServiceName[]    = "_matterc";
-constexpr char kOperationalServiceName[]       = "_matter";
-constexpr char kCommissionerServiceName[]      = "_matterd";
-constexpr char kOperationalProtocol[]          = "_tcp";
-constexpr char kCommissionProtocol[]           = "_udp";
-constexpr char kLocalDomain[]                  = "local";
-constexpr size_t kOperationalServiceNamePrefix = 16 + 1 + 16; // 2 * 64-bit value in HEX + hyphen
-constexpr size_t kCommissionServiceNamePrefix  = 16;
+constexpr char kSubtypeServiceNamePart[]    = "_sub";
+constexpr char kCommissionableServiceName[] = "_matterc";
+constexpr char kOperationalServiceName[]    = "_matter";
+constexpr char kCommissionerServiceName[]   = "_matterd";
+constexpr char kOperationalProtocol[]       = "_tcp";
+constexpr char kCommissionProtocol[]        = "_udp";
+constexpr char kLocalDomain[]               = "local";
 
 // each includes space for a null terminator, which becomes a . when the names are appended.
 constexpr size_t kMaxCommisisonableServiceNameSize =
-    kMaxSubtypeDescSize + sizeof(kSubtypeServiceNamePart) + sizeof(kCommissionableServiceName);
+    Common::kSubTypeMaxLength + 1 + sizeof(kSubtypeServiceNamePart) + sizeof(kCommissionableServiceName);
 
 // each includes space for a null terminator, which becomes a . when the names are appended.
 constexpr size_t kMaxCommisisonerServiceNameSize =
-    kMaxSubtypeDescSize + sizeof(kSubtypeServiceNamePart) + sizeof(kCommissionerServiceName);
+    Common::kSubTypeMaxLength + 1 + sizeof(kSubtypeServiceNamePart) + sizeof(kCommissionerServiceName);
 
 // + 1 for nullchar on prefix.
 constexpr size_t kMaxOperationalServiceNameSize =
-    kOperationalServiceNamePrefix + 1 + sizeof(kOperationalServiceName) + sizeof(kOperationalProtocol) + sizeof(kLocalDomain);
+    Operational::kInstanceNameMaxLength + 1 + sizeof(kOperationalServiceName) + sizeof(kOperationalProtocol) + sizeof(kLocalDomain);
 
 /// builds the MDNS advertising name for a given fabric + nodeid pair
 CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peerId);

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -32,20 +32,19 @@
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
+#include <lib/dnssd/Constants.h>
 #include <lib/dnssd/ServiceNaming.h>
 
 namespace chip {
 namespace Dnssd {
 
 // None of these sizes include an null character at the end.
-static constexpr uint8_t kDnssdInstanceNameMaxSize = 33; // [Node]-[Fabric] ID in hex - 16+1+16
-static constexpr uint8_t kDnssdHostNameMaxSize     = 16; // 64-bits in hex.
-static constexpr size_t kDnssdProtocolTextMaxSize  = std::max(sizeof(kOperationalProtocol), sizeof(kCommissionProtocol)) - 1;
+static constexpr size_t kDnssdProtocolTextMaxSize = std::max(sizeof(kOperationalProtocol), sizeof(kCommissionProtocol)) - 1;
 static constexpr size_t kDnssdTypeMaxSize =
     std::max({ sizeof(kCommissionableServiceName), sizeof(kOperationalServiceName), sizeof(kCommissionerServiceName) }) - 1;
 static constexpr uint8_t kDnssdTypeAndProtocolMaxSize     = kDnssdTypeMaxSize + kDnssdProtocolTextMaxSize + 1; // <type>.<protocol>
 static constexpr uint16_t kDnssdTextMaxSize               = 64;
-static constexpr uint8_t kDnssdFullTypeAndProtocolMaxSize = kMaxSubtypeDescSize + /* '.' */ 1 + kDnssdTypeAndProtocolMaxSize;
+static constexpr uint8_t kDnssdFullTypeAndProtocolMaxSize = Common::kSubTypeMaxLength + /* '.' */ 1 + kDnssdTypeAndProtocolMaxSize;
 
 enum class DnssdServiceProtocol : uint8_t
 {
@@ -63,8 +62,8 @@ struct TextEntry
 
 struct DnssdService
 {
-    char mName[kDnssdInstanceNameMaxSize + 1];
-    char mHostName[kDnssdHostNameMaxSize + 1] = "";
+    char mName[Common::kInstanceNameMaxLength + 1];
+    char mHostName[kHostNameMaxLength + 1] = "";
     char mType[kDnssdTypeMaxSize + 1];
     DnssdServiceProtocol mProtocol;
     Inet::IPAddressType mAddressType;

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -230,8 +230,8 @@ void TestGetRotatingDeviceId(nlTestSuite * inSuite, void * inContext)
 
     sprintf(ri, "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031");
     GetRotatingDeviceId(GetSpan(ri), id, &len);
-    NL_TEST_ASSERT(inSuite, len == kMaxRotatingIdLen);
-    for (uint8_t i = 0; i < kMaxRotatingIdLen; ++i)
+    NL_TEST_ASSERT(inSuite, len == sizeof(id));
+    for (uint8_t i = 0; i < sizeof(id); ++i)
     {
         NL_TEST_ASSERT(inSuite, id[i] == i);
     }

--- a/src/lib/support/Fold.h
+++ b/src/lib/support/Fold.h
@@ -1,0 +1,49 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+
+namespace chip {
+
+/**
+ * Apply the functor sequentially to the previous value and a subsequent element of the container.
+ *
+ * This provides a similar functionality to std::acumulate, but can be used in constexpr contexts.
+ */
+template <class Container, class Functor, class ValueType = typename Container::value_type>
+constexpr ValueType Fold(const Container & container, ValueType initial, Functor functor)
+{
+    for (const auto & element : container)
+    {
+        initial = functor(initial, element);
+    }
+
+    return initial;
+}
+
+/**
+ * Sum all elements of the container using "+" operator.
+ */
+template <class Container, class ValueType = typename Container::value_type>
+constexpr ValueType Sum(const Container & container)
+{
+    return Fold(container, ValueType{}, std::plus<ValueType>{});
+}
+
+} // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -32,6 +32,7 @@ chip_test_suite("tests") {
     "TestDefer.cpp",
     "TestErrorStr.cpp",
     "TestFixedBufferAllocator.cpp",
+    "TestFold.cpp",
     "TestOwnerOf.cpp",
     "TestPool.cpp",
     "TestPrivateHeap.cpp",

--- a/src/lib/support/tests/TestFold.cpp
+++ b/src/lib/support/tests/TestFold.cpp
@@ -1,0 +1,82 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/support/Fold.h>
+#include <lib/support/UnitTestRegistration.h>
+
+#include <algorithm>
+#include <cstring>
+#include <initializer_list>
+#include <nlunit-test.h>
+
+using namespace chip;
+
+namespace {
+
+void TestFoldMax(nlTestSuite * inSuite, void * inContext)
+{
+    using List   = std::initializer_list<int>;
+    using Limits = std::numeric_limits<int>;
+    const auto max = [](int left, int right) { return std::max(left, right); };
+
+    // Test empty list
+    NL_TEST_ASSERT(inSuite, Fold(List{}, -1000, max) == -1000);
+
+    // Test one-element (less than the initial value)
+    NL_TEST_ASSERT(inSuite, Fold(List{ -1001 }, -1000, max) == -1000);
+
+    // Test one-element (greater than the initial value)
+    NL_TEST_ASSERT(inSuite, Fold(List{ -999 }, -1000, max) == -999);
+
+    // Test limits
+    NL_TEST_ASSERT(inSuite, Fold(List{ 1000, Limits::max(), 0 }, 0, max) == Limits::max());
+    NL_TEST_ASSERT(inSuite, Fold(List{ Limits::max(), 1000, Limits::min() }, Limits::min(), max) == Limits::max());
+}
+
+void TestSum(nlTestSuite * inSuite, void * inContext)
+{
+    using List   = std::initializer_list<int>;
+    using Limits = std::numeric_limits<int>;
+
+    // Test empty list
+    NL_TEST_ASSERT(inSuite, Sum(List{}) == 0);
+
+    // Test one-element (min)
+    NL_TEST_ASSERT(inSuite, Sum(List{ Limits::min() }) == Limits::min());
+
+    // Test one-element (max)
+    NL_TEST_ASSERT(inSuite, Sum(List{ Limits::max() }) == Limits::max());
+
+    // Test multiple elements
+    NL_TEST_ASSERT(inSuite, Sum(List{ 0, 5, 1, 4, 2, 3 }) == 15);
+}
+
+const nlTest sTests[] = { NL_TEST_DEF("Test fold (max)", TestFoldMax), NL_TEST_DEF("Test sum", TestSum), NL_TEST_SENTINEL() };
+
+} // namespace
+
+int TestFold()
+{
+    nlTestSuite theSuite = { "Fold tests", &sTests[0], nullptr, nullptr };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestFold)

--- a/src/lib/support/tests/TestFold.cpp
+++ b/src/lib/support/tests/TestFold.cpp
@@ -30,8 +30,8 @@ namespace {
 
 void TestFoldMax(nlTestSuite * inSuite, void * inContext)
 {
-    using List   = std::initializer_list<int>;
-    using Limits = std::numeric_limits<int>;
+    using List     = std::initializer_list<int>;
+    using Limits   = std::numeric_limits<int>;
     const auto max = [](int left, int right) { return std::max(left, right); };
 
     // Test empty list

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -320,7 +320,7 @@ void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, 
     service.mProtocol    = context->protocol;
 
     strncpy(service.mName, name, sizeof(service.mName));
-    service.mName[kDnssdInstanceNameMaxSize] = 0;
+    service.mName[Common::kInstanceNameMaxLength] = 0;
 
     strncpy(service.mType, regtype, sizeof(service.mType));
     service.mType[kDnssdTypeMaxSize] = 0;

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -72,7 +72,7 @@ struct ResolveContext : public GenericContext
 {
     DnssdResolveCallback callback;
 
-    char name[kDnssdInstanceNameMaxSize + 1];
+    char name[Common::kInstanceNameMaxLength + 1];
     chip::Inet::IPAddressType addressType;
 
     ResolveContext(void * cbContext, DnssdResolveCallback cb, const char * cbContextName, chip::Inet::IPAddressType cbAddressType)
@@ -89,7 +89,7 @@ struct GetAddrInfoContext : public GenericContext
 {
     DnssdResolveCallback callback;
     std::vector<TextEntry> textEntries;
-    char name[kDnssdInstanceNameMaxSize + 1];
+    char name[Common::kInstanceNameMaxLength + 1];
     uint32_t interfaceId;
     uint16_t port;
 

--- a/src/platform/OpenThread/DnssdImpl.cpp
+++ b/src/platform/OpenThread/DnssdImpl.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
 
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     MutableByteSpan mac(macBuffer);
-    char hostname[kDnssdHostNameMaxSize + 1] = "";
+    char hostname[kHostNameMaxLength + 1] = "";
     ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetPrimaryMACAddress(mac));
     MakeHostName(hostname, sizeof(hostname), mac);
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1805,7 +1805,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
     Impl()->LockThreadStack();
 
     VerifyOrExit(aHostName, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(strlen(aHostName) <= SrpClient::kMaxHostNameSize, error = CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrExit(strlen(aHostName) <= Dnssd::kHostNameMaxLength, error = CHIP_ERROR_INVALID_STRING_LENGTH);
 
     // Avoid adding the same host name multiple times
     if (strcmp(mSrpClient.mHostName, aHostName) != 0)
@@ -1837,7 +1837,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ClearSrpHost(co
     Impl()->LockThreadStack();
 
     VerifyOrExit(aHostName, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(strlen(aHostName) <= SrpClient::kMaxHostNameSize, error = CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrExit(strlen(aHostName) <= Dnssd::kHostNameMaxLength, error = CHIP_ERROR_INVALID_STRING_LENGTH);
     VerifyOrExit(mSrpClient.mInitializedCallback, error = CHIP_ERROR_INCORRECT_STATE);
 
     // Add host and remove it with notifying SRP server to clean old information related to the host.
@@ -1953,9 +1953,9 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnDnsBrowseResult(otEr
     CHIP_ERROR error;
     DnsResult browseResult;
     // type buffer size is kDnssdTypeAndProtocolMaxSize + . + kMaxDomainNameSize + . + termination character
-    char type[chip::Dnssd::kDnssdTypeAndProtocolMaxSize + SrpClient::kMaxDomainNameSize + 3];
-    // hostname buffer size is kDnssdHostNameMaxSize + . + kMaxDomainNameSize + . + termination character
-    char hostname[chip::Dnssd::kDnssdHostNameMaxSize + SrpClient::kMaxDomainNameSize + 3];
+    char type[Dnssd::kDnssdTypeAndProtocolMaxSize + SrpClient::kMaxDomainNameSize + 3];
+    // hostname buffer size is kHostNameMaxLength + . + kMaxDomainNameSize + . + termination character
+    char hostname[Dnssd::kHostNameMaxLength + SrpClient::kMaxDomainNameSize + 3];
     // secure space for the raw TXT data in the worst-case scenario relevant for Matter:
     // each entry consists of txt_entry_size (1B) + txt_entry_key + "=" + txt_entry_data
     uint8_t txtBuffer[kMaxDnsServiceTxtEntriesNumber + kTotalDnsServiceTxtBufferSize];
@@ -2043,9 +2043,9 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnDnsResolveResult(otE
     CHIP_ERROR error;
     DnsResult resolveResult;
     // type buffer size is kDnssdTypeAndProtocolMaxSize + . + kMaxDomainNameSize + . + termination character
-    char type[chip::Dnssd::kDnssdTypeAndProtocolMaxSize + SrpClient::kMaxDomainNameSize + 3];
-    // hostname buffer size is kDnssdHostNameMaxSize + . + kMaxDomainNameSize + . + termination character
-    char hostname[chip::Dnssd::kDnssdHostNameMaxSize + SrpClient::kMaxDomainNameSize + 3];
+    char type[Dnssd::kDnssdTypeAndProtocolMaxSize + SrpClient::kMaxDomainNameSize + 3];
+    // hostname buffer size is kHostNameMaxLength + . + kMaxDomainNameSize + . + termination character
+    char hostname[Dnssd::kHostNameMaxLength + SrpClient::kMaxDomainNameSize + 3];
     // secure space for the raw TXT data in the worst-case scenario relevant for Matter:
     // each entry consists of txt_entry_size (1B) + txt_entry_key + "=" + txt_entry_data
     uint8_t txtBuffer[kMaxDnsServiceTxtEntriesNumber + kTotalDnsServiceTxtBufferSize];
@@ -2098,7 +2098,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_DnsResolve(cons
 
     // Append default SRP domain name to the service name.
     // fullServiceName buffer size is kDnssdTypeAndProtocolMaxSize + . separator + kDefaultDomainNameSize + termination character.
-    char fullServiceName[chip::Dnssd::kDnssdTypeAndProtocolMaxSize + 1 + SrpClient::kDefaultDomainNameSize + 1];
+    char fullServiceName[Dnssd::kDnssdTypeAndProtocolMaxSize + 1 + SrpClient::kDefaultDomainNameSize + 1];
     snprintf(fullServiceName, sizeof(fullServiceName), "%s.%s", aServiceName, SrpClient::kDefaultDomainName);
 
     error = MapOpenThreadError(

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -136,30 +136,29 @@ private:
     struct SrpClient
     {
         static constexpr uint8_t kMaxServicesNumber      = CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES;
-        static constexpr uint8_t kMaxHostNameSize        = 16;
         static constexpr const char * kDefaultDomainName = "default.service.arpa";
         static constexpr uint8_t kDefaultDomainNameSize  = 20;
         static constexpr uint8_t kMaxDomainNameSize      = 32;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
         // Thread supports both operational and commissionable discovery, so buffers sizes must be worst case.
-        static constexpr size_t kSubTypeMaxNumber   = Dnssd::kSubTypeMaxNumber;
-        static constexpr size_t kSubTypeTotalLength = Dnssd::kSubTypeTotalLength;
+        static constexpr size_t kSubTypeMaxNumber   = Dnssd::Common::kSubTypeMaxNumber;
+        static constexpr size_t kSubTypeTotalLength = Dnssd::Common::kSubTypeTotalLength;
         static constexpr size_t kTxtMaxNumber =
             std::max(Dnssd::CommissionAdvertisingParameters::kTxtMaxNumber, Dnssd::OperationalAdvertisingParameters::kTxtMaxNumber);
         static constexpr size_t kTxtTotalValueLength = std::max(Dnssd::CommissionAdvertisingParameters::kTxtTotalValueSize,
                                                                 Dnssd::OperationalAdvertisingParameters::kTxtTotalValueSize);
 #else
         // Thread only supports operational discovery.
-        static constexpr size_t kSubTypeMaxNumber    = 1;
-        static constexpr size_t kSubTypeTotalLength  = Dnssd::kSubTypeCompressedFabricIdMaxLength;
+        static constexpr size_t kSubTypeMaxNumber    = Dnssd::Operational::kSubTypeMaxNumber;
+        static constexpr size_t kSubTypeTotalLength  = Dnssd::Operational::kSubTypeTotalLength;
         static constexpr size_t kTxtMaxNumber        = Dnssd::OperationalAdvertisingParameters::kTxtMaxNumber;
         static constexpr size_t kTxtTotalValueLength = Dnssd::OperationalAdvertisingParameters::kTxtTotalValueSize;
 #endif
 
-        static constexpr size_t kServiceBufferSize = Dnssd::kDnssdInstanceNameMaxSize + 1 + // add null-terminator
-            Dnssd::kDnssdTypeAndProtocolMaxSize + 1 +                                       // add null-terminator
-            kSubTypeTotalLength + kSubTypeMaxNumber +                                       // add null-terminator for each subtype
+        static constexpr size_t kServiceBufferSize = Dnssd::Common::kInstanceNameMaxLength + 1 + // add null-terminator
+            Dnssd::kDnssdTypeAndProtocolMaxSize + 1 +                                            // add null-terminator
+            kSubTypeTotalLength + kSubTypeMaxNumber + // add null-terminator for each subtype
             kTxtTotalValueLength;
 
         struct Service
@@ -174,7 +173,7 @@ private:
             bool Matches(const char * aInstanceName, const char * aName) const;
         };
 
-        char mHostName[kMaxHostNameSize + 1];
+        char mHostName[Dnssd::kHostNameMaxLength + 1];
         otIp6Address mHostAddress;
         Service mServices[kMaxServicesNumber];
         bool mIsInitialized;
@@ -212,7 +211,7 @@ private:
     struct DnsServiceTxtEntries
     {
         uint8_t mBuffer[kTotalDnsServiceTxtBufferSize];
-        chip::Dnssd::TextEntry mTxtEntries[kMaxDnsServiceTxtEntriesNumber];
+        Dnssd::TextEntry mTxtEntries[kMaxDnsServiceTxtEntriesNumber];
     };
 
     struct DnsResult

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -145,7 +145,7 @@ void HandleResolve(jstring instanceName, jstring serviceType, jstring address, j
     JniUtfString jniAddress(env, address);
     Inet::IPAddress ipAddress;
 
-    VerifyOrReturn(strlen(jniInstanceName.c_str()) <= kDnssdInstanceNameMaxSize, dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+    VerifyOrReturn(strlen(jniInstanceName.c_str()) <= Operational::kInstanceNameMaxLength, dispatch(CHIP_ERROR_INVALID_ARGUMENT));
     VerifyOrReturn(strlen(jniServiceType.c_str()) <= kDnssdTypeAndProtocolMaxSize, dispatch(CHIP_ERROR_INVALID_ARGUMENT));
     VerifyOrReturn(CanCastTo<uint16_t>(port), dispatch(CHIP_ERROR_INVALID_ARGUMENT));
     VerifyOrReturn(Inet::IPAddress::FromString(jniAddress.c_str(), ipAddress), dispatch(CHIP_ERROR_INVALID_ARGUMENT));

--- a/src/platform/fake/DnssdImpl.h
+++ b/src/platform/fake/DnssdImpl.h
@@ -53,7 +53,7 @@ struct ExpectedTxt
 
 struct ExpectedSubtype
 {
-    char name[kMaxSubtypeDescSize] = "";
+    char name[Common::kSubTypeMaxLength + 1] = "";
     bool operator==(const char * subtype) const { return strcmp(name, subtype) == 0; }
 };
 struct ExpectedCall
@@ -169,13 +169,13 @@ struct ExpectedCall
         }
     }
 
-    static constexpr size_t kMaxTxtRecords           = 11;
-    static constexpr size_t kMaxSubtypes             = 10;
-    CallType callType                                = CallType::kUnknown;
-    DnssdServiceProtocol protocol                    = DnssdServiceProtocol::kDnssdProtocolUnknown;
-    char instanceName[kDnssdInstanceNameMaxSize + 1] = "";
-    char hostName[kDnssdHostNameMaxSize + 1]         = "";
-    char serviceName[kDnssdTypeMaxSize + 1]          = "";
+    static constexpr size_t kMaxTxtRecords                = 11;
+    static constexpr size_t kMaxSubtypes                  = 10;
+    CallType callType                                     = CallType::kUnknown;
+    DnssdServiceProtocol protocol                         = DnssdServiceProtocol::kDnssdProtocolUnknown;
+    char instanceName[Common::kInstanceNameMaxLength + 1] = "";
+    char hostName[kHostNameMaxLength + 1]                 = "";
+    char serviceName[kDnssdTypeMaxSize + 1]               = "";
     ExpectedSubtype subtype[kMaxSubtypes];
     size_t numSubtypes = 0;
     ExpectedTxt txt[kMaxTxtRecords];

--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -94,7 +94,7 @@ public:
 
 private:
     PeerAddress mPeerAddress;
-    char mInstanceName[chip::Dnssd::kMaxInstanceNameSize + 1];
+    char mInstanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
     UDCClientProcessingState mUDCClientProcessingState;
     uint64_t mExpirationTimeMs = 0;
 };

--- a/src/protocols/user_directed_commissioning/UDCClients.h
+++ b/src/protocols/user_directed_commissioning/UDCClients.h
@@ -135,7 +135,7 @@ public:
             }
 
             // TODO: check length of instanceName
-            if (strncmp(stateiter.GetInstanceName(), instanceName, chip::Dnssd::kMaxInstanceNameSize + 1) == 0)
+            if (strncmp(stateiter.GetInstanceName(), instanceName, Dnssd::Commissionable::kInstanceNameMaxLength + 1) == 0)
             {
                 state = &stateiter;
                 break;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -47,9 +47,8 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
     PayloadHeader payloadHeader;
     ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
 
-    char instanceName[chip::Dnssd::kMaxInstanceNameSize + 1];
-    size_t instanceNameLength =
-        (msg->DataLength() > (chip::Dnssd::kMaxInstanceNameSize)) ? chip::Dnssd::kMaxInstanceNameSize : msg->DataLength();
+    char instanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
+    size_t instanceNameLength = std::min<size_t>(msg->DataLength(), Dnssd::Commissionable::kInstanceNameMaxLength);
     msg->Read(Uint8::from_char(instanceName), instanceNameLength);
 
     instanceName[instanceNameLength] = '\0';

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -121,8 +121,8 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
 
     // encode our client message
-    char nameBuffer[Dnssd::kMaxInstanceNameSize + 1] = "Chris";
-    System::PacketBufferHandle payloadBuf            = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
+    char nameBuffer[Dnssd::Commissionable::kInstanceNameMaxLength + 1] = "Chris";
+    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
     udcClient.EncodeUDCMessage(std::move(payloadBuf));
 
     // prepare peerAddress for handleMessage
@@ -170,8 +170,8 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
 
 void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * inContext)
 {
-    char nameBuffer[Dnssd::kMaxInstanceNameSize + 1] = "Chris";
-    System::PacketBufferHandle payloadBuf            = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
+    char nameBuffer[Dnssd::Commissionable::kInstanceNameMaxLength + 1] = "Chris";
+    System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
     UserDirectedCommissioningClient udcClient;
 
     // obtain the UDC message
@@ -191,9 +191,8 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     NL_TEST_ASSERT(inSuite, payloadHeader.IsInitiator());
 
     // check the payload
-    char instanceName[chip::Dnssd::kMaxInstanceNameSize + 1];
-    size_t instanceNameLength = (payloadBuf->DataLength() > (chip::Dnssd::kMaxInstanceNameSize)) ? chip::Dnssd::kMaxInstanceNameSize
-                                                                                                 : payloadBuf->DataLength();
+    char instanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
+    size_t instanceNameLength = std::min<size_t>(payloadBuf->DataLength(), Dnssd::Commissionable::kInstanceNameMaxLength);
     payloadBuf->Read(Uint8::from_char(instanceName), instanceNameLength);
     instanceName[instanceNameLength] = '\0';
     ChipLogProgress(Inet, "UDC instance=%s", instanceName);


### PR DESCRIPTION
#### Problem
DNS-SD constants are currently defined in many places, some constants are duplicated, and there are constants that have
similar names, but different meanings (like the service instance name for the commissionable and operational node, respectively).

#### Change overview
Try to clean them up by putting most of them in a single `lib/dnssd/Constants.h` header file. Also, remove unnecessary
`kDnssd` prefixes since the constants are already in the `Dnssd` namespace.

#### Testing
Tested by CI. Also tested manually using nRF Connect and Linux (minimal mDNS) lighting-app - tried to commissioned all the apps and verified operational services show up.
