### PR TITLE
[TE7]:Add GetNetworkInterfaces/ReleaseNetworkInterfaces APIs in ConnectivityMgr

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -94,7 +94,8 @@ endif
 COMPONENT_ADD_INCLUDEDIRS +=   $(REL_OUTPUT_DIR)/src/include \
                                $(REL_CHIP_ROOT)/third_party/nlassert/repo/include \
                                $(REL_OUTPUT_DIR)/gen/third_party/connectedhomeip/src/app/include \
-                               $(REL_OUTPUT_DIR)/gen/include
+                               $(REL_OUTPUT_DIR)/gen/include \
+                               $(REL_CHIP_ROOT)/zzz_generated/app-common
 
 # Tell the ESP-IDF build system that the CHIP component defines its own build
 # and clean targets.

--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -257,6 +257,7 @@ target_include_directories(chip INTERFACE
     ${CHIP_ROOT}/src/include
     ${CHIP_ROOT}/src/lib
     ${CHIP_ROOT}/third_party/nlassert/repo/include
+    ${CHIP_ROOT}/zzz_generated/app-common
     ${CMAKE_CURRENT_BINARY_DIR}/gen/include
 )
 target_link_directories(chip INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/lib)

--- a/examples/shell/esp32/main/CMakeLists.txt
+++ b/examples/shell/esp32/main/CMakeLists.txt
@@ -25,5 +25,6 @@ idf_component_register(SRCS main.cpp
                       "${CHIP_SHELL_DIR}/shell_common/cmd_send.cpp"                      
                       PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common"
                       "${CHIP_SHELL_DIR}/shell_common/include"
                       PRIV_REQUIRES chip nvs_flash bt console esp32_mbedtls)

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -33,6 +33,7 @@ target_compile_options(app PRIVATE -Werror)
 
 target_include_directories(app PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common                           
                            ${APP_ROOT}/shell_common/include)
 
 target_sources(app PRIVATE

--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -23,7 +23,6 @@ static_library("cluster-objects") {
   ]
 
   public_deps = [
-    "${chip_root}/src/app",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -30,7 +30,6 @@
 #include <platform/CHIPDeviceEvent.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/enums.h>
 #include <app/util/basic-types.h>
 
 namespace chip {
@@ -51,8 +50,13 @@ template <class>
 class GenericPlatformManagerImpl_POSIX;
 } // namespace Internal
 
-struct NetworkInterface : public chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::Type
+// 48-bit IEEE MAC Address or a 64-bit IEEE MAC Address (e.g. EUI-64).
+constexpr size_t kMaxHardwareAddrSize = 8;
+
+struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::Type
 {
+    char Name[Inet::InterfaceIterator::kMaxIfNameLength];
+    uint8_t MacAddress[kMaxHardwareAddrSize];
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -49,6 +49,35 @@ template <class>
 class GenericPlatformManagerImpl_POSIX;
 } // namespace Internal
 
+constexpr size_t kMaxIfNameSize = 32;
+
+// 48-bit IEEE MAC Address or a 64-bit IEEE MAC Address (e.g. EUI-64).
+constexpr size_t kMaxHardwareAddrSize = 8;
+
+/**
+ * InterfaceType Types.
+ */
+enum class InterfaceType : uint8_t
+{
+    kInterfaceType_Unspecified = 0x00,
+    kInterfaceType_WiFi        = 0x01,
+    kInterfaceType_Ethernet    = 0x02,
+    kInterfaceType_Cellular    = 0x03,
+    kInterfaceType_Thread      = 0x04,
+};
+
+struct NetworkInterface
+{
+    char Name[kMaxIfNameSize];
+    bool FabricConnected;
+    bool OffPremiseServicesReachableIPv4;
+    bool OffPremiseServicesReachableIPv6;
+    bool Is64MacAddress;
+    char HardwareAddress[kMaxHardwareAddrSize];
+    InterfaceType Type;
+    struct NetworkInterface * Next; /* Pointer to the next structure.  */
+};
+
 class ConnectivityManagerImpl;
 
 /**
@@ -166,6 +195,10 @@ public:
     void ErasePersistentInfo();
     void ResetThreadNetworkDiagnosticsCounts();
     CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);
+
+    // General diagnostics methods
+    CHIP_ERROR GetNetworkInterfaces(struct NetworkInterface ** netifp);
+    void ReleaseNetworkInterfaces(struct NetworkInterface ** netifp);
 
     // Ethernet network diagnostics methods
     CHIP_ERROR GetEthPHYRate(uint8_t & pHYRate);
@@ -388,6 +421,16 @@ inline void ConnectivityManager::SetWiFiAPIdleTimeoutMS(uint32_t val)
 inline CHIP_ERROR ConnectivityManager::GetAndLogWifiStatsCounters()
 {
     return static_cast<ImplClass *>(this)->_GetAndLogWifiStatsCounters();
+}
+
+inline CHIP_ERROR ConnectivityManager::GetNetworkInterfaces(struct NetworkInterface ** netifp)
+{
+    return static_cast<ImplClass *>(this)->_GetNetworkInterfaces(netifp);
+}
+
+inline void ConnectivityManager::ReleaseNetworkInterfaces(struct NetworkInterface ** netifp)
+{
+    return static_cast<ImplClass *>(this)->_ReleaseNetworkInterfaces(netifp);
 }
 
 inline CHIP_ERROR ConnectivityManager::GetEthPHYRate(uint8_t & pHYRate)

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -29,6 +29,7 @@
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/enums.h>
 #include <app/util/basic-types.h>
 
@@ -50,14 +51,8 @@ template <class>
 class GenericPlatformManagerImpl_POSIX;
 } // namespace Internal
 
-struct NetworkInterface
+struct NetworkInterface : public chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::Type
 {
-    CharSpan Name;
-    ByteSpan HardwareAddress;
-    EmberAfInterfaceType Type;
-    bool FabricConnected;
-    bool OffPremiseServicesReachableIPv4;
-    bool OffPremiseServicesReachableIPv6;
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -59,11 +59,11 @@ constexpr size_t kMaxHardwareAddrSize = 8;
  */
 enum class InterfaceType : uint8_t
 {
-    kInterfaceType_Unspecified = 0x00,
-    kInterfaceType_WiFi        = 0x01,
-    kInterfaceType_Ethernet    = 0x02,
-    kInterfaceType_Cellular    = 0x03,
-    kInterfaceType_Thread      = 0x04,
+    Unspecified = 0x00,
+    WiFi        = 0x01,
+    Ethernet    = 0x02,
+    Cellular    = 0x03,
+    Thread      = 0x04,
 };
 
 struct NetworkInterface
@@ -75,7 +75,7 @@ struct NetworkInterface
     bool Is64MacAddress;
     char HardwareAddress[kMaxHardwareAddrSize];
     InterfaceType Type;
-    struct NetworkInterface * Next; /* Pointer to the next structure.  */
+    NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 
 class ConnectivityManagerImpl;
@@ -197,8 +197,8 @@ public:
     CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);
 
     // General diagnostics methods
-    CHIP_ERROR GetNetworkInterfaces(struct NetworkInterface ** netifp);
-    void ReleaseNetworkInterfaces(struct NetworkInterface ** netifp);
+    CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifp);
+    void ReleaseNetworkInterfaces(NetworkInterface ** netifp);
 
     // Ethernet network diagnostics methods
     CHIP_ERROR GetEthPHYRate(uint8_t & pHYRate);
