### PR TITLE
Add ENFORCE_FORMAT bits to emberAfPrint(ln).

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-core.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-core.cpp
@@ -98,7 +98,7 @@ void emAfPluginDoorLockServerWriteAttributes(const EmAfPluginDoorLockServerAttri
                                                            (uint8_t *) &data[i].value, ZCL_INT16U_ATTRIBUTE_TYPE);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
-            emberAfDoorLockClusterPrintln("Failed to write %s attribute 0x%2X: 0x%X", data[i].id, status, description);
+            emberAfDoorLockClusterPrintln("Failed to write %s attribute 0x%2X: 0x%X", description, data[i].id, status);
         }
     }
 }

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -149,7 +149,7 @@ static void printUserTables(void)
         EmberAfPluginDoorLockServerUser * user = &pinUserTable[i];
         emberAfDoorLockClusterPrint("%2x %x %x ", i, user->status, user->type);
         printPin(user->code.pin);
-        emberAfDoorLockClusterPrintln("");
+        emberAfDoorLockClusterPrintln("%s", "");
     }
     emberAfDoorLockClusterPrintln("RFID:");
     for (i = 0; i < EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE; i++)
@@ -157,7 +157,7 @@ static void printUserTables(void)
         EmberAfPluginDoorLockServerUser * user = &rfidUserTable[i];
         emberAfDoorLockClusterPrint("%2x %x %x ", i, user->status, user->type);
         printPin(user->code.rfid);
-        emberAfDoorLockClusterPrintln("");
+        emberAfDoorLockClusterPrintln("%s", "");
     }
 }
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -241,7 +241,7 @@ CHIP_ERROR writeFabricsIntoFabricsListAttribute()
 
     if (err == CHIP_NO_ERROR && Attributes::SupportedFabrics::Set(0, CHIP_CONFIG_MAX_DEVICE_ADMINS) != EMBER_ZCL_STATUS_SUCCESS)
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write %" PRIu8 " in supported fabrics count attribute",
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write %d in supported fabrics count attribute",
                        CHIP_CONFIG_MAX_DEVICE_ADMINS);
         err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
@@ -292,8 +292,8 @@ class OpCredsFabricTableDelegate : public FabricTableDelegate
     void OnFabricPersistedToStorage(FabricInfo * fabric) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Fabric %" PRIX16 " was persisted to storage. FabricId %0x" ChipLogFormatX64
-                       ", NodeId %0x" ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
+                       "OpCreds: Fabric %" PRIX8 " was persisted to storage. FabricId " ChipLogFormatX64
+                       ", NodeId " ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
                        fabric->GetFabricIndex(), ChipLogValueX64(fabric->GetFabricId()),
                        ChipLogValueX64(fabric->GetPeerId().GetNodeId()), fabric->GetVendorId());
         writeFabricsIntoFabricsListAttribute();
@@ -715,7 +715,7 @@ bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(app::CommandHandle
     }
 
     err = gFabricBeingCommissioned.GetOperationalKey()->NewCertificateSigningRequest(csr.Get(), csrLength);
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: NewCertificateSigningRequest returned %d", err);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: NewCertificateSigningRequest returned %" CHIP_ERROR_FORMAT, err.Format());
     SuccessOrExit(err);
     VerifyOrExit(csrLength < UINT8_MAX, err = CHIP_ERROR_INTERNAL);
 

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -215,7 +215,7 @@ void emAfPluginScenesServerPrintInfo(void)
                              entry.targetPositionTiltPercent100thsValue);
 #endif
         }
-        emberAfCorePrintln("");
+        emberAfCorePrintln("%s", "");
     }
 }
 

