### PR TITLE
[Ameba] Remove python2 from dockerfile

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -9,6 +9,7 @@ RUN set -x \
     && cd ${AMEBA_DIR} \
     && git clone --depth 1 --progress -b cmake_build https://github.com/pankore/ambd_sdk_with_chip_non_NDA.git \
     && cd ambd_sdk_with_chip_non_NDA \
+    && git pull \
     && git reset --hard 299dd4a \
     && git submodule update --depth 1 --init --progress \
     && : # last line

--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -9,6 +9,7 @@ RUN set -x \
     && cd ${AMEBA_DIR} \
     && git clone --depth 1 --progress -b cmake_build https://github.com/pankore/ambd_sdk_with_chip_non_NDA.git \
     && cd ambd_sdk_with_chip_non_NDA \
+    && git reset --hard 299dd4a \
     && git submodule update --depth 1 --init --progress \
     && : # last line
 

--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -9,7 +9,6 @@ RUN set -x \
     && cd ${AMEBA_DIR} \
     && git clone --depth 1 --progress -b cmake_build https://github.com/pankore/ambd_sdk_with_chip_non_NDA.git \
     && cd ambd_sdk_with_chip_non_NDA \
-    && git pull \
     && git reset --hard 299dd4a \
     && git submodule update --depth 1 --init --progress \
     && : # last line

--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -5,12 +5,10 @@ FROM connectedhomeip/chip-build:${VERSION}
 ARG AMEBA_DIR=/opt/ameba
 RUN set -x \
     && apt-get update \
-    && apt-get --no-install-recommends -y install python2 \
     && mkdir ${AMEBA_DIR} \
     && cd ${AMEBA_DIR} \
     && git clone --depth 1 --progress -b cmake_build https://github.com/pankore/ambd_sdk_with_chip_non_NDA.git \
     && cd ambd_sdk_with_chip_non_NDA \
-    && git pull \
     && git submodule update --depth 1 --init --progress \
     && : # last line
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.18 Version bump reason: Fix Mbed docker image for CI
+0.5.19 Update AmebaD to not require python2 anymore

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.19 Update AmebaD to not require python2 anymore
+0.5.19 Version bump reason: Update AmebaD to not require python2 anymore


### PR DESCRIPTION
#### Problem
To be aligned with the change applied in ameba sdk for fixing the 'python2: not found' issue in vscode instance build.

#### Change overview
Modification on dockerfile.

#### Testing
Tested with build_examples build without python2 installed.