### PR TITLE
Separate out cloudbuild 'all' vs smoke test (smaller build subset).

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,31 +1,31 @@
 steps:
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - '-c'
-      - source ./scripts/bootstrap.sh
-    id: Bootstrap
-    entrypoint: /usr/bin/bash
-    volumes:
-      - name: pwenv
-        path: /pwenv
-    timeout: 900s
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - "-c"
+          - source ./scripts/bootstrap.sh
+      id: Bootstrap
+      entrypoint: /usr/bin/bash
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      timeout: 900s
 
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - >-
-        ./scripts/build/build_examples.py --enable-flashbundle
-        build --create-archives /workspace/artifacts/
-    id: CompileAll
-    waitFor:
-      - Bootstrap
-    entrypoint: ./scripts/run_in_build_env.sh
-    volumes:
-      - name: pwenv
-        path: /pwenv
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle build
+              --create-archives /workspace/artifacts/
+      id: CompileAll
+      waitFor:
+          - Bootstrap
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
 
 logsBucket: matter-build-automation-build-logs
 

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,14 +1,31 @@
-# NOTE: /workspace/ is the persistent directory across steps
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.18"
-      id: "CompileAll"
-      entrypoint: "./scripts/run_in_build_env.sh"
-      args:
-          [
-              "./scripts/build/build_examples.py --enable-flashbundle build
-              --create-archives /workspace/artifacts/",
-          ]
-      timeout: 7200s
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - '-c'
+      - source ./scripts/bootstrap.sh
+    id: Bootstrap
+    entrypoint: /usr/bin/bash
+    volumes:
+      - name: pwenv
+        path: /pwenv
+    timeout: 900s
+
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - >-
+        ./scripts/build/build_examples.py --enable-flashbundle
+        build --create-archives /workspace/artifacts/
+    id: CompileAll
+    waitFor:
+      - Bootstrap
+    entrypoint: ./scripts/run_in_build_env.sh
+    volumes:
+      - name: pwenv
+        path: /pwenv
 
 logsBucket: matter-build-automation-build-logs
 

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -37,7 +37,7 @@ artifacts:
         location: "gs://matter-build-automation-artifacts/$PROJECT_ID/$COMMIT_SHA/"
         paths: ["/workspace/artifacts/*.tar.gz"]
 
-# Using higher CPU machines generally speeds up builds by > 4x (faster as we spend more time
-# building instead of docker download/checkout/bootstrap)
+# Using higher CPU machines generally speeds up builds, except bootstrap is always
+# slow.
 options:
-    machineType: "E2_HIGHCPU_8"
+    machineType: "E2_HIGHCPU_32"

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -13,6 +13,7 @@ steps:
       timeout: 900s
 
     - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -28,6 +29,7 @@ steps:
             path: /pwenv
 
     - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -43,6 +45,7 @@ steps:
             path: /pwenv
 
     - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -58,6 +61,7 @@ steps:
             path: /pwenv
 
     - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,0 +1,98 @@
