### PR TITLE
Fix namespace handling for bitmap types in zapTypeToClusterObjectType.

### DIFF
--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -396,7 +396,7 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
     }
 
     if (await typeChecker('isBitmap')) {
-      return ns + 'BitFlags<' + type + '>';
+      return 'chip::BitFlags<' + ns + type + '>';
     }
 
     if (await typeChecker('isStruct')) {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -1846,7 +1846,7 @@ public:
     static constexpr CommandId GetCommandId() { return CopyScene::Id; }
     static constexpr ClusterId GetClusterId() { return Scenes::Id; }
 
-    BitFlags<ScenesCopyMode> mode;
+    chip::BitFlags<ScenesCopyMode> mode;
     uint16_t groupIdFrom;
     uint8_t sceneIdFrom;
     uint16_t groupIdTo;
@@ -1861,7 +1861,7 @@ public:
     static constexpr CommandId GetCommandId() { return CopyScene::Id; }
     static constexpr ClusterId GetClusterId() { return Scenes::Id; }
 
-    BitFlags<ScenesCopyMode> mode;
+    chip::BitFlags<ScenesCopyMode> mode;
     uint16_t groupIdFrom;
     uint8_t sceneIdFrom;
     uint16_t groupIdTo;
@@ -2275,7 +2275,7 @@ public:
     static constexpr CommandId GetCommandId() { return OnWithTimedOff::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    BitFlags<OnOffControl> onOffControl;
+    chip::BitFlags<OnOffControl> onOffControl;
     uint16_t onTime;
     uint16_t offWaitTime;
 
@@ -2288,7 +2288,7 @@ public:
     static constexpr CommandId GetCommandId() { return OnWithTimedOff::Id; }
     static constexpr ClusterId GetClusterId() { return OnOff::Id; }
 
-    BitFlags<OnOffControl> onOffControl;
+    chip::BitFlags<OnOffControl> onOffControl;
     uint16_t onTime;
     uint16_t offWaitTime;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -4158,7 +4158,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
-    BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
     ApplianceStatus applianceStatus2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -4171,7 +4171,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
-    BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
     ApplianceStatus applianceStatus2;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4216,7 +4216,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
-    BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
     ApplianceStatus applianceStatus2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -4229,7 +4229,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
-    BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
+    chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
     ApplianceStatus applianceStatus2;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -9865,7 +9865,7 @@ public:
 
     uint8_t scheduleId;
     uint16_t userId;
-    BitFlags<DoorLockDayOfWeek> daysMask;
+    chip::BitFlags<DoorLockDayOfWeek> daysMask;
     uint8_t startHour;
     uint8_t startMinute;
     uint8_t endHour;
@@ -9882,7 +9882,7 @@ public:
 
     uint8_t scheduleId;
     uint16_t userId;
-    BitFlags<DoorLockDayOfWeek> daysMask;
+    chip::BitFlags<DoorLockDayOfWeek> daysMask;
     uint8_t startHour;
     uint8_t startMinute;
     uint8_t endHour;
@@ -12427,8 +12427,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
-    BitFlags<DayOfWeek> dayOfWeekForSequence;
-    BitFlags<ModeForSequence> modeForSequence;
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
+    chip::BitFlags<ModeForSequence> modeForSequence;
     DataModel::List<uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -12441,8 +12441,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
-    BitFlags<DayOfWeek> dayOfWeekForSequence;
-    BitFlags<ModeForSequence> modeForSequence;
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
+    chip::BitFlags<ModeForSequence> modeForSequence;
     DataModel::DecodableList<uint8_t> payload;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12464,8 +12464,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
-    BitFlags<DayOfWeek> dayOfWeekForSequence;
-    BitFlags<ModeForSequence> modeForSequence;
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
+    chip::BitFlags<ModeForSequence> modeForSequence;
     DataModel::List<uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -12478,8 +12478,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
-    BitFlags<DayOfWeek> dayOfWeekForSequence;
-    BitFlags<ModeForSequence> modeForSequence;
+    chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
+    chip::BitFlags<ModeForSequence> modeForSequence;
     DataModel::DecodableList<uint8_t> payload;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12541,8 +12541,8 @@ public:
     static constexpr CommandId GetCommandId() { return GetWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
-    BitFlags<DayOfWeek> daysToReturn;
-    BitFlags<ModeForSequence> modeToReturn;
+    chip::BitFlags<DayOfWeek> daysToReturn;
+    chip::BitFlags<ModeForSequence> modeToReturn;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12553,8 +12553,8 @@ public:
     static constexpr CommandId GetCommandId() { return GetWeeklySchedule::Id; }
     static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
 
-    BitFlags<DayOfWeek> daysToReturn;
-    BitFlags<ModeForSequence> modeToReturn;
+    chip::BitFlags<DayOfWeek> daysToReturn;
+    chip::BitFlags<ModeForSequence> modeToReturn;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetWeeklySchedule
@@ -13911,7 +13911,7 @@ public:
     static constexpr CommandId GetCommandId() { return ColorLoopSet::Id; }
     static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
 
-    BitFlags<ColorLoopUpdateFlags> updateFlags;
+    chip::BitFlags<ColorLoopUpdateFlags> updateFlags;
     ColorLoopAction action;
     ColorLoopDirection direction;
     uint16_t time;
@@ -13928,7 +13928,7 @@ public:
     static constexpr CommandId GetCommandId() { return ColorLoopSet::Id; }
     static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
 
-    BitFlags<ColorLoopUpdateFlags> updateFlags;
+    chip::BitFlags<ColorLoopUpdateFlags> updateFlags;
     ColorLoopAction action;
     ColorLoopDirection direction;
     uint16_t time;
@@ -16648,7 +16648,7 @@ public:
     static constexpr CommandId GetCommandId() { return ZoneStatusChangeNotification::Id; }
     static constexpr ClusterId GetClusterId() { return IasZone::Id; }
 
-    BitFlags<IasZoneStatus> zoneStatus;
+    chip::BitFlags<IasZoneStatus> zoneStatus;
     uint8_t extendedStatus;
     uint8_t zoneId;
     uint16_t delay;
@@ -16662,7 +16662,7 @@ public:
     static constexpr CommandId GetCommandId() { return ZoneStatusChangeNotification::Id; }
     static constexpr ClusterId GetClusterId() { return IasZone::Id; }
 
-    BitFlags<IasZoneStatus> zoneStatus;
+    chip::BitFlags<IasZoneStatus> zoneStatus;
     uint8_t extendedStatus;
     uint8_t zoneId;
     uint16_t delay;
@@ -17030,7 +17030,7 @@ struct Type
 {
 public:
     uint8_t zoneId;
-    BitFlags<IasZoneStatus> zoneStatus;
+    chip::BitFlags<IasZoneStatus> zoneStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -17702,7 +17702,7 @@ public:
     static constexpr CommandId GetCommandId() { return StartWarning::Id; }
     static constexpr ClusterId GetClusterId() { return IasWd::Id; }
 
-    BitFlags<WarningInfo> warningInfo;
+    chip::BitFlags<WarningInfo> warningInfo;
     uint16_t warningDuration;
     uint8_t strobeDutyCycle;
     uint8_t strobeLevel;
@@ -17716,7 +17716,7 @@ public:
     static constexpr CommandId GetCommandId() { return StartWarning::Id; }
     static constexpr ClusterId GetClusterId() { return IasWd::Id; }
 
-    BitFlags<WarningInfo> warningInfo;
+    chip::BitFlags<WarningInfo> warningInfo;
     uint16_t warningDuration;
     uint8_t strobeDutyCycle;
     uint8_t strobeLevel;
@@ -17736,7 +17736,7 @@ public:
     static constexpr CommandId GetCommandId() { return Squawk::Id; }
     static constexpr ClusterId GetClusterId() { return IasWd::Id; }
 
-    BitFlags<SquawkInfo> squawkInfo;
+    chip::BitFlags<SquawkInfo> squawkInfo;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -17747,7 +17747,7 @@ public:
     static constexpr CommandId GetCommandId() { return Squawk::Id; }
     static constexpr ClusterId GetClusterId() { return IasWd::Id; }
 
-    BitFlags<SquawkInfo> squawkInfo;
+    chip::BitFlags<SquawkInfo> squawkInfo;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Squawk
@@ -20106,7 +20106,7 @@ public:
     SimpleEnum c;
     chip::ByteSpan d;
     chip::Span<const char> e;
-    BitFlags<SimpleBitmap> f;
+    chip::BitFlags<SimpleBitmap> f;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20989,11 +20989,11 @@ public:
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
     uint32_t messageId;
-    BitFlags<MessagingControlMask> messageControl;
+    chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
     chip::Span<const char> message;
-    BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21005,11 +21005,11 @@ public:
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
     uint32_t messageId;
-    BitFlags<MessagingControlMask> messageControl;
+    chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
     chip::Span<const char> message;
-    BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace DisplayMessage
@@ -21052,7 +21052,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
     uint32_t messageId;
-    BitFlags<MessagingControlMask> messageControl;
+    chip::BitFlags<MessagingControlMask> messageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21064,7 +21064,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
     uint32_t messageId;
-    BitFlags<MessagingControlMask> messageControl;
+    chip::BitFlags<MessagingControlMask> messageControl;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CancelMessage
@@ -21124,11 +21124,11 @@ public:
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
     uint32_t messageId;
-    BitFlags<MessagingControlMask> messageControl;
+    chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
     chip::Span<const char> message;
-    BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21140,11 +21140,11 @@ public:
     static constexpr ClusterId GetClusterId() { return Messaging::Id; }
 
     uint32_t messageId;
-    BitFlags<MessagingControlMask> messageControl;
+    chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
     chip::Span<const char> message;
-    BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
+    chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace DisplayProtectedMessage
@@ -21528,8 +21528,8 @@ public:
     static constexpr CommandId GetCommandId() { return GetAlertsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
-    BitFlags<AlertCount> alertsCount;
-    DataModel::List<BitFlags<AlertStructure>> alertStructures;
+    chip::BitFlags<AlertCount> alertsCount;
+    DataModel::List<chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21540,8 +21540,8 @@ public:
     static constexpr CommandId GetCommandId() { return GetAlertsResponse::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
-    BitFlags<AlertCount> alertsCount;
-    DataModel::DecodableList<BitFlags<AlertStructure>> alertStructures;
+    chip::BitFlags<AlertCount> alertsCount;
+    DataModel::DecodableList<chip::BitFlags<AlertStructure>> alertStructures;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetAlertsResponse
@@ -21559,8 +21559,8 @@ public:
     static constexpr CommandId GetCommandId() { return AlertsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
-    BitFlags<AlertCount> alertsCount;
-    DataModel::List<BitFlags<AlertStructure>> alertStructures;
+    chip::BitFlags<AlertCount> alertsCount;
+    DataModel::List<chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21571,8 +21571,8 @@ public:
     static constexpr CommandId GetCommandId() { return AlertsNotification::Id; }
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
-    BitFlags<AlertCount> alertsCount;
-    DataModel::DecodableList<BitFlags<AlertStructure>> alertStructures;
+    chip::BitFlags<AlertCount> alertsCount;
+    DataModel::DecodableList<chip::BitFlags<AlertStructure>> alertStructures;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AlertsNotification


### PR DESCRIPTION
#### Problem
Namespace is being placed on the wrong thing: it should be on the type of the bitflags, not on the BitFlags itself.  Leads to generated types like `chip::app::Clusters::OnOff::BitFlags<something>`, which doesn't compile.

#### Change overview
Fix namespacing, so we get `chip::BitFlags<chip::app::Clusters:OnOff::something>` or equivalent.

#### Testing
Checked that with https://github.com/project-chip/connectedhomeip/pull/10606 this leads to correct code generation.