### PR TITLE
Fix setup paylod generated on opening commissioning window using ECM

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -344,7 +344,7 @@ CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration,
     }
 
     setupPayload.version               = 0;
-    setupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kBLE);
+    setupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
* Fixes #9964

#### Change overview
The generated SetupCode had `kBLE` as the `RendezvousInformationFlag`. Updated it to `kOnNetwork`.

#### Testing
Confirmed by running controller application that the generated QR code has correct discovery flag.
