### PR TITLE
[Android] Make openPairingWindow accept a device pointer

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -79,16 +79,23 @@ class MultiAdminClientFragment : Fragment() {
     scope.cancel()
   }
 
-  private fun sendBasicCommissioningCommandClick() {
+  private suspend fun sendBasicCommissioningCommandClick() {
     val testDuration = 100
-    deviceController.openPairingWindow(addressUpdateFragment.deviceId, testDuration)
+    deviceController.openPairingWindow(
+      ChipClient.getConnectedDevicePointer(
+        requireContext(),
+        addressUpdateFragment.deviceId
+      ), testDuration
+    )
   }
 
-  private fun sendEnhancedCommissioningCommandClick() {
+  private suspend fun sendEnhancedCommissioningCommandClick() {
     val testDuration = 100
     val testIteration = 800
+    val devicePointer =
+      ChipClient.getConnectedDevicePointer(requireContext(), addressUpdateFragment.deviceId)
     deviceController.openPairingWindowWithPIN(
-      addressUpdateFragment.deviceId, testDuration, testIteration,
+      devicePointer, testDuration, testIteration,
       discriminatorEd.text.toString().toInt(), setupPinCodeEd.text.toString().toULong().toLong()
     )
   }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -405,14 +405,18 @@ JNI_METHOD(void, updateDevice)(JNIEnv * env, jobject self, jlong handle, jlong f
     }
 }
 
-JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint duration)
+JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle, jlong devicePtr, jint duration)
 {
     chip::DeviceLayer::StackLock lock;
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    Device * chipDevice = nullptr;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     chip::SetupPayload setupPayload;
 
-    GetCHIPDevice(env, handle, deviceId, &chipDevice);
+    Device * chipDevice = reinterpret_cast<Device *>(devicePtr);
+    if (chipDevice == nullptr)
+    {
+        ChipLogProgress(Controller, "Could not cast device pointer to Device object");
+        return false;
+    }
 
     err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::CommissioningWindowOption::kOriginalSetupCode,
                                         setupPayload);
@@ -427,16 +431,20 @@ JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle
 }
 
 JNI_METHOD(jboolean, openPairingWindowWithPIN)
-(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint duration, jint iteration, jint discriminator, jlong setupPinCode)
+(JNIEnv * env, jobject self, jlong handle, jlong devicePtr, jint duration, jint iteration, jint discriminator, jlong setupPinCode)
 {
     chip::DeviceLayer::StackLock lock;
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    Device * chipDevice = nullptr;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     chip::SetupPayload setupPayload;
     setupPayload.discriminator = discriminator;
     setupPayload.setUpPINCode  = setupPinCode;
 
-    GetCHIPDevice(env, handle, deviceId, &chipDevice);
+    Device * chipDevice = reinterpret_cast<Device *>(devicePtr);
+    if (chipDevice == nullptr)
+    {
+        ChipLogProgress(Controller, "Could not cast device pointer to Device object");
+        return false;
+    }
 
     err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::CommissioningWindowOption::kTokenWithRandomPIN,
                                         setupPayload);

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -206,14 +206,14 @@ public class ChipDeviceController {
     updateDevice(deviceControllerPtr, fabricId, deviceId);
   }
 
-  public boolean openPairingWindow(long deviceId, int duration) {
-    return openPairingWindow(deviceControllerPtr, deviceId, duration);
+  public boolean openPairingWindow(long devicePtr, int duration) {
+    return openPairingWindow(deviceControllerPtr, devicePtr, duration);
   }
 
   public boolean openPairingWindowWithPIN(
-      long deviceId, int duration, int iteration, int discriminator, long setupPinCode) {
+      long devicePtr, int duration, int iteration, int discriminator, long setupPinCode) {
     return openPairingWindowWithPIN(
-        deviceControllerPtr, deviceId, duration, iteration, discriminator, setupPinCode);
+        deviceControllerPtr, devicePtr, duration, iteration, discriminator, setupPinCode);
   }
 
   public boolean isActive(long deviceId) {
@@ -257,11 +257,11 @@ public class ChipDeviceController {
 
   private native void updateDevice(long deviceControllerPtr, long fabricId, long deviceId);
 
-  private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
+  private native boolean openPairingWindow(long deviceControllerPtr, long devicePtr, int duration);
 
   private native boolean openPairingWindowWithPIN(
       long deviceControllerPtr,
-      long deviceId,
+      long devicePtr,
       int duration,
       int iteration,
       int discriminator,


### PR DESCRIPTION
#### Problem
* JNI `openPairingWindow` takes a device ID, but cluster code takes in device pointers
* It also uses GetDevice, so device is not guaranteed to be connected

#### Change overview
* Swap openPairingWindow to take device pointer, which is more flexible than device ID
* In app code, use `GetConnectedDevicePointer` to ensure device is connected when opening commissioning window.

#### Testing
* Commissioned device and opened commissioning window.
