### PR TITLE
Fix character string representation throughout our codegen to standardize on CharSpan

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -352,7 +352,7 @@ void PairingCommand::OnDefaultFailureResponse(void * context, uint8_t status)
     command->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
 }
 
-void PairingCommand::OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+void PairingCommand::OnAddNetworkResponse(void * context, uint8_t errorCode, CharSpan debugText)
 {
     ChipLogProgress(chipTool, "AddNetworkResponse");
 
@@ -385,7 +385,7 @@ void PairingCommand::OnAddNetworkResponse(void * context, uint8_t errorCode, uin
     }
 }
 
-void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, CharSpan debugText)
 {
     ChipLogProgress(chipTool, "EnableNetworkResponse");
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -166,8 +166,8 @@ public:
 
     /////////// Network Commissioning Callbacks /////////
     static void OnDefaultFailureResponse(void * context, uint8_t status);
-    static void OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
-    static void OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnAddNetworkResponse(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void OnEnableNetworkResponse(void * context, uint8_t errorCode, chip::CharSpan debugText);
 
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -122,7 +122,7 @@ static void OnOctetStringAttributeResponse(void * context, const chip::ByteSpan 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnCharStringAttributeResponse(void * context, const chip::ByteSpan value)
+static void OnCharStringAttributeResponse(void * context, const chip::CharSpan value)
 {
     ChipLogProgress(chipTool, "CharString attribute Response: %.*s", static_cast<int>(value.size()), value.data());
 
@@ -145,8 +145,7 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
         {{#if (isOctetString type)}}
         ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", entries[i].{{name}}.size());
         {{else if (isCharString type)}}
-        // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
-        // ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", entries[i].{{name}}.size(), entries[i].{{name}}.data());
+        ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", static_cast<int>(entries[i].{{name}}.size()), entries[i].{{name}}.data());
         {{else}}
         ChipLogProgress(chipTool, "  {{name}}: {{asPrintFormat type}}", entries[i].{{name}});
         {{/if}}
@@ -155,7 +154,7 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
         {{#if (isOctetString type)}}
         ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", entries[i].size());
         {{else if (isCharString type)}}
-        ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", entries[i].size(), entries[i].data());
+        ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", static_cast<int>(entries[i].size()), entries[i].data());
         {{else}}
         ChipLogProgress(chipTool, "{{type}}[%" PRIu16 "]: {{asPrintFormat type}}", i, entries[i]);
         {{/if}}

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -47,6 +47,7 @@
 #include <iostream>
 
 using chip::ByteSpan;
+using chip::CharSpan;
 using chip::EndpointId;
 using chip::VendorId;
 using chip::ArgParser::HelpOptions;
@@ -65,8 +66,8 @@ using chip::Controller::OnDeviceConnectionFailure;
 chip::Messaging::ExchangeContext * exchangeCtx = nullptr;
 Device * providerDevice                        = nullptr;
 BdxDownloader bdxDownloader;
-void OnQueryImageResponse(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-                          uint8_t * softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded,
+void OnQueryImageResponse(void * context, uint8_t status, uint32_t delayedActionTime, CharSpan imageURI, uint32_t softwareVersion,
+                          CharSpan softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded,
                           chip::ByteSpan metadataForRequestor)
 {
     ChipLogDetail(SoftwareUpdate, "%s", __FUNCTION__);

--- a/src/app/util/im-client-callbacks.h
+++ b/src/app/util/im-client-callbacks.h
@@ -48,6 +48,6 @@ typedef void (*Int32sAttributeCallback)(void * context, int32_t value);
 typedef void (*Int64uAttributeCallback)(void * context, uint64_t value);
 typedef void (*Int64sAttributeCallback)(void * context, int64_t value);
 typedef void (*OctetStringAttributeCallback)(void * context, const chip::ByteSpan value);
-typedef void (*CharStringAttributeCallback)(void * context, const chip::ByteSpan value);
+typedef void (*CharStringAttributeCallback)(void * context, const chip::CharSpan value);
 typedef void (*AttributeResponseFilter)(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess,
                                         chip::Callback::Cancelable * onFailure);

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -189,7 +189,7 @@ function asChipCallback(item)
   }
 
   if (StringHelper.isCharString(item.type)) {
-    return { name : 'CharString', type : 'const chip::ByteSpan' };
+    return { name : 'CharString', type : 'const chip::CharSpan' };
   }
 
   if (ListHelper.isList(item.type)) {

--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -53,6 +53,9 @@ function atomicType(arg)
   case 'octet_string':
   case 'long_octet_string':
     return 'chip::ByteSpan';
+  case 'char_string':
+  case 'long_char_string':
+    return 'chip::CharSpan';
   case 'eui64':
     return 'chip::node_id';
   case 'percent':

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -8,11 +8,7 @@ wasHandled = emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase na
 {{#if (zcl_command_arguments_count this.id)}}
 expectArgumentCount = {{ zcl_command_arguments_count this.id }};
 {{#zcl_command_arguments}}
-{{#if (isCharString type)}}
-const uint8_t * {{asSymbol label}};
-{{else}}
 {{asUnderlyingZclType type}} {{asSymbol label}};
-{{/if}}
 {{/zcl_command_arguments}}
 bool argExists[{{zcl_command_arguments_count this.id}}];
 
@@ -45,10 +41,7 @@ while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
   {
 {{#zcl_command_arguments}}
     case {{index}}:
-{{#if (isCharString type)}}
-      // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-      TLVUnpackError = aDataTlv.GetDataPtr({{asSymbol label}});
-{{else if isArray}}
+{{#if isArray}}
       // Just for compatibility, we will add array type support in IM later.
       TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>({{asSymbol label}}));
 {{else}}
@@ -78,7 +71,7 @@ if (CHIP_END_OF_TLV == TLVError)
 if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && {{zcl_command_arguments_count this.id}} == validArgumentCount)
 {
 {{/if}}
-wasHandled = emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(aCommandPath.mEndpointId, apCommandObj{{#zcl_command_arguments}}, {{#if (isCharString type)}}const_cast<uint8_t*>({{asSymbol label}}){{else}}{{asSymbol label}}{{/if}}{{/zcl_command_arguments}});
+wasHandled = emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(aCommandPath.mEndpointId, apCommandObj{{#zcl_command_arguments}}, {{asSymbol label}}{{/zcl_command_arguments}});
 {{#if (zcl_command_arguments_count this.id)}}
 }
 {{/if}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -281,8 +281,7 @@ bool emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Call
     {{#if (isOctetString type)}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", {{asSymbol label}}.size());
     {{else if (isCharString type)}}
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", {{asSymbol label}}.size(), {{asSymbol label}}.data());
+    ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", static_cast<int>({{asSymbol label}}.size()), {{asSymbol label}}.data());
     {{else}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: {{asPrintFormat type}}", {{asSymbol label}});
     {{/if}}

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -328,8 +328,7 @@ class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callba
             {{#if (isOctetString type)}}
             jbyteArray {{asSymbol label}}Arr;
             {{else if (isShortString type)}}
-            // ByteSpan is not properly returned yet, temporarily use empty string
-            UtfString {{asSymbol label}}Str(env, "");
+            UtfString {{asSymbol label}}Str(env, {{asSymbol label}});
             {{/if}}
             {{/chip_cluster_response_arguments}}
 

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -113,7 +113,7 @@ public class ChipClusters {
       {{#if (isOctetString type)}}
       public byte[] {{asLowerCamelCase name}};
       {{else if (isCharString type)}}
-      // Add String member here after ByteSpan is properly emitted in C++ layer
+      public String {{asLowerCamelCase name}};
       {{else}}
       public {{asJavaBasicType label type}} {{asLowerCamelCase name}};
       {{/if}}
@@ -124,7 +124,7 @@ public class ChipClusters {
         {{#if (isOctetString type)}}
         byte[] {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{else if (isCharString type)}}
-        // Add String field here after ByteSpan is properly emitted in C++ layer
+        String {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{else}}
         {{asJavaBasicType label type}} {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{/if}}

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -330,7 +330,7 @@ public:
         }
     }
 
-    static void CallbackFn(void * context, const chip::ByteSpan value)
+    static void CallbackFn(void * context, const chip::CharSpan value)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -891,7 +891,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * setupPIN)
+    static void CallbackFn(void * context, chip::CharSpan setupPIN)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -899,8 +899,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPAccountLoginClusterGetSetupPINResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString setupPINStr(env, "");
+        UtfString setupPINStr(env, setupPIN);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -962,7 +961,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, chip::CharSpan data)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -970,8 +969,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPApplicationLauncherClusterLaunchAppResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        UtfString dataStr(env, data);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1033,7 +1031,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    static void CallbackFn(void * context, chip::CharSpan data, uint8_t contentLaunchStatus)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1041,8 +1039,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPContentLauncherClusterLaunchContentResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        UtfString dataStr(env, data);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1104,7 +1101,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    static void CallbackFn(void * context, chip::CharSpan data, uint8_t contentLaunchStatus)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1112,8 +1109,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPContentLauncherClusterLaunchURLResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        UtfString dataStr(env, data);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -2789,7 +2785,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2797,8 +2793,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterArmFailSafeResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -2860,7 +2855,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2868,8 +2863,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -2931,7 +2925,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2939,8 +2933,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -3210,7 +3203,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, chip::CharSpan groupName)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3218,8 +3211,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGroupsClusterViewGroupResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString groupNameStr(env, "");
+        UtfString groupNameStr(env, groupName);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4172,7 +4164,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4180,8 +4172,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4243,7 +4234,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4251,8 +4242,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4314,7 +4304,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4322,8 +4312,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterDisableNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4385,7 +4374,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4393,8 +4382,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterEnableNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4456,7 +4444,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4464,8 +4452,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterRemoveNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4527,7 +4514,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText,
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText,
                            /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
                            /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
     {
@@ -4537,8 +4524,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterScanNetworksResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4605,7 +4591,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4613,8 +4599,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4676,7 +4661,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::CharSpan debugText)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4684,8 +4669,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        UtfString debugTextStr(env, debugText);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4816,9 +4800,9 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-                           uint8_t * softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded,
-                           chip::ByteSpan metadataForRequestor)
+    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, chip::CharSpan imageURI,
+                           uint32_t softwareVersion, chip::CharSpan softwareVersionString, chip::ByteSpan updateToken,
+                           bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4826,10 +4810,8 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString imageURIStr(env, "");
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString softwareVersionStringStr(env, "");
+        UtfString imageURIStr(env, imageURI);
+        UtfString softwareVersionStringStr(env, softwareVersionString);
         jbyteArray updateTokenArr;
         jbyteArray metadataForRequestorArr;
 
@@ -5589,7 +5571,7 @@ public:
     };
 
     static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                           uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
+                           chip::CharSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5597,8 +5579,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterViewSceneResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString sceneNameStr(env, "");
+        UtfString sceneNameStr(env, sceneName);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -5737,7 +5718,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, chip::CharSpan data)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5745,8 +5726,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPTargetNavigatorClusterNavigateTargetResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        UtfString dataStr(env, data);
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -86,8 +86,7 @@ void OnAttributeResponse<chip::ByteSpan>(void * /* context */, chip::ByteSpan va
 template <>
 void OnAttributeResponse<chip::CharSpan>(void * /* context */, chip::CharSpan value)
 {
-    std::string strValue(value.data(), value.size());
-    ChipLogProgress(Zcl, "  attributeValue: (span of length %zd) %s", value.size(), strValue.c_str());
+    ChipLogProgress(Zcl, "  attributeValue: '%.*s'", static_cast<int>(value.size()), value.data());
     if (gSuccessResponseDelegate != nullptr)
         gSuccessResponseDelegate();
 }

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -84,6 +84,15 @@ void OnAttributeResponse<chip::ByteSpan>(void * /* context */, chip::ByteSpan va
 }
 
 template <>
+void OnAttributeResponse<chip::CharSpan>(void * /* context */, chip::CharSpan value)
+{
+    std::string strValue(value.data(), value.size());
+    ChipLogProgress(Zcl, "  attributeValue: (span of length %zd) %s", value.size(), strValue.c_str());
+    if (gSuccessResponseDelegate != nullptr)
+        gSuccessResponseDelegate();
+}
+
+template <>
 void OnAttributeResponse<bool>(void * /* context */, bool value)
 {
     ChipLogProgress(Zcl, "  attributeValue: %s", value ? "true" : "false");
@@ -752,7 +761,7 @@ chip::Callback::Callback<Int32sAttributeCallback> gInt32sAttributeCallback{ OnAt
 chip::Callback::Callback<Int64uAttributeCallback> gInt64uAttributeCallback{ OnAttributeResponse<uint64_t>, nullptr };
 chip::Callback::Callback<Int64sAttributeCallback> gInt64sAttributeCallback{ OnAttributeResponse<int64_t>, nullptr };
 chip::Callback::Callback<OctetStringAttributeCallback> gOctetStringAttributeCallback{ OnAttributeResponse<ByteSpan>, nullptr };
-chip::Callback::Callback<CharStringAttributeCallback> gCharStringAttributeCallback{ OnAttributeResponse<ByteSpan>, nullptr };
+chip::Callback::Callback<CharStringAttributeCallback> gCharStringAttributeCallback{ OnAttributeResponse<CharSpan>, nullptr };
 
 } // namespace
 

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -68,6 +68,15 @@ void OnAttributeResponse<chip::ByteSpan>(void * /* context */, chip::ByteSpan va
 }
 
 template <>
+void OnAttributeResponse<chip::CharSpan>(void * /* context */, chip::CharSpan value)
+{
+    std::string strValue(value.data(), value.size());
+    ChipLogProgress(Zcl, "  attributeValue: (span of length %zd) %s", value.size(), strValue.c_str());
+    if (gSuccessResponseDelegate != nullptr)
+        gSuccessResponseDelegate();
+}
+
+template <>
 void OnAttributeResponse<bool>(void * /* context */, bool value)
 {
     ChipLogProgress(Zcl, "  attributeValue: %s", value ? "true" : "false");
@@ -131,7 +140,7 @@ chip::Callback::Callback<Int32sAttributeCallback> gInt32sAttributeCallback{OnAtt
 chip::Callback::Callback<Int64uAttributeCallback> gInt64uAttributeCallback{OnAttributeResponse<uint64_t>, nullptr};
 chip::Callback::Callback<Int64sAttributeCallback> gInt64sAttributeCallback{OnAttributeResponse<int64_t>, nullptr};
 chip::Callback::Callback<OctetStringAttributeCallback> gOctetStringAttributeCallback{OnAttributeResponse<ByteSpan>, nullptr};
-chip::Callback::Callback<CharStringAttributeCallback> gCharStringAttributeCallback{OnAttributeResponse<ByteSpan>, nullptr};
+chip::Callback::Callback<CharStringAttributeCallback> gCharStringAttributeCallback{OnAttributeResponse<CharSpan>, nullptr};
 
 } // namespace
 

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -70,8 +70,7 @@ void OnAttributeResponse<chip::ByteSpan>(void * /* context */, chip::ByteSpan va
 template <>
 void OnAttributeResponse<chip::CharSpan>(void * /* context */, chip::CharSpan value)
 {
-    std::string strValue(value.data(), value.size());
-    ChipLogProgress(Zcl, "  attributeValue: (span of length %zd) %s", value.size(), strValue.c_str());
+    ChipLogProgress(Zcl, "  attributeValue: '%.*s'", static_cast<int>(value.size()), value.data());
     if (gSuccessResponseDelegate != nullptr)
         gSuccessResponseDelegate();
 }

--- a/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
@@ -12,7 +12,7 @@ public:
       {{else if (isStrEqual partial-type "List")}}
       , uint16_t count, {{chipType}} * entries
       {{else if partial-type}}
-      , {{#if (isCharString partial-type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType partial-type}}{{/if}} value
+      , {{asUnderlyingZclType partial-type}} value
       {{else}}
       {{/if}}
     );
@@ -24,7 +24,7 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
   {{else if (isStrEqual partial-type "List")}}
   , uint16_t count, {{chipType}} * entries
   {{else if partial-type}}
-  , {{#if (isCharString partial-type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType partial-type}}{{/if}} value
+  , {{asUnderlyingZclType partial-type}} value
   {{else}}
   {{/if}}
 )
@@ -38,7 +38,7 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
       {{else if (isOctetString type)}}
       @"{{asSymbol label}}" : [NSData dataWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size()],
       {{else if (isCharString type)}}
-      @"{{asSymbol label}}" : [NSString stringWithFormat:@"%s", {{asSymbol label}}],
+      @"{{asSymbol label}}" : [[NSString alloc] initWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size() encoding:NSUTF8StringEncoding],
       {{else}}
       @"{{asSymbol label}}" : [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{asSymbol label}}],
       {{/if}}
@@ -54,7 +54,7 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
           {{#if (isOctetString type)}}
           @"{{name}}" : [NSData dataWithBytes:entries[i].{{name}}.data() length:entries[i].{{name}}.size()],
           {{else if (isCharString type)}}
-          @"{{name}}" : [[NSString alloc] initWithBytes:entries[i].{{name}}+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i].{{name}}) encoding:NSUTF8StringEncoding],
+          @"{{name}}" : [[NSString alloc] initWithBytes:entries[i].{{name}}.data() length:entries[i].{{name}}.size() encoding:NSUTF8StringEncoding],
           {{else}}
           @"{{name}}" : [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entries[i].{{name}}],
           {{/if}}
@@ -63,7 +63,7 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
         {{else if (isOctetString type)}}
         array[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
         {{else if (isCharString type)}}
-        array[i] = [[NSString alloc] initWithBytes:entries[i]+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i]) encoding:NSUTF8StringEncoding];
+        array[i] = [[NSString alloc] initWithBytes:entries[i].data() length:entries[i].size() encoding:NSUTF8StringEncoding];
         {{else}}
         array[i] = [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entries[i]];
         {{/if}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -26,7 +26,7 @@ void CHIPOctetStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::B
     DispatchSuccess(context, @ { @"value" : [NSData dataWithBytes:value.data() length:value.size()] });
 };
 
-void CHIPCharStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::ByteSpan value)
+void CHIPCharStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::CharSpan value)
 {
     DispatchSuccess(
         context, @ { @"value" : [[NSString alloc] initWithBytes:value.data() length:value.size() encoding:NSUTF8StringEncoding] });
@@ -448,35 +448,35 @@ void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBri
     DispatchSuccess(context, @ { @"value" : array });
 };
 
-void CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge::OnSuccessFn(void * context, uint8_t * setupPIN)
+void CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge::OnSuccessFn(void * context, chip::CharSpan setupPIN)
 {
     DispatchSuccess(context, @ {
-        @"setupPIN" : [NSString stringWithFormat:@"%s", setupPIN],
+        @"setupPIN" : [[NSString alloc] initWithBytes:setupPIN.data() length:setupPIN.size() encoding:NSUTF8StringEncoding],
     });
 };
 
-void CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint8_t * data)
+void CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, chip::CharSpan data)
 {
     DispatchSuccess(context, @ {
         @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"data" : [NSString stringWithFormat:@"%s", data],
+        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPContentLauncherClusterLaunchContentResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    void * context, chip::CharSpan data, uint8_t contentLaunchStatus)
 {
     DispatchSuccess(context, @ {
-        @"data" : [NSString stringWithFormat:@"%s", data],
+        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
         @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:contentLaunchStatus],
     });
 };
 
 void CHIPContentLauncherClusterLaunchURLResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    void * context, chip::CharSpan data, uint8_t contentLaunchStatus)
 {
     DispatchSuccess(context, @ {
-        @"data" : [NSString stringWithFormat:@"%s", data],
+        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
         @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:contentLaunchStatus],
     });
 };
@@ -677,29 +677,29 @@ void CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge::OnSuccessFn(voi
 };
 
 void CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
@@ -731,12 +731,12 @@ void CHIPGroupsClusterRemoveGroupResponseCallbackBridge::OnSuccessFn(void * cont
 };
 
 void CHIPGroupsClusterViewGroupResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
+    void * context, uint8_t status, uint16_t groupId, chip::CharSpan groupName)
 {
     DispatchSuccess(context, @ {
         @"status" : [NSNumber numberWithUnsignedChar:status],
         @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"groupName" : [NSString stringWithFormat:@"%s", groupName],
+        @"groupName" : [[NSString alloc] initWithBytes:groupName.data() length:groupName.size() encoding:NSUTF8StringEncoding],
     });
 };
 
@@ -832,57 +832,57 @@ void CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge::OnSuccessFn(void *
 };
 
 void CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSuccessFn(void * context, uint8_t errorCode,
-    uint8_t * debugText, /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
+    chip::CharSpan debugText, /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
         // wifiScanResults : /* TYPE WARNING: array array defaults to */ uint8_t *
         // Conversion from this type to Objc is not properly implemented yet
         // threadScanResults : /* TYPE WARNING: array array defaults to */ uint8_t *
@@ -891,20 +891,20 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
 };
 
 void CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
 void CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, uint8_t * debugText)
+    void * context, uint8_t errorCode, chip::CharSpan debugText)
 {
     DispatchSuccess(context, @ {
         @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 
@@ -918,15 +918,17 @@ void CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallbackBridg
 };
 
 void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status,
-    uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion, uint8_t * softwareVersionString,
+    uint32_t delayedActionTime, chip::CharSpan imageURI, uint32_t softwareVersion, chip::CharSpan softwareVersionString,
     chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
 {
     DispatchSuccess(context, @ {
         @"status" : [NSNumber numberWithUnsignedChar:status],
         @"delayedActionTime" : [NSNumber numberWithUnsignedLong:delayedActionTime],
-        @"imageURI" : [NSString stringWithFormat:@"%s", imageURI],
+        @"imageURI" : [[NSString alloc] initWithBytes:imageURI.data() length:imageURI.size() encoding:NSUTF8StringEncoding],
         @"softwareVersion" : [NSNumber numberWithUnsignedLong:softwareVersion],
-        @"softwareVersionString" : [NSString stringWithFormat:@"%s", softwareVersionString],
+        @"softwareVersionString" : [[NSString alloc] initWithBytes:softwareVersionString.data()
+                                                            length:softwareVersionString.size()
+                                                          encoding:NSUTF8StringEncoding],
         @"updateToken" : [NSData dataWithBytes:updateToken.data() length:updateToken.size()],
         @"userConsentNeeded" : [NSNumber numberWithBool:userConsentNeeded],
         @"metadataForRequestor" : [NSData dataWithBytes:metadataForRequestor.data() length:metadataForRequestor.size()],
@@ -1020,7 +1022,7 @@ void CHIPScenesClusterStoreSceneResponseCallbackBridge::OnSuccessFn(
 };
 
 void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint16_t groupId,
-    uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+    uint8_t sceneId, uint16_t transitionTime, chip::CharSpan sceneName,
     /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
     DispatchSuccess(context, @ {
@@ -1028,7 +1030,7 @@ void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(void * contex
         @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
         @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
         @"transitionTime" : [NSNumber numberWithUnsignedShort:transitionTime],
-        @"sceneName" : [NSString stringWithFormat:@"%s", sceneName],
+        @"sceneName" : [[NSString alloc] initWithBytes:sceneName.data() length:sceneName.size() encoding:NSUTF8StringEncoding],
         // extensionFieldSets : /* TYPE WARNING: array array defaults to */ uint8_t *
         // Conversion from this type to Objc is not properly implemented yet
     });
@@ -1044,11 +1046,12 @@ void CHIPTvChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
     });
 };
 
-void CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint8_t * data)
+void CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge::OnSuccessFn(
+    void * context, uint8_t status, chip::CharSpan data)
 {
     DispatchSuccess(context, @ {
         @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"data" : [NSString stringWithFormat:@"%s", data],
+        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
     });
 };
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -47,7 +47,7 @@ public:
                                           bool keepAlive = false) :
         CHIPCallbackBridge<CharStringAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::ByteSpan value);
+    static void OnSuccessFn(void * context, chip::CharSpan value);
 };
 
 class CHIPBooleanAttributeCallbackBridge : public CHIPCallbackBridge<BooleanAttributeCallback>
@@ -440,7 +440,7 @@ public:
                                                              CHIPActionBlock action, bool keepAlive = false) :
         CHIPCallbackBridge<AccountLoginClusterGetSetupPINResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t * setupPIN);
+    static void OnSuccessFn(void * context, chip::CharSpan setupPIN);
 };
 
 class CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge
@@ -451,7 +451,7 @@ public:
                                                                   CHIPActionBlock action, bool keepAlive = false) :
         CHIPCallbackBridge<ApplicationLauncherClusterLaunchAppResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint8_t * data);
+    static void OnSuccessFn(void * context, uint8_t status, chip::CharSpan data);
 };
 
 class CHIPContentLauncherClusterLaunchContentResponseCallbackBridge
@@ -462,7 +462,7 @@ public:
                                                                   CHIPActionBlock action, bool keepAlive = false) :
         CHIPCallbackBridge<ContentLauncherClusterLaunchContentResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t * data, uint8_t contentLaunchStatus);
+    static void OnSuccessFn(void * context, chip::CharSpan data, uint8_t contentLaunchStatus);
 };
 
 class CHIPContentLauncherClusterLaunchURLResponseCallbackBridge
@@ -473,7 +473,7 @@ public:
                                                               CHIPActionBlock action, bool keepAlive = false) :
         CHIPCallbackBridge<ContentLauncherClusterLaunchURLResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t * data, uint8_t contentLaunchStatus);
+    static void OnSuccessFn(void * context, chip::CharSpan data, uint8_t contentLaunchStatus);
 };
 
 class CHIPDoorLockClusterClearAllPinsResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterClearAllPinsResponseCallback>
@@ -730,7 +730,7 @@ public:
         CHIPCallbackBridge<GeneralCommissioningClusterArmFailSafeResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                    keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge
@@ -742,7 +742,7 @@ public:
         CHIPCallbackBridge<GeneralCommissioningClusterCommissioningCompleteResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                              keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge
@@ -754,7 +754,7 @@ public:
         CHIPCallbackBridge<GeneralCommissioningClusterSetRegulatoryConfigResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                            keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPGroupsClusterAddGroupResponseCallbackBridge : public CHIPCallbackBridge<GroupsClusterAddGroupResponseCallback>
@@ -796,7 +796,7 @@ public:
                                                      bool keepAlive = false) :
         CHIPCallbackBridge<GroupsClusterViewGroupResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName);
+    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, chip::CharSpan groupName);
 };
 
 class CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge
@@ -950,7 +950,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterAddThreadNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                         keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge
@@ -962,7 +962,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterAddWiFiNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                       keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge
@@ -974,7 +974,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterDisableNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                       keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge
@@ -986,7 +986,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterEnableNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge
@@ -998,7 +998,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterRemoveNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge
@@ -1010,7 +1010,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterScanNetworksResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                     keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText,
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText,
                             /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
                             /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
 };
@@ -1024,7 +1024,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterUpdateThreadNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                            keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge
@@ -1036,7 +1036,7 @@ public:
         CHIPCallbackBridge<NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                          keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
 };
 
 class CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallbackBridge
@@ -1060,8 +1060,8 @@ public:
         CHIPCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                        keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI,
-                            uint32_t softwareVersion, uint8_t * softwareVersionString, chip::ByteSpan updateToken,
+    static void OnSuccessFn(void * context, uint8_t status, uint32_t delayedActionTime, chip::CharSpan imageURI,
+                            uint32_t softwareVersion, chip::CharSpan softwareVersionString, chip::ByteSpan updateToken,
                             bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
 };
 
@@ -1172,7 +1172,7 @@ public:
         CHIPCallbackBridge<ScenesClusterViewSceneResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                            uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
+                            chip::CharSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 };
 
 class CHIPTvChannelClusterChangeChannelResponseCallbackBridge
@@ -1194,7 +1194,7 @@ public:
                                                                    CHIPActionBlock action, bool keepAlive = false) :
         CHIPCallbackBridge<TargetNavigatorClusterNavigateTargetResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint8_t * data);
+    static void OnSuccessFn(void * context, uint8_t status, chip::CharSpan data);
 };
 
 class CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -65,14 +65,10 @@ class UtfString
 {
 public:
     UtfString(JNIEnv * env, const char * data) : mEnv(env) { mData = data != nullptr ? mEnv->NewStringUTF(data) : nullptr; }
-    UtfString(JNIEnv * env, chip::ByteSpan data) : mEnv(env)
+    UtfString(JNIEnv * env, chip::CharSpan data) : mEnv(env)
     {
-        std::ostringstream os;
-        for (size_t i = 0; i < data.size(); i++)
-        {
-            os << data.data()[i];
-        }
-        mData = env->NewStringUTF(os.str().c_str());
+        std::string str(data.data(), data.size());
+        mData = env->NewStringUTF(str.c_str());
     }
     ~UtfString() { mEnv->DeleteLocalRef(mData); }
 

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -35,7 +35,7 @@ typedef struct _SimpleStruct
     bool b;
     uint8_t c;
     chip::ByteSpan d;
-    uint8_t * e;
+    chip::CharSpan e;
     uint8_t f;
 } SimpleStruct;
 
@@ -68,15 +68,15 @@ typedef struct _DoubleNestedStructList
 // Struct for ContentLaunchAdditionalInfo
 typedef struct _ContentLaunchAdditionalInfo
 {
-    uint8_t * name;
-    uint8_t * value;
+    chip::CharSpan name;
+    chip::CharSpan value;
 } ContentLaunchAdditionalInfo;
 
 // Struct for ContentLaunchParamater
 typedef struct _ContentLaunchParamater
 {
     uint8_t Type;
-    uint8_t * Value;
+    chip::CharSpan Value;
     /* TYPE WARNING: array array defaults to */ uint8_t * ExternalIDList;
 } ContentLaunchParamater;
 
@@ -84,7 +84,7 @@ typedef struct _ContentLaunchParamater
 typedef struct _ApplicationLauncherApp
 {
     uint16_t catalogVendorId;
-    uint8_t * applicationId;
+    chip::CharSpan applicationId;
 } ApplicationLauncherApp;
 
 // Struct for AudioOutputInfo
@@ -118,7 +118,7 @@ typedef struct _BatFaultChangeType
 // Struct for ContentLaunchBrandingInformation
 typedef struct _ContentLaunchBrandingInformation
 {
-    uint8_t * providerName;
+    chip::CharSpan providerName;
     uint8_t background;
     uint8_t logo;
     uint8_t progressBar;
@@ -129,16 +129,16 @@ typedef struct _ContentLaunchBrandingInformation
 // Struct for ContentLaunchDimension
 typedef struct _ContentLaunchDimension
 {
-    uint8_t * width;
-    uint8_t * height;
+    chip::CharSpan width;
+    chip::CharSpan height;
     uint8_t metric;
 } ContentLaunchDimension;
 
 // Struct for ContentLaunchStyleInformation
 typedef struct _ContentLaunchStyleInformation
 {
-    uint8_t * imageUrl;
-    uint8_t * color;
+    chip::CharSpan imageUrl;
+    chip::CharSpan color;
     uint8_t size;
 } ContentLaunchStyleInformation;
 
@@ -408,9 +408,9 @@ typedef struct _TvChannelInfo
 // Struct for TvChannelLineupInfo
 typedef struct _TvChannelLineupInfo
 {
-    uint8_t * operatorName;
-    uint8_t * lineupName;
-    uint8_t * postalCode;
+    chip::CharSpan operatorName;
+    chip::CharSpan lineupName;
+    chip::CharSpan postalCode;
     uint8_t lineupInfoType;
 } TvChannelLineupInfo;
 

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -12062,7 +12062,7 @@ bool emberAfGroupsClusterViewGroupCallback(chip::app::CommandHandler * commandOb
  * @brief Groups Cluster ViewGroupResponse Command callback (from server)
  */
 bool emberAfGroupsClusterViewGroupResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t * groupName);
+                                                   uint16_t groupId, chip::CharSpan groupName);
 /**
  * @brief Groups Cluster GetGroupMembership Command callback (from client)
  */
@@ -12119,7 +12119,8 @@ bool emberAfScenesClusterViewSceneCallback(chip::app::CommandHandler * commandOb
  * @brief Scenes Cluster ViewSceneResponse Command callback (from server)
  */
 bool emberAfScenesClusterViewSceneResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                   chip::CharSpan sceneName,
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 /**
  * @brief Scenes Cluster RemoveScene Command callback (from client)
@@ -12194,7 +12195,7 @@ bool emberAfScenesClusterEnhancedViewSceneCallback(
  */
 bool emberAfScenesClusterEnhancedViewSceneResponseCallback(
     chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId, uint8_t sceneId,
-    uint16_t transitionTime, uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
+    uint16_t transitionTime, chip::CharSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 /**
  * @brief Scenes Cluster CopyScene Command callback (from client)
  */
@@ -12591,12 +12592,10 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(
 /**
  * @brief OTA Software Update Provider Cluster QueryImageResponse Command callback (from server)
  */
-bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::EndpointId endpoint,
-                                                                       chip::app::CommandSender * commandObj, uint8_t status,
-                                                                       uint32_t delayedActionTime, uint8_t * imageURI,
-                                                                       uint32_t softwareVersion, uint8_t * softwareVersionString,
-                                                                       chip::ByteSpan updateToken, bool userConsentNeeded,
-                                                                       chip::ByteSpan metadataForRequestor);
+bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(
+    chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status, uint32_t delayedActionTime,
+    chip::CharSpan imageURI, uint32_t softwareVersion, chip::CharSpan softwareVersionString, chip::ByteSpan updateToken,
+    bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
 /**
  * @brief OTA Software Update Provider Cluster ApplyUpdateRequestResponse Command callback (from server)
  */
@@ -12619,7 +12618,7 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(
  * @brief General Commissioning Cluster ArmFailSafeResponse Command callback (from server)
  */
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                   uint8_t errorCode, uint8_t * debugText);
+                                                                   uint8_t errorCode, chip::CharSpan debugText);
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback (from client)
  */
@@ -12631,7 +12630,7 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
  */
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::EndpointId endpoint,
                                                                            chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                           uint8_t * debugText);
+                                                                           chip::CharSpan debugText);
 /**
  * @brief General Commissioning Cluster CommissioningComplete Command callback (from client)
  */
@@ -12643,7 +12642,7 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(
  */
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::EndpointId endpoint,
                                                                              chip::app::CommandSender * commandObj,
-                                                                             uint8_t errorCode, uint8_t * debugText);
+                                                                             uint8_t errorCode, chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback (from client)
  */
@@ -12654,7 +12653,7 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(
  * @brief Network Commissioning Cluster ScanNetworksResponse Command callback (from server)
  */
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
+    chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t errorCode, chip::CharSpan debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
 /**
@@ -12668,7 +12667,7 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::EndpointId endpoint,
                                                                       chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                      uint8_t * debugText);
+                                                                      chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback (from client)
  */
@@ -12680,7 +12679,7 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::EndpointId endpoint,
                                                                          chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                         uint8_t * debugText);
+                                                                         chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback (from client)
  */
@@ -12692,7 +12691,7 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::EndpointId endpoint,
                                                                         chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                        uint8_t * debugText);
+                                                                        chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback (from client)
  */
@@ -12704,7 +12703,7 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::EndpointId endpoint,
                                                                            chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                           uint8_t * debugText);
+                                                                           chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback (from client)
  */
@@ -12716,7 +12715,7 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::EndpointId endpoint,
                                                                      chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                     uint8_t * debugText);
+                                                                     chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback (from client)
  */
@@ -12728,7 +12727,7 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::EndpointId endpoint,
                                                                      chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                     uint8_t * debugText);
+                                                                     chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback (from client)
  */
@@ -12740,7 +12739,7 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(
  */
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::EndpointId endpoint,
                                                                       chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                      uint8_t * debugText);
+                                                                      chip::CharSpan debugText);
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback (from client)
  */
@@ -13187,14 +13186,14 @@ bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::EndpointId endpoi
  */
 bool emberAfDoorLockClusterOperationEventNotificationCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                               uint8_t source, uint8_t eventCode, uint16_t userId,
-                                                              chip::ByteSpan pin, uint32_t timeStamp, uint8_t * data);
+                                                              chip::ByteSpan pin, uint32_t timeStamp, chip::CharSpan data);
 /**
  * @brief Door Lock Cluster ProgrammingEventNotification Command callback (from server)
  */
 bool emberAfDoorLockClusterProgrammingEventNotificationCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                                 uint8_t source, uint8_t eventCode, uint16_t userId,
                                                                 chip::ByteSpan pin, uint8_t userType, uint8_t userStatus,