--- a/src/app/util/af-main-common.cpp
+++ b/src/app/util/af-main-common.cpp
@@ -550,13 +550,13 @@ void emAfPrintStatus(const char * task, EmberStatus status)
 
 static void printMessage(EmberApsFrame * apsFrame, uint16_t messageLength, uint8_t * messageContents)
 {
-    emberAfAppPrint("Cluster: 0x%2X, %d bytes,", apsFrame->clusterId, messageLength);
+    emberAfAppPrint("Cluster: " ChipLogFormatMEI ", %d bytes,", ChipLogValueMEI(apsFrame->clusterId), messageLength);
     if (messageLength >= 3)
     {
         emberAfAppPrint(" ZCL %p Cmd ID: %d", (messageContents[0] & ZCL_CLUSTER_SPECIFIC_COMMAND ? "Cluster" : "Global"),
                         messageContents[2]);
     }
-    emberAfAppPrintln("");
+    emberAfAppPrintln("%s", "");
 }
 
 void emAfMessageSentHandler(const MessageSendDestination & destination, EmberApsFrame * apsFrame, EmberStatus status,

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -283,8 +283,9 @@ void emberAfPrintAttributeTable(void)
                 // manually reset the watchdog.
                 //        halResetWatchdog();
 
-                emberAfAttributesPrint("%2x / %p / %2x / ", cluster->clusterId,
-                                       (emberAfAttributeIsClient(metaData) ? "clnt" : "srvr"), metaData->attributeId);
+                emberAfAttributesPrint(ChipLogFormatMEI " / %p / " ChipLogFormatMEI " / ", ChipLogValueMEI(cluster->clusterId),
+                                       (emberAfAttributeIsClient(metaData) ? "clnt" : "srvr"),
+                                       ChipLogValueMEI(metaData->attributeId));
                 mfgCode = emAfGetManufacturerCodeForAttribute(cluster, metaData);
                 if (mfgCode == EMBER_AF_NULL_MANUFACTURER_CODE)
                 {
@@ -352,8 +353,8 @@ void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, ClusterId clu
         return;
     }
 
-    emberAfAttributesPrintln("OTA READ: ep:%x cid:%2x attid:%2x msk:%x mfcode:%2x", endpoint, clusterId, attrId, mask,
-                             manufacturerCode);
+    emberAfAttributesPrintln("OTA READ: ep:%" PRIx16 " cid:" ChipLogFormatMEI " attid:" ChipLogFormatMEI " msk:%x mfcode:%2x",
+                             endpoint, ChipLogValueMEI(clusterId), ChipLogValueMEI(attrId), mask, manufacturerCode);
 
     // lookup the attribute in our table
     status = emAfReadAttribute(endpoint, clusterId, attrId, mask, manufacturerCode, data, ATTRIBUTE_LARGEST, &dataType);
@@ -369,7 +370,8 @@ void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, ClusterId clu
     {
         emberAfPutInt32uInResp(attrId);
         emberAfPutStatusInResp(status);
-        emberAfAttributesPrintln("READ: clus %2x, attr %2x failed %x", clusterId, attrId, status);
+        emberAfAttributesPrintln("READ: clus " ChipLogFormatMEI ", attr " ChipLogFormatMEI " failed %x", ChipLogValueMEI(clusterId),
+                                 ChipLogValueMEI(attrId), status);
         emberAfAttributesFlush();
         return;
     }
@@ -406,7 +408,8 @@ void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, ClusterId clu
         appResponseLength = static_cast<uint16_t>(appResponseLength + dataLen);
     }
 
-    emberAfAttributesPrintln("READ: clus %2x, attr %2x, dataLen: %x, OK", clusterId, attrId, dataLen);
+    emberAfAttributesPrintln("READ: clus " ChipLogFormatMEI ", attr " ChipLogFormatMEI ", dataLen: %x, OK",
+                             ChipLogValueMEI(clusterId), ChipLogValueMEI(attrId), dataLen);
     emberAfAttributesFlush();
 }
 
