### PR TITLE
[ChipTool] Add an additional argument node-id to most command using t…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,8 +77,7 @@ jobs:
             - name: Build chip-tool
               timeout-minutes: 5
               run: |
-                  # config_pair_with_random_id=false so CI runs faster.
-                  scripts/examples/gn_build_example.sh examples/chip-tool out/debug/standalone/ is_tsan=${USE_TSAN} config_use_separate_eventloop=${USE_SEPARATE_EVENTLOOP} config_pair_with_random_id=false
+                  scripts/examples/gn_build_example.sh examples/chip-tool out/debug/standalone/ is_tsan=${USE_TSAN} config_use_separate_eventloop=${USE_SEPARATE_EVENTLOOP}
             - name: Copy objdir
               run: |
                   # The idea is to not upload our objdir unless builds have
@@ -162,8 +161,7 @@ jobs:
             - name: Build chip-tool
               timeout-minutes: 10
               run: |
-                  # config_pair_with_random_id=false so CI runs faster.
-                  scripts/examples/gn_build_example.sh examples/chip-tool out/debug/standalone/ is_tsan=${USE_TSAN} config_use_separate_eventloop=${USE_SEPARATE_EVENTLOOP} config_pair_with_random_id=false
+                  scripts/examples/gn_build_example.sh examples/chip-tool out/debug/standalone/ is_tsan=${USE_TSAN} config_use_separate_eventloop=${USE_SEPARATE_EVENTLOOP}
             - name: Copy objdir
               run: |
                   # The idea is to not upload our objdir unless builds have

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -22,11 +22,6 @@ assert(chip_build_tools)
 declare_args() {
   # Use a separate eventloop for CHIP tasks
   config_use_separate_eventloop = true
-
-  # Generate a new node id on every pairing.  This significantly slows
-  # down running a lot of pairings (because of all the disk traffic for
-  # saving the config file), so we disable it in some configurations.
-  config_pair_with_random_id = true
 }
 
 executable("chip-tool") {
@@ -48,10 +43,7 @@ executable("chip-tool") {
     "main.cpp",
   ]
 
-  defines = [
-    "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}",
-    "CONFIG_PAIR_WITH_RANDOM_ID=${config_pair_with_random_id}",
-  ]
+  defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}" ]
 
   deps = [
     "${chip_root}/src/controller/data_model",

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -23,14 +23,14 @@
 
 using namespace ::chip;
 
-CHIP_ERROR ModelCommand::Run(NodeId remoteId)
+CHIP_ERROR ModelCommand::RunCommand()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);
 
-    err = mController.GetConnectedDevice(remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    CHIP_ERROR err = mController.GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %" CHIP_ERROR_FORMAT,
-                              remoteId, err.Format()));
+                              mNodeId, err.Format()));
 
 exit:
     return err;

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -38,15 +38,20 @@ public:
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {}
 
-    void AddArguments() { AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId); }
+    void AddArguments()
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+        AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId);
+    }
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return 10; }
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endPointId) = 0;
 
 private:
+    chip::NodeId mNodeId;
     uint8_t mEndPointId;
 
     static void OnDeviceConnectedFn(void * context, ChipDevice * device);

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -94,7 +94,7 @@ CHIP_ERROR CHIPCommand::Run()
 void CHIPCommand::RunQueuedCommand(intptr_t commandArg)
 {
     auto * command = reinterpret_cast<CHIPCommand *>(commandArg);
-    CHIP_ERROR err = command->Run(command->mStorage.GetRemoteNodeId());
+    CHIP_ERROR err = command->RunCommand();
     if (err != CHIP_NO_ERROR)
     {
         command->SetCommandExitStatus(err);

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -54,7 +54,7 @@ protected:
     // 1) If error is returned, Run() must not call SetCommandExitStatus.
     // 2) If success is returned Run() must either have called
     //    SetCommandExitStatus() or scheduled async work that will do that.
-    virtual CHIP_ERROR Run(NodeId remoteId) = 0;
+    virtual CHIP_ERROR RunCommand() = 0;
 
     // Get the wait duration, in seconds, before the command times out.
     virtual uint16_t GetWaitDurationInSeconds() const = 0;

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -18,7 +18,7 @@
 
 #include "DiscoverCommand.h"
 
-CHIP_ERROR DiscoverCommand::Run(NodeId remoteId)
+CHIP_ERROR DiscoverCommand::RunCommand()
 {
     mController.RegisterDeviceAddressUpdateDelegate(this);
     return RunCommand(mNodeId, mFabricId);

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -35,7 +35,7 @@ public:
     void OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR error) override{};
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return 30; }
 
     virtual CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) = 0;

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -21,7 +21,7 @@
 
 using namespace ::chip;
 
