### PR TITLE
Add equality comparison to ConcreteAttributePath and ConcreteCommandPath

### DIFF
--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -32,6 +32,11 @@ struct ConcreteAttributePath
         mEndpointId(aEndpointId), mClusterId(aClusterId), mAttributeId(aAttributeId)
     {}
 
+    bool operator==(const ConcreteAttributePath & other) const
+    {
+        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId;
+    }
+
     const EndpointId mEndpointId   = 0;
     const ClusterId mClusterId     = 0;
     const AttributeId mAttributeId = 0;

--- a/src/app/ConcreteCommandPath.h
+++ b/src/app/ConcreteCommandPath.h
@@ -33,6 +33,11 @@ struct ConcreteCommandPath
         mEndpointId(aEndpointId), mClusterId(aClusterId), mCommandId(aCommandId)
     {}
 
+    bool operator==(const ConcreteCommandPath & other) const
+    {
+        return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mCommandId == other.mCommandId;
+    }
+
     const EndpointId mEndpointId = 0;
     const ClusterId mClusterId   = 0;
     const CommandId mCommandId   = 0;


### PR DESCRIPTION
#### Problem

I have some code where I need to compare concrete paths, instead of manually comparing every elements it would be great if `ConcreteCommandPath` and `ConcreteAttributePath` knows how to do that.

#### Change overview
 * Add equality operator overloading to `ConcreteAttributePath` and `ConcreteCommandPath`

#### Testing
 It was tested locally by replacing some code I have.
