### PR TITLE
[ChipTool] Add a command to enumerate the paired devices and show ip/…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -34,6 +34,8 @@ executable("chip-tool") {
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
+    "commands/pairing/CommissionedListCommand.cpp",
+    "commands/pairing/CommissionedListCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "CommissionedListCommand.h"
 #include "PairingCommand.h"
 
 class Unpair : public PairingCommand
@@ -169,6 +170,7 @@ void registerCommandsPairing(Commands & commands)
         make_unique<PairOnNetworkDeviceType>(),
         make_unique<PairOnNetworkInstanceName>(),
         make_unique<OpenCommissioningWindow>(),
+        make_unique<CommissionedListCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/CommissionedListCommand.cpp
+++ b/examples/chip-tool/commands/pairing/CommissionedListCommand.cpp
@@ -1,0 +1,98 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CommissionedListCommand.h"
+
+#include <lib/core/CHIPEncoding.h>
+#include <lib/support/PersistentStorageMacros.h>
+#include <lib/support/SafeInt.h>
+#include <lib/support/Span.h>
+
+CHIP_ERROR CommissionedListCommand::Run()
+{
+    ReturnLogErrorOnFailure(mStorage.Init());
+    return PrintInformation();
+}
+
+CHIP_ERROR CommissionedListCommand::PrintInformation()
+{
+    uint64_t pairedNodesIds[chip::Controller::kNumMaxPairedDevices];
+    uint16_t pairedNodesIdsSize = sizeof(pairedNodesIds);
+    memset(pairedNodesIds, 0, pairedNodesIdsSize);
+
+    PERSISTENT_KEY_OP(static_cast<uint64_t>(0), chip::kPairedDeviceListKeyPrefix, key,
+                      ReturnLogErrorOnFailure(mStorage.SyncGetKeyValue(key, pairedNodesIds, pairedNodesIdsSize)));
+
+    chip::SerializableU64Set<chip::Controller::kNumMaxPairedDevices> devices;
+    devices.Deserialize(chip::ByteSpan((uint8_t *) pairedNodesIds, pairedNodesIdsSize));
+
+    uint16_t pairedDevicesCount = 0;
+    while (pairedNodesIds[pairedDevicesCount] != 0x0 && pairedDevicesCount < chip::Controller::kNumMaxPairedDevices)
+    {
+        pairedDevicesCount++;
+    }
+
+    if (pairedDevicesCount == 0)
+    {
+        ChipLogProgress(chipTool, "No paired devices.");
+    }
+    else
+    {
+        fprintf(stdout, "NOTES: Only the devices locally commissioned with chip-tool are displayed.\n");
+        fprintf(stdout, "+---------------------------------------------------------------------------------------------+\n");
+        fprintf(stdout, "|       NodeId       |                   Address                     | Port |    Interface    |\n");
+        fprintf(stdout, "+---------------------------------------------------------------------------------------------+\n");
+        for (uint16_t i = 0; i < pairedDevicesCount; i++)
+        {
+            ReturnLogErrorOnFailure(PrintDeviceInformation(pairedNodesIds[i]));
+        }
+        fprintf(stdout, "+---------------------------------------------------------------------------------------------+\n");
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CommissionedListCommand::PrintDeviceInformation(chip::NodeId deviceId)
+{
+    chip::Controller::SerializedDevice deviceInfo;
+    uint16_t size = sizeof(deviceInfo.inner);
+
+    PERSISTENT_KEY_OP(deviceId, chip::kPairedDeviceKeyPrefix, key,
+                      ReturnLogErrorOnFailure(mStorage.SyncGetKeyValue(key, deviceInfo.inner, size)));
+    VerifyOrReturnError(size <= sizeof(deviceInfo.inner), CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
+
+    chip::Controller::SerializableDevice serializable;
+    constexpr size_t maxlen = BASE64_ENCODED_LEN(sizeof(serializable));
+    const size_t len        = strnlen(chip::Uint8::to_const_char(&deviceInfo.inner[0]), maxlen);
+
+    VerifyOrReturnError(len < sizeof(chip::Controller::SerializedDevice), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(chip::CanCastTo<uint16_t>(len), CHIP_ERROR_INVALID_ARGUMENT);
+
+    CHIP_ZERO_AT(serializable);
+    const uint16_t deserializedLen = chip::Base64Decode(chip::Uint8::to_const_char(deviceInfo.inner), static_cast<uint16_t>(len),
+                                                        chip::Uint8::to_uchar(reinterpret_cast<uint8_t *>(&serializable)));
+
+    VerifyOrReturnError(deserializedLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(deserializedLen <= sizeof(serializable), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const uint16_t port = chip::Encoding::LittleEndian::HostSwap16(serializable.mDevicePort);
+    fprintf(stderr, "| 0x%-16" PRIx64 " | %-45s | %-5u| %-15s |\n", deviceId, serializable.mDeviceAddr, port,
+            serializable.mInterfaceName);
+
+    return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/commands/pairing/CommissionedListCommand.h
+++ b/examples/chip-tool/commands/pairing/CommissionedListCommand.h
@@ -1,0 +1,35 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../../config/PersistentStorage.h"
+#include "../common/Command.h"
+
+class CommissionedListCommand : public Command
+{
+public:
+    CommissionedListCommand() : Command("list") {}
+    CHIP_ERROR Run() override;
+
+private:
+    CHIP_ERROR PrintInformation();
+    CHIP_ERROR PrintDeviceInformation(chip::NodeId deviceId);
+
+    PersistentStorage mStorage;
+};


### PR DESCRIPTION
…port/interface informations for them

#### Problem
When pairing to multiple devices using `chip-tool` it is sometimes useful in order to debug to have some informations about the devices such as the IP/Port/Interface.

This PR adds `./out/debug/standalone/chip-tool pairing list`, which results into:
```
+---------------------------------------------------------------------------------------------+
|       NodeId       |                   Address                     | Port |    Interface    |
+---------------------------------------------------------------------------------------------+
| 0x12344321         | ::1                                           | 5540 |                 |
| 0x01234567         | ::1                                           | 5541 |                 |
+---------------------------------------------------------------------------------------------+
```
#### Change overview
* Add a command that makes human readable the pairing related informations of `chip_tool_config.ini`.


#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
