### PR TITLE
Add templated AddArgument for enum types (like VendorID)

### DIFF
--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -145,6 +145,12 @@ public:
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64);
     }
 
+    template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out)
+    {
+        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out));
+    }
+
     virtual CHIP_ERROR Run() = 0;
 
 private:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* In #10434, generated code in `zzz_generated/chip-tool/zap-generated/cluster/Commands.h` calls `AddArgument` with an enum type `chip::VendorID`, but the build fails as there is no `AddArgument` that takes in enums
* Fixes #10677 

#### Change overview
* adds templated `AddArgument` for enum types

#### Testing
Tested with #10434, confirmed build succeeds
