### PR TITLE
Add a non expanded versions of command argument to zap-templates/comm…

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -186,13 +186,13 @@ class {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}: public ModelCom
 public:
     {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}(): ModelCommand("{{asDelimitedCommand name}}")
     {
-        {{#chip_cluster_command_arguments}}
+        {{#chip_cluster_command_arguments_with_structs_expanded}}
         {{#if (isString type)}}
         AddArgument("{{asUpperCamelCase label}}", &m{{asUpperCamelCase label}});
         {{else}}
         AddArgument("{{asUpperCamelCase label}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asUpperCamelCase label}});
         {{/if}}
-        {{/chip_cluster_command_arguments}}
+        {{/chip_cluster_command_arguments_with_structs_expanded}}
         ModelCommand::AddArguments();
     }
     ~{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}()
@@ -207,7 +207,7 @@ public:
 
         chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments}}, m{{asUpperCamelCase label}}{{/chip_cluster_command_arguments}});
+        return cluster.{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments_with_structs_expanded}}, m{{asUpperCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     }
 
 private:
@@ -217,9 +217,9 @@ private:
     chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback = new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     {{/if}}
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    {{#chip_cluster_command_arguments}}
+    {{#chip_cluster_command_arguments_with_structs_expanded}}
     {{#if (isCharString type)}}chip::ByteSpan{{else}}{{chipType}}{{/if}} m{{asUpperCamelCase label}};
-    {{/chip_cluster_command_arguments}}
+    {{/chip_cluster_command_arguments_with_structs_expanded}}
 };
 
 {{/chip_cluster_commands}}

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -356,7 +356,7 @@ function chip_tests_item_parameters(options)
       return [];
     }
 
-    const commandArgs = item.arguments;
+    const commandArgs = item.expandedArguments || item.arguments;
     const commands    = commandArgs.map(commandArg => {
       commandArg = JSON.parse(JSON.stringify(commandArg));
 

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -431,15 +431,16 @@ function enhancedCommands(commands, types)
     return commands.find(command => command.responseName == responseName);
   });
 
-  // At this stage, 'command.arguments' may contains 'struct'. But controllers does not know (yet) how
+  // At this stage, 'command.arguments' may contains 'struct'. But some controllers does not know (yet) how
   // to handle them. So those needs to be inlined.
   commands.forEach(command => {
     if (command.isResponse) {
       return;
     }
 
-    command.arguments = inlineStructItems(command.arguments);
+    command.expandedArguments = inlineStructItems(command.arguments);
   });
+
   return commands;
 }
 

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -37,7 +37,7 @@ namespace Controller {
 
 // {{asUpperCamelCase name}} Cluster Commands
 {{#chip_cluster_commands}}
-CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}})
+CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}})
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVWriter * writer     = nullptr;
@@ -58,7 +58,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
 
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
-{{#chip_cluster_command_arguments}}
+{{#chip_cluster_command_arguments_with_structs_expanded}}
 {{#first}}
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 {{/first}}
@@ -72,7 +72,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
 {{/if}}
 {{else}}
     // Command takes no arguments.
-{{/chip_cluster_command_arguments}}
+{{/chip_cluster_command_arguments_with_structs_expanded}}
 
     SuccessOrExit(err = sender->FinishCommand());
 

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -25,7 +25,7 @@ public:
 
     // Cluster Commands
     {{/first}}
-    CHIP_ERROR {{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}});
+    CHIP_ERROR {{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     {{/chip_cluster_commands}}
 
     // Cluster Attributes

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -222,6 +222,38 @@ function chip_cluster_command_arguments(options)
 }
 
 /**
+ * Creates block iterator over the current command arguments for a given cluster/side.
+ *
+ * This function is meant to be used inside a {{#chip_cluster_commands}}
+ * block. It will throw otherwise.
+ *
+ * The arguments list built by this function differs from {{chip_cluster_command_arguments}}.
+ * For example, if a command contains a single struct argument "SomeStruct", with the following type:
+ *
+ * struct SomeStruct {
+ *   uint8_t a;
+ *   uint16_t b;
+ *   uint32_t c;
+ * }
+ *
+ * then that argument will be expanded into 3 arguments (uint8_t a, uint16_t b, uint32_t c).
+ *
+ * @param {*} options
+ */
+function chip_cluster_command_arguments_with_structs_expanded(options)
+{
+  const commandId = checkIsInsideCommandBlock(this, 'chip_cluster_command_arguments');
+  const commands  = getCommands.call(this.parent, 'chip_cluster_commands_argments_with_structs_expanded');
+
+  const filter = command => command.id == commandId;
+  return asBlocks.call(this, commands.then(items => {
+    const item = items.find(filter);
+    return item.expandedArguments || item.arguments;
+  }),
+      options);
+}
+
+/**
  * Creates block iterator over the current response arguments for a given cluster/side.
  *
  * This function is meant to be used inside a {{#chip_cluster_responses}}
@@ -319,18 +351,19 @@ function chip_available_cluster_commands(options)
 //
 // Module exports
 //
-exports.chip_clusters                   = chip_clusters;
-exports.chip_has_clusters               = chip_has_clusters;
-exports.chip_client_clusters            = chip_client_clusters;
-exports.chip_has_client_clusters        = chip_has_client_clusters;
-exports.chip_server_clusters            = chip_server_clusters;
-exports.chip_has_server_clusters        = chip_has_server_clusters;
-exports.chip_cluster_commands           = chip_cluster_commands;
-exports.chip_cluster_command_arguments  = chip_cluster_command_arguments;
-exports.chip_server_global_responses    = chip_server_global_responses;
-exports.chip_cluster_responses          = chip_cluster_responses;
-exports.chip_cluster_response_arguments = chip_cluster_response_arguments
-exports.chip_attribute_list_entryTypes  = chip_attribute_list_entryTypes;
-exports.chip_server_cluster_attributes  = chip_server_cluster_attributes;
-exports.chip_server_has_list_attributes = chip_server_has_list_attributes;
-exports.chip_available_cluster_commands = chip_available_cluster_commands;
+exports.chip_clusters                                        = chip_clusters;
+exports.chip_has_clusters                                    = chip_has_clusters;
+exports.chip_client_clusters                                 = chip_client_clusters;
+exports.chip_has_client_clusters                             = chip_has_client_clusters;
+exports.chip_server_clusters                                 = chip_server_clusters;
+exports.chip_has_server_clusters                             = chip_has_server_clusters;
+exports.chip_cluster_commands                                = chip_cluster_commands;
+exports.chip_cluster_command_arguments                       = chip_cluster_command_arguments;
+exports.chip_cluster_command_arguments_with_structs_expanded = chip_cluster_command_arguments_with_structs_expanded;
+exports.chip_server_global_responses                         = chip_server_global_responses;
+exports.chip_cluster_responses                               = chip_cluster_responses;
+exports.chip_cluster_response_arguments                      = chip_cluster_response_arguments
+exports.chip_attribute_list_entryTypes                       = chip_attribute_list_entryTypes;
+exports.chip_server_cluster_attributes                       = chip_server_cluster_attributes;
+exports.chip_server_has_list_attributes                      = chip_server_has_list_attributes;
+exports.chip_available_cluster_commands                      = chip_available_cluster_commands;

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -521,19 +521,19 @@ JNI_METHOD(jlong, {{asUpperCamelCase name}}Cluster, initWithDevice)(JNIEnv * env
 }
 
 {{#chip_cluster_commands}}
-JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback{{#chip_cluster_command_arguments}}, {{asJniBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}})
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJniBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}})
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
     {{asUpperCamelCase ../name}}Cluster * cppCluster;
     
-    {{#chip_cluster_command_arguments}}
+    {{#chip_cluster_command_arguments_with_structs_expanded}}
     {{#if (isOctetString type)}}
     JniByteArray {{asLowerCamelCase label}}Arr(env, {{asLowerCamelCase label}});
     {{else if (isCharString type)}}
     JniUtfString {{asLowerCamelCase label}}Str(env, {{asLowerCamelCase label}});
     {{/if}}
-    {{/chip_cluster_command_arguments}}
+    {{/chip_cluster_command_arguments_with_structs_expanded}}
 
     {{#if hasSpecificResponse}}
     std::unique_ptr<CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback, void (*)(CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback *)> onSuccess(
@@ -548,7 +548,7 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})
     cppCluster = reinterpret_cast<{{asUpperCamelCase ../name}}Cluster *>(clusterPtr);
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asLowerCamelCase label}}, strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
+    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asLowerCamelCase label}}, strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     SuccessOrExit(err);
 
 exit: 

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -75,13 +75,13 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
   {{#chip_cluster_commands}}
 
-    public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback{{#chip_cluster_command_arguments}}, {{asJavaBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}}) {
-      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}});
+    public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJavaBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}}) {
+      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     }
 
   {{/chip_cluster_commands}}
   {{#chip_cluster_commands}}
-    private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback{{#chip_cluster_command_arguments}}, {{asJavaBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}});
+    private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJavaBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
   {{/chip_cluster_commands}}
   {{#chip_cluster_responses}}
     public interface {{asUpperCamelCase name}}Callback {

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -114,12 +114,12 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 // Cluster {{asUpperCamelCase name}}
 
 {{#chip_cluster_commands}}
-chip::ChipError::StorageType chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asLowerCamelCase label}}, uint32_t {{asLowerCamelCase label}}_Len{{else}}{{chipType}} {{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}})
+chip::ChipError::StorageType chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isString type)}}const uint8_t * {{asLowerCamelCase label}}, uint32_t {{asLowerCamelCase label}}_Len{{else}}{{chipType}} {{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::{{asUpperCamelCase clusterName}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.{{asUpperCamelCase name}}(nullptr, nullptr{{#chip_cluster_command_arguments}}, {{#if (isString type)}}chip::ByteSpan({{asLowerCamelCase label}}, {{asLowerCamelCase label}}_Len){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}}).AsInteger();
+    return cluster.{{asUpperCamelCase name}}(nullptr, nullptr{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isString type)}}chip::ByteSpan({{asLowerCamelCase label}}, {{asLowerCamelCase label}}_Len){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}).AsInteger();
 }
 {{/chip_cluster_commands}}
 

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -22,9 +22,9 @@ class ChipClusters:
                     "commandId": {{asHex code 8}},
                     "commandName": "{{asUpperCamelCase name}}",
                     "args": {
-{{#chip_cluster_command_arguments}}
+{{#chip_cluster_command_arguments_with_structs_expanded}}
                         "{{asLowerCamelCase label}}": "{{#if (isCharString type)}}str{{else}}{{asPythonType chipType}}{{/if}}",
-{{/chip_cluster_command_arguments}}
+{{/chip_cluster_command_arguments_with_structs_expanded}}
                     },
                 },
 {{/chip_cluster_commands}}
@@ -117,14 +117,14 @@ class ChipClusters:
 
 {{#chip_client_clusters}}
 {{#chip_cluster_commands}}
-    def Cluster{{asUpperCamelCase clusterName}}_Command{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}: {{asPythonType chipType}}{{/chip_cluster_command_arguments}}):
-{{#chip_cluster_command_arguments}}
+    def Cluster{{asUpperCamelCase clusterName}}_Command{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asLowerCamelCase label}}: {{asPythonType chipType}}{{/chip_cluster_command_arguments_with_structs_expanded}}):
+{{#chip_cluster_command_arguments_with_structs_expanded}}
 {{#if (isCharString type)}}
         {{asLowerCamelCase label}} = {{asLowerCamelCase label}}.encode("utf-8") + b'\x00'
 {{/if}}
-{{/chip_cluster_command_arguments}}
+{{/chip_cluster_command_arguments_with_structs_expanded}}
         return self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(
-                device, ZCLendpoint, ZCLgroupid{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}{{#if (isString type)}}, len({{asLowerCamelCase label}}){{/if}}{{/chip_cluster_command_arguments}}
+                device, ZCLendpoint, ZCLgroupid{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asLowerCamelCase label}}{{#if (isString type)}}, len({{asLowerCamelCase label}}){{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}
         )
 {{/chip_cluster_commands}}
 {{/chip_client_clusters}}
@@ -162,7 +162,7 @@ class ChipClusters:
         # Cluster {{asUpperCamelCase name}}
 {{#chip_cluster_commands}}
         # Cluster {{asUpperCamelCase clusterName}} Command {{asUpperCamelCase name}}
-        self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_cluster_command_arguments}}]
+        self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}]
         self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{/chip_cluster_commands}}
 {{#chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -22,9 +22,9 @@ using chip::Callback::Cancelable;
 
 {{#chip_cluster_commands}}
 {{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}DefaultSuccess{{/if}}{{/inline}}
-{{#*inline "callbackParams"}}{{#chip_cluster_command_arguments}}, {{#if (isString type)}}[self asSpan:{{/if}}{{asLowerCamelCase label}}{{#if (isString type)}}]{{/if}}{{/chip_cluster_command_arguments}}{{/inline}}
+{{#*inline "callbackParams"}}{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isString type)}}[self asSpan:{{/if}}{{asLowerCamelCase label}}{{#if (isString type)}}]{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}{{/inline}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
+- (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments_with_structs_expanded}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments_with_structs_expanded}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#chip_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
+- (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments_with_structs_expanded}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments_with_structs_expanded}}responseHandler:(ResponseHandler)responseHandler;
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler;
 {{/if}}


### PR DESCRIPTION
…on/ClustersHelper.js

#### Problem

Currently ZAP templates expect basic types such a `uint8_t`, `uint16_t`, `bool`, etc... But with #10362 we can now send complex parameters such as `List` and `Struct` over  the wire.

In order to support migrating `chip-tool` and the YAML tests to it, there is a need to have an iterator that does not do struct expansion in #10498

#### Change overview
 * Add a `chip_cluster_command_arguments` helper that does not try to expand structs
 * Rename the previous `chip_cluster_command_arguments` helper to `chip_cluster_command_arguments_with_structs_expanded`
 * Update the templates to use `chip_cluster_command_arguments_with_structs_expanded`
 * Run codegen and observe no changes

#### Testing
After codegen no code was changed.