-                                                                uint32_t timeStamp, uint8_t * data);
+                                                                uint32_t timeStamp, chip::CharSpan data);
 /**
  * @brief Window Covering Cluster UpOrOpen Command callback (from client)
  */
@@ -13479,7 +13478,7 @@ bool emberAfIasAceClusterEmergencyCallback(chip::app::CommandHandler * commandOb
  */
 bool emberAfIasAceClusterGetZoneInformationResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                             uint8_t zoneId, uint16_t zoneType, chip::NodeId ieeeAddress,
-                                                            uint8_t * zoneLabel);
+                                                            chip::CharSpan zoneLabel);
 /**
  * @brief IAS ACE Cluster Fire Command callback (from client)
  */
@@ -13489,7 +13488,7 @@ bool emberAfIasAceClusterFireCallback(chip::app::CommandHandler * commandObj, co
  * @brief IAS ACE Cluster ZoneStatusChanged Command callback (from server)
  */
 bool emberAfIasAceClusterZoneStatusChangedCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t zoneId,
-                                                   uint16_t zoneStatus, uint8_t audibleNotification, uint8_t * zoneLabel);
+                                                   uint16_t zoneStatus, uint8_t audibleNotification, chip::CharSpan zoneLabel);
 /**
  * @brief IAS ACE Cluster Panic Command callback (from client)
  */
