### PR TITLE
[python] Remove "fabricid" parameter from "resolve" command

### DIFF
--- a/docs/guides/nxp_imx8m_linux_examples.md
+++ b/docs/guides/nxp_imx8m_linux_examples.md
@@ -284,12 +284,8 @@ Thermostat-app is used as an example below.
         AP and the **i.MX8 Mini EVK** and mDNS only works on local network.
 
         Resolve the target device with DNS-SD and update the address of the
-        node. The compressed fabric id is necessary for the resolve command.
+        node.
 
                 chip-device-ctrl > close-ble  # Shutdown the BLE connection
-                chip-device-ctrl > get-fabricid
-                  Get fabric ID complete
-                  Raw Fabric ID: 0x0000000000000000 (0)
-                  Compressed Fabric ID: 0x7e58da6d9bbc85de (9104266811028571614)
-                chip-device-ctrl > resolve 9104266811028571614 8889                                # The 9104266811028571614 is the decimal compressed Fabric ID. 8889 is the node ID.
+                chip-device-ctrl > resolve 8889                                                    # The 8889 is the node ID.
                 chip-device-ctrl > zcl Thermostat SetpointRaiseLower 8889 1 0 mode=1 amount=10     # Now the ZCL command will be send via IP network.

--- a/docs/guides/python_chip_controller_building.md
+++ b/docs/guides/python_chip_controller_building.md
@@ -283,12 +283,12 @@ previously commissioned. Depending on the network type:
 -   For Wi-Fi or Ethernet devices, the Matter accessory uses the mDNS (Multicast
     Domain Name System) protocol.
 
-Assuming your Fabric ID is _5544332211_ and Node ID is _1234_ (use the Node ID
-you noted down when you established the secure connection over Bluetooth LE)),
-run the following command:
+Assuming your Node ID is _1234_ (use the Node ID you noted down when you
+established the secure connection over Bluetooth LE)), run the following
+command:
 
 ```
-chip-device-ctrl > resolve 5544332211 1234
+chip-device-ctrl > resolve 1234
 ```
 
 A notification in the log indicates that the node address has been updated. The
@@ -407,13 +407,13 @@ Discover available Matter accessory devices:
 chip-device-ctrl > discover -all
 ```
 
-### `resolve <fabric_id> <node_id>`
+### `resolve <node_id>`
 
-Resolve DNS-SD name corresponding with the given fabric and Node IDs and update
-address of the node in the device controller:
+Resolve DNS-SD name corresponding with the given Node ID and update address of
+the node in the device controller:
 
 ```
-chip-device-ctrl > resolve 5544332211 1234
+chip-device-ctrl > resolve 1234
 ```
 
 ### `setup-payload generate [-v <Vendor ID>] [-p <Product ID>] [-cf <Custom Flow>] [-dc <Discovery Capabilities>] [-dv <Discriminator Value>] [-ps <Passcode>]`

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -204,12 +204,8 @@ commissioning and cluster control.
          - chip-device-ctrl > close-ble
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
-    Get fabric ID using `get-fabricid` and use the decimal value of compressed
-    fabric id.
 
-         - chip-device-ctrl > get-fabricid
-
-         - chip-device-ctrl > resolve <Compressed Fabric ID> 135246
+         - chip-device-ctrl > resolve 135246
 
 ### Cluster control
 

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -248,7 +248,7 @@ combination with JLinkRTTClient as follows:
 
       close-ble
 
-      resolve 0 1234
+      resolve 1234
 
       zcl OnOff Toggle 1234 1 0
     ```

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -237,7 +237,7 @@ combination with JLinkRTTClient as follows:
 
       close-ble
 
