### PR TITLE
Be a bit more consistent about type handling in ZAP templates.

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -426,7 +426,7 @@ function chip_tests_item_parameters(options)
             value = new Boolean(value);
             break;
           default:
-            throw new Error('Unsupported value: ', value);
+            throw new Error('Unsupported value: ' + JSON.stringify(value));
           }
         }
 

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -196,10 +196,6 @@ function asChipCallback(item)
     return { name : 'List', type : null };
   }
 
-  if (item.type == 'boolean') {
-    return { name : 'Boolean', type : 'bool' };
-  }
-
   const basicType = ChipTypesHelper.asBasicType(item.chipType);
   switch (basicType) {
   case 'int8_t':
@@ -212,6 +208,8 @@ function asChipCallback(item)
   case 'uint32_t':
   case 'uint64_t':
     return { name : 'Int' + basicType.replace(/[^0-9]/g, '') + 'u', type : basicType };
+  case 'bool':
+    return { name : 'Boolean', type : 'bool' };
   default:
     return { name : 'Unsupported', type : null };
   }

--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -20,6 +20,8 @@ function atomicType(arg)
   switch (arg.name) {
   case 'boolean':
     return 'bool';
+  case 'single':
+    return 'float';
   case 'int40s':
   case 'int48s':
   case 'int56s':

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -350,10 +350,6 @@ function asMEI(prefix, suffix)
  */
 async function zapTypeToClusterObjectType(type, isDecodable, options)
 {
-  if (type == 'single') {
-    return 'float';
-  }
-
   async function fn(pkgId)
   {
     const ns          = options.hash.ns ? ('chip::app::Clusters::' + asUpperCamelCase(options.hash.ns) + '::') : '';

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -7910,12 +7910,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -7925,12 +7925,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -7940,12 +7940,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -7955,12 +7955,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonMonoxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -7976,12 +7976,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -7991,12 +7991,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8006,12 +8006,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8021,12 +8021,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, CarbonDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8042,12 +8042,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8057,12 +8057,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8072,12 +8072,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8087,12 +8087,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8108,12 +8108,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8123,12 +8123,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8138,12 +8138,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8153,12 +8153,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, EthyleneOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8174,12 +8174,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8189,12 +8189,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8204,12 +8204,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8219,12 +8219,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8240,12 +8240,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8255,12 +8255,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8270,12 +8270,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8285,12 +8285,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, HydrogenSulphideConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8306,12 +8306,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8321,12 +8321,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8336,12 +8336,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8351,12 +8351,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, NitricOxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8372,12 +8372,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8387,12 +8387,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8402,12 +8402,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8417,12 +8417,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, NitrogenDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8438,12 +8438,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8453,12 +8453,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8468,12 +8468,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8483,12 +8483,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, OxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8504,12 +8504,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8519,12 +8519,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8534,12 +8534,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8549,12 +8549,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, OzoneConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8570,12 +8570,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8585,12 +8585,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8600,12 +8600,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8615,12 +8615,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, SulfurDioxideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8636,12 +8636,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8651,12 +8651,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8666,12 +8666,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8681,12 +8681,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, DissolvedOxygenConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8702,12 +8702,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8717,12 +8717,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8732,12 +8732,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8747,12 +8747,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, BromateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8768,12 +8768,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8783,12 +8783,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8798,12 +8798,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8813,12 +8813,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChloraminesConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8834,12 +8834,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8849,12 +8849,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8864,12 +8864,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8879,12 +8879,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorineConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8900,12 +8900,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8915,12 +8915,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8930,12 +8930,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8945,12 +8945,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, FecalColiformAndEColiConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8966,12 +8966,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8981,12 +8981,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -8996,12 +8996,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9011,12 +9011,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, FluorideConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9032,12 +9032,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9047,12 +9047,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9062,12 +9062,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9077,12 +9077,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, HaloaceticAcidsConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9098,12 +9098,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9113,12 +9113,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9128,12 +9128,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9143,12 +9143,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TotalTrihalomethanesConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9164,12 +9164,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9179,12 +9179,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9194,12 +9194,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9209,12 +9209,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TotalColiformBacteriaConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9230,12 +9230,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9245,12 +9245,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9260,12 +9260,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9275,12 +9275,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, TurbidityConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9296,12 +9296,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9311,12 +9311,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9326,12 +9326,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9341,12 +9341,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, CopperConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9362,12 +9362,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9377,12 +9377,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9392,12 +9392,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9407,12 +9407,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, LeadConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9428,12 +9428,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9443,12 +9443,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9458,12 +9458,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9473,12 +9473,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ManganeseConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9494,12 +9494,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9509,12 +9509,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9524,12 +9524,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9539,12 +9539,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, SulfateConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9560,12 +9560,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9575,12 +9575,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9590,12 +9590,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9605,12 +9605,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, BromodichloromethaneConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9626,12 +9626,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9641,12 +9641,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9656,12 +9656,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9671,12 +9671,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, BromoformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9692,12 +9692,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9707,12 +9707,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9722,12 +9722,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9737,12 +9737,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Tolerance::Id,
                                       (uint8_t *) tolerance, sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChlorodibromomethaneConcentrationMeasurement::Id, Tolerance::Id,
                                        (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9758,12 +9758,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MeasuredValue::Id,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MeasuredValue::Id,
                                        (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9773,12 +9773,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9788,12 +9788,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9803,12 +9803,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, ChloroformConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9824,12 +9824,12 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MeasuredValue::Id, (uint8_t *) &measuredValue,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9839,12 +9839,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MinMeasuredValue::Id,
                                        (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9854,12 +9854,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, MaxMeasuredValue::Id,
                                        (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
@@ -9869,12 +9869,12 @@ EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
 {
     return emberAfReadServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) tolerance,
                                       sizeof(*tolerance));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
 {
     return emberAfWriteServerAttribute(endpoint, SodiumConcentrationMeasurement::Id, Tolerance::Id, (uint8_t *) &tolerance,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -2886,23 +2886,23 @@ namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2912,23 +2912,23 @@ namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2938,23 +2938,23 @@ namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2964,23 +2964,23 @@ namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2990,23 +2990,23 @@ namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3016,23 +3016,23 @@ namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3042,23 +3042,23 @@ namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3068,23 +3068,23 @@ namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3094,23 +3094,23 @@ namespace OxygenConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3120,23 +3120,23 @@ namespace OzoneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3146,23 +3146,23 @@ namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3172,23 +3172,23 @@ namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3198,23 +3198,23 @@ namespace BromateConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3224,23 +3224,23 @@ namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3250,23 +3250,23 @@ namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3276,23 +3276,23 @@ namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3302,23 +3302,23 @@ namespace FluorideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3328,23 +3328,23 @@ namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3354,23 +3354,23 @@ namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3380,23 +3380,23 @@ namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3406,23 +3406,23 @@ namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3432,23 +3432,23 @@ namespace CopperConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3458,23 +3458,23 @@ namespace LeadConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3484,23 +3484,23 @@ namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3510,23 +3510,23 @@ namespace SulfateConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3536,23 +3536,23 @@ namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3562,23 +3562,23 @@ namespace BromoformConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3588,23 +3588,23 @@ namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3614,23 +3614,23 @@ namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3640,23 +3640,23 @@ namespace SodiumConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t ** tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, /* TYPE WARNING: single defaults to */ uint8_t * tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
 } // namespace Tolerance
 
 } // namespace Attributes


### PR DESCRIPTION
* Instead of checking for "item.type == 'boolean'", which would not
  work right for command args (where the type is "BOOLEAN"), go
  through our normal type-mapping machinery and then use the resulting
  uniform output.

* Add "single" to our atomic type overrides and remove manual handling
  of it in zapTypeToClusterObjectType.  This incidentally fixes all
  the generated accessors for single-typed attributes.

* Fix a debugging exception message to include the value that could not be
  handled in a more-correct way.

#### Problem
Want to stop lower-casing attribute types in the ZAP database.  Ran into codegen breakage when I did that, for the "boolean" thing.

#### Change overview
See above.

#### Testing
No behavior changes or generated code changes apart from the fixed "single" bits.