### PR TITLE
[TE7]:Support read attribute with complex type for general diagnostic cluster

### DIFF
--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -16,15 +16,19 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/AttributeAccessInterface.h>
 #include <app/util/attribute-storage.h>
+#include <platform/ConnectivityManager.h>
 #include <platform/PlatformManager.h>
 
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::GeneralDiagnostics::Attributes;
+using chip::DeviceLayer::ConnectivityMgr;
 using chip::DeviceLayer::PlatformManager;
 
 namespace {
@@ -40,6 +44,7 @@ public:
 private:
     template <typename T>
     CHIP_ERROR ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &), AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadNetworkInterfaces(AttributeValueEncoder & aEncoder);
 };
 
 template <typename T>
@@ -60,6 +65,27 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformMana
     return aEncoder.Encode(data);
 }
 
+CHIP_ERROR GeneralDiagosticsAttrAccess::ReadNetworkInterfaces(AttributeValueEncoder & aEncoder)
+{
+    DeviceLayer::NetworkInterface * netifs;
+
+    ReturnErrorOnFailure(ConnectivityMgr().GetNetworkInterfaces(&netifs));
+
+    CHIP_ERROR err = aEncoder.EncodeList([&netifs](const TagBoundEncoder & encoder) -> CHIP_ERROR {
+        for (DeviceLayer::NetworkInterface * ifp = netifs; ifp != nullptr; ifp = ifp->Next)
+        {
+            GeneralDiagnostics::Structs::NetworkInterfaceType::Type * networkInterface = ifp;
+            ReturnErrorOnFailure(encoder.Encode(*networkInterface));
+        }
+
+        return CHIP_NO_ERROR;
+    });
+
+    ConnectivityMgr().ReleaseNetworkInterfaces(netifs);
+
+    return err;
+}
+
 GeneralDiagosticsAttrAccess gAttrAccess;
 
 CHIP_ERROR GeneralDiagosticsAttrAccess::Read(const ConcreteAttributePath & aPath, AttributeValueEncoder & aEncoder)
