### PR TITLE
Remove unused local variables, imports

### DIFF
--- a/scripts/build/builders/ameba.py
+++ b/scripts/build/builders/ameba.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
-import shlex
 
 from enum import Enum, auto
 

--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 
 from enum import Enum, auto

--- a/scripts/tools/memory/block.py
+++ b/scripts/tools/memory/block.py
@@ -69,7 +69,6 @@ def main(argv):
             ssdf = ssdf[ssdf.symbol.str.fullmatch(block_re)]
             memdf.report.write_dfs(config, {'Symbols': ssdf})
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/scripts/tools/memory/diffsyms.py
+++ b/scripts/tools/memory/diffsyms.py
@@ -88,7 +88,6 @@ def main(argv):
         memdf.report.write_dfs(config, {'Differences': df})
 
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/scripts/tools/memory/gaps.py
+++ b/scripts/tools/memory/gaps.py
@@ -103,7 +103,6 @@ def main(argv):
                     print(i, file=fp)
 
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -601,7 +601,6 @@ def main(argv):
                                tabulate={'floatfmt': '5.1f'})
 
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/scripts/tools/memory/gh_sizes.py
+++ b/scripts/tools/memory/gh_sizes.py
@@ -185,7 +185,6 @@ def main(argv):
         memdf.report.write_dfs(config, summaries, sys.stdout, 'simple')
 
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/scripts/tools/memory/memdf/report.py
+++ b/scripts/tools/memory/memdf/report.py
@@ -22,7 +22,7 @@ import pathlib
 import sys
 
 from typing import (Any, Callable, Dict, List, Mapping, IO, Optional, Protocol,
-                    Sequence, Tuple, Union)
+                    Sequence, Union)
 
 import cxxfilt  # type: ignore
 import pandas as pd  # type: ignore

--- a/scripts/tools/memory/report_summary.py
+++ b/scripts/tools/memory/report_summary.py
@@ -54,7 +54,6 @@ def main(argv):
         memdf.report.write_dfs(config, {SymbolDF.name: summary})
 
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/scripts/tools/memory/report_tree.py
+++ b/scripts/tools/memory/report_tree.py
@@ -170,7 +170,6 @@ def main(argv):
             tree.print()
 
     except Exception as exception:
-        status = 1
         raise exception
 
     return status

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -379,7 +379,7 @@ class ChipDeviceController(object):
         device = self.GetConnectedDeviceSync(nodeid)
 
         # We are not using IM for Attributes.
-        res = self._Cluster.WriteAttribute(
+        self._Cluster.WriteAttribute(
             device, cluster, attribute, endpoint, groupid, value, False)
         if blocking:
             return im.GetAttributeWriteResponse(im.DEFAULT_ATTRIBUTEWRITE_APPID)


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

#### Problem

Fix all LGTM alerts

#### Change overview
To reduce the number of alerts found by the LGTM system, unused variables and imports were removed
