### PR TITLE
Fix Mbed docker image for CI

### DIFF
--- a/integrations/docker/images/chip-build-mbed-os/Dockerfile
+++ b/integrations/docker/images/chip-build-mbed-os/Dockerfile
@@ -34,6 +34,5 @@ RUN set -x \
 # ------------------------------------------------------------------------------
 # Configure environment variables
 ENV OPENOCD_PATH=/opt/openocd/
-ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 
 ENV PATH="${PATH}:${OPENOCD_PATH}/bin"

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.17 Version bump reason: Add for Ameba platform
+0.5.18 Version bump reason: Fix Mbed docker image for CI


### PR DESCRIPTION
#### Problem
The Mbed OS docker image included the PW_ENVIRONMENT_ROOT definition which causes that the default .environment directory is not created when we used the Mbed OS docker image directly. The CI workflow scripts refer to the .environment directory and that causes the fault.
PW_ENVIRONMENT_ROOT definition is redundant so we can remove it.

The issue is identified during #10619 and was caused by #9432 PR. 

#### Change overview
Remove PW_ENVIRONMENT_ROOT  env from Mbed docker image

#### Testing
Locally build and tested