@@ -72,6 +98,9 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::Read(const ConcreteAttributePath & aPath
 
     switch (aPath.mAttributeId)
     {
+    case NetworkInterfaces::Id: {
+        return ReadNetworkInterfaces(aEncoder);
+    }
     case RebootCount::Id: {
         return ReadIfSupported(&PlatformManager::GetRebootCount, aEncoder);
     }

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -74,8 +74,7 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::ReadNetworkInterfaces(AttributeValueEnco
     CHIP_ERROR err = aEncoder.EncodeList([&netifs](const TagBoundEncoder & encoder) -> CHIP_ERROR {
         for (DeviceLayer::NetworkInterface * ifp = netifs; ifp != nullptr; ifp = ifp->Next)
         {
-            GeneralDiagnostics::Structs::NetworkInterfaceType::Type * networkInterface = ifp;
-            ReturnErrorOnFailure(encoder.Encode(*networkInterface));
+            ReturnErrorOnFailure(encoder.Encode(*ifp));
         }
 
         return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Attribute 'NetworkInterfaces' in general diagnostic cluster is mandatory and we need to support. Right now, we can create them on-the-fly using AttributeAccessInterface interface when read.


#### Change overview
Support read attribute with complex type for general diagnostic cluster

Please note, this PR contains the platform change in https://github.com/project-chip/connectedhomeip/pull/10622.

#### Testing
How was this tested? (at least one bullet point required)
* Client side to read complex type is not ready, verify with debug python-device-controller
```
chip-device-ctrl > zclread GeneralDiagnostics NetworkInterfaces 12344321 0 0
[1634615923.778182][1228212:1228220] CHIP:DMG: SendReadRequest: Client[0] [ INIT]
[1634615923.778389][1228212:1228220] CHIP:IN: Prepared encrypted message 0x26a9930 to 0x0000000000BC5C01 of type 0x2 and protocolId (0, 1) on exchange 36537i with MessageCounter:14.
[1634615923.778484][1228212:1228220] CHIP:IN: Sending encrypted msg 0x26a9930 with MessageCounter:14 to 0x0000000000BC5C01 at monotonic time: 735441328 msec
[1634615923.778674][1228212:1228220] CHIP:DMG: Client[0] moving to [AwaitingInitialReport]
[1634615923.783194][1228212:1228220] CHIP:EM: Received message of type 0x5 with protocolId (0, 1) and MessageCounter:9 on exchange 36537i
[1634615923.783217][1228212:1228220] CHIP:EM: Rxd Ack; Removing MessageCounter:14 from Retrans Table on exchange 36537i
[1634615923.783225][1228212:1228220] CHIP:EM: Removed CHIP MessageCounter:14 from RetransTable on exchange 36537i
[1634615923.783245][1228212:1228220] CHIP:DMG: ReportData =
[1634615923.783254][1228212:1228220] CHIP:DMG: {
[1634615923.783260][1228212:1228220] CHIP:DMG:  AttributeDataList =
[1634615923.783269][1228212:1228220] CHIP:DMG:  [
[1634615923.783276][1228212:1228220] CHIP:DMG:    AttributeDataElement =
[1634615923.783284][1228212:1228220] CHIP:DMG:    {
[1634615923.783292][1228212:1228220] CHIP:DMG:      AttributePath =
[1634615923.783301][1228212:1228220] CHIP:DMG:      {
[1634615923.783310][1228212:1228220] CHIP:DMG:        NodeId = 0xbc5c01,
[1634615923.783319][1228212:1228220] CHIP:DMG:        EndpointId = 0x0,
[1634615923.783328][1228212:1228220] CHIP:DMG:        ClusterId = 0x33,
[1634615923.783338][1228212:1228220] CHIP:DMG:        FieldTag = 0x0,
[1634615923.783347][1228212:1228220] CHIP:DMG:      }
[1634615923.783359][1228212:1228220] CHIP:DMG:        
[1634615923.783366][1228212:1228220] CHIP:DMG:      Data = [
[1634615923.783376][1228212:1228220] CHIP:DMG:        
[1634615923.783384][1228212:1228220] CHIP:DMG:        {
[1634615923.783407][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.783420][1228212:1228220] CHIP:DMG:            0x62, 0x72, 0x2d, 0x33, 0x61, 0x61, 0x30, 0x38, 0x36, 0x36, 0x64, 0x31, 0x32, 0x61, 0x37, 
[1634615923.783431][1228212:1228220] CHIP:DMG:          ]
[1634615923.783443][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.783451][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.783463][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.783472][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.783483][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0xd2, 0xaa, 0xe3, 0x62, 
[1634615923.783495][1228212:1228220] CHIP:DMG:          ]
[1634615923.783505][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.783514][1228212:1228220] CHIP:DMG:        },
[1634615923.783524][1228212:1228220] CHIP:DMG:        {
[1634615923.783533][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.783546][1228212:1228220] CHIP:DMG:            0x62, 0x72, 0x2d, 0x63, 0x65, 0x65, 0x63, 0x62, 0x30, 0x35, 0x65, 0x37, 0x31, 0x37, 0x31, 
[1634615923.783557][1228212:1228220] CHIP:DMG:          ]
[1634615923.783567][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.783575][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.783586][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.783595][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.783605][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0xb3, 0x70, 0x8, 0x4a, 
[1634615923.783615][1228212:1228220] CHIP:DMG:          ]
[1634615923.783626][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.783635][1228212:1228220] CHIP:DMG:        },
[1634615923.783643][1228212:1228220] CHIP:DMG:        {
[1634615923.783651][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.783664][1228212:1228220] CHIP:DMG:            0x62, 0x72, 0x2d, 0x63, 0x64, 0x61, 0x66, 0x30, 0x30, 0x63, 0x32, 0x65, 0x38, 0x30, 0x31, 
[1634615923.783675][1228212:1228220] CHIP:DMG:          ]
[1634615923.783685][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.783695][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.783705][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.783715][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.783725][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0x1a, 0xe8, 0x4a, 0x99, 
[1634615923.783737][1228212:1228220] CHIP:DMG:          ]
[1634615923.783749][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.783758][1228212:1228220] CHIP:DMG:        },
[1634615923.783767][1228212:1228220] CHIP:DMG:        {
[1634615923.783776][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.783788][1228212:1228220] CHIP:DMG:            0x62, 0x72, 0x2d, 0x62, 0x30, 0x65, 0x32, 0x30, 0x62, 0x36, 0x64, 0x66, 0x63, 0x34, 0x36, 
[1634615923.783799][1228212:1228220] CHIP:DMG:          ]
[1634615923.783808][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.783819][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.783829][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.783839][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.783849][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0xa4, 0xea, 0x2b, 0xf1, 
[1634615923.783861][1228212:1228220] CHIP:DMG:          ]
[1634615923.783870][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.783880][1228212:1228220] CHIP:DMG:        },
[1634615923.783889][1228212:1228220] CHIP:DMG:        {
[1634615923.783897][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.783907][1228212:1228220] CHIP:DMG:            0x64, 0x6f, 0x63, 0x6b, 0x65, 0x72, 0x30, 
[1634615923.783918][1228212:1228220] CHIP:DMG:          ]
[1634615923.783927][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.783938][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.783947][1228212:1228220] CHIP:DMG:          0x3 = true, 
[1634615923.783957][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.783968][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0xf1, 0xbf, 0x30, 0x81, 
[1634615923.783980][1228212:1228220] CHIP:DMG:          ]
[1634615923.783989][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.783999][1228212:1228220] CHIP:DMG:        },
[1634615923.784009][1228212:1228220] CHIP:DMG:        {
[1634615923.784016][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.784027][1228212:1228220] CHIP:DMG:            0x62, 0x72, 0x2d, 0x35, 0x39, 0x34, 0x66, 0x65, 0x32, 0x65, 0x38, 0x37, 0x61, 0x66, 0x35, 
[1634615923.784038][1228212:1228220] CHIP:DMG:          ]
[1634615923.784048][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.784058][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.784068][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.784077][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.784087][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0x22, 0x4, 0xbd, 0x4c, 
[1634615923.784098][1228212:1228220] CHIP:DMG:          ]
[1634615923.784108][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.784118][1228212:1228220] CHIP:DMG:        },
[1634615923.784127][1228212:1228220] CHIP:DMG:        {
[1634615923.784137][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.784148][1228212:1228220] CHIP:DMG:            0x62, 0x72, 0x2d, 0x34, 0x61, 0x36, 0x61, 0x38, 0x33, 0x65, 0x65, 0x38, 0x66, 0x31, 0x38, 
[1634615923.784159][1228212:1228220] CHIP:DMG:          ]
[1634615923.784169][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.784179][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.784189][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.784199][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.784208][1228212:1228220] CHIP:DMG:            0x2, 0x42, 0x8d, 0x78, 0xe6, 0x6d, 
[1634615923.784218][1228212:1228220] CHIP:DMG:          ]
[1634615923.784228][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.784236][1228212:1228220] CHIP:DMG:        },
[1634615923.784246][1228212:1228220] CHIP:DMG:        {
[1634615923.784255][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.784265][1228212:1228220] CHIP:DMG:            0x77, 0x6c, 0x70, 0x33, 0x73, 0x30, 
[1634615923.784276][1228212:1228220] CHIP:DMG:          ]
[1634615923.784285][1228212:1228220] CHIP:DMG:          0x1 = true, 
[1634615923.784296][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.784306][1228212:1228220] CHIP:DMG:          0x3 = true, 
[1634615923.784314][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.784325][1228212:1228220] CHIP:DMG:            0xb0, 0xa4, 0x60, 0xe, 0xcf, 0xae, 
[1634615923.784335][1228212:1228220] CHIP:DMG:          ]
[1634615923.784346][1228212:1228220] CHIP:DMG:          0x5 = 1, 
[1634615923.784355][1228212:1228220] CHIP:DMG:        },
[1634615923.784365][1228212:1228220] CHIP:DMG:        {
[1634615923.784375][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.784385][1228212:1228220] CHIP:DMG:            0x65, 0x6e, 0x70, 0x31, 0x73, 0x30, 
[1634615923.784397][1228212:1228220] CHIP:DMG:          ]
[1634615923.784406][1228212:1228220] CHIP:DMG:          0x1 = false, 
[1634615923.784416][1228212:1228220] CHIP:DMG:          0x2 = false, 
[1634615923.784426][1228212:1228220] CHIP:DMG:          0x3 = false, 
[1634615923.784436][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.784446][1228212:1228220] CHIP:DMG:            0x5c, 0x85, 0x7e, 0x48, 0x5e, 0xac, 
[1634615923.784456][1228212:1228220] CHIP:DMG:          ]
[1634615923.784467][1228212:1228220] CHIP:DMG:          0x5 = 2, 
[1634615923.784476][1228212:1228220] CHIP:DMG:        },
[1634615923.784482][1228212:1228220] CHIP:DMG:        {
[1634615923.784489][1228212:1228220] CHIP:DMG:          0x0 = [
[1634615923.784495][1228212:1228220] CHIP:DMG:            0x6c, 0x6f, 
[1634615923.784502][1228212:1228220] CHIP:DMG:          ]
[1634615923.784509][1228212:1228220] CHIP:DMG:          0x1 = true, 
[1634615923.784515][1228212:1228220] CHIP:DMG:          0x2 = true, 
[1634615923.784522][1228212:1228220] CHIP:DMG:          0x3 = true, 
[1634615923.784528][1228212:1228220] CHIP:DMG:          0x4 = [
[1634615923.784534][1228212:1228220] CHIP:DMG:            0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
[1634615923.784542][1228212:1228220] CHIP:DMG:          ]
[1634615923.784548][1228212:1228220] CHIP:DMG:          0x5 = 0, 
[1634615923.784554][1228212:1228220] CHIP:DMG:        },
[1634615923.784560][1228212:1228220] CHIP:DMG:      ],
[1634615923.784566][1228212:1228220] CHIP:DMG:      DataElementVersion = 0x0,
[1634615923.784571][1228212:1228220] CHIP:DMG:    },
[1634615923.784594][1228212:1228220] CHIP:DMG:    
[1634615923.784599][1228212:1228220] CHIP:DMG:  ],
[1634615923.784620][1228212:1228220] CHIP:DMG:  
[1634615923.784625][1228212:1228220] CHIP:DMG: }
[1634615923.785190][1228212:1228220] CHIP:ZCL: ReadAttributesResponse:
[1634615923.785198][1228212:1228220] CHIP:ZCL:   ClusterId: 0x0000_0033
[1634615923.785204][1228212:1228220] CHIP:ZCL:   attributeId: 0x0000_0000
[1634615923.785208][1228212:1228220] CHIP:ZCL:   status: Success                (0x0000)
[1634615923.785213][1228212:1228220] CHIP:ZCL:   attribute TLV Type: 0x16
[1634615923.785258][1228212:1228220] CHIP:EM: Piggybacking Ack for MessageCounter:9 on exchange: 36537i
[1634615923.785274][1228212:1228220] CHIP:IN: Prepared encrypted message 0x26a9930 to 0x0000000000BC5C01 of type 0x1 and protocolId (0, 1) on exchange 36537i with MessageCounter:15.
[1634615923.785284][1228212:1228220] CHIP:IN: Sending encrypted msg 0x26a9930 with MessageCounter:15 to 0x0000000000BC5C01 at monotonic time: 735441335 msec
AttributeReadResult(path=AttributePath(nodeId=12344321, endpointId=0, clusterId=51, attributeId=0), status=0, value=[{0: b'br-3aa0866d12a7', 1: False, 2: True, 3: False, 4: b'\x02B\xd2\xaa\xe3b', 5: 0}, {0: b'br-ceecb05e7171', 1: False, 2: True, 3: False, 4: b'\x02B\xb3p\x08J', 5: 0}, {0: b'br-cdaf00c2e801', 1: False, 2: True, 3: False, 4: b'\x02B\x1a\xe8J\x99', 5: 0}, {0: b'br-b0e20b6dfc46', 1: False, 2: True, 3: False, 4: b'\x02B\xa4\xea+\xf1', 5: 0}, {0: b'docker0', 1: False, 2: True, 3: True, 4: b'\x02B\xf1\xbf0\x81', 5: 0}, {0: b'br-594fe2e87af5', 1: False, 2: True, 3: False, 4: b'\x02B"\x04\xbdL', 5: 0}, {0: b'br-4a6a83ee8f18', 1: False, 2: True, 3: False, 4: b'\x02B\x8dx\xe6m', 5: 0}, {0: b'wlp3s0', 1: True, 2: True, 3: True, 4: b'\xb0\xa4`\x0e\xcf\xae', 5: 1}, {0: b'enp1s0', 1: False, 2: False, 3: False, 4: b'\\\x85~H^\xac', 5: 2}, {0: b'lo', 1: True, 2: True, 3: True, 4: b'\x00\x00\x00\x00\x00\x00', 5: 0}])

```