@@ -13600,7 +13599,7 @@ bool emberAfTargetNavigatorClusterNavigateTargetCallback(
  * @brief Target Navigator Cluster NavigateTargetResponse Command callback (from server)
  */
 bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                 uint8_t status, uint8_t * data);
+                                                                 uint8_t status, chip::CharSpan data);
 /**
  * @brief Media Playback Cluster MediaPlay Command callback (from client)
  */
@@ -13772,7 +13771,7 @@ bool emberAfContentLauncherClusterLaunchContentCallback(
  * @brief Content Launcher Cluster LaunchContentResponse Command callback (from server)
  */
 bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                uint8_t * data, uint8_t contentLaunchStatus);
+                                                                chip::CharSpan data, uint8_t contentLaunchStatus);
 /**
  * @brief Content Launcher Cluster LaunchURL Command callback (from client)
  */
@@ -13783,7 +13782,7 @@ bool emberAfContentLauncherClusterLaunchURLCallback(
  * @brief Content Launcher Cluster LaunchURLResponse Command callback (from server)
  */
 bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                            uint8_t * data, uint8_t contentLaunchStatus);
+                                                            chip::CharSpan data, uint8_t contentLaunchStatus);
 /**
  * @brief Audio Output Cluster SelectOutput Command callback (from client)
  */
