### PR TITLE
Fix glob matching of "{,xyz}" matching empty string

### DIFF
--- a/scripts/build/glob_matcher.py
+++ b/scripts/build/glob_matcher.py
@@ -52,6 +52,12 @@ def _GlobMatch(glob: str, value: str) -> bool:
                 return False
             glob, value = glob[1:], value[1:]
 
+    # if value is empty it has a chance to match subgroups
+    if not value and glob.startswith('{') and glob.endswith('}'):
+        for choice in glob[1: -1].split(','):
+            if _GlobMatch(choice, value):
+                return True
+
     return glob == '*' or (not glob and not value)
 
 

--- a/scripts/build/test_glob_matcher.py
+++ b/scripts/build/test_glob_matcher.py
@@ -79,6 +79,23 @@ class TestGlobMatcher(unittest.TestCase):
         self.assertFalse(GlobMatcher('{a,b}x{c,d}').matches('axe'))
         self.assertFalse(GlobMatcher('{a,b}x{c,d}').matches('exd'))
 
+    def test_combined(self):
+        self.assertTrue(GlobMatcher('a{,bc}').matches('a'))
+        self.assertTrue(GlobMatcher('a{,bc}').matches('abc'))
+        self.assertTrue(GlobMatcher('ab{c*d,ef}xz').matches('abcdxz'))
+        self.assertTrue(GlobMatcher('ab{c*d,ef}xz').matches('abc1234dxz'))
+        self.assertTrue(GlobMatcher('ab{c*d,ef}xz').matches('abefxz'))
+
+        self.assertFalse(GlobMatcher('a{,bc}').matches('ab'))
+        self.assertFalse(GlobMatcher('a{,bc}').matches('ax'))
+        self.assertFalse(GlobMatcher('a{,bc}').matches('abcd'))
+        self.assertFalse(GlobMatcher('ab{c*d,ef}xz').matches('abxz'))
+        self.assertFalse(GlobMatcher('ab{c*d,ef}xz').matches('abcxz'))
+        self.assertFalse(GlobMatcher('ab{c*d,ef}xz').matches('abdxz'))
+        self.assertFalse(GlobMatcher('ab{c*d,ef}xz').matches('abxz'))
+        self.assertFalse(GlobMatcher('ab{c*d,ef}xz').matches('abexz'))
+        self.assertFalse(GlobMatcher('ab{c*d,ef}xz').matches('abfxz'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### Problem
Glob matcher does not allow empty string matching, preventing target builds like "linux-x64-all-clusters{,-ipv6only}" .

#### Change overview
Add logic allowing a group matcher to match empty strings
and associated unit test.

#### Testing
Unit tests added.
