### PR TITLE
Make sure to pass ints for the length for %.*s formatting.

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -162,7 +162,7 @@ bool emberAfGroupsClusterAddGroupCallback(app::CommandHandler * commandObj, cons
     EmberAfStatus status;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    emberAfGroupsClusterPrintln("RX: AddGroup 0x%2x, \"%.*s\"", groupId, groupName.size(), groupName.data());
+    emberAfGroupsClusterPrintln("RX: AddGroup 0x%2x, \"%.*s\"", groupId, static_cast<int>(groupName.size()), groupName.data());
 
     status = addEntryToGroupTable(emberAfCurrentEndpoint(), groupId, groupName);
 
@@ -444,7 +444,8 @@ bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(app::CommandHandler * com
     EmberAfStatus status;
     EmberStatus sendStatus = EMBER_SUCCESS;
 
-    emberAfGroupsClusterPrintln("RX: AddGroupIfIdentifying 0x%2x, \"%.*s\"", groupId, groupName.size(), groupName.data());
+    emberAfGroupsClusterPrintln("RX: AddGroupIfIdentifying 0x%2x, \"%.*s\"", groupId, static_cast<int>(groupName.size()),
+                                groupName.data());
 
     if (!emberAfIsDeviceIdentifying(emberAfCurrentEndpoint()))
     {

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -759,7 +759,7 @@ bool emberAfPluginScenesServerParseAddScene(
     uint8_t i, index = EMBER_AF_SCENE_TABLE_NULL_INDEX;
 
     emberAfScenesClusterPrintln("RX: %pAddScene 0x%2x, 0x%x, 0x%2x, \"%.*s\"", (enhanced ? "Enhanced" : ""), groupId, sceneId,
-                                transitionTime, sceneName.size(), sceneName.data());
+                                transitionTime, static_cast<int>(sceneName.size()), sceneName.data());
 
     auto fieldSetIter = extensionFieldSets.begin();
 


### PR DESCRIPTION
#### Problem
`%.*s`formatting for strings expects the length to be an it.  Some places were passing size_t, which can be a different size from int, leading to problems when the varargs bits grab the wrong set of bytes off the stack.

#### Change overview
Cast to int in the right places.

#### Testing
Would need to find a platform where int and size_t were different sizes and exercise the relevant code (which we don't yet exercise in any case)...  No testing so far.