@@ -13806,7 +13805,7 @@ bool emberAfApplicationLauncherClusterLaunchAppCallback(
  * @brief Application Launcher Cluster LaunchAppResponse Command callback (from server)
  */
 bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                uint8_t status, uint8_t * data);
+                                                                uint8_t status, chip::CharSpan data);
 /**
  * @brief Application Basic Cluster ChangeStatus Command callback (from client)
  */
@@ -13823,7 +13822,7 @@ bool emberAfAccountLoginClusterGetSetupPINCallback(
  * @brief Account Login Cluster GetSetupPINResponse Command callback (from server)
  */
 bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                           uint8_t * setupPIN);
+                                                           chip::CharSpan setupPIN);
 /**
  * @brief Account Login Cluster Login Command callback (from client)
  */
@@ -13946,7 +13945,7 @@ bool emberAfTestClusterClusterTestListInt8UReverseRequestCallback(
  */
 bool emberAfMessagingClusterDisplayMessageCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                    uint32_t messageId, uint8_t messageControl, uint32_t startTime,
-                                                   uint16_t durationInMinutes, uint8_t * message,
+                                                   uint16_t durationInMinutes, chip::CharSpan message,
                                                    uint8_t optionalExtendedMessageControl);
 /**
  * @brief Messaging Cluster GetLastMessage Command callback (from client)
@@ -13970,7 +13969,7 @@ bool emberAfMessagingClusterMessageConfirmationCallback(
  */
 bool emberAfMessagingClusterDisplayProtectedMessageCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                             uint32_t messageId, uint8_t messageControl, uint32_t startTime,
