### PR TITLE
Allow Config Manager on the Darwin platform to store Discriminator in RAM

### DIFF
--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -75,8 +75,6 @@ uint16_t PosixConfig::mPosixSetupDiscriminator = 0xF00; // CHIP_DEVICE_CONFIG_US
 CHIP_ERROR PosixConfig::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    mPosixSetupDiscriminator = 0xF00; // CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     return err;
 }
 
@@ -96,13 +94,8 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
     if (key == kConfigKey_SetupDiscriminator)
     {
         val = mPosixSetupDiscriminator;
-        err = CHIP_NO_ERROR;
+        return CHIP_NO_ERROR;
     }
-    else
-    {
-        SuccessOrExit(err);
-    }
-
 exit:
     return err;
 }
@@ -150,11 +143,7 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
     if (key == kConfigKey_SetupDiscriminator)
     {
         mPosixSetupDiscriminator = val;
-        err                      = CHIP_NO_ERROR;
-    }
-    else
-    {
-        SuccessOrExit(err);
+        return CHIP_NO_ERROR;
     }
 exit:
     return err;

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -96,7 +96,6 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
         val = mPosixSetupDiscriminator;
         return CHIP_NO_ERROR;
     }
-exit:
     return err;
 }
 
@@ -145,7 +144,6 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
         mPosixSetupDiscriminator = val;
         return CHIP_NO_ERROR;
     }
-exit:
     return err;
 }
 

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -70,13 +70,13 @@ const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNam
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
-uint16_t PosixConfig::mPosixSetupDiscriminator;
+uint16_t PosixConfig::mPosixSetupDiscriminator = 0xF00; //CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
 
 CHIP_ERROR PosixConfig::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mPosixSetupDiscriminator = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR;
+    mPosixSetupDiscriminator = 0xF00; // CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
     return err;
 }
 

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -70,7 +70,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNam
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
-uint16_t  PosixConfig::mPosixSetupDiscriminator;
+uint16_t PosixConfig::mPosixSetupDiscriminator;
 
 CHIP_ERROR PosixConfig::Init()
 {

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -73,6 +73,8 @@ const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 CHIP_ERROR PosixConfig::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mPosixSetupDiscriminator = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR;
     return err;
 }
 
@@ -88,7 +90,16 @@ exit:
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
 {
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    SuccessOrExit(err);
+
+    if (key == kConfigKey_SetupDiscriminator)
+        {
+            val = mPosixSetupDiscriminator;
+            err = CHIP_NO_ERROR;
+        }
+    else
+        {
+            SuccessOrExit(err);
+        }
 
 exit:
     return err;
@@ -133,8 +144,16 @@ exit:
 CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
 {
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    SuccessOrExit(err);
 
+    if (key == kConfigKey_SetupDiscriminator)
+        {
+            mPosixSetupDiscriminator = val;
+            err = CHIP_NO_ERROR;
+        }
+    else
+        {
+            SuccessOrExit(err);
+        }
 exit:
     return err;
 }

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -70,7 +70,7 @@ const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNam
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
-uint16_t PosixConfig::mPosixSetupDiscriminator = 0xF00; //CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
+uint16_t PosixConfig::mPosixSetupDiscriminator = 0xF00; // CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
 
 CHIP_ERROR PosixConfig::Init()
 {

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -92,14 +92,14 @@ CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 
     if (key == kConfigKey_SetupDiscriminator)
-        {
-            val = mPosixSetupDiscriminator;
-            err = CHIP_NO_ERROR;
-        }
+    {
+        val = mPosixSetupDiscriminator;
+        err = CHIP_NO_ERROR;
+    }
     else
-        {
-            SuccessOrExit(err);
-        }
+    {
+        SuccessOrExit(err);
+    }
 
 exit:
     return err;
@@ -146,14 +146,14 @@ CHIP_ERROR PosixConfig::WriteConfigValue(Key key, uint32_t val)
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 
     if (key == kConfigKey_SetupDiscriminator)
-        {
-            mPosixSetupDiscriminator = val;
-            err = CHIP_NO_ERROR;
-        }
+    {
+        mPosixSetupDiscriminator = val;
+        err                      = CHIP_NO_ERROR;
+    }
     else
-        {
-            SuccessOrExit(err);
-        }
+    {
+        SuccessOrExit(err);
+    }
 exit:
     return err;
 }

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -70,6 +70,8 @@ const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb         = { kConfigNam
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";
 
+uint16_t  PosixConfig::mPosixSetupDiscriminator;
+
 CHIP_ERROR PosixConfig::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -103,7 +103,7 @@ protected:
 
 private:
     // TODO: This is temporary until Darwin implements a proper ReadConfigValue
-    uint16_t mPosixSetupDiscriminator;
+    static uint16_t mPosixSetupDiscriminator;
 };
 
 struct PosixConfig::Key

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -100,6 +100,9 @@ protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
+private:
+    // TODO: This is temporary until Darwin implements a proper ReadConfigValue
+    uint16_t mPosixSetupDiscriminator;
 };
 
 struct PosixConfig::Key

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -100,6 +100,7 @@ protected:
     // NVS Namespace helper functions.
     static CHIP_ERROR EnsureNamespace(const char * ns);
     static CHIP_ERROR ClearNamespace(const char * ns);
+
 private:
     // TODO: This is temporary until Darwin implements a proper ReadConfigValue
     uint16_t mPosixSetupDiscriminator;


### PR DESCRIPTION
#### Problem
Config manager on Darwin Platform returns an error when setting the Discriminator value. This is due to the fact that this and most other config keys are stored in the NVM and Darwin does not have an NVM implementation.

#### Change overview
Allow Config Manager on the Darwin platform to store Discriminator in RAM. Add a mPosixSetupDiscriminator member to the PosixConfig class for Darwin. This is a temporary solution until Darwin implements NVM or Configuration manager is reworked to not rely on NVM for the Discriminator. 

#### Testing
Carol Yang verified that the ota-requestor application on Mac initializes without errors