### PR TITLE
[CI] Add an additional delayInMs argument when running a test

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -20,6 +20,7 @@
 
 #include "../common/CHIPCommand.h"
 #include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <lib/support/UnitTestUtils.h>
 #include <zap-generated/tests/CHIPClustersTest.h>
 
 class TestCommand : public CHIPCommand
@@ -28,7 +29,9 @@ public:
     TestCommand(const char * commandName) :
         CHIPCommand(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
-    {}
+    {
+        AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
+    }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR Run(NodeId remoteId) override;
@@ -103,4 +106,13 @@ protected:
 
     chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+
+    void Wait()
+    {
+        if (mDelayInMs)
+        {
+            chip::test_utils::SleepMillis(mDelayInMs);
+        }
+    };
+    uint64_t mDelayInMs = 0;
 };

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -21,6 +21,8 @@ class {{filename}}: public TestCommand
           return;
       }
 
+      Wait();
+
       // Ensure we increment mTestIndex before we start running the relevant
       // command.  That way if we lose the timeslice after we send the message
       // but before our function call returns, we won't end up with an

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -19,14 +19,16 @@
 set -e
 
 declare -i iterations=2
+declare -i delay=0
 declare -i background_pid=0
 declare test_case_wrapper=()
 
 usage() {
-    echo "test_suites.sh [-a APPLICATION] [-i ITERATIONS] [-h] [-s CASE_NAME] [-w COMMAND]"
+    echo "test_suites.sh [-a APPLICATION] [-i ITERATIONS] [-h] [-s CASE_NAME] [-w COMMAND] [-d DELAY]"
     echo "  -a APPLICATION: runs chip-tool against 'chip-<APPLICATION>-app' (default: all-clusters)"
-    echo "  -i ITERATIONS: number of iterations to run (default: $iterations)"
+    echo "  -d DELAY: milliseconds to wait before running an individual test step (default: $delay)"
     echo "  -h: this help message"
+    echo "  -i ITERATIONS: number of iterations to run (default: $iterations)"
     echo "  -s CASE_NAME: runs single test case name (e.g. Test_TC_OO_2_2"
     echo "                for Test_TC_OO_2_2.yaml) (by default, all are run)"
     echo "  -w COMMAND: prefix all instantiations with a command (e.g. valgrind) (default: '')"
@@ -35,11 +37,12 @@ usage() {
 }
 
 # read shell arguments
-while getopts a:i:hs:w: flag; do
+while getopts a:d:i:hs:w: flag; do
     case "$flag" in
         a) application=$OPTARG ;;
-        i) iterations=$OPTARG ;;
+        d) delay=$OPTARG ;;
         h) usage ;;
+        i) iterations=$OPTARG ;;
         s) single_case=$OPTARG ;;
         w) test_case_wrapper=("$OPTARG") ;;
     esac
@@ -61,7 +64,7 @@ if [[ $iterations == 0 ]]; then
     exit 1
 fi
 
-echo "Running tests for application: $application, with iterations set to: $iterations"
+echo "Running tests for application: $application, with iterations set to: $iterations and delay set to $delay"
 
 cleanup() {
     if [[ $background_pid != 0 ]]; then
@@ -123,7 +126,7 @@ for j in "${iter_array[@]}"; do
         echo "          * Pairing to device"
         "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode MT:D8XA0CQM00KA0648G00
         echo "          * Starting test run: $i"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i"
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$delay"
         # Prevent cleanup trying to kill a process we already killed.
         temp_background_pid=$background_pid
         background_pid=0

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -43,6 +43,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -155,6 +157,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -291,6 +295,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -472,6 +478,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -548,6 +556,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -655,6 +665,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -735,6 +747,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -905,6 +919,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -1324,6 +1340,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -1461,6 +1479,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -1532,6 +1552,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -1750,6 +1772,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -5648,6 +5672,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -5821,6 +5847,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -5872,6 +5900,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -6055,6 +6085,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -6326,6 +6358,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -6562,6 +6596,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -6988,6 +7024,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -7434,6 +7472,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -8110,6 +8150,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -8155,6 +8197,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -8298,6 +8342,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -8696,6 +8742,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -8824,6 +8872,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -8954,6 +9004,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -9082,6 +9134,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -9226,6 +9280,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -9304,6 +9360,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -9448,6 +9506,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -9558,6 +9618,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -9673,6 +9735,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -9751,6 +9815,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -9831,6 +9897,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -9909,6 +9977,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -9989,6 +10059,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -10067,6 +10139,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -10147,6 +10221,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -10225,6 +10301,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -10369,6 +10447,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -10447,6 +10527,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -10987,6 +11069,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -11294,6 +11378,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -11583,6 +11669,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -11868,6 +11956,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -12093,6 +12183,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -12284,6 +12376,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -12507,6 +12601,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -12733,6 +12829,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -12927,6 +13025,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -13119,6 +13219,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -13341,6 +13443,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -13534,6 +13638,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -13726,6 +13832,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -13990,6 +14098,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -14221,6 +14331,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -14446,6 +14558,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
@@ -14732,6 +14846,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -14957,6 +15073,8 @@ public:
             return;
         }
 
+        Wait();
+
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message
         // but before our function call returns, we won't end up with an
@@ -15150,6 +15268,8 @@ public:
             SetCommandExitStatus(CHIP_NO_ERROR);
             return;
         }
+
+        Wait();
 
         // Ensure we increment mTestIndex before we start running the relevant
         // command.  That way if we lose the timeslice after we send the message


### PR DESCRIPTION
#### Problem

Some real accessories may have some latency when writing attributes, running a test suite using `chip-tool` against them may lead to unexpected behaviours.

#### Change overview
 * Add a `delayInMs` argument to `chip-tool` so it is possible to introduce some artificial delay between test steps. By default it is set to 0 for our CI.

#### Testing
I have manually checked that the delay passed as an argument is taken into account.