@@ -423,12 +423,12 @@ inline CHIP_ERROR ConnectivityManager::GetAndLogWifiStatsCounters()
     return static_cast<ImplClass *>(this)->_GetAndLogWifiStatsCounters();
 }
 
-inline CHIP_ERROR ConnectivityManager::GetNetworkInterfaces(struct NetworkInterface ** netifp)
+inline CHIP_ERROR ConnectivityManager::GetNetworkInterfaces(NetworkInterface ** netifp)
 {
     return static_cast<ImplClass *>(this)->_GetNetworkInterfaces(netifp);
 }
 
-inline void ConnectivityManager::ReleaseNetworkInterfaces(struct NetworkInterface ** netifp)
+inline void ConnectivityManager::ReleaseNetworkInterfaces(NetworkInterface ** netifp)
 {
     return static_cast<ImplClass *>(this)->_ReleaseNetworkInterfaces(netifp);
 }

--- a/src/include/platform/internal/GenericConnectivityManagerImpl.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl.h
@@ -47,6 +47,8 @@ public:
     uint16_t _GetUserSelectedModeTimeout();
     void _SetUserSelectedModeTimeout(uint16_t val);
 
+    void _ReleaseNetworkInterfaces(struct NetworkInterface ** netifp);
+    CHIP_ERROR _GetNetworkInterfaces(struct NetworkInterface ** netifp);
     CHIP_ERROR _GetEthPHYRate(uint8_t & pHYRate);
     CHIP_ERROR _GetEthFullDuplex(bool & fullDuplex);
     CHIP_ERROR _GetEthCarrierDetect(bool & carrierDetect);