@@ -455,7 +458,8 @@ EmberAfStatus emberAfAppendAttributeReportFields(EndpointId endpoint, ClusterId 
     *bufIndex = static_cast<uint8_t>(*bufIndex + size);
 
 kickout:
-    emberAfAttributesPrintln("REPORT: clus 0x%2x, attr 0x%2x: 0x%x", clusterId, attributeId, status);
+    emberAfAttributesPrintln("REPORT: clus " ChipLogFormatMEI ", attr " ChipLogFormatMEI ": 0x%x", ChipLogValueMEI(clusterId),
+                             ChipLogValueMEI(attributeId), status);
     emberAfAttributesFlush();
 
     return status;
@@ -504,7 +508,8 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
     // if we dont support that attribute
     if (metadata == NULL)
     {
-        emberAfAttributesPrintln("%pep %x clus %2x attr %2x not supported", "WRITE ERR: ", endpoint, cluster, attributeID);
+        emberAfAttributesPrintln("%pep %x clus " ChipLogFormatMEI " attr " ChipLogFormatMEI " not supported",
+                                 "WRITE ERR: ", endpoint, ChipLogValueMEI(cluster), ChipLogValueMEI(attributeID));
         emberAfAttributesFlush();
         return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
     }

--- a/src/app/util/ember-print.h
+++ b/src/app/util/ember-print.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/util/debug-printing.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -27,14 +28,14 @@
  * @param category - Currently ignored as zcl categories do not map to chip categories. Defaults to kLogCategory_Progress
  * @param format - Format string to print
  * */
-void emberAfPrint(int category, const char * format, ...);
+void emberAfPrint(int category, const char * format, ...) ENFORCE_FORMAT(2, 3);
 
 /**
  * @brief Prints a log followed by new line line
  * @param category - Currently ignored as zcl categories do not map to chip categories. Defaults to kLogCategory_Progress
  * @param format - Format string to print
  * */
-void emberAfPrintln(int category, const char * format, ...);
+void emberAfPrintln(int category, const char * format, ...) ENFORCE_FORMAT(2, 3);
 
 /**
  * @brief Prints a buffer

--- a/src/app/util/esi-management.cpp
+++ b/src/app/util/esi-management.cpp
@@ -256,7 +256,7 @@ uint8_t emberAfPluginEsiManagementUpdateEsiAndGetIndex(const EmberAfClusterComma
     // The source ESI is not in the ESI table.
     if (esiEntry == NULL)
     {
-        emberAfDebugPrintln("source ESI 0x%x not found in table", cmd->SourceNodeId());
+        emberAfDebugPrintln("source ESI " ChipLogFormatX64 " not found in table", ChipLogValueX64(cmd->SourceNodeId()));
         // We add the ESI to the table.
         esiEntry = emberAfPluginEsiManagementGetFreeEntry();
         if (esiEntry != NULL)

--- a/src/app/util/process-cluster-message.cpp
+++ b/src/app/util/process-cluster-message.cpp
@@ -60,8 +60,9 @@ bool emAfProcessClusterSpecificCommand(EmberAfClusterCommand * cmd)
     // or identify cluster (see device enabled attr of basic cluster)
     if (!emberAfIsDeviceEnabled(cmd->apsFrame->destinationEndpoint) && cmd->apsFrame->clusterId != ZCL_IDENTIFY_CLUSTER_ID)
     {
-        emberAfCorePrintln("%pd, dropping ep 0x%x clus 0x%2x cmd 0x%x", "disable", cmd->apsFrame->destinationEndpoint,
-                           cmd->apsFrame->clusterId, cmd->commandId);
+        emberAfCorePrintln("%pd, dropping ep 0x%x clus " ChipLogFormatMEI " cmd " ChipLogFormatMEI, "disable",
+                           cmd->apsFrame->destinationEndpoint, ChipLogValueMEI(cmd->apsFrame->clusterId),
+                           ChipLogValueMEI(cmd->commandId));
         emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_FAILURE);
         return true;
     }

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -119,7 +119,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         clusterId != ZCL_IDENTIFY_CLUSTER_ID)
     {
         emberAfCorePrintln("disabled");
-        emberAfDebugPrintln("%pd, dropping global cmd:%x", "disable", zclCmd);
+        emberAfDebugPrintln("%pd, dropping global cmd:" ChipLogFormatMEI, "disable", ChipLogValueMEI(zclCmd));
         emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_FAILURE);
         return true;
     }
@@ -164,8 +164,8 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         uint8_t numberAttributes;
         uint8_t * complete;
 
-        emberAfAttributesPrintln("%p%p: clus %2x", "DISC_ATTR",
-                                 (zclCmd == ZCL_DISCOVER_ATTRIBUTES_EXTENDED_COMMAND_ID ? "_EXT" : ""), clusterId);
+        emberAfAttributesPrintln("%p%p: clus " ChipLogFormatMEI, "DISC_ATTR",
+                                 (zclCmd == ZCL_DISCOVER_ATTRIBUTES_EXTENDED_COMMAND_ID ? "_EXT" : ""), ChipLogValueMEI(clusterId));
 
         // set the cmd byte - this is byte 3 index 2, but since we have
         // already incremented past the 3 byte ZCL header (our index is at 3),

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -338,7 +338,7 @@ void emberAfDecodeAndPrintClusterWithMfgCode(ClusterId cluster, uint16_t mfgCode
     if (index == 0xFFFF)
     {
         static_assert(sizeof(ClusterId) == 4, "Adjust the print formatting");
-        emberAfPrint(emberAfPrintActiveArea, "(Unknown clus. [0x%4x])", cluster);
+        emberAfPrint(emberAfPrintActiveArea, "(Unknown clus. [" ChipLogFormatMEI "])", ChipLogValueMEI(cluster));
     }
     else
     {
@@ -376,15 +376,16 @@ static void printIncomingZclMessage(const EmberAfClusterCommand * cmd)
     if (emberAfPrintReceivedMessages)
     {
         // emberAfAppPrint("\r\nT%4x:", emberAfGetCurrentTime());
-        emberAfAppPrint("RX len %d, ep %x, clus 0x%2x ", cmd->bufLen, cmd->apsFrame->destinationEndpoint, cmd->apsFrame->clusterId);
+        emberAfAppPrint("RX len %d, ep %x, clus " ChipLogFormatMEI " ", cmd->bufLen, cmd->apsFrame->destinationEndpoint,
+                        ChipLogValueMEI(cmd->apsFrame->clusterId));
         emberAfAppDebugExec(emberAfDecodeAndPrintClusterWithMfgCode(cmd->apsFrame->clusterId, cmd->mfgCode));
         if (cmd->mfgSpecific)
         {
             emberAfAppPrint(" mfgId %2x", cmd->mfgCode);
         }
-        emberAfAppPrint(" FC %x seq %x cmd %x payload[",
+        emberAfAppPrint(" FC %x seq %x cmd " ChipLogFormatMEI " payload[",
                         cmd->buffer[0], // frame control
-                        cmd->seqNum, cmd->commandId);
+                        cmd->seqNum, ChipLogValueMEI(cmd->commandId));
         emberAfAppFlush();
         emberAfAppPrintBuffer(cmd->buffer + cmd->payloadStartIndex,                        // message
                               static_cast<uint16_t>(cmd->bufLen - cmd->payloadStartIndex), // length
@@ -401,14 +402,16 @@ static bool dispatchZclMessage(EmberAfClusterCommand * cmd)
 
     if (index == 0xFFFF)
     {
-        emberAfDebugPrint("Drop cluster 0x%2x command 0x%x", cmd->apsFrame->clusterId, cmd->commandId);
+        emberAfDebugPrint("Drop cluster " ChipLogFormatMEI " command " ChipLogFormatMEI, ChipLogValueMEI(cmd->apsFrame->clusterId),
+                          ChipLogValueMEI(cmd->commandId));
         emberAfDebugPrint(" due to invalid endpoint: ");
         emberAfDebugPrintln("0x%x", cmd->apsFrame->destinationEndpoint);
         return false;
     }
     else if (emberAfNetworkIndexFromEndpointIndex(index) != cmd->networkIndex)
     {
-        emberAfDebugPrint("Drop cluster 0x%2x command 0x%x", cmd->apsFrame->clusterId, cmd->commandId);
+        emberAfDebugPrint("Drop cluster " ChipLogFormatMEI " command " ChipLogFormatMEI, ChipLogValueMEI(cmd->apsFrame->clusterId),
+                          ChipLogValueMEI(cmd->commandId));
         emberAfDebugPrint(" for endpoint 0x%x due to wrong %s: ", cmd->apsFrame->destinationEndpoint, "network");
         emberAfDebugPrintln("%d", cmd->networkIndex);
         return false;


### PR DESCRIPTION
This should catch format strings not matching arguments.

#### Problem
Format strings not matching args.

#### Change overview
Ask the compiler to check that sort of thing for us, and fix the problems it flags.

#### Testing
Tree compiles.