### PR TITLE
Remove usage of GetDevice() API in Android controller

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -36,7 +36,10 @@ import kotlinx.android.synthetic.main.enter_thread_network_fragment.xpanIdEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.pwdEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.ssidEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.view.saveNetworkBtn
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 /**
  * Fragment to collect Wi-Fi network information from user and send it to device being provisioned.
@@ -65,15 +68,15 @@ class EnterNetworkFragment : Fragment() {
     }
 
     return inflater.inflate(layoutRes, container, false).apply {
-      saveNetworkBtn.setOnClickListener { scope.launch { onSaveNetworkClicked() } }
+      saveNetworkBtn.setOnClickListener { onSaveNetworkClicked() }
     }
   }
 
-  private suspend fun onSaveNetworkClicked() {
+  private fun onSaveNetworkClicked() {
     if (networkType == ProvisionNetworkType.WIFI) {
-      saveWifiNetwork()
+      scope.launch { saveWifiNetwork() }
     } else {
-      saveThreadNetwork()
+      scope.launch { saveThreadNetwork() }
     }
   }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -36,11 +36,14 @@ import kotlinx.android.synthetic.main.enter_thread_network_fragment.xpanIdEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.pwdEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.ssidEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.view.saveNetworkBtn
+import kotlinx.coroutines.*
 
 /**
  * Fragment to collect Wi-Fi network information from user and send it to device being provisioned.
  */
 class EnterNetworkFragment : Fragment() {
+
+  private val scope = CoroutineScope(Dispatchers.Main + Job())
 
   private val networkType: ProvisionNetworkType
     get() = requireNotNull(
@@ -58,15 +61,15 @@ class EnterNetworkFragment : Fragment() {
     }
 
     if (USE_HARDCODED_WIFI) {
-      saveHardcodedWifiNetwork()
+      scope.launch { saveHardcodedWifiNetwork() }
     }
 
     return inflater.inflate(layoutRes, container, false).apply {
-      saveNetworkBtn.setOnClickListener { onSaveNetworkClicked() }
+      saveNetworkBtn.setOnClickListener { scope.launch { onSaveNetworkClicked() } }
     }
   }
 
-  private fun onSaveNetworkClicked() {
+  private suspend fun onSaveNetworkClicked() {
     if (networkType == ProvisionNetworkType.WIFI) {
       saveWifiNetwork()
     } else {
@@ -74,11 +77,11 @@ class EnterNetworkFragment : Fragment() {
     }
   }
 
-  private fun saveHardcodedWifiNetwork() {
+  private suspend fun saveHardcodedWifiNetwork() {
     addAndEnableWifiNetwork(HARDCODED_WIFI_SSID, HARDCODED_WIFI_PASSWORD)
   }
 
-  private fun saveWifiNetwork() {
+  private suspend fun saveWifiNetwork() {
     val ssid = ssidEd?.text
     val pwd = pwdEd?.text
 
@@ -90,7 +93,7 @@ class EnterNetworkFragment : Fragment() {
     addAndEnableWifiNetwork(ssid.toString(), pwd.toString())
   }
 
-  private fun addAndEnableWifiNetwork(ssid: String, password: String) {
+  private suspend fun addAndEnableWifiNetwork(ssid: String, password: String) {
     // Uses UTF-8 as default
     val ssidBytes = ssid.toByteArray()
     val pwdBytes = password.toByteArray()
@@ -150,7 +153,7 @@ class EnterNetworkFragment : Fragment() {
     }, ssidBytes, pwdBytes, /* breadcrumb = */ 0L, ADD_NETWORK_TIMEOUT)
   }
 
-  private fun saveThreadNetwork() {
+  private suspend fun saveThreadNetwork() {
     val channelStr = channelEd.text
     val panIdStr = panIdEd.text
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -95,8 +95,8 @@ class EnterNetworkFragment : Fragment() {
     val ssidBytes = ssid.toByteArray()
     val pwdBytes = password.toByteArray()
 
-    val devicePtr = ChipClient.getDeviceController(requireContext())
-      .getDevicePointer(DeviceIdUtil.getLastDeviceId(requireContext()))
+    val devicePtr =
+      ChipClient.getConnectedDevicePointer(requireContext(), DeviceIdUtil.getLastDeviceId(requireContext()))
     val cluster = NetworkCommissioningCluster(devicePtr, /* endpointId = */ 0)
 
     val enableNetworkCallback = object :
@@ -186,8 +186,8 @@ class EnterNetworkFragment : Fragment() {
       return
     }
 
-    val devicePtr = ChipClient.getDeviceController(requireContext())
-      .getDevicePointer(DeviceIdUtil.getLastDeviceId(requireContext()))
+    val devicePtr =
+      ChipClient.getConnectedDevicePointer(requireContext(), DeviceIdUtil.getLastDeviceId(requireContext()))
     val cluster = NetworkCommissioningCluster(devicePtr, /* endpointId = */ 0)
 
     val operationalDataset = makeThreadOperationalDataset(

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -247,6 +247,8 @@ public:
 
     virtual void ReleaseDevice(Device * device);
 
+    void ReleaseDeviceById(NodeId remoteDeviceId);
+
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     void RegisterDeviceAddressUpdateDelegate(DeviceAddressUpdateDelegate * delegate) { mDeviceAddressUpdateDelegate = delegate; }
     void RegisterDeviceDiscoveryDelegate(DeviceDiscoveryDelegate * delegate) { mDeviceDiscoveryDelegate = delegate; }
@@ -305,7 +307,6 @@ protected:
     uint16_t FindDeviceIndex(SessionHandle session);
     uint16_t FindDeviceIndex(NodeId id);
     void ReleaseDevice(uint16_t index);
-    void ReleaseDeviceById(NodeId remoteDeviceId);
     CHIP_ERROR InitializePairedDeviceList();
     CHIP_ERROR SetPairedDeviceList(ByteSpan pairedDeviceSerializedSet);
     ControllerDeviceInitParams GetControllerDeviceInitParams();

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -362,7 +362,11 @@ JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlon
     uint16_t port;
     char addrStr[50];
 
-    CHIP_ERROR err = wrapper->Controller()->GetPeerAddressAndPort(PeerId().SetCompressedFabricId().SetNodeId(), addr, port);
+    CHIP_ERROR err =
+        wrapper->Controller()->GetPeerAddressAndPort(PeerId()
+                                                         .SetCompressedFabricId(wrapper->Controller()->GetCompressedFabricId())
+                                                         .SetNodeId(static_cast<chip::NodeId>(deviceId)),
+                                                     addr, port);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -107,8 +107,8 @@ public class ChipDeviceController {
   /**
    * Through GetConnectedDeviceCallback, returns a pointer to a connected device or an error.
    *
-   * <p>TODO(#8443): This method and getConnectedDevicePointer() could benefit from ChipDevice
-   * abstraction to hide the pointer passing.
+   * <p>TODO(#8443): This method could benefit from a ChipDevice abstraction to hide the pointer
+   * passing.
    */
   public void getConnectedDevicePointer(long nodeId, GetConnectedDeviceCallback callback) {
     GetConnectedDeviceCallbackJni jniCallback = new GetConnectedDeviceCallbackJni(callback);

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -105,17 +105,11 @@ public class ChipDeviceController {
   }
 
   /**
-   * Returns a pointer to a device with the specified nodeId. The device is not guaranteed to be
-   * connected.
+   * Through GetConnectedDeviceCallback, returns a pointer to a connected device or an error.
    *
    * <p>TODO(#8443): This method and getConnectedDevicePointer() could benefit from ChipDevice
    * abstraction to hide the pointer passing.
    */
-  public long getDevicePointer(long nodeId) {
-    return getDevicePointer(deviceControllerPtr, nodeId);
-  }
-
-  /** Through GetConnectedDeviceCallback, returns a pointer to a connected device or an error. */
   public void getConnectedDevicePointer(long nodeId, GetConnectedDeviceCallback callback) {
     GetConnectedDeviceCallbackJni jniCallback = new GetConnectedDeviceCallbackJni(callback);
     getConnectedDevicePointer(deviceControllerPtr, nodeId, jniCallback.getCallbackHandle());
@@ -239,8 +233,6 @@ public class ChipDeviceController {
       @Nullable byte[] csrNonce);
 
   private native void unpairDevice(long deviceControllerPtr, long deviceId);
-
-  private native long getDevicePointer(long deviceControllerPtr, long deviceId);
 
   private native void getConnectedDevicePointer(
       long deviceControllerPtr, long deviceId, long callbackHandle);


### PR DESCRIPTION
#### Problem
Android Controller code needs update to remove usage of `GetDevice()` API.

#### Change overview
- Use `GetPeerAddressAndPort()` to get device's address
- Use `ReleaseDeviceById()` to disconnect the device.
- Remaining usage of `GetDevice()` have been removed in #10590 

#### Testing
Run existing CI tests to ensure that the controller behavior is intact.
