### PR TITLE
Add a way to Get() a CharSpan from a TLVReader.

### DIFF
--- a/src/app/data-model/Decode.h
+++ b/src/app/data-model/Decode.h
@@ -71,12 +71,7 @@ inline CHIP_ERROR Decode(TLV::TLVReader & reader, ByteSpan & x)
 //
 inline CHIP_ERROR Decode(TLV::TLVReader & reader, Span<const char> & x)
 {
-    ByteSpan bs;
-
-    VerifyOrReturnError(reader.GetType() == TLV::kTLVType_UTF8String, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
-    ReturnErrorOnFailure(reader.Get(bs));
-    x = Span<const char>(Uint8::to_const_char(bs.data()), bs.size());
-    return CHIP_NO_ERROR;
+    return reader.Get(x);
 }
 
 /*

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -455,7 +455,7 @@ public:
     CHIP_ERROR Get(float & v);
 
     /**
-     * Get the value of the current element as a chip::ByteSpan
+     * Get the value of the current element as a ByteSpan
      *
      * @param[out]  v                       Receives the value associated with current TLV element.
      *
@@ -464,7 +464,19 @@ public:
      *                                      the reader is not positioned on an element.
      *
      */
-    CHIP_ERROR Get(chip::ByteSpan & v);
+    CHIP_ERROR Get(ByteSpan & v);
+
+    /**
+     * Get the value of the current element as a CharSpan
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV character string, or
+     *                                      the reader is not positioned on an element.
+     *
+     */
+    CHIP_ERROR Get(CharSpan & v);
 
     /**
      * Get the value of the current element as an enum value, if it's an integer
@@ -2415,7 +2427,8 @@ public:
     CHIP_ERROR Get(uint64_t & v) { return mUpdaterReader.Get(v); }
     CHIP_ERROR Get(float & v) { return mUpdaterReader.Get(v); }
     CHIP_ERROR Get(double & v) { return mUpdaterReader.Get(v); }
-    CHIP_ERROR Get(chip::ByteSpan & v) { return mUpdaterReader.Get(v); }
+    CHIP_ERROR Get(ByteSpan & v) { return mUpdaterReader.Get(v); }
+    CHIP_ERROR Get(CharSpan & v) { return mUpdaterReader.Get(v); }
 
     CHIP_ERROR GetBytes(uint8_t * buf, uint32_t bufSize) { return mUpdaterReader.GetBytes(buf, bufSize); }
     CHIP_ERROR DupBytes(uint8_t *& buf, uint32_t & dataLen) { return mUpdaterReader.DupBytes(buf, dataLen); }

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -298,6 +298,19 @@ CHIP_ERROR TLVReader::Get(ByteSpan & v)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR TLVReader::Get(CharSpan & v)
+{
+    if (!TLVTypeIsUTF8String(ElementType()))
+    {
+        return CHIP_ERROR_WRONG_TLV_TYPE;
+    }
+
+    const uint8_t * bytes;
+    ReturnErrorOnFailure(GetDataPtr(bytes)); // Does length sanity checks
+    v = CharSpan(Uint8::to_const_char(bytes), GetLength());
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, size_t bufSize)
 {
     if (!TLVTypeIsString(ElementType()))
@@ -949,15 +962,7 @@ CHIP_ERROR ContiguousBufferTLVReader::OpenContainer(ContiguousBufferTLVReader & 
 
 CHIP_ERROR ContiguousBufferTLVReader::GetStringView(Span<const char> & data)
 {
-    if (!TLVTypeIsUTF8String(ElementType()))
-    {
-        return CHIP_ERROR_WRONG_TLV_TYPE;
-    }
-
-    const uint8_t * bytes;
-    ReturnErrorOnFailure(GetDataPtr(bytes)); // Does length sanity checks
-    data = Span<const char>(Uint8::to_const_char(bytes), GetLength());
-    return CHIP_NO_ERROR;
+    return Get(data);
 }
 
 CHIP_ERROR ContiguousBufferTLVReader::GetByteView(ByteSpan & data)


### PR DESCRIPTION
This parallels the equivalent we have for ByteSpan.

Can be removed once more consumers are converter to the contiguous
buffer reader.

#### Problem
No good way inside some zap templates to read a CharSpan from a TLVReader.

#### Change overview
Add one.

#### Testing
Just moving code around from the existing Decode() method.