@@ -81,6 +83,16 @@ inline uint16_t GenericConnectivityManagerImpl<ImplClass>::_GetUserSelectedModeT
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl<ImplClass>::_SetUserSelectedModeTimeout(uint16_t val)
 {}
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl<ImplClass>::_ReleaseNetworkInterfaces(struct NetworkInterface ** netifp)
+{}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetNetworkInterfaces(struct NetworkInterface ** netifp)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
 
 template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthPHYRate(uint8_t & pHYRate)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl.h
@@ -47,8 +47,8 @@ public:
     uint16_t _GetUserSelectedModeTimeout();
     void _SetUserSelectedModeTimeout(uint16_t val);
 
-    void _ReleaseNetworkInterfaces(struct NetworkInterface ** netifp);
-    CHIP_ERROR _GetNetworkInterfaces(struct NetworkInterface ** netifp);
+    void _ReleaseNetworkInterfaces(NetworkInterface ** netifp);
+    CHIP_ERROR _GetNetworkInterfaces(NetworkInterface ** netifp);
     CHIP_ERROR _GetEthPHYRate(uint8_t & pHYRate);
     CHIP_ERROR _GetEthFullDuplex(bool & fullDuplex);
     CHIP_ERROR _GetEthCarrierDetect(bool & carrierDetect);
@@ -85,11 +85,11 @@ inline void GenericConnectivityManagerImpl<ImplClass>::_SetUserSelectedModeTimeo
 {}
 
 template <class ImplClass>
-inline void GenericConnectivityManagerImpl<ImplClass>::_ReleaseNetworkInterfaces(struct NetworkInterface ** netifp)
+inline void GenericConnectivityManagerImpl<ImplClass>::_ReleaseNetworkInterfaces(NetworkInterface ** netifp)
 {}
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetNetworkInterfaces(struct NetworkInterface ** netifp)
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetNetworkInterfaces(NetworkInterface ** netifp)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericConnectivityManagerImpl.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl.h
@@ -47,8 +47,8 @@ public:
     uint16_t _GetUserSelectedModeTimeout();
     void _SetUserSelectedModeTimeout(uint16_t val);
 
-    void _ReleaseNetworkInterfaces(NetworkInterface ** netifp);
-    CHIP_ERROR _GetNetworkInterfaces(NetworkInterface ** netifp);
+    void _ReleaseNetworkInterfaces(NetworkInterface * netifp);
+    CHIP_ERROR _GetNetworkInterfaces(NetworkInterface ** netifpp);
     CHIP_ERROR _GetEthPHYRate(uint8_t & pHYRate);
     CHIP_ERROR _GetEthFullDuplex(bool & fullDuplex);
     CHIP_ERROR _GetEthCarrierDetect(bool & carrierDetect);
@@ -85,11 +85,11 @@ inline void GenericConnectivityManagerImpl<ImplClass>::_SetUserSelectedModeTimeo
 {}
 
 template <class ImplClass>
