### PR TITLE
Size reports: Don't comment on outdated builds

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -367,6 +367,11 @@ def gh_get_comments_for_pr(gh: ghapi.core.GhApi, pr: int):
         ghapi.all.paged(gh.issues.list_comments, pr))
 
 
+def gh_get_commits_for_pr(gh: ghapi.core.GhApi, pr: int):
+    return itertools.chain.from_iterable(
+        ghapi.all.paged(gh.pulls.list_commits, pr))
+
+
 def percent_change(a: int, b: int) -> float:
     if a == 0:
         return 0.0 if b == 0 else float('inf')
@@ -455,6 +460,20 @@ def gh_send_change_report(db: SizeDatabase, df: pd.DataFrame,
     if not db.gh:
         return False
     pr = df.attrs['pr']
+
+    # Check the most recent commit on the PR, so that we don't comment on
+    # builds that are already outdated.
+    commit = df.attrs['commit']
+    commits = sorted(gh_get_commits_for_pr(db.gh, pr),
+                     key=lambda c: c.commit.committer.date,
+                     reverse=True)
+    if commits and commit != commits[0].sha:
+        logging.debug('SCS: PR #%s: not commenting for stale %s; newest is %s',
+                      pr, commit, commits[0].sha)
+        return False
+
+    # Check for an existing size report comment. If one exists, we'll add
+    # the new report to it.
     title = df.attrs['title']
     existing_comment_id = 0
     for comment in gh_get_comments_for_pr(db.gh, pr):
@@ -545,7 +564,6 @@ def report_matching_commits(db: SizeDatabase) -> Dict[str, pd.DataFrame]:
 
         if (pr and comment_enabled
                 and (comment_limit == 0 or comment_limit > comment_count)):
-            comment_count += 1
             if gh_send_change_report(db, df, tdf):
                 # Mark the originating builds, and remove the originating
                 # artifacts, so that they don't generate duplicate report
@@ -555,6 +573,7 @@ def report_matching_commits(db: SizeDatabase) -> Dict[str, pd.DataFrame]:
                     for artifact_id in df.attrs['artifacts']:
                         logging.info('RMC: deleting artifact %d', artifact_id)
                         db.delete_artifact(artifact_id)
+                comment_count += 1
     return dfs
 
 


### PR DESCRIPTION
#### Problem

`gh_report.py` may send comments on builds that are already outdated,
and may do so out of chronological order, which clutters PRs and may
eclipse the actually relevant report.

#### Change overview

Before commenting, check that the report is for the latest commit.

#### Testing

Offline run identified and correctly handled such a case.

    scripts/tools/memory/gh_report.py --db=/tmp/test.db --log-level=debug \
        --pr --github-repo project-chip/connectedhomeip \
        --github-limit-artifacts=500 --github-limit-artifact-pages=100 \
        --github-keep --github-comment --github-dryrun-comment
