### PR TITLE
Start WiFi station management on primary wlan interface if it exists

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -218,6 +218,10 @@ namespace DeviceLayer {
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+char ConnectivityManagerImpl::sWiFiIfName[];
+#endif
+
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -246,14 +250,14 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    if (ConnectivityUtils::GetWiFiInterfaceName(mWiFiIfName, IFNAMSIZ) == CHIP_NO_ERROR)
+    if (ConnectivityUtils::GetWiFiInterfaceName(sWiFiIfName, IFNAMSIZ) == CHIP_NO_ERROR)
     {
-        ChipLogProgress(DeviceLayer, "Got WiFi interface: %s", mWiFiIfName);
+        ChipLogProgress(DeviceLayer, "Got WiFi interface: %s", sWiFiIfName);
     }
     else
     {
         ChipLogError(DeviceLayer, "Failed to get WiFi interface");
-        mWiFiIfName[0] = '\0';
+        sWiFiIfName[0] = '\0';
     }
 
     if (ResetWiFiStatsCount() != CHIP_NO_ERROR)
@@ -494,7 +498,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
     }
     else
     {
-        ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create wpa_supplicant1 interface proxy %s: %s",
+        ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create wpa_supplicant interface proxy %s: %s",
                         mWpaSupplicant.interfacePath, err ? err->message : "unknown error");
 
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
@@ -527,7 +531,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         GVariant * args = nullptr;
         GVariantBuilder builder;
 
