### PR TITLE
Bug-fix to Controller Commands Test

### DIFF
--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -72,9 +72,9 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip
                   aCommandPath.mEndpointId, ChipLogValueMEI(aCommandPath.mClusterId), ChipLogValueMEI(aCommandPath.mCommandId));
 
     if (aCommandPath.mClusterId == TestCluster::Id &&
-        aCommandPath.mCommandId == TestCluster::Commands::TestStructArrayArgumentRequest::Type::GetCommandId())
+        aCommandPath.mCommandId == TestCluster::Commands::TestSimpleArgumentRequest::Type::GetCommandId())
     {
-        TestCluster::Commands::TestStructArrayArgumentRequest::DecodableType dataRequest;
+        TestCluster::Commands::TestSimpleArgumentRequest::DecodableType dataRequest;
 
         if (DataModel::Decode(aReader, dataRequest) != CHIP_NO_ERROR)
         {


### PR DESCRIPTION
In TestCommands.cpp, the logic in DispatchSingleClusterCommand was
expecting and decoding the wrong kind of command. This was oddly not
triggering a failure before, but it is now asserting (as it should).

Tests: Ensured TestCommands runs successfully.

