### PR TITLE
Better IPv6 handling of AddrAny (which maps to IPv4 if enabled in lwip)

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -90,7 +90,11 @@ ip_addr_t IPAddress::ToLwIPAddr(void) const
         break;
 
     default:
+#if INET_CONFIG_ENABLE_IPV4
         ret = *IP_ADDR_ANY;
+#else
+        ret = *IP6_ADDR_ANY;
+#endif
         break;
     }
 

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -142,7 +142,8 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
         //
         // We may want to consider having separate AnyV4 and AnyV6 constants
         // inside CHIP to resolve this ambiguity
-        if (addr.Type() == kIPAddressType_Any) && (addrType == kIPAddressType_IPv6)) {
+        if ((addr.Type() == kIPAddressType_Any) && (addrType == kIPAddressType_IPv6))
+        {
             ipAddr = *IP6_ADDR_ANY;
         }
 

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -146,11 +146,6 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
             ipAddr = *IP6_ADDR_ANY;
         }
 
-#if INET_CONFIG_ENABLE_IPV4
-        lwip_ip_addr_type lType = IPAddress::ToLwIPAddrType(addrType);
-        IP_SET_TYPE_VAL(ipAddr, lType);
-#endif // INET_CONFIG_ENABLE_IPV4
-
         res = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipAddr, port));
 #else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
         if (addrType == kIPAddressType_IPv6)

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -134,10 +134,23 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
     {
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         ip_addr_t ipAddr = addr.ToLwIPAddr();
+
+        // TODO: IPAddress ANY has only one constant state, however addrType
+        // has separate IPV4 and IPV6 'any' settings. This tries to correct
+        // for this as LWIP default if IPv4 is compiled in is to consider
+        // 'any == any_v4'
+        //
+        // We may want to consider having separate AnyV4 and AnyV6 constants
+        // inside CHIP to resolve this ambiguity
+        if (addr.Type() == kIPAddressType_Any) && (addrType == kIPAddressType_IPv6)) {
+            ipAddr = *IP6_ADDR_ANY;
+        }
+
 #if INET_CONFIG_ENABLE_IPV4
         lwip_ip_addr_type lType = IPAddress::ToLwIPAddrType(addrType);
         IP_SET_TYPE_VAL(ipAddr, lType);
 #endif // INET_CONFIG_ENABLE_IPV4
+
         res = chip::System::MapErrorLwIP(udp_bind(mUDP, &ipAddr, port));
 #else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
         if (addrType == kIPAddressType_IPv6)


### PR DESCRIPTION
#### Problem
IPv6 listening not performed properly when IPv4 is disabled, generally the 'force address type'  inside UDP bind handling is hackish:

- chip only has a single 'AddrAny' constant. LWIP with IPv4 enabled maps `IP_ADDR_ANY` to the IPv4 constant
- this results in 'toLwipAddr'  to generate the IPv4 listen address and that stays as such when IPv4 is disabled (very counter intuitive)
- once an IPv4 is set, the GetPCB validation done during 'send' will detect ipv4 and refuse to send packets over the UDP interface.


#### Change overview
- force returning the IPv6 ANY any when IPv4 is disabled in CHIP
- revise the hack for IPv6 when IPv4 is enabled for compilation: we still likely want to explicitly use `IP6_ADDR_ANY` instead of relying on using the v4 address  and changing the type (even if it may be equivalent, it is not as clear to prove).

#### Testing
Manually tested on separate IPv6 validation branch: ESP32 was able to send IPv6 broadcasts at boot with  matter mDNS packets and was also able to reply to mDNS queries (sporadically though - I am  still debugging this as I suspect some problems with joining or using multicast groups but have yet to determine the side)