-                                                            uint16_t durationInMinutes, uint8_t * message,
+                                                            uint16_t durationInMinutes, chip::CharSpan message,
                                                             uint8_t optionalExtendedMessageControl);
 /**
  * @brief Messaging Cluster GetMessageCancellation Command callback (from client)

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -122,8 +122,8 @@ struct TypeInfo
 namespace BatteryManufacturer {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryManufacturer::Id; }
@@ -292,8 +292,8 @@ struct TypeInfo
 namespace Battery2Manufacturer {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2Manufacturer::Id; }
@@ -462,8 +462,8 @@ struct TypeInfo
 namespace Battery3Manufacturer {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3Manufacturer::Id; }
@@ -906,7 +906,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     uint16_t groupId;
-    chip::Span<const char> groupName;
+    chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -918,7 +918,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     uint16_t groupId;
-    chip::Span<const char> groupName;
+    chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddGroup
@@ -998,7 +998,7 @@ public:
 
     uint8_t status;
     uint16_t groupId;
-    chip::Span<const char> groupName;
+    chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1011,7 +1011,7 @@ public:
 
     uint8_t status;
     uint16_t groupId;
-    chip::Span<const char> groupName;
+    chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ViewGroupResponse
@@ -1178,7 +1178,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     uint16_t groupId;
-    chip::Span<const char> groupName;
+    chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1190,7 +1190,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     uint16_t groupId;
-    chip::Span<const char> groupName;
+    chip::CharSpan groupName;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddGroupIfIdentifying
@@ -1263,7 +1263,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1278,7 +1278,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1370,7 +1370,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1386,7 +1386,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1702,7 +1702,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1717,7 +1717,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1809,7 +1809,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -1825,7 +1825,7 @@ public:
     uint16_t groupId;
     uint8_t sceneId;
     uint16_t transitionTime;
-    chip::Span<const char> sceneName;
+    chip::CharSpan sceneName;
     DataModel::DecodableList<Structs::SceneExtensionFieldSet::DecodableType> extensionFieldSets;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3152,8 +3152,8 @@ namespace Attributes {
 namespace ActiveText {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveText::Id; }
@@ -3162,8 +3162,8 @@ struct TypeInfo
 namespace Description {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Description::Id; }
@@ -3172,8 +3172,8 @@ struct TypeInfo
 namespace InactiveText {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InactiveText::Id; }
@@ -4776,8 +4776,8 @@ struct TypeInfo
 namespace VendorName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorName::Id; }
@@ -4796,8 +4796,8 @@ struct TypeInfo
 namespace ProductName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductName::Id; }
@@ -4816,8 +4816,8 @@ struct TypeInfo
 namespace UserLabel {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UserLabel::Id; }
@@ -4826,8 +4826,8 @@ struct TypeInfo
 namespace Location {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Location::Id; }
@@ -4846,8 +4846,8 @@ struct TypeInfo
 namespace HardwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HardwareVersionString::Id; }
@@ -4866,8 +4866,8 @@ struct TypeInfo
 namespace SoftwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareVersionString::Id; }
@@ -4876,8 +4876,8 @@ struct TypeInfo
 namespace ManufacturingDate {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ManufacturingDate::Id; }
@@ -4886,8 +4886,8 @@ struct TypeInfo
 namespace PartNumber {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartNumber::Id; }
@@ -4896,8 +4896,8 @@ struct TypeInfo
 namespace ProductURL {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductURL::Id; }
@@ -4906,8 +4906,8 @@ struct TypeInfo
 namespace ProductLabel {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductLabel::Id; }
@@ -4916,8 +4916,8 @@ struct TypeInfo
 namespace SerialNumber {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SerialNumber::Id; }
@@ -5013,7 +5013,7 @@ public:
     uint16_t hardwareVersion;
     uint32_t softwareVersion;
     OTADownloadProtocol protocolsSupported;
-    chip::Span<const char> location;
+    chip::CharSpan location;
     bool requestorCanConsent;
     chip::ByteSpan metadataForProvider;
 
@@ -5031,7 +5031,7 @@ public:
     uint16_t hardwareVersion;
     uint32_t softwareVersion;
     OTADownloadProtocol protocolsSupported;
-    chip::Span<const char> location;
+    chip::CharSpan location;
     bool requestorCanConsent;
     chip::ByteSpan metadataForProvider;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -5121,9 +5121,9 @@ public:
 
     OTAQueryStatus status;
     uint32_t delayedActionTime;
-    chip::Span<const char> imageURI;
+    chip::CharSpan imageURI;
     uint32_t softwareVersion;
-    chip::Span<const char> softwareVersionString;
+    chip::CharSpan softwareVersionString;
     chip::ByteSpan updateToken;
     bool userConsentNeeded;
     chip::ByteSpan metadataForRequestor;
@@ -5139,9 +5139,9 @@ public:
 
     OTAQueryStatus status;
     uint32_t delayedActionTime;
-    chip::Span<const char> imageURI;
+    chip::CharSpan imageURI;
     uint32_t softwareVersion;
-    chip::Span<const char> softwareVersionString;
+    chip::CharSpan softwareVersionString;
     chip::ByteSpan updateToken;
     bool userConsentNeeded;
     chip::ByteSpan metadataForRequestor;
@@ -5286,8 +5286,8 @@ struct TypeInfo
 namespace Description {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Description::Id; }
@@ -5456,8 +5456,8 @@ struct TypeInfo
 namespace BatteryReplacementDescription {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryReplacementDescription::Id; }
@@ -5476,8 +5476,8 @@ struct TypeInfo
 namespace BatteryANSIDesignation {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryANSIDesignation::Id; }
@@ -5486,8 +5486,8 @@ struct TypeInfo
 namespace BatteryIECDesignation {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryIECDesignation::Id; }
@@ -5674,7 +5674,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -5686,7 +5686,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ArmFailSafeResponse
@@ -5707,7 +5707,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     RegulatoryLocationType location;
-    chip::Span<const char> countryCode;
+    chip::CharSpan countryCode;
     uint64_t breadcrumb;
     uint32_t timeoutMs;
 
@@ -5721,7 +5721,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     RegulatoryLocationType location;
-    chip::Span<const char> countryCode;
+    chip::CharSpan countryCode;
     uint64_t breadcrumb;
     uint32_t timeoutMs;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -5742,7 +5742,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -5754,7 +5754,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace SetRegulatoryConfigResponse
@@ -5797,7 +5797,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -5809,7 +5809,7 @@ public:
     static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace CommissioningCompleteResponse
@@ -5989,7 +5989,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     DataModel::List<Structs::WiFiInterfaceScanResult::Type> wifiScanResults;
     DataModel::List<Structs::ThreadInterfaceScanResult::Type> threadScanResults;
 
@@ -6003,7 +6003,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     DataModel::DecodableList<Structs::WiFiInterfaceScanResult::DecodableType> wifiScanResults;
     DataModel::DecodableList<Structs::ThreadInterfaceScanResult::DecodableType> threadScanResults;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -6061,7 +6061,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6073,7 +6073,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddWiFiNetworkResponse
@@ -6129,7 +6129,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6141,7 +6141,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace UpdateWiFiNetworkResponse
@@ -6194,7 +6194,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6206,7 +6206,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace AddThreadNetworkResponse
@@ -6259,7 +6259,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6271,7 +6271,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace UpdateThreadNetworkResponse
@@ -6324,7 +6324,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6336,7 +6336,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RemoveNetworkResponse
@@ -6389,7 +6389,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6401,7 +6401,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace EnableNetworkResponse
@@ -6454,7 +6454,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6466,7 +6466,7 @@ public:
     static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
 
     uint8_t errorCode;
-    chip::Span<const char> debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace DisableNetworkResponse
@@ -8196,8 +8196,8 @@ namespace Attributes {
 namespace VendorName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorName::Id; }
@@ -8216,8 +8216,8 @@ struct TypeInfo
 namespace ProductName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductName::Id; }
@@ -8226,8 +8226,8 @@ struct TypeInfo
 namespace UserLabel {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UserLabel::Id; }
@@ -8246,8 +8246,8 @@ struct TypeInfo
 namespace HardwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HardwareVersionString::Id; }
@@ -8266,8 +8266,8 @@ struct TypeInfo
 namespace SoftwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareVersionString::Id; }
@@ -8276,8 +8276,8 @@ struct TypeInfo
 namespace ManufacturingDate {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ManufacturingDate::Id; }
@@ -8286,8 +8286,8 @@ struct TypeInfo
 namespace PartNumber {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartNumber::Id; }
@@ -8296,8 +8296,8 @@ struct TypeInfo
 namespace ProductURL {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductURL::Id; }
@@ -8306,8 +8306,8 @@ struct TypeInfo
 namespace ProductLabel {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductLabel::Id; }
@@ -8316,8 +8316,8 @@ struct TypeInfo
 namespace SerialNumber {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SerialNumber::Id; }
@@ -8850,7 +8850,7 @@ public:
     static constexpr CommandId GetCommandId() { return UpdateFabricLabel::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::Span<const char> label;
+    chip::CharSpan label;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8861,7 +8861,7 @@ public:
     static constexpr CommandId GetCommandId() { return UpdateFabricLabel::Id; }
     static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
 
-    chip::Span<const char> label;
+    chip::CharSpan label;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace UpdateFabricLabel
@@ -9313,7 +9313,7 @@ public:
     static constexpr CommandId GetCommandId() { return Toggle::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    chip::Span<const char> pin;
+    chip::CharSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -9324,7 +9324,7 @@ public:
     static constexpr CommandId GetCommandId() { return Toggle::Id; }
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
 
-    chip::Span<const char> pin;
+    chip::CharSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Toggle
@@ -10821,7 +10821,7 @@ public:
     uint16_t userId;
     chip::ByteSpan pin;
     uint32_t timeStamp;
-    chip::Span<const char> data;
+    chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -10837,7 +10837,7 @@ public:
     uint16_t userId;
     chip::ByteSpan pin;
     uint32_t timeStamp;
-    chip::Span<const char> data;
+    chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace OperationEventNotification
@@ -10868,7 +10868,7 @@ public:
     DoorLockUserType userType;
     DoorLockUserStatus userStatus;
     uint32_t timeStamp;
-    chip::Span<const char> data;
+    chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -10886,7 +10886,7 @@ public:
     DoorLockUserType userType;
     DoorLockUserStatus userStatus;
     uint32_t timeStamp;
-    chip::Span<const char> data;
+    chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ProgrammingEventNotification
@@ -11086,8 +11086,8 @@ struct TypeInfo
 namespace Language {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Language::Id; }
@@ -14603,8 +14603,8 @@ struct TypeInfo
 namespace CompensationText {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompensationText::Id; }
@@ -15168,8 +15168,8 @@ struct TypeInfo
 namespace LampType {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampType::Id; }
@@ -15178,8 +15178,8 @@ struct TypeInfo
 namespace LampManufacturer {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampManufacturer::Id; }
@@ -17537,7 +17537,7 @@ public:
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
     IasAceArmMode armMode;
-    chip::Span<const char> armDisarmCode;
+    chip::CharSpan armDisarmCode;
     uint8_t zoneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -17550,7 +17550,7 @@ public:
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
     IasAceArmMode armMode;
-    chip::Span<const char> armDisarmCode;
+    chip::CharSpan armDisarmCode;
     uint8_t zoneId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -17600,7 +17600,7 @@ public:
 
     uint8_t numberOfZones;
     DataModel::List<uint8_t> zoneIds;
-    chip::Span<const char> armDisarmCode;
+    chip::CharSpan armDisarmCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -17613,7 +17613,7 @@ public:
 
     uint8_t numberOfZones;
     DataModel::DecodableList<uint8_t> zoneIds;
-    chip::Span<const char> armDisarmCode;
+    chip::CharSpan armDisarmCode;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Bypass
@@ -17733,7 +17733,7 @@ public:
     uint8_t zoneId;
     IasZoneType zoneType;
     chip::NodeId ieeeAddress;
-    chip::Span<const char> zoneLabel;
+    chip::CharSpan zoneLabel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -17747,7 +17747,7 @@ public:
     uint8_t zoneId;
     IasZoneType zoneType;
     chip::NodeId ieeeAddress;
-    chip::Span<const char> zoneLabel;
+    chip::CharSpan zoneLabel;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetZoneInformationResponse
@@ -17794,7 +17794,7 @@ public:
     uint8_t zoneId;
     uint16_t zoneStatus;
     IasAceAudibleNotification audibleNotification;
-    chip::Span<const char> zoneLabel;
+    chip::CharSpan zoneLabel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -17808,7 +17808,7 @@ public:
     uint8_t zoneId;
     uint16_t zoneStatus;
     IasAceAudibleNotification audibleNotification;
-    chip::Span<const char> zoneLabel;
+    chip::CharSpan zoneLabel;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ZoneStatusChanged
@@ -18251,8 +18251,8 @@ namespace Attributes {
 namespace WakeOnLanMacAddress {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return WakeOnLan::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WakeOnLanMacAddress::Id; }
@@ -18324,9 +18324,9 @@ enum class Fields
 struct Type
 {
 public:
-    chip::Span<const char> operatorName;
-    chip::Span<const char> lineupName;
-    chip::Span<const char> postalCode;
+    chip::CharSpan operatorName;
+    chip::CharSpan lineupName;
+    chip::CharSpan postalCode;
     TvChannelLineupInfoType lineupInfoType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -18352,7 +18352,7 @@ public:
     static constexpr CommandId GetCommandId() { return ChangeChannel::Id; }
     static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
 
-    chip::Span<const char> match;
+    chip::CharSpan match;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -18363,7 +18363,7 @@ public:
     static constexpr CommandId GetCommandId() { return ChangeChannel::Id; }
     static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
 
-    chip::Span<const char> match;
+    chip::CharSpan match;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ChangeChannel
@@ -18546,7 +18546,7 @@ public:
     static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
 
     uint8_t target;
-    chip::Span<const char> data;
+    chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -18558,7 +18558,7 @@ public:
     static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
 
     uint8_t target;
-    chip::Span<const char> data;
+    chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace NavigateTarget
@@ -18577,7 +18577,7 @@ public:
     static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
 
     NavigateTargetStatus status;
-    chip::Span<const char> data;
+    chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -18589,7 +18589,7 @@ public:
     static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
 
     NavigateTargetStatus status;
-    chip::Span<const char> data;
+    chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace NavigateTargetResponse
@@ -19486,7 +19486,7 @@ public:
     static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
 
     uint8_t index;
-    chip::Span<const char> name;
+    chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19498,7 +19498,7 @@ public:
     static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
 
     uint8_t index;
-    chip::Span<const char> name;
+    chip::CharSpan name;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RenameInput
@@ -19799,8 +19799,8 @@ enum class Fields
 struct Type
 {
 public:
-    chip::Span<const char> name;
-    chip::Span<const char> value;
+    chip::CharSpan name;
+    chip::CharSpan value;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -19821,7 +19821,7 @@ struct Type
 {
 public:
     ContentLaunchParameterEnum type;
-    chip::Span<const char> value;
+    chip::CharSpan value;
     DataModel::List<Structs::ContentLaunchAdditionalInfo::Type> externalIDList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -19831,7 +19831,7 @@ struct DecodableType
 {
 public:
     ContentLaunchParameterEnum type;
-    chip::Span<const char> value;
+    chip::CharSpan value;
     DataModel::DecodableList<Structs::ContentLaunchAdditionalInfo::DecodableType> externalIDList;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19851,7 +19851,7 @@ enum class Fields
 struct Type
 {
 public:
-    chip::Span<const char> providerName;
+    chip::CharSpan providerName;
     uint8_t background;
     uint8_t logo;
     uint8_t progressBar;
@@ -19876,8 +19876,8 @@ enum class Fields
 struct Type
 {
 public:
-    chip::Span<const char> width;
-    chip::Span<const char> height;
+    chip::CharSpan width;
+    chip::CharSpan height;
     ContentLaunchMetricType metric;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -19898,8 +19898,8 @@ enum class Fields
 struct Type
 {
 public:
-    chip::Span<const char> imageUrl;
-    chip::Span<const char> color;
+    chip::CharSpan imageUrl;
+    chip::CharSpan color;
     uint8_t size;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -19927,7 +19927,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
     bool autoPlay;
-    chip::Span<const char> data;
+    chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19939,7 +19939,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
     bool autoPlay;
-    chip::Span<const char> data;
+    chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchContent
@@ -19957,7 +19957,7 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchContentResponse::Id; }
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
-    chip::Span<const char> data;
+    chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -19969,7 +19969,7 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchContentResponse::Id; }
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
-    chip::Span<const char> data;
+    chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19988,8 +19988,8 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchURL::Id; }
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
-    chip::Span<const char> contentURL;
-    chip::Span<const char> displayString;
+    chip::CharSpan contentURL;
+    chip::CharSpan displayString;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20000,8 +20000,8 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchURL::Id; }
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
-    chip::Span<const char> contentURL;
-    chip::Span<const char> displayString;
+    chip::CharSpan contentURL;
+    chip::CharSpan displayString;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchURL
@@ -20019,7 +20019,7 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchURLResponse::Id; }
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
-    chip::Span<const char> data;
+    chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -20031,7 +20031,7 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchURLResponse::Id; }
     static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
 
-    chip::Span<const char> data;
+    chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20148,7 +20148,7 @@ public:
     static constexpr ClusterId GetClusterId() { return AudioOutput::Id; }
 
     uint8_t index;
-    chip::Span<const char> name;
+    chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20160,7 +20160,7 @@ public:
     static constexpr ClusterId GetClusterId() { return AudioOutput::Id; }
 
     uint8_t index;
-    chip::Span<const char> name;
+    chip::CharSpan name;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace RenameOutput
@@ -20216,7 +20216,7 @@ struct Type
 {
 public:
     uint16_t catalogVendorId;
-    chip::Span<const char> applicationId;
+    chip::CharSpan applicationId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20243,9 +20243,9 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchApp::Id; }
     static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
 
-    chip::Span<const char> data;
+    chip::CharSpan data;
     uint16_t catalogVendorId;
-    chip::Span<const char> applicationId;
+    chip::CharSpan applicationId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20256,9 +20256,9 @@ public:
     static constexpr CommandId GetCommandId() { return LaunchApp::Id; }
     static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
 
-    chip::Span<const char> data;
+    chip::CharSpan data;
     uint16_t catalogVendorId;
-    chip::Span<const char> applicationId;
+    chip::CharSpan applicationId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchApp
@@ -20277,7 +20277,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
 
     ApplicationLauncherStatus status;
-    chip::Span<const char> data;
+    chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20289,7 +20289,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
 
     ApplicationLauncherStatus status;
-    chip::Span<const char> data;
+    chip::CharSpan data;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace LaunchAppResponse
@@ -20379,8 +20379,8 @@ namespace Attributes {
 namespace VendorName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorName::Id; }
@@ -20399,8 +20399,8 @@ struct TypeInfo
 namespace ApplicationName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationName::Id; }
@@ -20419,8 +20419,8 @@ struct TypeInfo
 namespace ApplicationId {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationId::Id; }
@@ -20464,7 +20464,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetSetupPIN::Id; }
     static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
 
-    chip::Span<const char> tempAccountIdentifier;
+    chip::CharSpan tempAccountIdentifier;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20475,7 +20475,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetSetupPIN::Id; }
     static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
 
-    chip::Span<const char> tempAccountIdentifier;
+    chip::CharSpan tempAccountIdentifier;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetSetupPIN
@@ -20492,7 +20492,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetSetupPINResponse::Id; }
     static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
 
-    chip::Span<const char> setupPIN;
+    chip::CharSpan setupPIN;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20503,7 +20503,7 @@ public:
     static constexpr CommandId GetCommandId() { return GetSetupPINResponse::Id; }
     static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
 
-    chip::Span<const char> setupPIN;
+    chip::CharSpan setupPIN;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace GetSetupPINResponse
@@ -20521,8 +20521,8 @@ public:
     static constexpr CommandId GetCommandId() { return Login::Id; }
     static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
 
-    chip::Span<const char> tempAccountIdentifier;
-    chip::Span<const char> setupPIN;
+    chip::CharSpan tempAccountIdentifier;
+    chip::CharSpan setupPIN;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20533,8 +20533,8 @@ public:
     static constexpr CommandId GetCommandId() { return Login::Id; }
     static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
 
-    chip::Span<const char> tempAccountIdentifier;
-    chip::Span<const char> setupPIN;
+    chip::CharSpan tempAccountIdentifier;
+    chip::CharSpan setupPIN;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace Login
@@ -20584,7 +20584,7 @@ public:
     bool b;
     SimpleEnum c;
     chip::ByteSpan d;
-    chip::Span<const char> e;
+    chip::CharSpan e;
     chip::BitFlags<SimpleBitmap> f;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -21456,8 +21456,8 @@ struct TypeInfo
 namespace CharString {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CharString::Id; }
@@ -21466,8 +21466,8 @@ struct TypeInfo
 namespace LongCharString {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LongCharString::Id; }
@@ -21745,7 +21745,7 @@ public:
     chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
-    chip::Span<const char> message;
+    chip::CharSpan message;
     chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -21761,7 +21761,7 @@ public:
     chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
-    chip::Span<const char> message;
+    chip::CharSpan message;
     chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21880,7 +21880,7 @@ public:
     chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
-    chip::Span<const char> message;
+    chip::CharSpan message;
     chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -21896,7 +21896,7 @@ public:
     chip::BitFlags<MessagingControlMask> messageControl;
     uint32_t startTime;
     uint16_t durationInMinutes;
-    chip::Span<const char> message;
+    chip::CharSpan message;
     chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21976,8 +21976,8 @@ struct TypeInfo
 namespace CompanyName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompanyName::Id; }
@@ -21996,8 +21996,8 @@ struct TypeInfo
 namespace BrandName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BrandName::Id; }
@@ -22091,8 +22091,8 @@ namespace Attributes {
 namespace CompanyName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompanyName::Id; }
@@ -22121,8 +22121,8 @@ struct TypeInfo
 namespace CustomerName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CustomerName::Id; }
@@ -22171,8 +22171,8 @@ struct TypeInfo
 namespace UtilityName {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UtilityName::Id; }
@@ -22181,8 +22181,8 @@ struct TypeInfo
 namespace Pod {
 struct TypeInfo
 {
-    using Type          = chip::Span<const char>;
-    using DecodableType = chip::Span<const char>;
+    using Type          = chip::CharSpan;
+    using DecodableType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Pod::Id; }

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -143,7 +143,7 @@ static void OnOctetStringAttributeResponse(void * context, const chip::ByteSpan 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnCharStringAttributeResponse(void * context, const chip::ByteSpan value)
+static void OnCharStringAttributeResponse(void * context, const chip::CharSpan value)
 {
     ChipLogProgress(chipTool, "CharString attribute Response: %.*s", static_cast<int>(value.size()), value.data());
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -1508,11 +1508,11 @@ void ThreadNetworkDiagnosticsClusterActiveNetworkFaultsListListAttributeFilter(T
 #pragma GCC diagnostic pop
 #endif // __clang__
 
-bool emberAfAccountLoginClusterGetSetupPINResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t * setupPIN)
+bool emberAfAccountLoginClusterGetSetupPINResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
+                                                           chip::CharSpan setupPIN)
 {
     ChipLogProgress(Zcl, "GetSetupPINResponse:");
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  setupPIN: %.*s", setupPIN.size(), setupPIN.data());
+    ChipLogProgress(Zcl, "  setupPIN: %.*s", static_cast<int>(setupPIN.size()), setupPIN.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("AccountLoginClusterGetSetupPINResponseCallback");
 
@@ -1523,12 +1523,11 @@ bool emberAfAccountLoginClusterGetSetupPINResponseCallback(EndpointId endpoint, 
 }
 
 bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                uint8_t status, uint8_t * data)
+                                                                uint8_t status, chip::CharSpan data)
 {
     ChipLogProgress(Zcl, "LaunchAppResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.size()), data.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ApplicationLauncherClusterLaunchAppResponseCallback");
 
@@ -1539,11 +1538,10 @@ bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(EndpointId endpo
 }
 
 bool emberAfContentLauncherClusterLaunchContentResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                uint8_t * data, uint8_t contentLaunchStatus)
+                                                                chip::CharSpan data, uint8_t contentLaunchStatus)
 {
     ChipLogProgress(Zcl, "LaunchContentResponse:");
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.size()), data.data());
     ChipLogProgress(Zcl, "  contentLaunchStatus: %" PRIu8 "", contentLaunchStatus);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ContentLauncherClusterLaunchContentResponseCallback");
@@ -1554,12 +1552,11 @@ bool emberAfContentLauncherClusterLaunchContentResponseCallback(EndpointId endpo
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchURLResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t * data,
-                                                            uint8_t contentLaunchStatus)
+bool emberAfContentLauncherClusterLaunchURLResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
+                                                            chip::CharSpan data, uint8_t contentLaunchStatus)
 {
     ChipLogProgress(Zcl, "LaunchURLResponse:");
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.size()), data.data());
     ChipLogProgress(Zcl, "  contentLaunchStatus: %" PRIu8 "", contentLaunchStatus);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ContentLauncherClusterLaunchURLResponseCallback");
@@ -1913,12 +1910,11 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(EndpointId endpoint
 }
 
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                   uint8_t errorCode, uint8_t * debugText)
+                                                                   uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "ArmFailSafeResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterArmFailSafeResponseCallback");
 
@@ -1929,12 +1925,11 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(EndpointId en
 }
 
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                             uint8_t errorCode, uint8_t * debugText)
+                                                                             uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "CommissioningCompleteResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterCommissioningCompleteResponseCallback");
 
@@ -1945,12 +1940,11 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(End
 }
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                           uint8_t errorCode, uint8_t * debugText)
+                                                                           uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "SetRegulatoryConfigResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterSetRegulatoryConfigResponseCallback");
 
@@ -2008,13 +2002,12 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(EndpointId endpoint, app::C
 }
 
 bool emberAfGroupsClusterViewGroupResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t * groupName)
+                                                   uint16_t groupId, chip::CharSpan groupName)
 {
     ChipLogProgress(Zcl, "ViewGroupResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  groupName: %.*s", groupName.size(), groupName.data());
+    ChipLogProgress(Zcl, "  groupName: %.*s", static_cast<int>(groupName.size()), groupName.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GroupsClusterViewGroupResponseCallback");
 
@@ -2205,12 +2198,11 @@ bool emberAfMediaPlaybackClusterMediaStopResponseCallback(EndpointId endpoint, a
 }
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                        uint8_t errorCode, uint8_t * debugText)
+                                                                        uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "AddThreadNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterAddThreadNetworkResponseCallback");
 
@@ -2221,12 +2213,11 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(Endpoint
 }
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                      uint8_t errorCode, uint8_t * debugText)
+                                                                      uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "AddWiFiNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterAddWiFiNetworkResponseCallback");
 
@@ -2237,12 +2228,11 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(EndpointId
 }
 
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                      uint8_t errorCode, uint8_t * debugText)
+                                                                      uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "DisableNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterDisableNetworkResponseCallback");
 
@@ -2253,12 +2243,11 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(EndpointId
 }
 
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                     uint8_t errorCode, uint8_t * debugText)
+                                                                     uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "EnableNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterEnableNetworkResponseCallback");
 
@@ -2269,12 +2258,11 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(EndpointId 
 }
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                     uint8_t errorCode, uint8_t * debugText)
+                                                                     uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "RemoveNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterRemoveNetworkResponseCallback");
 
@@ -2285,14 +2273,13 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(EndpointId 
 }
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    EndpointId endpoint, app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
+    EndpointId endpoint, app::CommandSender * commandObj, uint8_t errorCode, chip::CharSpan debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
 {
     ChipLogProgress(Zcl, "ScanNetworksResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
     ChipLogProgress(Zcl, "  wifiScanResults: %p", wifiScanResults);
     ChipLogProgress(Zcl, "  threadScanResults: %p", threadScanResults);
 
@@ -2305,12 +2292,11 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
 }
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                           uint8_t errorCode, uint8_t * debugText)
+                                                                           uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "UpdateThreadNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterUpdateThreadNetworkResponseCallback");
 
@@ -2321,12 +2307,11 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(Endpo
 }
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                         uint8_t errorCode, uint8_t * debugText)
+                                                                         uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "UpdateWiFiNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback");
 
@@ -2353,18 +2338,18 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(E
 
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
                                                                        uint8_t status, uint32_t delayedActionTime,
-                                                                       uint8_t * imageURI, uint32_t softwareVersion,
-                                                                       uint8_t * softwareVersionString, chip::ByteSpan updateToken,
-                                                                       bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
+                                                                       chip::CharSpan imageURI, uint32_t softwareVersion,
+                                                                       chip::CharSpan softwareVersionString,
+                                                                       chip::ByteSpan updateToken, bool userConsentNeeded,
+                                                                       chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(Zcl, "QueryImageResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  delayedActionTime: %" PRIu32 "", delayedActionTime);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  imageURI: %.*s", imageURI.size(), imageURI.data());
+    ChipLogProgress(Zcl, "  imageURI: %.*s", static_cast<int>(imageURI.size()), imageURI.data());
     ChipLogProgress(Zcl, "  softwareVersion: %" PRIu32 "", softwareVersion);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  softwareVersionString: %.*s", softwareVersionString.size(), softwareVersionString.data());
+    ChipLogProgress(Zcl, "  softwareVersionString: %.*s", static_cast<int>(softwareVersionString.size()),
+                    softwareVersionString.data());
     ChipLogProgress(Zcl, "  updateToken: %zu", updateToken.size());
     ChipLogProgress(Zcl, "  userConsentNeeded: %d", userConsentNeeded);
     ChipLogProgress(Zcl, "  metadataForRequestor: %zu", metadataForRequestor.size());
@@ -2521,7 +2506,8 @@ bool emberAfScenesClusterStoreSceneResponseCallback(EndpointId endpoint, app::Co
 }
 
 bool emberAfScenesClusterViewSceneResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                   chip::CharSpan sceneName,
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
     ChipLogProgress(Zcl, "ViewSceneResponse:");
@@ -2529,8 +2515,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(EndpointId endpoint, app::Com
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", sceneId);
     ChipLogProgress(Zcl, "  transitionTime: %" PRIu16 "", transitionTime);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  sceneName: %.*s", sceneName.size(), sceneName.data());
+    ChipLogProgress(Zcl, "  sceneName: %.*s", static_cast<int>(sceneName.size()), sceneName.data());
     ChipLogProgress(Zcl, "  extensionFieldSets: %p", extensionFieldSets);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterViewSceneResponseCallback");
@@ -2558,12 +2543,11 @@ bool emberAfTvChannelClusterChangeChannelResponseCallback(EndpointId endpoint, a
 }
 
 bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                 uint8_t status, uint8_t * data)
+                                                                 uint8_t status, chip::CharSpan data)
 {
     ChipLogProgress(Zcl, "NavigateTargetResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.size()), data.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("TargetNavigatorClusterNavigateTargetResponseCallback");
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
@@ -34,10 +34,11 @@
 // #6308 should handle IM error code on the application side, either modify this function or remove this.
 
 // Cluster Specific Response Callbacks
-typedef void (*AccountLoginClusterGetSetupPINResponseCallback)(void * context, uint8_t * setupPIN);
-typedef void (*ApplicationLauncherClusterLaunchAppResponseCallback)(void * context, uint8_t status, uint8_t * data);
-typedef void (*ContentLauncherClusterLaunchContentResponseCallback)(void * context, uint8_t * data, uint8_t contentLaunchStatus);
-typedef void (*ContentLauncherClusterLaunchURLResponseCallback)(void * context, uint8_t * data, uint8_t contentLaunchStatus);
+typedef void (*AccountLoginClusterGetSetupPINResponseCallback)(void * context, chip::CharSpan setupPIN);
+typedef void (*ApplicationLauncherClusterLaunchAppResponseCallback)(void * context, uint8_t status, chip::CharSpan data);
+typedef void (*ContentLauncherClusterLaunchContentResponseCallback)(void * context, chip::CharSpan data,
+                                                                    uint8_t contentLaunchStatus);
+typedef void (*ContentLauncherClusterLaunchURLResponseCallback)(void * context, chip::CharSpan data, uint8_t contentLaunchStatus);
 typedef void (*DoorLockClusterClearAllPinsResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterClearAllRfidsResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterClearHolidayScheduleResponseCallback)(void * context, uint8_t status);
@@ -70,16 +71,16 @@ typedef void (*DoorLockClusterSetWeekdayScheduleResponseCallback)(void * context
 typedef void (*DoorLockClusterSetYeardayScheduleResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterUnlockDoorResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterUnlockWithTimeoutResponseCallback)(void * context, uint8_t status);
-typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
+typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, chip::CharSpan debugText);
 typedef void (*GeneralCommissioningClusterCommissioningCompleteResponseCallback)(void * context, uint8_t errorCode,
-                                                                                 uint8_t * debugText);
+                                                                                 chip::CharSpan debugText);
 typedef void (*GeneralCommissioningClusterSetRegulatoryConfigResponseCallback)(void * context, uint8_t errorCode,
-                                                                               uint8_t * debugText);
+                                                                               chip::CharSpan debugText);
 typedef void (*GroupsClusterAddGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId);
 typedef void (*GroupsClusterGetGroupMembershipResponseCallback)(void * context, uint8_t capacity, uint8_t groupCount,
                                                                 /* TYPE WARNING: array array defaults to */ uint8_t * groupList);
 typedef void (*GroupsClusterRemoveGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId);
