### PR TITLE
Remove the "m5stack-all-clusters-rpc" build variant due to build failure

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -90,7 +90,6 @@ def Esp32Targets():
 
     yield esp32_target.Extend('m5stack-all-clusters', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS)
     yield esp32_target.Extend('m5stack-all-clusters-ipv6only', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_ipv4=False)
-    yield esp32_target.Extend('m5stack-all-clusters-rpc', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_rpcs=True)
     yield esp32_target.Extend('c3devkit-all-clusters', board=Esp32Board.C3DevKit, app=Esp32App.ALL_CLUSTERS)
 
     devkitc = esp32_target.Extend('devkitc', board=Esp32Board.DevKitC)

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -16,7 +16,6 @@ esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
-esp32-m5stack-all-clusters-rpc
 infineon-p6-lock
 nrf-nrf52840-light
 nrf-nrf52840-lock

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -176,17 +176,6 @@ bash -c 'source $IDF_PATH/export.sh;
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults
 idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-ipv6only reconfigure'
 
-# Generating esp32-m5stack-all-clusters-rpc
-mkdir -p {out}/esp32-m5stack-all-clusters-rpc
-
-cp examples/all-clusters-app/esp32/sdkconfig_m5stack_rpc.defaults {out}/esp32-m5stack-all-clusters-rpc/sdkconfig.defaults
-
-rm -f examples/all-clusters-app/esp32/sdkconfig
-
-bash -c 'source $IDF_PATH/export.sh; 
-export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc/sdkconfig.defaults
-idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-rpc reconfigure'
-
 # Generating infineon-p6-lock
 gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-lock
 
@@ -432,13 +421,6 @@ rm -f examples/all-clusters-app/esp32/sdkconfig
 bash -c 'source $IDF_PATH/export.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults
 idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-ipv6only build'
-
-rm -f examples/all-clusters-app/esp32/sdkconfig
-
-# Building esp32-m5stack-all-clusters-rpc
-bash -c 'source $IDF_PATH/export.sh; 
-export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc/sdkconfig.defaults
-idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-rpc build'
 
 # Building infineon-p6-lock
 ninja -C {out}/infineon-p6-lock


### PR DESCRIPTION
#### Problem
Error compiling the variant: IDF python environment is different than the usual pigweed RPC environment and this results in a build failure

#### Change overview
Remove the -rpc variant from ESP builds

#### Testing
Locally checked targets, CI validates the build commands.
