### PR TITLE
[Cleanup] Remove some usage of cluster-id.h to use ids/Clusters.h instead

### DIFF
--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -18,13 +18,7 @@
 
 #pragma once
 
-//#include <zap-generated/attribute-id.h>
-//#include <zap-generated/cluster-id.h>
-//#include <app/chip-zcl-zpro-codec.h>
-//#include <app/util/af-types.h>
-//#include <app/util/af.h>
 #include <app/util/attribute-storage.h>
-//#include <app/util/util.h>
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/examples/common/pigweed/rpc_services/Locking.h
+++ b/examples/common/pigweed/rpc_services/Locking.h
@@ -21,9 +21,8 @@
 #include "app/util/attribute-storage.h"
 #include "locking_service/locking_service.rpc.pb.h"
 #include "pigweed/rpc_services/internal/StatusUtils.h"
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 
 namespace chip {
 namespace rpc {
@@ -36,16 +35,14 @@ public:
     virtual pw::Status Set(ServerContext &, const chip_rpc_LockingState & request, pw_protobuf_Empty & response)
     {
         uint8_t locked = request.locked;
-        RETURN_STATUS_IF_NOT_OK(emberAfWriteServerAttribute(kEndpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, &locked,
-                                                            ZCL_BOOLEAN_ATTRIBUTE_TYPE));
+        RETURN_STATUS_IF_NOT_OK(app::Clusters::OnOff::Attributes::OnOff::Set(kEndpoint, locked));
         return pw::OkStatus();
     }
 
     virtual pw::Status Get(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_LockingState & response)
     {
         uint8_t locked;
-        RETURN_STATUS_IF_NOT_OK(
-            emberAfReadServerAttribute(kEndpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, &locked, sizeof(locked)));
+        RETURN_STATUS_IF_NOT_OK(app::Clusters::OnOff::Attributes::OnOff::Get(kEndpoint, &locked));
         response.locked = locked;
         return pw::OkStatus();
     }

--- a/examples/tv-app/linux/include/wake-on-lan/WakeOnLanManager.cpp
+++ b/examples/tv-app/linux/include/wake-on-lan/WakeOnLanManager.cpp
@@ -18,10 +18,9 @@
 
 #include "WakeOnLanManager.h"
 
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/command-id.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/basic-types.h>
@@ -34,6 +33,7 @@
 #include <sstream>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 
 CHIP_ERROR WakeOnLanManager::Init()
 {
@@ -51,9 +51,8 @@ void WakeOnLanManager::store(chip::EndpointId endpoint, char macAddress[32])
     uint8_t bufferMemory[32];
     MutableByteSpan zclString(bufferMemory);
     MakeZclCharString(zclString, macAddress);
-    EmberAfStatus macAddressStatus =
-        emberAfWriteServerAttribute(endpoint, ZCL_WAKE_ON_LAN_CLUSTER_ID, ZCL_WAKE_ON_LAN_MAC_ADDRESS_ATTRIBUTE_ID,
-                                    zclString.data(), ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+    EmberAfStatus macAddressStatus = emberAfWriteServerAttribute(
+        endpoint, WakeOnLan::Id, WakeOnLan::Attributes::WakeOnLanMacAddress::Id, zclString.data(), ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
     if (macAddressStatus != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Failed to store mac address attribute.");

--- a/src/app/clusters/binary-input-server/binary-input-server.cpp
+++ b/src/app/clusters/binary-input-server/binary-input-server.cpp
@@ -19,14 +19,15 @@
 
 #include <app/util/af.h>
 
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 
 #ifndef emberAfBinaryInputBasicClusterPrintln
 #define emberAfBinaryInputBasicClusterPrintln(...) ChipLogProgress(Zcl, __VA_ARGS__);
@@ -34,24 +35,24 @@ using namespace chip;
 
 EmberAfStatus emberAfBinaryInputBasicClusterGetPresentValue(EndpointId endpoint, bool * presentValue)
 {
-    return emberAfReadServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_PRESENT_VALUE_ATTRIBUTE_ID,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, BinaryInputBasic::Attributes::PresentValue::Id,
                                       (uint8_t *) presentValue, sizeof(uint8_t));
 }
 
 EmberAfStatus emberAfBinaryInputBasicClusterGetOutOfService(EndpointId endpoint, bool * isOutOfService)
 {
-    return emberAfReadServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_OUT_OF_SERVICE_ATTRIBUTE_ID,
+    return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, BinaryInputBasic::Attributes::OutOfService::Id,
                                       (uint8_t *) isOutOfService, sizeof(uint8_t));
 }
 
 EmberAfStatus emberAfBinaryInputBasicClusterSetPresentValueCallback(EndpointId endpoint, bool presentValue)
 {
-    return emberAfWriteServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_PRESENT_VALUE_ATTRIBUTE_ID,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, BinaryInputBasic::Attributes::PresentValue::Id,
                                        (uint8_t *) &presentValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 EmberAfStatus emberAfBinaryInputBasicClusterSetOutOfServiceCallback(EndpointId endpoint, bool isOutOfService)
 {
-    return emberAfWriteServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_OUT_OF_SERVICE_ATTRIBUTE_ID,
+    return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, BinaryInputBasic::Attributes::OutOfService::Id,
                                        (uint8_t *) &isOutOfService, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -21,15 +21,17 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/command-id.h>
 #include <app-common/zap-generated/enums.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app-common/zap-generated/ids/Commands.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::KeypadInput;
 
 EmberAfKeypadInputStatus keypadInputClusterSendKey(EmberAfKeypadInputCecKeyCode keyCode);
@@ -37,8 +39,8 @@ EmberAfKeypadInputStatus keypadInputClusterSendKey(EmberAfKeypadInputCecKeyCode 
 static void sendResponse(app::CommandHandler * command, EmberAfKeypadInputStatus keypadInputStatus)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_KEYPAD_INPUT_CLUSTER_ID,
-                                         ZCL_SEND_KEY_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, KeypadInput::Id,
+                                         KeypadInput::Commands::SendKeyResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
 
     VerifyOrExit(command != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/power-source-server/power-source-server.cpp
+++ b/src/app/clusters/power-source-server/power-source-server.cpp
@@ -34,10 +34,6 @@
 
 #include "power-source-server.h"
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/CommandHandler.h>
 #include <app/reporting/reporting.h>
 #include <app/util/af-event.h>

--- a/src/app/clusters/pump-configuration-and-control-client/pump-configuration-and-control-client.cpp
+++ b/src/app/clusters/pump-configuration-and-control-client/pump-configuration-and-control-client.cpp
@@ -21,10 +21,6 @@
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
-
 using namespace chip;
 
 void emberAfPumpConfigurationAndControlClusterInitCallback(EndpointId endpoint)

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -33,6 +33,7 @@
 #include <app/util/af.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::TargetNavigator;
 
 TargetNavigatorResponse targetNavigatorClusterNavigateTarget(uint8_t target, std::string data);
@@ -40,8 +41,9 @@ TargetNavigatorResponse targetNavigatorClusterNavigateTarget(uint8_t target, std
 void sendResponse(app::CommandHandler * command, TargetNavigatorResponse response)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TARGET_NAVIGATOR_CLUSTER_ID,
-                                         ZCL_NAVIGATE_TARGET_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, TargetNavigator::Id,
+                                         TargetNavigator::Commands::NavigateTargetResponse::Id,
+                                         (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/thermostat-client/thermostat-client.cpp
+++ b/src/app/clusters/thermostat-client/thermostat-client.cpp
@@ -17,9 +17,6 @@
 
 #include <app/util/af.h>
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app/CommandHandler.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>


### PR DESCRIPTION
#### Problem

There is a lot of usages of the previous "CLUSTER_ID" macros. This PR removes some of them. There will likely be a few different PRs for that since this is some cleanup task between 2 tasks...