-typedef void (*GroupsClusterViewGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName);
+typedef void (*GroupsClusterViewGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId, chip::CharSpan groupName);
 typedef void (*IdentifyClusterIdentifyQueryResponseCallback)(void * context, uint16_t timeout);
 typedef void (*KeypadInputClusterSendKeyResponseCallback)(void * context, uint8_t status);
 typedef void (*MediaPlaybackClusterMediaFastForwardResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
@@ -93,23 +94,29 @@ typedef void (*MediaPlaybackClusterMediaSkipBackwardResponseCallback)(void * con
 typedef void (*MediaPlaybackClusterMediaSkipForwardResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
 typedef void (*MediaPlaybackClusterMediaStartOverResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
 typedef void (*MediaPlaybackClusterMediaStopResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
-typedef void (*NetworkCommissioningClusterAddThreadNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterAddWiFiNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterDisableNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterEnableNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterRemoveNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
+typedef void (*NetworkCommissioningClusterAddThreadNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                            chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterAddWiFiNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                          chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterDisableNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                          chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterEnableNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                         chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterRemoveNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                         chip::CharSpan debugText);
 typedef void (*NetworkCommissioningClusterScanNetworksResponseCallback)(
-    void * context, uint8_t errorCode, uint8_t * debugText, /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
+    void * context, uint8_t errorCode, chip::CharSpan debugText,
+    /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
 typedef void (*NetworkCommissioningClusterUpdateThreadNetworkResponseCallback)(void * context, uint8_t errorCode,
-                                                                               uint8_t * debugText);
+                                                                               chip::CharSpan debugText);
 typedef void (*NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback)(void * context, uint8_t errorCode,
-                                                                             uint8_t * debugText);
+                                                                             chip::CharSpan debugText);
 typedef void (*OtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback)(void * context, uint8_t action,
                                                                                    uint32_t delayedActionTime);
 typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallback)(
-    void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-    uint8_t * softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
+    void * context, uint8_t status, uint32_t delayedActionTime, chip::CharSpan imageURI, uint32_t softwareVersion,
+    chip::CharSpan softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
 typedef void (*OperationalCredentialsClusterAttestationResponseCallback)(void * context, chip::ByteSpan AttestationElements,
                                                                          chip::ByteSpan Signature);
 typedef void (*OperationalCredentialsClusterCertificateChainResponseCallback)(void * context, chip::ByteSpan Certificate);
@@ -125,12 +132,12 @@ typedef void (*ScenesClusterRemoveAllScenesResponseCallback)(void * context, uin
 typedef void (*ScenesClusterRemoveSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
 typedef void (*ScenesClusterStoreSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
 typedef void (*ScenesClusterViewSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId,
-                                                       uint16_t transitionTime, uint8_t * sceneName,
+                                                       uint16_t transitionTime, chip::CharSpan sceneName,
                                                        /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 typedef void (*TvChannelClusterChangeChannelResponseCallback)(void * context,
                                                               /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch,
                                                               uint8_t ErrorType);
-typedef void (*TargetNavigatorClusterNavigateTargetResponseCallback)(void * context, uint8_t status, uint8_t * data);
+typedef void (*TargetNavigatorClusterNavigateTargetResponseCallback)(void * context, uint8_t status, chip::CharSpan data);
 typedef void (*TestClusterClusterTestAddArgumentsResponseCallback)(void * context, uint8_t returnValue);
 typedef void (*TestClusterClusterTestListInt8UReverseResponseCallback)(void * context,
                                                                        /* TYPE WARNING: array array defaults to */ uint8_t * arg1);

--- a/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
@@ -68,7 +68,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         {
         case Commands::GetSetupPINResponse::Id: {
             expectArgumentCount = 1;
-            const uint8_t * setupPIN;
+            chip::CharSpan setupPIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -99,8 +99,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(setupPIN);
+                    TLVUnpackError = aDataTlv.Get(setupPIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -121,8 +120,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfAccountLoginClusterGetSetupPINResponseCallback(aCommandPath.mEndpointId, apCommandObj,
-                                                                                   const_cast<uint8_t *>(setupPIN));
+                wasHandled =
+                    emberAfAccountLoginClusterGetSetupPINResponseCallback(aCommandPath.mEndpointId, apCommandObj, setupPIN);
             }
             break;
         }
@@ -170,7 +169,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         case Commands::LaunchAppResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
-            const uint8_t * data;
+            chip::CharSpan data;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -204,8 +203,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(status);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -227,7 +225,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfApplicationLauncherClusterLaunchAppResponseCallback(aCommandPath.mEndpointId, apCommandObj,
-                                                                                        status, const_cast<uint8_t *>(data));
+                                                                                        status, data);
             }
             break;
         }
@@ -274,7 +272,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         {
         case Commands::LaunchContentResponse::Id: {
             expectArgumentCount = 2;
-            const uint8_t * data;
+            chip::CharSpan data;
             uint8_t contentLaunchStatus;
             bool argExists[2];
 
@@ -306,8 +304,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 case 1:
                     TLVUnpackError = aDataTlv.Get(contentLaunchStatus);
@@ -331,14 +328,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfContentLauncherClusterLaunchContentResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, const_cast<uint8_t *>(data), contentLaunchStatus);
+                wasHandled = emberAfContentLauncherClusterLaunchContentResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                        data, contentLaunchStatus);
             }
             break;
         }
         case Commands::LaunchURLResponse::Id: {
             expectArgumentCount = 2;
-            const uint8_t * data;
+            chip::CharSpan data;
             uint8_t contentLaunchStatus;
             bool argExists[2];
 
@@ -370,8 +367,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 case 1:
                     TLVUnpackError = aDataTlv.Get(contentLaunchStatus);
@@ -395,8 +391,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfContentLauncherClusterLaunchURLResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, const_cast<uint8_t *>(data), contentLaunchStatus);
+                wasHandled = emberAfContentLauncherClusterLaunchURLResponseCallback(aCommandPath.mEndpointId, apCommandObj, data,
+                                                                                    contentLaunchStatus);
             }
             break;
         }
@@ -1948,7 +1944,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         case Commands::ArmFailSafeResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1982,8 +1978,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2004,15 +1999,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                           errorCode, debugText);
             }
             break;
         }
         case Commands::CommissioningCompleteResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -2046,8 +2041,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2069,14 +2063,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::SetRegulatoryConfigResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -2110,8 +2104,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2133,7 +2126,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
