### PR TITLE
Fix some code generation issues for Darwin.

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -390,6 +390,9 @@ function chip_tests_item_parameters(options)
           value = value.map(v => attachGlobal(global, v));
         } else if (value instanceof Object) {
           for (key in value) {
+            if (key == "global") {
+              continue;
+            }
             value[key] = attachGlobal(global, value[key]);
           }
         } else {

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -62,6 +62,8 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
         {{#if hasExpectedValue}}
         {{#if isList}}
         XCTAssertEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] count], {{expectedValue.length}});
+        {{else if isArray}}
+        XCTAssertEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] count], {{expectedValue.length}});
         {{else}}
         {{#if (isString type)}}
         {{#if (isOctetString type)}}


### PR DESCRIPTION
I tried adding TestClusterComplexTypes to the Darwin test codegen, and code generation failed due to two bugs:

1. Trying to attach a "global" property to something that has such a property already, which leads to us setting global.global = global, and then we are in an infinite loop.

2. There is no handling of array return values in expectation checking.

With these fixed we still don't generate the right code (because
CHIPClusters APIs can't handle the things that TestClusterComplexTypes
is doing, so we need to stop using those), but at least we succeed at
generation.

#### Problem
Codegen bugs that result in inscrutable failures when trying to add tests with commands that have list fields.

#### Change overview
Fix bugs so we at least get through codegen.

#### Testing
No changes to actual generated code for now.
