### PR TITLE
Fix compile error if disable CHIP_DEVICE_CONFIG_ENABLE_WPA

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -220,8 +220,10 @@ ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
     mWiFiStationMode                = kWiFiStationMode_Disabled;
     mWiFiStationReconnectIntervalMS = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
+#endif
 
     if (ConnectivityUtils::GetEthInterfaceName(mEthIfName, IFNAMSIZ) == CHIP_NO_ERROR)
     {
@@ -877,11 +879,9 @@ void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void 
 {
     sInstance.DriveAPState();
 }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, const char * key)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
     CHIP_ERROR ret  = CHIP_NO_ERROR;
     GError * err    = nullptr;
     GVariant * args = nullptr;
@@ -1025,10 +1025,8 @@ exit:
         g_error_free(err);
 
     return ret;
-#else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#endif
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 CHIP_ERROR ConnectivityManagerImpl::_GetEthPHYRate(uint8_t & pHYRate)
 {

--- a/src/platform/Linux/DeviceNetworkProvisioningDelegateImpl.cpp
+++ b/src/platform/Linux/DeviceNetworkProvisioningDelegateImpl.cpp
@@ -29,7 +29,11 @@ CHIP_ERROR DeviceNetworkProvisioningDelegateImpl::_ProvisionWiFiNetwork(const ch
 
     ChipLogProgress(NetworkProvisioning, "LinuxNetworkProvisioningDelegate: SSID: %s", ssid);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
     err = ConnectivityMgrImpl().ProvisionWiFiNetwork(ssid, key);
+#else
+    err = CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
 
     if (err != CHIP_NO_ERROR)
     {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* ToT broken on disabled CHIP_DEVICE_CONFIG_ENABLE_WPA 
* Fixes #10576 

#### Change overview
Fix compile error if disable CHIP_DEVICE_CONFIG_ENABLE_WPA

#### Testing
How was this tested? (at least one bullet point required)
* Disable CHIP_DEVICE_CONFIG_ENABLE_WPA and confirm gn_build pass.