-      resolve 0 1234
+      resolve 1234
 
       zcl OnOff Toggle 1234 1 0
     ```

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -177,12 +177,8 @@ commissioning and cluster control.
          - chip-device-ctrl > close-ble
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
-    Get fabric ID using `get-fabricid` and use the decimal value of compressed
-    fabric id.
 
-         - chip-device-ctrl > get-fabricid
-
-         - chip-device-ctrl > resolve <Compressed Fabric ID> 135246
+         - chip-device-ctrl > resolve 135246
 
 ### Cluster control
 

--- a/examples/lock-app/p6/README.md
+++ b/examples/lock-app/p6/README.md
@@ -135,7 +135,7 @@ Once P6 is up and running, we need to set up a device controller on Raspberry Pi
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
 
-         - chip-device-ctrl > resolve 0 1234
+         - chip-device-ctrl > resolve 1234
 
 <a name="Notes"></a>
 

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -177,12 +177,8 @@ commissioning and cluster control.
          - chip-device-ctrl > close-ble
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
-    Get fabric ID using `get-fabricid` and use the decimal value of compressed
-    fabric id.
 
-         - chip-device-ctrl > get-fabricid
-
-         - chip-device-ctrl > resolve <Compressed Fabric ID> 135246
+         - chip-device-ctrl > resolve 135246
 
 ### Cluster control
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -135,6 +135,7 @@ ChipError::StorageType pychip_DeviceController_OpenCommissioningWindow(chip::Con
 void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceCommissioner * devCtrl);
 bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
                                                       uint32_t len);
+ChipError::StorageType pychip_DeviceController_UpdateDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
 
 // Pairing Delegate
 ChipError::StorageType
@@ -146,7 +147,6 @@ ChipError::StorageType pychip_ScriptDevicePairingDelegate_SetCommissioningComple
 
 void pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(
     chip::Controller::DeviceAddressUpdateDelegate_OnUpdateComplete callback);
-ChipError::StorageType pychip_Resolver_ResolveNode(uint64_t fabricid, chip::NodeId nodeid);
 
 // BLE
 ChipError::StorageType pychip_DeviceCommissioner_CloseBleConnection(chip::Controller::DeviceCommissioner * devCtrl);
@@ -475,11 +475,9 @@ void pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(
     sDeviceAddressUpdateDelegate.SetOnAddressUpdateComplete(callback);
 }
 
-ChipError::StorageType pychip_Resolver_ResolveNode(uint64_t fabricid, chip::NodeId nodeid)
+ChipError::StorageType pychip_DeviceController_UpdateDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-    return Dnssd::Resolver::Instance()
-        .ResolveNodeId(PeerId().SetNodeId(nodeid).SetCompressedFabricId(fabricid), Inet::kIPAddressType_Any)
-        .AsInteger();
+    return devCtrl->UpdateDevice(nodeid).AsInteger();
 }
 
 ChipError::StorageType pychip_Stack_Init()

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -571,17 +571,17 @@ class DeviceMgrCmd(Cmd):
 
     def do_resolve(self, line):
         """
-        resolve <fabricid> <nodeid>
+        resolve <nodeid>
 
-        Resolve DNS-SD name corresponding with the given fabric and node IDs and
+        Resolve DNS-SD name corresponding with the given node ID and
         update address of the node in the device controller.
         """
         try:
             args = shlex.split(line)
-            if len(args) == 2:
-                err = self.devCtrl.ResolveNode(int(args[0]), int(args[1]))
+            if len(args) == 1:
+                err = self.devCtrl.ResolveNode(int(args[0]))
                 if err == 0:
-                    address = self.devCtrl.GetAddressAndPort(int(args[1]))
+                    address = self.devCtrl.GetAddressAndPort(int(args[0]))
                     address = "{}:{}".format(
                         *address) if address else "unknown"
                     print("Current address: " + address)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -202,7 +202,8 @@ class ChipDeviceController(object):
 
     def ResolveNode(self, nodeid):
         return self._ChipStack.CallAsync(
-            lambda: self._dmLib.pychip_DeviceController_UpdateDevice(self.devCtrl, nodeid)
+            lambda: self._dmLib.pychip_DeviceController_UpdateDevice(
+                self.devCtrl, nodeid)
         )
 
     def GetAddressAndPort(self, nodeid):

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -200,9 +200,9 @@ class ChipDeviceController(object):
                 self.devCtrl, ipaddr, setupPinCode, nodeid)
         )
 
-    def ResolveNode(self, fabricid, nodeid):
+    def ResolveNode(self, nodeid):
         return self._ChipStack.CallAsync(
-            lambda: self._dmLib.pychip_Resolver_ResolveNode(fabricid, nodeid)
+            lambda: self._dmLib.pychip_DeviceController_UpdateDevice(self.devCtrl, nodeid)
         )
 
     def GetAddressAndPort(self, nodeid):
@@ -497,9 +497,9 @@ class ChipDeviceController(object):
                 _DeviceAddressUpdateDelegate_OnUpdateComplete]
             self._dmLib.pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete.restype = None
 
-            self._dmLib.pychip_Resolver_ResolveNode.argtypes = [
-                c_uint64, c_uint64]
-            self._dmLib.pychip_Resolver_ResolveNode.restype = c_uint32
+            self._dmLib.pychip_DeviceController_UpdateDevice.argtypes = [
+                c_void_p, c_uint64]
+            self._dmLib.pychip_DeviceController_UpdateDevice.restype = c_uint32
 
             self._dmLib.pychip_GetConnectedDeviceByNodeId.argtypes = [
                 c_void_p, c_uint64, _DeviceAvailableFunct]

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -220,11 +220,10 @@ class BaseTestHelper:
             return False
 
     def TestResolve(self, nodeid):
-        fabricid = self.devCtrl.GetCompressedFabricId()
         self.logger.info(
-            "Resolve: node id = {:08x} (compressed) fabric id = {:08x}".format(nodeid, fabricid))
+            "Resolve: node id = {:08x}".format(nodeid))
         try:
-            self.devCtrl.ResolveNode(fabricid=fabricid, nodeid=nodeid)
+            self.devCtrl.ResolveNode(nodeid=nodeid)
             addr = self.devCtrl.GetAddressAndPort(nodeid)
             if not addr:
                 return False


### PR DESCRIPTION
#### Problem
Now that the fabric ID is auto-generated, requiring a user to pass it manually only makes the commissioning process more tedious as the user must enter yet another command: "get-fabricid".

#### Change overview
Remove the fabric ID parameter.

#### Testing
Existing Cirque tests + verified the full commissioning flow manually.