+steps:
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - '-c'
+      - source ./scripts/bootstrap.sh
+    id: Bootstrap
+    entrypoint: /usr/bin/bash
+    volumes:
+      - name: pwenv
+        path: /pwenv
+    timeout: 900s
+
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - >-
+        ./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-m5stack-*'
+        build --create-archives /workspace/artifacts/
+    waitFor:
+      - Bootstrap
+    entrypoint: ./scripts/run_in_build_env.sh
+    volumes:
+      - name: pwenv
+        path: /pwenv
+
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - >-
+        ./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-nrf52840-{lock,light}'
+        build --create-archives /workspace/artifacts/
+    waitFor:
+      - Bootstrap
+    entrypoint: ./scripts/run_in_build_env.sh
+    volumes:
+      - name: pwenv
+        path: /pwenv
+
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - >-
+        ./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-brd4161a-{lock,light}'
+        build --create-archives /workspace/artifacts/
+    waitFor:
+      - Bootstrap
+    entrypoint: ./scripts/run_in_build_env.sh
+    volumes:
+      - name: pwenv
+        path: /pwenv
+
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - >-
+        ./scripts/build/build_examples.py --enable-flashbundle --target-glob 'linux-*'
+        build --create-archives /workspace/artifacts/
+    waitFor:
+      - Bootstrap
+    entrypoint: ./scripts/run_in_build_env.sh
+    volumes:
+      - name: pwenv
+        path: /pwenv
+
+  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
+    env:
+      - PW_ENVIRONMENT_ROOT=/pwenv
+    args:
+      - >-
+        ./scripts/build/build_examples.py --enable-flashbundle --target-glob 'android-{arm64,x64}-chip-tool'
+        build --create-archives /workspace/artifacts/
+    waitFor:
+      - Bootstrap
+    entrypoint: ./scripts/run_in_build_env.sh
+    volumes:
+      - name: pwenv
+        path: /pwenv
+
+logsBucket: matter-build-automation-build-logs
+
+# Global timeout for all steps
+timeout: 7200s
+
+artifacts:
+    objects:
+        location: "gs://matter-build-automation-artifacts/$PROJECT_ID/$COMMIT_SHA/"
+        paths: ["/workspace/artifacts/*.tar.gz"]
+
+# Using higher CPU machines generally speeds up builds by > 4x (faster as we spend more time
+# building instead of docker download/checkout/bootstrap)
+options:
+    machineType: "E2_HIGHCPU_8"

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,86 +1,91 @@
 steps:
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - '-c'
-      - source ./scripts/bootstrap.sh
-    id: Bootstrap
-    entrypoint: /usr/bin/bash
-    volumes:
-      - name: pwenv
-        path: /pwenv
-    timeout: 900s
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - "-c"
+          - source ./scripts/bootstrap.sh
+      id: Bootstrap
+      entrypoint: /usr/bin/bash
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      timeout: 900s
 
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - >-
-        ./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-m5stack-*'
-        build --create-archives /workspace/artifacts/
-    waitFor:
-      - Bootstrap
-    entrypoint: ./scripts/run_in_build_env.sh
-    volumes:
-      - name: pwenv
-        path: /pwenv
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob '*-m5stack-*' build --create-archives
+              /workspace/artifacts/
+      waitFor:
+          - Bootstrap
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
 
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - >-
-        ./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-nrf52840-{lock,light}'
-        build --create-archives /workspace/artifacts/
-    waitFor:
-      - Bootstrap
-    entrypoint: ./scripts/run_in_build_env.sh
-    volumes:
-      - name: pwenv
-        path: /pwenv
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob '*-nrf52840-{lock,light}' build --create-archives
+              /workspace/artifacts/
+      waitFor:
+          - Bootstrap
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
 
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - >-
-        ./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-brd4161a-{lock,light}'
-        build --create-archives /workspace/artifacts/
-    waitFor:
-      - Bootstrap
-    entrypoint: ./scripts/run_in_build_env.sh
-    volumes:
-      - name: pwenv
-        path: /pwenv
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob '*-brd4161a-{lock,light}' build --create-archives
+              /workspace/artifacts/
+      waitFor:
+          - Bootstrap
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
 
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - >-
-        ./scripts/build/build_examples.py --enable-flashbundle --target-glob 'linux-*'
-        build --create-archives /workspace/artifacts/
-    waitFor:
-      - Bootstrap
-    entrypoint: ./scripts/run_in_build_env.sh
-    volumes:
-      - name: pwenv
-        path: /pwenv
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob 'linux-*' build --create-archives
+              /workspace/artifacts/
+      waitFor:
+          - Bootstrap
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
 
-  - name: 'connectedhomeip/chip-build-vscode:0.5.18'
-    env:
-      - PW_ENVIRONMENT_ROOT=/pwenv
-    args:
-      - >-
-        ./scripts/build/build_examples.py --enable-flashbundle --target-glob 'android-{arm64,x64}-chip-tool'
-        build --create-archives /workspace/artifacts/
-    waitFor:
-      - Bootstrap
-    entrypoint: ./scripts/run_in_build_env.sh
-    volumes:
-      - name: pwenv
-        path: /pwenv
+    - name: "connectedhomeip/chip-build-vscode:0.5.18"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob 'android-{arm64,x64}-chip-tool' build
+              --create-archives /workspace/artifacts/
+      waitFor:
+          - Bootstrap
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
 
 logsBucket: matter-build-automation-build-logs
 


### PR DESCRIPTION


#### Problem
Cloudbuild is slow (nearing 2h) and easily fails on new platform additions (e.g. AmebaD recently).

This allows cloudbuild to selectively 'build evetyhing' vs a smaller
subset. Smaller subset (smoke test) allows for:
  - less chances for failed builds due to new platforms being added
  - faster builds because not taking into account as many platform
    and build variations (like ipv6 or rpc)

Build all is still available for scheduled builds

#### Change overview
Have both smoke and build-all yamls for cloudbuild

#### Testing
Tested locally using:

```
cloud-build-local --config integrations/cloudbuild/smoke-test.yaml --dryrun=false `pwd`
```