-inline void GenericConnectivityManagerImpl<ImplClass>::_ReleaseNetworkInterfaces(NetworkInterface ** netifp)
+inline void GenericConnectivityManagerImpl<ImplClass>::_ReleaseNetworkInterfaces(NetworkInterface * netifp)
 {}
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetNetworkInterfaces(NetworkInterface ** netifp)
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetNetworkInterfaces(NetworkInterface ** netifpp)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -295,6 +295,7 @@ if (chip_device_platform != "none") {
     public_deps = [
       ":platform_base",
       "${chip_root}/src/app:app_buildconfig",
+      "${chip_root}/src/app/common:cluster-objects",
       "${chip_root}/src/crypto",
       "${chip_root}/src/lib/support",
     ]

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1036,15 +1036,15 @@ exit:
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
-void ConnectivityManagerImpl::_ReleaseNetworkInterfaces(struct NetworkInterface ** netifp)
+void ConnectivityManagerImpl::_ReleaseNetworkInterfaces(NetworkInterface ** netifp)
 {
     if (*netifp != nullptr)
     {
-        struct NetworkInterface * p = *netifp;
+        NetworkInterface * p = *netifp;
 
         while (p)
         {
-            struct NetworkInterface * del = p;
+            NetworkInterface * del = p;
             p                             = p->Next;
             delete del;
         }
@@ -1053,7 +1053,7 @@ void ConnectivityManagerImpl::_ReleaseNetworkInterfaces(struct NetworkInterface 
     }
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(struct NetworkInterface ** netifp)
+CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(NetworkInterface ** netifp)
 {
     CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
     struct ifaddrs * ifaddr = nullptr;
@@ -1064,7 +1064,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(struct NetworkInterfac
     }
     else
     {
-        struct NetworkInterface dummy;
+        NetworkInterface dummy;
 
         dummy.Next = nullptr;
 
@@ -1074,7 +1074,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(struct NetworkInterfac
         {
             if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_PACKET)
             {
-                struct NetworkInterface * ifp = new NetworkInterface();
+                NetworkInterface * ifp = new NetworkInterface();
 
                 strncpy(ifp->Name, ifa->ifa_name, kMaxIfNameSize);
                 ifp->Name[kMaxIfNameSize - 1] = '\0';

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1071,11 +1071,11 @@ CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(NetworkInterface ** ne
             {
                 NetworkInterface * ifp = new NetworkInterface();
 
-                ifp->Name            = CharSpan(ifa->ifa_name, strlen(ifa->ifa_name));
-                ifp->FabricConnected = ifa->ifa_flags & IFF_RUNNING;
-                ifp->Type            = ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name);
+                ifp->name            = CharSpan(ifa->ifa_name, strlen(ifa->ifa_name));
+                ifp->fabricConnected = ifa->ifa_flags & IFF_RUNNING;
+                ifp->type            = ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name);
 
-                if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, ifp->HardwareAddress) != CHIP_NO_ERROR)
+                if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, ifp->hardwareAddress) != CHIP_NO_ERROR)
                 {
                     ChipLogError(DeviceLayer, "Failed to get network hardware address");
                 }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -154,6 +154,8 @@ private:
     static std::mutex mWpaSupplicantMutex;
 #endif
 
+    void _ReleaseNetworkInterfaces(struct NetworkInterface ** netifp);
+    CHIP_ERROR _GetNetworkInterfaces(struct NetworkInterface ** netifp);
     CHIP_ERROR _GetEthPHYRate(uint8_t & pHYRate);
     CHIP_ERROR _GetEthFullDuplex(bool & fullDuplex);
     CHIP_ERROR _GetEthTimeSinceReset(uint64_t & timeSinceReset);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -154,8 +154,8 @@ private:
     static std::mutex mWpaSupplicantMutex;
 #endif
 
-    void _ReleaseNetworkInterfaces(NetworkInterface ** netifp);
-    CHIP_ERROR _GetNetworkInterfaces(NetworkInterface ** netifp);
+    void _ReleaseNetworkInterfaces(NetworkInterface * netifp);
+    CHIP_ERROR _GetNetworkInterfaces(NetworkInterface ** netifpp);
     CHIP_ERROR _GetEthPHYRate(uint8_t & pHYRate);
     CHIP_ERROR _GetEthFullDuplex(bool & fullDuplex);
     CHIP_ERROR _GetEthTimeSinceReset(uint64_t & timeSinceReset);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -154,8 +154,8 @@ private:
     static std::mutex mWpaSupplicantMutex;
 #endif
 
-    void _ReleaseNetworkInterfaces(struct NetworkInterface ** netifp);
-    CHIP_ERROR _GetNetworkInterfaces(struct NetworkInterface ** netifp);
+    void _ReleaseNetworkInterfaces(NetworkInterface ** netifp);
+    CHIP_ERROR _GetNetworkInterfaces(NetworkInterface ** netifp);
     CHIP_ERROR _GetEthPHYRate(uint8_t & pHYRate);
     CHIP_ERROR _GetEthFullDuplex(bool & fullDuplex);
     CHIP_ERROR _GetEthTimeSinceReset(uint64_t & timeSinceReset);

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -240,49 +240,102 @@ double ConnectivityUtils::ConvertFrequenceToFloat(const iw_freq * in)
     return result;
 }
 
-ConnectionType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
+bool ConnectivityUtils::CheckReachableIPv4(struct ifaddrs * ifap, const char * ifname)
 {
-    ConnectionType ret = ConnectionType::kConnectionUnknown;
-    int skfd           = -1;
+    for (struct ifaddrs * ifa = ifap; ifa; ifa = ifa->ifa_next)
+    {
+        if (strcmp(ifname, ifa->ifa_name) != 0)
+            continue;
 
-    if ((skfd = socket(AF_INET, SOCK_STREAM, 0)) == -1)
+        if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
+            return true;
+    }
+
+    return false;
+}
+
+bool ConnectivityUtils::CheckReachableIPv6(struct ifaddrs * ifap, const char * ifname)
+{
+    for (struct ifaddrs * ifa = ifap; ifa; ifa = ifa->ifa_next)
+    {
+        if (strcmp(ifname, ifa->ifa_name) != 0)
+            continue;
+
+        if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6)
+            return true;
+    }
+
+    return false;
+}
+
+InterfaceType ConnectivityUtils::GetInterfaceConnectionType(const char * ifname)
+{
+    InterfaceType ret = InterfaceType::kInterfaceType_Unspecified;
+    int sock          = -1;
+
+    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to open socket");
-        return ConnectionType::kConnectionUnknown;
+        return InterfaceType::kInterfaceType_Unspecified;
     }
 
     // Test wireless extensions for CONNECTION_WIFI
     struct iwreq pwrq = {};
     strncpy(pwrq.ifr_name, ifname, IFNAMSIZ - 1);
 
-    if (ioctl(skfd, SIOCGIWNAME, &pwrq) != -1)
+    if (ioctl(sock, SIOCGIWNAME, &pwrq) != -1)
     {
-        ret = ConnectionType::kConnectionWiFi;
+        ret = InterfaceType::kInterfaceType_WiFi;
     }
-    else
+    else if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
     {
-        // Test ethtool for CONNECTION_ETHERNET
-        if ((strncmp(ifname, "en", 2) == 0) || (strncmp(ifname, "eth", 3) == 0))
-        {
-            struct ethtool_cmd ecmd = {};
-            ecmd.cmd                = ETHTOOL_GSET;
-            struct ifreq ifr        = {};
-            ifr.ifr_data            = reinterpret_cast<char *>(&ecmd);
-            strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+        struct ethtool_cmd ecmd = {};
+        ecmd.cmd                = ETHTOOL_GSET;
+        struct ifreq ifr        = {};
+        ifr.ifr_data            = reinterpret_cast<char *>(&ecmd);
+        strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
 
-            if (ioctl(skfd, SIOCETHTOOL, &ifr) != -1)
-                ret = ConnectionType::kConnectionEthernet;
+        if (ioctl(sock, SIOCETHTOOL, &ifr) != -1)
+            ret = InterfaceType::kInterfaceType_Ethernet;
+    }
+
+    close(sock);
+
+    return ret;
+}
+
+CHIP_ERROR ConnectivityUtils::GetInterfaceHardwareAddrs(const char * ifname, char * outMacAddr)
+{
+    CHIP_ERROR err = CHIP_ERROR_READ_FAILED;
+    int skfd;
+
+    if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+    {
+        ChipLogError(DeviceLayer, "yujuan: Failed to create a channel to the NET kernel.");
+        return CHIP_ERROR_OPEN_FAILED;
+    }
+
+    if (ifname[0] != '\0')
+    {
+        struct ifreq req;
+
+        strcpy(req.ifr_name, ifname);
+        if (ioctl(skfd, SIOCGIFHWADDR, &req) != -1)
+        {
+            // Copy 48-bit IEEE MAC Address
+            memcpy(outMacAddr, req.ifr_ifru.ifru_hwaddr.sa_data, 6);
+            err = CHIP_NO_ERROR;
         }
     }
 
     close(skfd);
 
-    return ret;
+    return err;
 }
 
 CHIP_ERROR ConnectivityUtils::GetWiFiInterfaceName(char * ifname, size_t bufSize)
 {
-    CHIP_ERROR ret          = CHIP_ERROR_READ_FAILED;
+    CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
     struct ifaddrs * ifaddr = nullptr;
 
     if (getifaddrs(&ifaddr) == -1)
@@ -297,11 +350,11 @@ CHIP_ERROR ConnectivityUtils::GetWiFiInterfaceName(char * ifname, size_t bufSize
           can free list later */
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (GetInterfaceConnectionType(ifa->ifa_name) == ConnectionType::kConnectionWiFi)
+            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::kInterfaceType_WiFi)
             {
                 strncpy(ifname, ifa->ifa_name, bufSize);
                 ifname[bufSize - 1] = '\0';
-                ret                 = CHIP_NO_ERROR;
+                err                 = CHIP_NO_ERROR;
                 break;
             }
         }
@@ -309,7 +362,7 @@ CHIP_ERROR ConnectivityUtils::GetWiFiInterfaceName(char * ifname, size_t bufSize
         freeifaddrs(ifaddr);
     }
 
-    return ret;
+    return err;
 }
 
 CHIP_ERROR ConnectivityUtils::GetWiFiParameter(int skfd,            /* Socket to the kernel */
@@ -492,7 +545,7 @@ CHIP_ERROR ConnectivityUtils::GetEthInterfaceName(char * ifname, size_t bufSize)
           can free list later */
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
-            if (GetInterfaceConnectionType(ifa->ifa_name) == ConnectionType::kConnectionEthernet)
+            if (GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::kInterfaceType_Ethernet)
             {
                 strncpy(ifname, ifa->ifa_name, bufSize);
                 ifname[bufSize - 1] = '\0';

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -42,10 +42,8 @@ class ConnectivityUtils
 public:
     static uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
     static uint8_t MapFrequencyToChannel(const uint16_t frequency);
-    static bool CheckReachableIPv4(struct ifaddrs * ifap, const char * ifname);
-    static bool CheckReachableIPv6(struct ifaddrs * ifap, const char * ifname);
-    static InterfaceType GetInterfaceConnectionType(const char * ifname);
-    static CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, char * outMacAddr);
+    static EmberAfInterfaceType GetInterfaceConnectionType(const char * ifname);
+    static CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, ByteSpan & address);
     static CHIP_ERROR GetWiFiInterfaceName(char * ifname, size_t bufSize);
     static CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber);
     static CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi);

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -42,8 +42,8 @@ class ConnectivityUtils
 public:
     static uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
     static uint8_t MapFrequencyToChannel(const uint16_t frequency);