-CHIP_ERROR DiscoverCommissionablesCommand::Run(NodeId remoteId)
+CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()
 {
     mController.RegisterDeviceDiscoveryDelegate(this);
     Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kNone, (uint64_t) 0);

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -29,6 +29,6 @@ public:
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return 30; }
 };

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -21,7 +21,7 @@
 
 using namespace ::chip;
 
-CHIP_ERROR DiscoverCommissionersCommand::Run(NodeId remoteId)
+CHIP_ERROR DiscoverCommissionersCommand::RunCommand()
 {
     return mCommissionableNodeController.DiscoverCommissioners();
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
@@ -27,7 +27,7 @@ public:
     DiscoverCommissionersCommand() : CHIPCommand("commissioners") {}
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return 3; }
     void Shutdown() override;
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -32,36 +32,14 @@ using namespace ::chip;
 constexpr uint64_t kBreadcrumb = 0;
 constexpr uint32_t kTimeoutMs  = 6000;
 
-CHIP_ERROR PairingCommand::Run(NodeId remoteId)
+CHIP_ERROR PairingCommand::RunCommand()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     mController.RegisterDeviceAddressUpdateDelegate(this);
     mController.RegisterPairingDelegate(this);
 
-    if (mPairingMode != PairingMode::OpenCommissioningWindow)
-    {
-#if CONFIG_PAIR_WITH_RANDOM_ID
-        // Generate a random remote id so we don't end up reusing the same node id
-        // for different nodes.
-        //
-        // TODO: Ideally we'd just ask for an operational cert for the commissionnee
-        // and get the node from that, but the APIs are not set up that way yet.
-        NodeId randomId;
-        ReturnErrorOnFailure(Controller::ExampleOperationalCredentialsIssuer::GetRandomOperationalNodeId(&randomId));
-
-        ChipLogProgress(Controller, "Generated random node id: 0x" ChipLogFormatX64, ChipLogValueX64(randomId));
-
-        ReturnErrorOnFailure(mStorage.SetRemoteNodeId(randomId));
-        remoteId = randomId;
-#else  // CONFIG_PAIR_WITH_RANDOM_ID
-       // Use the default id, not whatever happens to be in our storage, since this
-       // is a new pairing.
-        remoteId = kTestDeviceNodeId;
-#endif // CONFIG_PAIR_WITH_RANDOM_ID
-    }
-
-    err = RunInternal(remoteId);
+    err = RunInternal(mNodeId);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init Failure! PairDevice: %s", ErrorStr(err)));
 
 exit:
@@ -71,8 +49,6 @@ exit:
 CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    mRemoteId = remoteId;
 
     InitCallbacks();
 
@@ -190,8 +166,7 @@ CHIP_ERROR PairingCommand::Unpair(NodeId remoteId)
 
 CHIP_ERROR PairingCommand::OpenCommissioningWindow()
 {
-    CHIP_ERROR err =
-        mController.OpenCommissioningWindow(mRemoteId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption);
+    CHIP_ERROR err = mController.OpenCommissioningWindow(mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption);
     SetCommandExitStatus(err);
     return err;
 }
@@ -271,8 +246,8 @@ CHIP_ERROR PairingCommand::SetupNetwork()
         break;
     case PairingNetworkType::WiFi:
     case PairingNetworkType::Thread:
-        err = mController.GetDevice(mRemoteId, &mDevice);
-        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Setup failure! No pairing for device: %" PRIu64, mRemoteId));
+        err = mController.GetDevice(mNodeId, &mDevice);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Setup failure! No pairing for device: %" PRIu64, mNodeId));
 
         mCluster.Associate(mDevice, mEndpointId);
 
@@ -436,15 +411,15 @@ void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, 
 
 CHIP_ERROR PairingCommand::UpdateNetworkAddress()
 {
-    ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " Compressed FabricId: %" PRIx64 " ...", mRemoteId,
+    ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " Compressed FabricId: %" PRIx64 " ...", mNodeId,
                     mController.GetCompressedFabricId());
