### PR TITLE
Size reports: Indicate which platforms are ‘below the fold’

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -239,7 +239,7 @@ class SizeDatabase(memdf.util.sqlite.Database):
         artifact_limit = self.config['github.limit-artifacts']
         artifact_pages = self.config['github.limit-artifact-pages']
 
-        # Size artifacts have names of the form
+        # Size artifacts have names of the form:
         #   Size,{group},{pr},{commit_hash},{parent_hash}
         # Record them keyed by group and commit_hash to match them up
         # after we have the entire list.

--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -478,7 +478,8 @@ def gh_send_change_report(db: SizeDatabase, df: pd.DataFrame,
                               tabulate={'floatfmt': '5.1f'})
 
     count = len(df.attrs['things'])
-    summary = f'{count} build{"" if count == 1 else "s"}'
+    platforms = ', '.join(set(df['platform']))
+    summary = f'{count} build{"" if count == 1 else "s"} (for {platforms})'
     md.write(f'\n<details>\n<summary>{summary}</summary>\n\n')
     memdf.report.write_df(db.config,
                           df,

--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -478,7 +478,7 @@ def gh_send_change_report(db: SizeDatabase, df: pd.DataFrame,
                               tabulate={'floatfmt': '5.1f'})
 
     count = len(df.attrs['things'])
-    platforms = ', '.join(set(df['platform']))
+    platforms = ', '.join(sorted(list(set(df['platform']))))
     summary = f'{count} build{"" if count == 1 else "s"} (for {platforms})'
     md.write(f'\n<details>\n<summary>{summary}</summary>\n\n')
     memdf.report.write_df(db.config,


### PR DESCRIPTION
#### Problem

Since CI runs take varying lengths of time, size reports may arrive
piecemeal, leading to comments of this form:

> PR #10525: Size comparison from 2377fea to 04e4368
>
> ► 8 builds
> ► 14 builds
> ► 2 builds
> ► 10 builds

A reader looking for a particular build has to check multiple sections.

#### Change overview

Add a list of built platforms to each summary, so comments look like:

> PR #10525: Size comparison from 2377fea to 04e4368
>
> ► 8 builds (for k32w, p6, qpg, telink)
> ► 14 builds (for efr32, linux, mbed)
> ► 2 builds (for esp32)
> ► 10 builds (for nrfconnect)

#### Testing

Offline run.