-    static EmberAfInterfaceType GetInterfaceConnectionType(const char * ifname);
-    static CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, ByteSpan & address);
+    static app::Clusters::GeneralDiagnostics::InterfaceType GetInterfaceConnectionType(const char * ifname);
+    static CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t bufSize);
     static CHIP_ERROR GetWiFiInterfaceName(char * ifname, size_t bufSize);
     static CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber);
     static CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi);

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -32,13 +32,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-enum class ConnectionType
-{
-    kConnectionUnknown,
-    kConnectionEthernet,
-    kConnectionWiFi
-};
-
 static constexpr uint16_t kWiFi_BAND_2_4_GHZ      = 2400;
 static constexpr uint16_t kWiFi_BAND_5_0_GHZ      = 5000;
 static constexpr char kWpaSupplicantServiceName[] = "fi.w1.wpa_supplicant1";
@@ -49,7 +42,10 @@ class ConnectivityUtils
 public:
     static uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
     static uint8_t MapFrequencyToChannel(const uint16_t frequency);
-    static ConnectionType GetInterfaceConnectionType(const char * ifname);
+    static bool CheckReachableIPv4(struct ifaddrs * ifap, const char * ifname);
+    static bool CheckReachableIPv6(struct ifaddrs * ifap, const char * ifname);
+    static InterfaceType GetInterfaceConnectionType(const char * ifname);
+    static CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, char * outMacAddr);
     static CHIP_ERROR GetWiFiInterfaceName(char * ifname, size_t bufSize);
     static CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber);
     static CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi);

