### PR TITLE
Fix cloudbuild: building "all" now includes AmebaD which requires newer Docker image

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,6 +1,6 @@
 # NOTE: /workspace/ is the persistent directory across steps
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.15"
+    - name: "connectedhomeip/chip-build-vscode:0.5.17"
       id: "CompileAll"
       entrypoint: "./scripts/run_in_build_env.sh"
       args:


### PR DESCRIPTION
#### Problem
build-all includes now AmebaD, however that build requires 0.5.17 docker image.

#### Change overview
Bump cloudbuild to 0.5.17 (only cloudbuild for now, #10619  includes the rest)

#### Testing
Cloud build CI will validate this.
