### PR TITLE
Don't double-send certs

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1843,8 +1843,7 @@ CommissioningStage DeviceCommissioner::GetNextCommissioningStage()
     case CommissioningStage::kConfigRegulatory:
         return CommissioningStage::kDeviceAttestation;
     case CommissioningStage::kDeviceAttestation:
-        return CommissioningStage::kCheckCertificates;
-    case CommissioningStage::kCheckCertificates:
+        // TODO(cecille): device attestation casues operational cert provisioinging to happen, This should be a separate stage.
         // For thread and wifi, this should go to network setup then enable. For on-network we can skip right to finding the
         // operational network because the provisioning of certificates will trigger the device to start operational advertising.
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
@@ -1863,6 +1862,7 @@ CommissioningStage DeviceCommissioner::GetNextCommissioningStage()
     case CommissioningStage::kNetworkSetup:
     case CommissioningStage::kNetworkEnable:
     case CommissioningStage::kScanNetworks:
+    case CommissioningStage::kCheckCertificates:
         return CommissioningStage::kError;
     // Neither of these have a next stage so return kError;
     case CommissioningStage::kCleanup:


### PR DESCRIPTION
#### Problem
When device attestation was added, it added a call to send the
operational certs right after device attestatation. This was
previously done as a separate stage in the state machine and it was
also added as a separate stage after device attestation. This causes
the certs to be sent twice.

#### Change overview
Removes the second explicit stage to add certs.

#### Testing
Checked fabric table logs on the linux lighting app and saw only a single fabric added on the first commissioning when using on network commissioning.