-    return mController.UpdateDevice(mRemoteId);
+    return mController.UpdateDevice(mNodeId);
 }
 
 void PairingCommand::OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR err)
 {
     ChipLogProgress(chipTool, "OnAddressUpdateComplete: %" PRIx64 ": %s", nodeId, ErrorStr(err));
-    if (err != CHIP_NO_ERROR && nodeId == mRemoteId)
+    if (err != CHIP_NO_ERROR && nodeId == mNodeId)
     {
         // Set exit status only if the address update failed.
         // Otherwise wait for OnCommissioningComplete() callback.
@@ -464,7 +439,7 @@ void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & 
 
     Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : INET_NULL_INTERFACEID;
     PeerAddress peerAddress       = PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
-    CHIP_ERROR err                = Pair(mRemoteId, peerAddress);
+    CHIP_ERROR err                = Pair(mNodeId, peerAddress);
     if (CHIP_NO_ERROR != err)
     {
         SetCommandExitStatus(err);

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -62,6 +62,8 @@ public:
         mFilterType(filterType), mRemoteAddr{ IPAddress::Any, INET_NULL_INTERFACEID },
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+
         switch (networkType)
         {
         case PairingNetworkType::None:
@@ -146,7 +148,7 @@ public:
     }
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return 120; }
     void Shutdown() override;
 
@@ -192,7 +194,7 @@ private:
     const PairingNetworkType mNetworkType;
     const chip::Dnssd::DiscoveryFilterType mFilterType;
     Command::AddressWithInterface mRemoteAddr;
-    NodeId mRemoteId;
+    NodeId mNodeId;
     uint16_t mRemotePort;
     uint64_t mFabricId;
     uint16_t mTimeout;

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -24,14 +24,12 @@
 
 using namespace ::chip;
 
-CHIP_ERROR ReportingCommand::Run(NodeId remoteId)
+CHIP_ERROR ReportingCommand::RunCommand()
 {
-    CHIP_ERROR err = mController.GetConnectedDevice(remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    CHIP_ERROR err = mController.GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
     VerifyOrExit(
         err == CHIP_NO_ERROR,
-        ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %s", remoteId, ErrorStr(err)));
-
-    mRemoteId = remoteId;
+        ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %s", mNodeId, ErrorStr(err)));
 
 exit:
     return err;
@@ -46,7 +44,7 @@ void ReportingCommand::OnDeviceConnectedFn(void * context, chip::Controller::Dev
     chip::Controller::BasicCluster cluster;
     cluster.Associate(device, command->mEndPointId);
 
-    command->AddReportCallbacks(command->mRemoteId, command->mEndPointId);
+    command->AddReportCallbacks(command->mNodeId, command->mEndPointId);
 
     CHIP_ERROR err = cluster.MfgSpecificPing(nullptr, nullptr);
     if (err != CHIP_NO_ERROR)

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -34,17 +34,18 @@ public:
         CHIPCommand(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId);
     }
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return UINT16_MAX; }
 
     virtual void AddReportCallbacks(NodeId remoteId, uint8_t endPointId) = 0;
 
 private:
-    NodeId mRemoteId;
+    NodeId mNodeId;
     uint8_t mEndPointId;
 
     static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -18,9 +18,9 @@
 
 #include "TestCommand.h"
 
-CHIP_ERROR TestCommand::Run(NodeId remoteId)
+CHIP_ERROR TestCommand::RunCommand()
 {
-    return mController.GetConnectedDevice(remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    return mController.GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }
 
 void TestCommand::OnDeviceConnectedFn(void * context, chip::Controller::Device * device)

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -30,11 +30,12 @@ public:
         CHIPCommand(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
     }
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR Run(NodeId remoteId) override;
+    CHIP_ERROR RunCommand() override;
     uint16_t GetWaitDurationInSeconds() const override { return 30; }
 
     virtual void NextTest() = 0;
@@ -44,6 +45,7 @@ public:
 
 protected:
     ChipDevice * mDevice;
+    chip::NodeId mNodeId;
 
     static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);
     static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -37,7 +37,6 @@ constexpr const char kDefaultSectionName[] = "Default";
 constexpr const char kPortKey[]            = "ListenPort";
 constexpr const char kLoggingKey[]         = "LoggingLevel";
 constexpr const char kLocalNodeIdKey[]     = "LocalNodeId";
-constexpr const char kRemoteNodeIdKey[]    = "RemoteNodeId";
 constexpr LogCategory kDefaultLoggingLevel = kLogCategory_Detail;
 
 namespace {
@@ -209,43 +208,23 @@ LogCategory PersistentStorage::GetLoggingLevel()
     return chipLogLevel;
 }
 
-NodeId PersistentStorage::GetNodeId(const char * key, NodeId defaultVal)
+NodeId PersistentStorage::GetLocalNodeId()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     uint64_t nodeId;
     uint16_t size = static_cast<uint16_t>(sizeof(nodeId));
-    err           = SyncGetKeyValue(key, &nodeId, size);
+    err           = SyncGetKeyValue(kLocalNodeIdKey, &nodeId, size);
     if (err == CHIP_NO_ERROR)
     {
         return static_cast<NodeId>(Encoding::LittleEndian::HostSwap64(nodeId));
     }
 
-    return defaultVal;
+    return kTestControllerNodeId;
 }
 
-NodeId PersistentStorage::GetLocalNodeId()
-{
-    return GetNodeId(kLocalNodeIdKey, kTestControllerNodeId);
-}
-
-NodeId PersistentStorage::GetRemoteNodeId()
-{
-    return GetNodeId(kRemoteNodeIdKey, kTestDeviceNodeId);
-}
-
-CHIP_ERROR PersistentStorage::SetNodeId(const char * key, NodeId value)
+CHIP_ERROR PersistentStorage::SetLocalNodeId(NodeId value)
 {
     uint64_t nodeId = Encoding::LittleEndian::HostSwap64(value);
-    return SyncSetKeyValue(key, &nodeId, sizeof(nodeId));
-}
-
-CHIP_ERROR PersistentStorage::SetLocalNodeId(NodeId nodeId)
-{
-    return SetNodeId(kLocalNodeIdKey, nodeId);
-}
-
-CHIP_ERROR PersistentStorage::SetRemoteNodeId(NodeId nodeId)
-{
-    return SetNodeId(kRemoteNodeIdKey, nodeId);
+    return SyncSetKeyValue(kLocalNodeIdKey, &nodeId, sizeof(nodeId));
 }

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -36,19 +36,13 @@ public:
     uint16_t GetListenPort();
     chip::Logging::LogCategory GetLoggingLevel();
 
-    // Return the stored node ids, or the default ones if nothing is stored.
+    // Return the stored local node id, or the default one if nothing is stored.
     chip::NodeId GetLocalNodeId();
-    chip::NodeId GetRemoteNodeId();
 
-    // Store node ids.
+    // Store local node id.
     CHIP_ERROR SetLocalNodeId(chip::NodeId nodeId);
-    CHIP_ERROR SetRemoteNodeId(chip::NodeId nodeId);
 
 private:
-    // Helpers for node ids.
-    chip::NodeId GetNodeId(const char * key, chip::NodeId defaultVal);
-    CHIP_ERROR SetNodeId(const char * key, chip::NodeId value);
-
     CHIP_ERROR CommitConfig();
     inipp::Ini<char> mConfig;
 };

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -20,6 +20,7 @@ set -e
 
 declare -i iterations=2
 declare -i delay=0
+declare -i node_id=0x12344321
 declare -i background_pid=0
 declare test_case_wrapper=()
 
@@ -124,9 +125,9 @@ for j in "${iter_array[@]}"; do
         # the data is there yet.
         background_pid="$(</tmp/pid)"
         echo "          * Pairing to device"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode MT:D8XA0CQM00KA0648G00
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode "$node_id" MT:D8XA0CQM00KA0648G00
         echo "          * Starting test run: $i"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$delay"
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$node_id" "$delay"
         # Prevent cleanup trying to kill a process we already killed.
         temp_background_pid=$background_pid
         background_pid=0


### PR DESCRIPTION
…he chip stack

#### Problem

When running a command using `chip-tool` one can not specify a "NodeId", `chip-tool` either uses a random one or a default one. That makes it not possible to use `chip-tool` to communicate with multiple devices at the same time.

#### Change overview
* Add `node-id` parameter to commands that makes uses of it
* Remove `chip-tool` `config_pair_with_random_id` build flag

#### Testing
 I have updated `scripts/tests/test_suites.sh` to use this parameter.