### PR TITLE
[Android] Fix build by changing computePaseVerifier to take device pointer

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -442,21 +442,22 @@ JNI_METHOD(void, deleteDeviceController)(JNIEnv * env, jobject self, jlong handl
 }
 
 JNI_METHOD(jobject, computePaseVerifier)
-(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jlong setupPincode, jint iterations, jbyteArray salt)
+(JNIEnv * env, jobject self, jlong handle, jlong devicePtr, jlong setupPincode, jint iterations, jbyteArray salt)
 {
     chip::DeviceLayer::StackLock lock;
+
     Device * chipDevice = nullptr;
-
-    ChipLogProgress(Controller, "computePaseVerifier() called");
-    GetCHIPDevice(env, handle, deviceId, &chipDevice);
-
     CHIP_ERROR err = CHIP_NO_ERROR;
     jobject params;
     jbyteArray verifierBytes;
     uint32_t passcodeId;
     PASEVerifier verifier;
-
     JniByteArray jniSalt(env, salt);
+
+    ChipLogProgress(Controller, "computePaseVerifier() called");
+
+    chipDevice = reinterpret_cast<Device *>(devicePtr);
+    VerifyOrExit(chipDevice != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = chipDevice->ComputePASEVerifier(iterations, setupPincode, jniSalt.byteSpan(), verifier, passcodeId);
     SuccessOrExit(err);

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -447,7 +447,7 @@ JNI_METHOD(jobject, computePaseVerifier)
     chip::DeviceLayer::StackLock lock;
 
     Device * chipDevice = nullptr;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
     jobject params;
     jbyteArray verifierBytes;
     uint32_t passcodeId;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -217,18 +217,18 @@ public class ChipDeviceController {
   /**
    * Generates a new PASE verifier and passcode ID for the given setup PIN code.
    *
-   * @param deviceId the ID of the device for which to generate the PASE verifier
+   * @param devicePtr a pointer to the device object for which to generate the PASE verifier
    * @param setupPincode the PIN code to use
    * @param iterations the number of iterations for computing the verifier
    * @param salt the 16-byte salt
    */
   public PaseVerifierParams computePaseVerifier(
-      long deviceId, long setupPincode, int iterations, byte[] salt) {
-    return computePaseVerifier(deviceControllerPtr, deviceId, setupPincode, iterations, salt);
+      long devicePtr, long setupPincode, int iterations, byte[] salt) {
+    return computePaseVerifier(deviceControllerPtr, devicePtr, setupPincode, iterations, salt);
   }
 
   private native PaseVerifierParams computePaseVerifier(
-      long deviceControllerPtr, long deviceId, long setupPincode, int iterations, byte[] salt);
+      long deviceControllerPtr, long devicePtr, long setupPincode, int iterations, byte[] salt);
 
   private native long newDeviceController();
 


### PR DESCRIPTION
#### Problem
* Merge conflict between #10612 which removed GetDevice, and #10519 which was using it

#### Change overview
* Switch `computePaseVerifier` to take in a device pointer, which is expected to be the connected device pointer when called from an app.

#### Testing
* Called `computePaseVerifier` manually from CHIPTool app.