--- a/src/platform/mbed/ConnectivityManagerImpl.cpp
+++ b/src/platform/mbed/ConnectivityManagerImpl.cpp
@@ -111,7 +111,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
     mSecurityType                 = NSAPI_SECURITY_WPA_WPA2;
 
-    NetworkInterface * net_if = NetworkInterface::get_default_instance();
+    ::NetworkInterface * net_if = ::NetworkInterface::get_default_instance();
     if (net_if == nullptr)
     {
         ChipLogError(DeviceLayer, "No network interface available");

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -78,6 +78,10 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
     if (current_os == "zephyr" || current_os == "android") {
       test_sources += [ "TestKeyValueStoreMgr.cpp" ]
     }
+
+    if (chip_device_platform == "linux") {
+      test_sources += [ "TestConnectivityMgr.cpp" ]
+    }
   }
 } else {
   import("${chip_root}/build/chip/chip_test_group.gni")

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -1,0 +1,107 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for the Connectivity Manager
+ *      code functionality.
+ *
+ */
+
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace chip;
+using namespace chip::Logging;
+using namespace chip::Inet;
+using namespace chip::DeviceLayer;
+
+// =================================
+//      Unit tests
+// =================================
+
+static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
+{
+    // ConfigurationManager is initialized from PlatformManager indirectly
+    CHIP_ERROR err = PlatformMgr().InitChipStack();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+static void TestConnectivityMgr_GetNetworkInterfaces(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    NetworkInterface * netifs = nullptr;
+
+    err = ConnectivityMgr().GetNetworkInterfaces(&netifs);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, netifs != nullptr);
+
+    ConnectivityMgr().ReleaseNetworkInterfaces(&netifs);
+    NL_TEST_ASSERT(inSuite, netifs == nullptr);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = {
+
+    NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
+    NL_TEST_DEF("Test ConfigurationMgr::GetNetworkInterfaces", TestConnectivityMgr_GetNetworkInterfaces), NL_TEST_SENTINEL()
+};
+
+/**
+ *  Set up the test suite.
+ */
+int TestConnectivityMgr_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestConnectivityMgr_Teardown(void * inContext)
+{
+    PlatformMgr().Shutdown();
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+int TestConnectivityMgr()
+{
+    nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConnectivityMgr_Setup, TestConnectivityMgr_Teardown };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestConnectivityMgr)

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -61,8 +61,7 @@ static void TestConnectivityMgr_GetNetworkInterfaces(nlTestSuite * inSuite, void
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, netifs != nullptr);
 
-    ConnectivityMgr().ReleaseNetworkInterfaces(&netifs);
-    NL_TEST_ASSERT(inSuite, netifs == nullptr);
+    ConnectivityMgr().ReleaseNetworkInterfaces(netifs);
 }
 
 /**


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We need APIs to retrieve current network interfaces from the platform, this is needed for General Diagnostics.

#### Change overview
Add GetNetworkInterfaces/ReleaseNetworkInterfaces APIs in ConnectivityMgr

#### Testing
How was this tested? (at least one bullet point required)
* New unit tests were added to cover these APIs.