@@ -2375,7 +2368,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             expectArgumentCount = 3;
             uint8_t status;
             uint16_t groupId;
-            const uint8_t * groupName;
+            chip::CharSpan groupName;
             bool argExists[3];
 
             memset(argExists, 0, sizeof argExists);
@@ -2412,8 +2405,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(groupId);
                     break;
                 case 2:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.Get(groupName);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2435,7 +2427,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 3 == validArgumentCount)
             {
                 wasHandled = emberAfGroupsClusterViewGroupResponseCallback(aCommandPath.mEndpointId, apCommandObj, status, groupId,
-                                                                           const_cast<uint8_t *>(groupName));
+                                                                           groupName);
             }
             break;
         }
@@ -3371,7 +3363,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         case Commands::AddThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3405,8 +3397,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3427,15 +3418,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(aCommandPath.mEndpointId,
+                                                                                                apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::AddWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3469,8 +3460,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3491,15 +3481,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(aCommandPath.mEndpointId,
+                                                                                              apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::DisableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3533,8 +3523,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3555,15 +3544,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(aCommandPath.mEndpointId,
+                                                                                              apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::EnableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3597,8 +3586,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3619,15 +3607,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                             errorCode, debugText);
             }
             break;
         }
         case Commands::RemoveNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3661,8 +3649,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3683,15 +3670,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                             errorCode, debugText);
             }
             break;
         }
         case Commands::ScanNetworksResponse::Id: {
             expectArgumentCount = 4;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults;
             /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults;
             bool argExists[4];
@@ -3727,8 +3714,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 case 2:
                     // Just for compatibility, we will add array type support in IM later.
@@ -3758,15 +3744,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText), wifiScanResults,
-                    threadScanResults);
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText, wifiScanResults, threadScanResults);
             }
             break;
         }
         case Commands::UpdateThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3800,8 +3785,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3823,14 +3807,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::UpdateWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3864,8 +3848,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3887,7 +3870,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
@@ -3999,9 +3982,9 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             expectArgumentCount = 8;
             uint8_t status;
             uint32_t delayedActionTime;
-            const uint8_t * imageURI;
+            chip::CharSpan imageURI;
             uint32_t softwareVersion;
-            const uint8_t * softwareVersionString;
+            chip::CharSpan softwareVersionString;
             chip::ByteSpan updateToken;
             bool userConsentNeeded;
             chip::ByteSpan metadataForRequestor;
@@ -4041,15 +4024,13 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(delayedActionTime);
                     break;
                 case 2:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(imageURI);
+                    TLVUnpackError = aDataTlv.Get(imageURI);
                     break;
                 case 3:
                     TLVUnpackError = aDataTlv.Get(softwareVersion);
                     break;
                 case 4:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(softwareVersionString);
+                    TLVUnpackError = aDataTlv.Get(softwareVersionString);
                     break;
                 case 5:
                     TLVUnpackError = aDataTlv.Get(updateToken);