-        ChipLogProgress(DeviceLayer, "wpa_supplicant: can't find interface %s: %s", CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME,
+        ChipLogProgress(DeviceLayer, "wpa_supplicant: can't find interface %s: %s", sWiFiIfName,
                         err ? err->message : "unknown error");
 
         ChipLogProgress(DeviceLayer, "wpa_supplicant: try to create interface %s", CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
@@ -543,6 +547,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         {
             mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
             ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface: %s", mWpaSupplicant.interfacePath);
+
+            strncpy(sWiFiIfName, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, IFNAMSIZ);
+            sWiFiIfName[IFNAMSIZ - 1] = '\0';
 
             wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
                                                                   kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
@@ -640,8 +647,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
 
         g_signal_connect(mWpaSupplicant.proxy, "interface-removed", G_CALLBACK(_OnWpaInterfaceRemoved), NULL);
 
-        wpa_fi_w1_wpa_supplicant1_call_get_interface(mWpaSupplicant.proxy, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, nullptr,
-                                                     _OnWpaInterfaceReady, nullptr);
+        wpa_fi_w1_wpa_supplicant1_call_get_interface(mWpaSupplicant.proxy, sWiFiIfName, nullptr, _OnWpaInterfaceReady, nullptr);
     }
     else
     {
@@ -663,6 +669,8 @@ void ConnectivityManagerImpl::StartWiFiManagement()
     mWpaSupplicant.iface         = nullptr;
     mWpaSupplicant.interfacePath = nullptr;
     mWpaSupplicant.networkPath   = nullptr;
+
+    ChipLogProgress(DeviceLayer, "wpa_supplicant: Start WiFi management");
 
     wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
                                                 kWpaSupplicantObjectPath, nullptr, _OnWpaProxyReady, nullptr);
@@ -960,7 +968,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
             {
                 char ifName[chip::Inet::InterfaceIterator::kMaxIfNameLength];
                 if (it.IsUp() && CHIP_NO_ERROR == it.GetInterfaceName(ifName, sizeof(ifName)) &&
-                    strncmp(ifName, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, sizeof(ifName)) == 0)
+                    strncmp(ifName, sWiFiIfName, sizeof(ifName)) == 0)
                 {
                     chip::Inet::IPAddress addr = it.GetAddress();
                     if (addr.IsIPv4())
@@ -982,7 +990,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
             // Run dhclient for IP on WiFi.
             // TODO: The wifi can be managed by networkmanager on linux so we don't have to care about this.
             char cmdBuffer[128];
-            sprintf(cmdBuffer, CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
+            sprintf(cmdBuffer, CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD, sWiFiIfName);
             int dhclientSystemRet = system(cmdBuffer);
             if (dhclientSystemRet != 0)
             {
@@ -990,7 +998,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
             }
             else
             {
-                ChipLogProgress(DeviceLayer, "dhclient is running on the %s interface.", CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
+                ChipLogProgress(DeviceLayer, "dhclient is running on the %s interface.", sWiFiIfName);
             }
 
             // Return success as long as the device is connected to the network
@@ -1166,34 +1174,34 @@ CHIP_ERROR ConnectivityManagerImpl::ResetEthernetStatsCount()
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 CHIP_ERROR ConnectivityManagerImpl::_GetWiFiChannelNumber(uint16_t & channelNumber)
 {
-    if (mWiFiIfName[0] == '\0')
+    if (sWiFiIfName[0] == '\0')
     {
         return CHIP_ERROR_READ_FAILED;
     }
 
-    return ConnectivityUtils::GetWiFiChannelNumber(mWiFiIfName, channelNumber);
+    return ConnectivityUtils::GetWiFiChannelNumber(sWiFiIfName, channelNumber);
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_GetWiFiRssi(int8_t & rssi)
 {
-    if (mWiFiIfName[0] == '\0')
+    if (sWiFiIfName[0] == '\0')
     {
         return CHIP_ERROR_READ_FAILED;
     }
 
-    return ConnectivityUtils::GetWiFiRssi(mWiFiIfName, rssi);
+    return ConnectivityUtils::GetWiFiRssi(sWiFiIfName, rssi);
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
 {
     uint32_t count;
 
-    if (mWiFiIfName[0] == '\0')
+    if (sWiFiIfName[0] == '\0')
     {
         return CHIP_ERROR_READ_FAILED;
     }
 
-    ReturnErrorOnFailure(ConnectivityUtils::GetWiFiBeaconLostCount(mWiFiIfName, count));
+    ReturnErrorOnFailure(ConnectivityUtils::GetWiFiBeaconLostCount(sWiFiIfName, count));
     VerifyOrReturnError(count >= mBeaconLostCount, CHIP_ERROR_INVALID_INTEGER_VALUE);
     beaconLostCount = count - mBeaconLostCount;
 
@@ -1202,12 +1210,12 @@ CHIP_ERROR ConnectivityManagerImpl::_GetWiFiBeaconLostCount(uint32_t & beaconLos
 
 CHIP_ERROR ConnectivityManagerImpl::_GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
 {
-    if (mWiFiIfName[0] == '\0')
+    if (sWiFiIfName[0] == '\0')
     {
         return CHIP_ERROR_READ_FAILED;
     }
 
-    return ConnectivityUtils::GetWiFiCurrentMaxRate(mWiFiIfName, currentMaxRate);
+    return ConnectivityUtils::GetWiFiCurrentMaxRate(sWiFiIfName, currentMaxRate);
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -110,6 +110,10 @@ public:
     bool IsWiFiManagementStarted();
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    static const char * GetWiFiIfName() { return sWiFiIfName; }
+#endif
+
 private:
     // ===== Members that implement the ConnectivityManager abstract interface.
 
@@ -220,7 +224,7 @@ private:
     uint32_t mPacketUnicastRxCount   = 0;
     uint32_t mPacketUnicastTxCount   = 0;
     uint64_t mOverrunCount           = 0;
-    char mWiFiIfName[IFNAMSIZ];
+    static char sWiFiIfName[IFNAMSIZ];
 #endif
 };
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -108,6 +108,7 @@ void GDBus_Thread()
 #endif
 } // namespace
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 void PlatformManagerImpl::WiFIIPChangeListener()
 {
     int sock;
@@ -149,7 +150,7 @@ void PlatformManagerImpl::WiFIIPChangeListener()
                         char name[IFNAMSIZ];
                         ChipDeviceEvent event;
                         if_indextoname(addressMessage->ifa_index, name);
-                        if (strcmp(name, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME) != 0)
+                        if (strcmp(name, ConnectivityManagerImpl::GetWiFiIfName()) != 0)
                         {
                             continue;
                         }
@@ -174,6 +175,7 @@ void PlatformManagerImpl::WiFIIPChangeListener()
         }
     }
 }
+#endif // #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {
@@ -198,8 +200,10 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     gdbusThread.detach();
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     std::thread wifiIPThread(WiFIIPChangeListener);
     wifiIPThread.detach();
+#endif
 
     // Initialize the configuration system.
     err = Internal::PosixConfig::Init();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we collect WiFi diagnostic stats from the primary wlan interface of the system, but we always start WiFi station management on pre-configured wifi interface(default to 'wlan0').

* If the system's primary wlan interface does not match with the pre-configured CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, we need to first create this interface and start wifi station management on this interface. In this case, we will collect wifi diagnostic information from a different interface.
 
#### Change overview
* Start WiFi station management on primary wlan interface if it exists
* Create pre-configured interface if no wlan interface detected and start wifi station management on this interface 

#### Testing
How was this tested? (at least one bullet point required)
* run 'sudo ./chip-lighting-app' and confirm the primary wlan interface is detected and daemon succeed to start wifi management on this interface.

```
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/out/debug/standalone$ sudo ./chip-lighting-app
[sudo] password for yufengw: 
[1634700255.712904][1271147:1271147] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====
[1634700255.712925][1271147:1271147] CHIP:DL: AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>
[1634700255.712933][1271147:1271147] CHIP:DL: AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>
[1634700255.712942][1271147:1271147] CHIP:DL: AUDIT: * buf1: 0A58A8CEDAB9C6AF797ADA6F469FA0F8
[1634700255.712948][1271147:1271147] CHIP:DL: AUDIT: * buf2: D8EAA7BD65437A765275D82B391C3129
[1634700255.712959][1271147:1271147] CHIP:DL: AUDIT: * r1: 0x0EE69285 r2: 0x6F556D68
[1634700255.712964][1271147:1271147] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====
[1634700255.713203][1271147:1271147] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-vVydvm)
[1634700255.713418][1271147:1271147] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1634700255.713432][1271147:1271147] CHIP:DL: NVS set: chip-counters/reboot-count = 4 (0x4)
[1634700255.713714][1271147:1271147] CHIP:DL: Got Ethernet interface: enp1s0
[1634700255.713890][1271147:1271147] CHIP:DL: Found the primary Ethernet interface:enp1s0
[1634700255.714052][1271147:1271147] CHIP:DL: Got WiFi interface: wlp3s0
[1634700255.714336][1271147:1271147] CHIP:DL: Found the primary WiFi interface:wlp3s0
[1634700255.714361][1271147:1271147] CHIP:DL: Device Configuration:
[1634700255.714366][1271147:1271147] CHIP:DL:   Serial Number: TEST_SN
[1634700255.714370][1271147:1271147] CHIP:DL:   Vendor Id: 9050 (0x235A)
[1634700255.714373][1271147:1271147] CHIP:DL:   Product Id: 65279 (0xFEFF)
[1634700255.714378][1271147:1271147] CHIP:DL:   Product Revision: 0
[1634700255.714382][1271147:1271147] CHIP:DL:   Setup Pin Code: 20202021
[1634700255.714386][1271147:1271147] CHIP:DL:   Setup Discriminator: 3840 (0xF00)
[1634700255.714392][1271147:1271147] CHIP:DL:   Manufacturing Date: (not set)
[1634700255.714395][1271147:1271147] CHIP:DL:   Device Type: 257 (0x101)
[1634700255.714416][1271147:1271147] CHIP:SVR: SetupQRCode: [MT:YNJV7.3O00KA0648G00]
[1634700255.714423][1271147:1271147] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
[1634700255.714430][1271147:1271147] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AYNJV7.3O00KA0648G00
[1634700255.714440][1271147:1271147] CHIP:SVR: Manual pairing code: [34970112332]
[1634700255.714463][1271147:1271147] CHIP:DL: wpa_supplicant: Start WiFi management
[1634700255.716249][1271147:1271150] CHIP:DL: wpa_supplicant: connected to wpa_supplicant proxy
[1634700255.716567][1271147:1271150] CHIP:DL: wpa_supplicant: WiFi interface: /fi/w1/wpa_supplicant1/Interfaces/9
[1634700255.719807][1271147:1271150] CHIP:DL: wpa_supplicant: connected to wpa_supplicant interface proxy
```