@@ -4080,9 +4061,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 8 == validArgumentCount)
             {
                 wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, status, delayedActionTime, const_cast<uint8_t *>(imageURI),
-                    softwareVersion, const_cast<uint8_t *>(softwareVersionString), updateToken, userConsentNeeded,
-                    metadataForRequestor);
+                    aCommandPath.mEndpointId, apCommandObj, status, delayedActionTime, imageURI, softwareVersion,
+                    softwareVersionString, updateToken, userConsentNeeded, metadataForRequestor);
             }
             break;
         }
@@ -4766,7 +4746,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             uint16_t groupId;
             uint8_t sceneId;
             uint16_t transitionTime;
-            const uint8_t * sceneName;
+            chip::CharSpan sceneName;
             /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets;
             bool argExists[6];
 
@@ -4810,8 +4790,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(transitionTime);
                     break;
                 case 4:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.Get(sceneName);
                     break;
                 case 5:
                     // Just for compatibility, we will add array type support in IM later.
@@ -4837,8 +4816,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 6 == validArgumentCount)
             {
                 wasHandled = emberAfScenesClusterViewSceneResponseCallback(aCommandPath.mEndpointId, apCommandObj, status, groupId,
-                                                                           sceneId, transitionTime,
-                                                                           const_cast<uint8_t *>(sceneName), extensionFieldSets);
+                                                                           sceneId, transitionTime, sceneName, extensionFieldSets);
             }
             break;
         }
@@ -4991,7 +4969,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         case Commands::NavigateTargetResponse::Id: {
             expectArgumentCount = 2;
             uint8_t status;
-            const uint8_t * data;
+            chip::CharSpan data;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -5025,8 +5003,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(status);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -5048,7 +5025,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfTargetNavigatorClusterNavigateTargetResponseCallback(aCommandPath.mEndpointId, apCommandObj,
-                                                                                         status, const_cast<uint8_t *>(data));
+                                                                                         status, data);
             }
             break;
         }

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClientCallbacks.cpp
@@ -231,18 +231,18 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(E
 
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
                                                                        uint8_t status, uint32_t delayedActionTime,
-                                                                       uint8_t * imageURI, uint32_t softwareVersion,
-                                                                       uint8_t * softwareVersionString, chip::ByteSpan updateToken,
-                                                                       bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
+                                                                       chip::CharSpan imageURI, uint32_t softwareVersion,
+                                                                       chip::CharSpan softwareVersionString,
+                                                                       chip::ByteSpan updateToken, bool userConsentNeeded,
+                                                                       chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(Zcl, "QueryImageResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  delayedActionTime: %" PRIu32 "", delayedActionTime);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  imageURI: %.*s", imageURI.size(), imageURI.data());
+    ChipLogProgress(Zcl, "  imageURI: %.*s", static_cast<int>(imageURI.size()), imageURI.data());
     ChipLogProgress(Zcl, "  softwareVersion: %" PRIu32 "", softwareVersion);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  softwareVersionString: %.*s", softwareVersionString.size(), softwareVersionString.data());
+    ChipLogProgress(Zcl, "  softwareVersionString: %.*s", static_cast<int>(softwareVersionString.size()),
+                    softwareVersionString.data());
     ChipLogProgress(Zcl, "  updateToken: %zu", updateToken.size());
     ChipLogProgress(Zcl, "  userConsentNeeded: %d", userConsentNeeded);
     ChipLogProgress(Zcl, "  metadataForRequestor: %zu", metadataForRequestor.size());

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClientCallbacks.h
@@ -37,7 +37,7 @@
 typedef void (*OtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback)(void * context, uint8_t action,
                                                                                    uint32_t delayedActionTime);
 typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallback)(
-    void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-    uint8_t * softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
+    void * context, uint8_t status, uint32_t delayedActionTime, chip::CharSpan imageURI, uint32_t softwareVersion,
+    chip::CharSpan softwareVersionString, chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
 
 // List specific responses

--- a/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
@@ -303,9 +303,9 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             expectArgumentCount = 8;
             uint8_t status;
             uint32_t delayedActionTime;
-            const uint8_t * imageURI;
+            chip::CharSpan imageURI;
             uint32_t softwareVersion;
-            const uint8_t * softwareVersionString;
+            chip::CharSpan softwareVersionString;
             chip::ByteSpan updateToken;
             bool userConsentNeeded;
             chip::ByteSpan metadataForRequestor;
@@ -345,15 +345,13 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(delayedActionTime);
                     break;
                 case 2:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(imageURI);
+                    TLVUnpackError = aDataTlv.Get(imageURI);
                     break;
                 case 3:
                     TLVUnpackError = aDataTlv.Get(softwareVersion);
                     break;
                 case 4:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(softwareVersionString);
+                    TLVUnpackError = aDataTlv.Get(softwareVersionString);
                     break;
                 case 5:
                     TLVUnpackError = aDataTlv.Get(updateToken);
@@ -384,9 +382,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 8 == validArgumentCount)
             {
                 wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, status, delayedActionTime, const_cast<uint8_t *>(imageURI),
-                    softwareVersion, const_cast<uint8_t *>(softwareVersionString), updateToken, userConsentNeeded,
-                    metadataForRequestor);
+                    aCommandPath.mEndpointId, apCommandObj, status, delayedActionTime, imageURI, softwareVersion,
+                    softwareVersionString, updateToken, userConsentNeeded, metadataForRequestor);
             }
             break;
         }

--- a/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.cpp
@@ -359,12 +359,11 @@ void OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter(TLV
 #endif // __clang__
 
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                   uint8_t errorCode, uint8_t * debugText)
+                                                                   uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "ArmFailSafeResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterArmFailSafeResponseCallback");
 
@@ -375,12 +374,11 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(EndpointId en
 }
 
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                             uint8_t errorCode, uint8_t * debugText)
+                                                                             uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "CommissioningCompleteResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterCommissioningCompleteResponseCallback");
 
@@ -391,12 +389,11 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(End
 }
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                           uint8_t errorCode, uint8_t * debugText)
+                                                                           uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "SetRegulatoryConfigResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterSetRegulatoryConfigResponseCallback");
 
@@ -407,12 +404,11 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(Endpo
 }
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                        uint8_t errorCode, uint8_t * debugText)
+                                                                        uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "AddThreadNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterAddThreadNetworkResponseCallback");
 
@@ -423,12 +419,11 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(Endpoint
 }
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                      uint8_t errorCode, uint8_t * debugText)
+                                                                      uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "AddWiFiNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterAddWiFiNetworkResponseCallback");
 
@@ -439,12 +434,11 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(EndpointId
 }
 
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                      uint8_t errorCode, uint8_t * debugText)
+                                                                      uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "DisableNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterDisableNetworkResponseCallback");
 
@@ -455,12 +449,11 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(EndpointId
 }
 
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                     uint8_t errorCode, uint8_t * debugText)
+                                                                     uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "EnableNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterEnableNetworkResponseCallback");
 
@@ -471,12 +464,11 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(EndpointId 
 }
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                     uint8_t errorCode, uint8_t * debugText)
+                                                                     uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "RemoveNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterRemoveNetworkResponseCallback");
 
@@ -487,14 +479,13 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(EndpointId 
 }
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    EndpointId endpoint, app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
+    EndpointId endpoint, app::CommandSender * commandObj, uint8_t errorCode, chip::CharSpan debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
 {
     ChipLogProgress(Zcl, "ScanNetworksResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
     ChipLogProgress(Zcl, "  wifiScanResults: %p", wifiScanResults);
     ChipLogProgress(Zcl, "  threadScanResults: %p", threadScanResults);
 
@@ -507,12 +498,11 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
 }
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                           uint8_t errorCode, uint8_t * debugText)
+                                                                           uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "UpdateThreadNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterUpdateThreadNetworkResponseCallback");
 
@@ -523,12 +513,11 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(Endpo
 }
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                         uint8_t errorCode, uint8_t * debugText)
+                                                                         uint8_t errorCode, chip::CharSpan debugText)
 {
     ChipLogProgress(Zcl, "UpdateWiFiNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback");
 

--- a/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.h
@@ -34,23 +34,29 @@
 // #6308 should handle IM error code on the application side, either modify this function or remove this.
 
 // Cluster Specific Response Callbacks
-typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
+typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, chip::CharSpan debugText);
 typedef void (*GeneralCommissioningClusterCommissioningCompleteResponseCallback)(void * context, uint8_t errorCode,
-                                                                                 uint8_t * debugText);
+                                                                                 chip::CharSpan debugText);
 typedef void (*GeneralCommissioningClusterSetRegulatoryConfigResponseCallback)(void * context, uint8_t errorCode,
-                                                                               uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterAddThreadNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterAddWiFiNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterDisableNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterEnableNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterRemoveNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
+                                                                               chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterAddThreadNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                            chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterAddWiFiNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                          chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterDisableNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                          chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterEnableNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                         chip::CharSpan debugText);
+typedef void (*NetworkCommissioningClusterRemoveNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                         chip::CharSpan debugText);
 typedef void (*NetworkCommissioningClusterScanNetworksResponseCallback)(
-    void * context, uint8_t errorCode, uint8_t * debugText, /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
+    void * context, uint8_t errorCode, chip::CharSpan debugText,
+    /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
 typedef void (*NetworkCommissioningClusterUpdateThreadNetworkResponseCallback)(void * context, uint8_t errorCode,
-                                                                               uint8_t * debugText);
+                                                                               chip::CharSpan debugText);
 typedef void (*NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback)(void * context, uint8_t errorCode,
-                                                                             uint8_t * debugText);
+                                                                             chip::CharSpan debugText);
 typedef void (*OperationalCredentialsClusterAttestationResponseCallback)(void * context, chip::ByteSpan AttestationElements,
                                                                          chip::ByteSpan Signature);
 typedef void (*OperationalCredentialsClusterCertificateChainResponseCallback)(void * context, chip::ByteSpan Certificate);

--- a/zzz_generated/tv-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/tv-app/zap-generated/IMClusterCommandHandler.cpp
@@ -447,7 +447,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         case Commands::ArmFailSafeResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -481,8 +481,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -503,15 +502,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                           errorCode, debugText);
             }
             break;
         }
         case Commands::CommissioningCompleteResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -545,8 +544,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -568,14 +566,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::SetRegulatoryConfigResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -609,8 +607,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -632,7 +629,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
@@ -1113,7 +1110,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
         case Commands::AddThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1147,8 +1144,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1169,15 +1165,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(aCommandPath.mEndpointId,
+                                                                                                apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::AddWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1211,8 +1207,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1233,15 +1228,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(aCommandPath.mEndpointId,
+                                                                                              apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::DisableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1275,8 +1270,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1297,15 +1291,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(aCommandPath.mEndpointId,
+                                                                                              apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::EnableNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1339,8 +1333,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1361,15 +1354,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                             errorCode, debugText);
             }
             break;
         }
         case Commands::RemoveNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1403,8 +1396,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1425,15 +1417,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(aCommandPath.mEndpointId, apCommandObj,
+                                                                                             errorCode, debugText);
             }
             break;
         }
         case Commands::ScanNetworksResponse::Id: {
             expectArgumentCount = 4;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults;
             /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults;
             bool argExists[4];
@@ -1469,8 +1461,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 case 2:
                     // Just for compatibility, we will add array type support in IM later.
@@ -1500,15 +1491,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText), wifiScanResults,
-                    threadScanResults);
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText, wifiScanResults, threadScanResults);
             }
             break;
         }
         case Commands::UpdateThreadNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1542,8 +1532,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1565,14 +1554,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Commands::UpdateWiFiNetworkResponse::Id: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::CharSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1606,8 +1595,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1629,7 +1617,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(
-                    aCommandPath.mEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                    aCommandPath.mEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }


### PR DESCRIPTION
#### Problem
We still have places using `const uint8_t*` (not null-terminated!) to represent character strings.

#### Change overview
Consistently use CharSpan.

#### Testing
Compiles and CI passes.  No intended behavior changes.