### PR TITLE
Fix some places where we use OCTET_STRING when we should use CHAR_STRING

### DIFF
--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -179,8 +179,8 @@ void EncodeFixedLabel(const char * label, const char * value, uint8_t * buffer, 
     uint16_t listCount = 1;
     _LabelStruct labelStruct;
 
-    labelStruct.label = chip::ByteSpan(Uint8::from_const_char(label), strlen(label));
-    labelStruct.value = chip::ByteSpan(Uint8::from_const_char(value), strlen(value));
+    labelStruct.label = chip::CharSpan(label, strlen(label));
+    labelStruct.value = chip::CharSpan(value, strlen(value));
 
     emberAfCopyList(ZCL_FIXED_LABEL_CLUSTER_ID, am, true, buffer, reinterpret_cast<uint8_t *>(&labelStruct), 1);
     emberAfCopyList(ZCL_FIXED_LABEL_CLUSTER_ID, am, true, buffer, reinterpret_cast<uint8_t *>(&listCount), 0);

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -200,10 +200,14 @@ void EncodeFixedLabel(const char * label, const char * value, uint8_t * buffer, 
     uint16_t listCount = 1;
     _LabelStruct labelStruct;
 
-    labelStruct.label = chip::ByteSpan(reinterpret_cast<const uint8_t *>(label), kFixedLabelElementsOctetStringSize);
+    // TODO: This size is obviously wrong.  See
+    // https://github.com/project-chip/connectedhomeip/issues/10743
+    labelStruct.label = CharSpan(label, kFixedLabelElementsOctetStringSize);
 
     strncpy(zclOctetStrBuf, value, sizeof(zclOctetStrBuf));
-    labelStruct.value = chip::ByteSpan(reinterpret_cast<uint8_t *>(&zclOctetStrBuf[0]), sizeof(zclOctetStrBuf));
+    // TODO: This size is obviously wrong.  See
+    // https://github.com/project-chip/connectedhomeip/issues/10743
+    labelStruct.value = CharSpan(&zclOctetStrBuf[0], sizeof(zclOctetStrBuf));
 
     emberAfCopyList(ZCL_FIXED_LABEL_CLUSTER_ID, am, true, buffer, reinterpret_cast<uint8_t *>(&labelStruct), 1);
     emberAfCopyList(ZCL_FIXED_LABEL_CLUSTER_ID, am, true, buffer, reinterpret_cast<uint8_t *>(&listCount), 0);

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -119,7 +119,6 @@ class {{filename}}: public TestCommand
         {{/chip_tests_item_parameters}}
 
         auto success = [](void * context, const responseType & data) {
-            {{! TODO Update CHAR_STRING to be of type chip::CharSpan instead of chip::ByteSpan }}
             (static_cast<{{filename}} *>(context))->OnSuccessResponse_{{index}}({{#chip_tests_item_response_parameters}}{{#not_first}}, {{/not_first}}data.{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
         };
 

--- a/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR AudioOutputManager::proxyGetListOfAudioOutputInfo(chip::app::Attribut
         {
             chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::Type audioOutputInfo;
             audioOutputInfo.outputType = EMBER_ZCL_AUDIO_OUTPUT_TYPE_HDMI;
-            audioOutputInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name) - 1);
+            audioOutputInfo.name       = chip::CharSpan(name, sizeof(name) - 1);
             audioOutputInfo.index      = static_cast<uint8_t>(1 + i);
             ReturnErrorOnFailure(encoder.Encode(audioOutputInfo));
         }

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -47,8 +47,8 @@ CHIP_ERROR MediaInputManager::proxyGetInputList(chip::app::AttributeValueEncoder
         for (int i = 0; i < maximumVectorSize; ++i)
         {
             chip::app::Clusters::MediaInput::Structs::MediaInputInfo::Type mediaInput;
-            mediaInput.description = chip::ByteSpan(chip::Uint8::from_char(description), sizeof(description) - 1);
-            mediaInput.name        = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name) - 1);
+            mediaInput.description = chip::CharSpan(description, sizeof(description) - 1);
+            mediaInput.name        = chip::CharSpan(name, sizeof(name) - 1);
             mediaInput.inputType   = EMBER_ZCL_MEDIA_INPUT_TYPE_HDMI;
             mediaInput.index       = static_cast<uint8_t>(1 + i);
             ReturnErrorOnFailure(encoder.Encode(mediaInput));

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR TargetNavigatorManager::proxyGetTargetInfoList(chip::app::AttributeVa
         for (int i = 0; i < maximumVectorSize; ++i)
         {
             chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::Type targetInfo;
-            targetInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name) - 1);
+            targetInfo.name       = chip::CharSpan(name, sizeof(name) - 1);
             targetInfo.identifier = static_cast<uint8_t>(1 + i);
             ReturnErrorOnFailure(encoder.Encode(targetInfo));
         }

--- a/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
+++ b/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
@@ -55,9 +55,9 @@ CHIP_ERROR TvChannelManager::proxyGetTvChannelList(chip::app::AttributeValueEnco
         for (int i = 0; i < maximumVectorSize; ++i)
         {
             chip::app::Clusters::TvChannel::Structs::TvChannelInfo::Type channelInfo;
-            channelInfo.affiliateCallSign = ByteSpan(Uint8::from_char(affiliateCallSign), sizeof(affiliateCallSign) - 1);
-            channelInfo.callSign          = ByteSpan(Uint8::from_char(callSign), sizeof(callSign) - 1);
-            channelInfo.name              = ByteSpan(Uint8::from_char(name), sizeof(name) - 1);
+            channelInfo.affiliateCallSign = CharSpan(affiliateCallSign, sizeof(affiliateCallSign) - 1);
+            channelInfo.callSign          = CharSpan(callSign, sizeof(callSign) - 1);
+            channelInfo.name              = CharSpan(name, sizeof(name) - 1);
             channelInfo.majorNumber       = static_cast<uint8_t>(1 + i);
             channelInfo.minorNumber       = static_cast<uint16_t>(2 + i);
             ReturnErrorOnFailure(encoder.Encode(channelInfo));

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -89,9 +89,7 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadFabricsList(EndpointId endpoint
             fabricDescriptor.vendorId    = fabricInfo.GetVendorId();
             fabricDescriptor.fabricId    = fabricInfo.GetFabricId();
 
-            // TODO: The type of 'label' should be 'CharSpan', need to fix the XML definition for broken member type.
-            fabricDescriptor.label =
-                ByteSpan(Uint8::from_const_char(fabricInfo.GetFabricLabel().data()), fabricInfo.GetFabricLabel().size());
+            fabricDescriptor.label         = fabricInfo.GetFabricLabel();
             fabricDescriptor.rootPublicKey = fabricInfo.GetRootPubkey();
 
             ReturnErrorOnFailure(encoder.Encode(fabricDescriptor));
@@ -176,7 +174,7 @@ EmberAfStatus writeFabric(FabricIndex fabricIndex, FabricId fabricId, NodeId nod
     fabricDescriptor->NodeId   = nodeId;
     if (!fabricLabel.empty())
     {
-        fabricDescriptor->Label = ByteSpan(Uint8::from_const_char(fabricLabel.data()), fabricLabel.size());
+        fabricDescriptor->Label = fabricLabel;
     }
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
@@ -407,7 +405,7 @@ namespace {
 
 FabricInfo gFabricBeingCommissioned;
 
-CHIP_ERROR SendNOCResponse(app::Command * commandObj, EmberAfNodeOperationalCertStatus status, uint8_t index, ByteSpan debug_text)
+CHIP_ERROR SendNOCResponse(app::Command * commandObj, EmberAfNodeOperationalCertStatus status, uint8_t index, CharSpan debug_text)
 {
     app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID,
                                          ZCL_NOC_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
@@ -422,8 +420,7 @@ CHIP_ERROR SendNOCResponse(app::Command * commandObj, EmberAfNodeOperationalCert
     {
         ReturnErrorOnFailure(writer->Put(TLV::ContextTag(1), index));
     }
-    // TODO: Change DebugText to CHAR_STRING once strings are supported in command/response fields
-    ReturnErrorOnFailure(writer->Put(TLV::ContextTag(2), debug_text));
+    ReturnErrorOnFailure(writer->PutString(TLV::ContextTag(2), debug_text));
     return commandObj->FinishCommand();
 }
 
@@ -494,7 +491,7 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
 exit:
 
     gFabricBeingCommissioned.Reset();
-    SendNOCResponse(commandObj, nocResponse, fabricIndex, ByteSpan());
+    SendNOCResponse(commandObj, nocResponse, fabricIndex, CharSpan());
 
     if (nocResponse != EMBER_ZCL_NODE_OPERATIONAL_CERT_STATUS_SUCCESS)
     {
@@ -538,7 +535,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
 
 exit:
 
-    SendNOCResponse(commandObj, nocResponse, fabricIndex, ByteSpan());
+    SendNOCResponse(commandObj, nocResponse, fabricIndex, CharSpan());
 
     if (nocResponse != EMBER_ZCL_NODE_OPERATIONAL_CERT_STATUS_SUCCESS)
     {

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -189,11 +189,6 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
 
     ChipLogDetail(Zcl, "OTA Provider received QueryImage");
 
-    // TODO: (#7112) support location param and verify length once CHAR_STRING is supported
-    // Using location parameter is blocked by #5542 (use Span for string arguments). For now, there is no way to safely get the
-    // length of the location string because it is not guaranteed to be null-terminated.
-    Span<const char> locationSpan;
-
     if (metadataForProvider.size() > kMaxMetadataLen)
     {
         ChipLogError(Zcl, "metadata size %zu exceeds max %zu", metadataForProvider.size(), kMaxMetadataLen);
@@ -201,7 +196,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
     }
 
     status = delegate->HandleQueryImage(commandObj, vendorId, productId, hardwareVersion, softwareVersion, protocolsSupported,
-                                        locationSpan, requestorCanConsent, metadataForProvider);
+                                        commandData.location, requestorCanConsent, metadataForProvider);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfSendImmediateDefaultResponse(status);

--- a/src/app/zap-templates/templates/app/attribute-size-src.zapt
+++ b/src/app/zap-templates/templates/app/attribute-size-src.zapt
@@ -4,6 +4,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -85,7 +86,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 {{chipType}} * entry = reinterpret_cast<{{chipType}} *>(write ? src : dest);
                 {{#chip_attribute_list_entryTypes}}
                 {{#if (isString type)}}
+                {{#if (isOctetString type)}}
                 ByteSpan * {{name}}Span = &entry->{{name}}; // {{type}}
+                {{else}}
+                ByteSpan {{name}}SpanStorage(Uint8::from_const_char(entry->{{name}}.data()), entry->{{name}}.size()); // {{type}}
+                ByteSpan * {{name}}Span = &{{name}}SpanStorage;
+                {{/if}}
                 if (CHIP_NO_ERROR != (write ? WriteByteSpan(dest + entryOffset, {{size}}, {{name}}Span) : ReadByteSpan(src + entryOffset, {{size}}, {{name}}Span)))
                 {
                     ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -45,7 +45,7 @@ limitations under the License.
     <cluster code="0x050b"/>
     <item name="index" type="INT8U"/>
     <item name="outputType" type="AudioOutputType"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="AudioOutputType" type="ENUM8">

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -19,8 +19,8 @@ limitations under the License.
 
   <struct name="LabelStruct">
     <cluster code="0x0040"/>
-    <item name="label" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="value" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="label" type="CHAR_STRING" length="16"/>
+    <item name="value" type="CHAR_STRING" length="16"/>
   </struct>
 
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -67,8 +67,7 @@ limitations under the License.
   </enum>
   <struct name="NetworkInterfaceType">
     <cluster code="0x0033"/>
-    <!-- TODO: CHAR_STRING not supported yet in structs. -->
-    <item name="Name" type="OCTET_STRING" length="32"/>
+    <item name="Name" type="CHAR_STRING" length="32"/>
     <item name="FabricConnected" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv4" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv6" type="BOOLEAN"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -53,8 +53,8 @@ limitations under the License.
     <cluster code="0x0507"/>
     <item name="index" type="INT8U"/>
     <item name="inputType" type="MediaInputType"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="description" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
+    <item name="description" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="MediaInputType" type="ENUM8">

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -24,7 +24,7 @@ limitations under the License.
     <item name="VendorId" type="INT16U"/> <!-- Change INT16U to new type VendorID #2395 -->
     <item name="FabricId" type="FABRIC_ID"/>
     <item name="NodeId" type="NODE_ID"/>
-    <item name="Label" type="OCTET_STRING" length="32"/><!-- TODO: Add Label once CHAR_STRING or OCTET_STRING works -->
+    <item name="Label" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="NodeOperationalCertStatus" type="ENUM8">
@@ -108,12 +108,11 @@ limitations under the License.
       <arg name="ICACValue" type="OCTET_STRING" optional="true"/>
     </command>
 
-    <!-- TODO: Change DebugText to CHAR_STRING once strings are supported in command/response fields -->
     <command source="server" code="0x08" name="NOCResponse" optional="false">
       <description>Response to AddNOC or UpdateNOC commands.</description>
       <arg name="StatusCode" type="INT8U"/>
       <arg name="FabricIndex" type="INT8U"/>
-      <arg name="DebugText" type="OCTET_STRING"/>
+      <arg name="DebugText" type="CHAR_STRING"/>
     </command>
 
     <command source="client" code="0x09" name="UpdateFabricLabel" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -19,8 +19,7 @@ limitations under the License.
   <struct name="ThreadMetrics">
     <cluster code="0x0034"/>
     <item name="Id" type="INT64U"/>
-    <!-- TODO: CHAR_STRING not supported yet in structs. -->
-    <item name="Name" type="OCTET_STRING" length="8"/>
+    <item name="Name" type="CHAR_STRING" length="8"/>
     <item name="StackFreeCurrent" type="INT32U"/>
     <item name="StackFreeMinimum" type="INT32U"/>
     <item name="StackSize" type="INT32U"/>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -51,6 +51,6 @@ limitations under the License.
   <struct name="NavigateTargetTargetInfo">
     <cluster code="0x0505"/>
     <item name="identifier" type="INT8U"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
   </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
@@ -59,9 +59,9 @@ limitations under the License.
     <cluster code="0x0504"/>
     <item name="majorNumber" type="INT16U"/>
     <item name="minorNumber" type="INT16U"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="callSign" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="affiliateCallSign" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
+    <item name="callSign" type="CHAR_STRING" length="32"/>
+    <item name="affiliateCallSign" type="CHAR_STRING" length="32"/>
   </struct>
 
   <struct name="TvChannelLineupInfo">

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1447,7 +1447,7 @@ void DeviceCommissioner::OnAddNOCFailureResponse(void * context, uint8_t status)
 }
 
 void DeviceCommissioner::OnOperationalCertificateAddResponse(void * context, uint8_t StatusCode, uint8_t FabricIndex,
-                                                             ByteSpan DebugText)
+                                                             CharSpan DebugText)
 {
     ChipLogProgress(Controller, "Device returned status %d on receiving the NOC", StatusCode);
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -645,7 +645,7 @@ private:
     /* Callback when adding operational certs to device results in failure */
     static void OnAddNOCFailureResponse(void * context, uint8_t status);
     /* Callback when the device confirms that it has added the operational certificates */
-    static void OnOperationalCertificateAddResponse(void * context, uint8_t StatusCode, uint8_t FabricIndex, ByteSpan DebugText);
+    static void OnOperationalCertificateAddResponse(void * context, uint8_t StatusCode, uint8_t FabricIndex, CharSpan DebugText);
 
     /* Callback when the device confirms that it has added the root certificate */
     static void OnRootCertSuccessResponse(void * context);

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -462,7 +462,8 @@ class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCall
                 jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entry.{{asLowerCamelCase name}}.size());
                 env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entry.{{asLowerCamelCase name}}.size(), reinterpret_cast<const jbyte *>(entry.{{asLowerCamelCase name}}.data()));
                 {{else if (isCharString type)}}
-                // Implement after ByteSpan is emitted instead of uint8_t *.
+                UtfString {{asLowerCamelCase name}}Str(env, entry.{{asLowerCamelCase name}});
+                jstring {{asLowerCamelCase name}}({{asLowerCamelCase name}}Str.jniValue());
                 {{else}}
                 {{asJniBasicType type}} {{asLowerCamelCase name}} = entry.{{asLowerCamelCase name}};
                 {{/if}}
@@ -481,7 +482,8 @@ class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCall
                 jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entry.size());
                 env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entry.size(), reinterpret_cast<const jbyte *>(entry.data()));
                 {{else if (isCharString type)}}
-                // Implement after ByteSpan is emitted instead of uint8_t *
+                UtfString {{asLowerCamelCase name}}Str(env, entry);
+                jstring {{asLowerCamelCase name}}({{asLowerCamelCase name}}Str.jniValue());
                 {{else}}
                 jclass entryTypeCls;
                 JniReferences::GetInstance().GetClassRef(env, "java/lang/{{asJavaBasicTypeForZclType type true}}", entryTypeCls);

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -364,9 +364,9 @@ public class ChipClusters {
     public static class AudioOutputListAttribute {
       public int index;
       public int outputType;
-      public byte[] name;
+      public String name;
 
-      public AudioOutputListAttribute(int index, int outputType, byte[] name) {
+      public AudioOutputListAttribute(int index, int outputType, String name) {
         this.index = index;
         this.outputType = outputType;
         this.name = name;
@@ -2702,10 +2702,10 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public static class LabelListAttribute {
-      public byte[] label;
-      public byte[] value;
+      public String label;
+      public String value;
 
-      public LabelListAttribute(byte[] label, byte[] value) {
+      public LabelListAttribute(String label, String value) {
         this.label = label;
         this.value = value;
       }
@@ -2899,7 +2899,7 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public static class NetworkInterfacesAttribute {
-      public byte[] name;
+      public String name;
       public boolean fabricConnected;
       public boolean offPremiseServicesReachableIPv4;
       public boolean offPremiseServicesReachableIPv6;
@@ -2907,7 +2907,7 @@ public class ChipClusters {
       public int type;
 
       public NetworkInterfacesAttribute(
-          byte[] name,
+          String name,
           boolean fabricConnected,
           boolean offPremiseServicesReachableIPv4,
           boolean offPremiseServicesReachableIPv6,
@@ -3594,10 +3594,10 @@ public class ChipClusters {
     public static class MediaInputListAttribute {
       public int index;
       public int inputType;
-      public byte[] name;
-      public byte[] description;
+      public String name;
+      public String description;
 
-      public MediaInputListAttribute(int index, int inputType, byte[] name, byte[] description) {
+      public MediaInputListAttribute(int index, int inputType, String name, String description) {
         this.index = index;
         this.inputType = inputType;
         this.name = name;
@@ -4551,7 +4551,7 @@ public class ChipClusters {
     }
 
     public interface NOCResponseCallback {
-      void onSuccess(int StatusCode, int FabricIndex, byte[] DebugText);
+      void onSuccess(int StatusCode, int FabricIndex, String DebugText);
 
       void onError(Exception error);
     }
@@ -4568,7 +4568,7 @@ public class ChipClusters {
       public int vendorId;
       public long fabricId;
       public long nodeId;
-      public byte[] label;
+      public String label;
 
       public FabricsListAttribute(
           int fabricIndex,
@@ -4576,7 +4576,7 @@ public class ChipClusters {
           int vendorId,
           long fabricId,
           long nodeId,
-          byte[] label) {
+          String label) {
         this.fabricIndex = fabricIndex;
         this.rootPublicKey = rootPublicKey;
         this.vendorId = vendorId;
@@ -5236,16 +5236,16 @@ public class ChipClusters {
     public static class TvChannelListAttribute {
       public int majorNumber;
       public int minorNumber;
-      public byte[] name;
-      public byte[] callSign;
-      public byte[] affiliateCallSign;
+      public String name;
+      public String callSign;
+      public String affiliateCallSign;
 
       public TvChannelListAttribute(
           int majorNumber,
           int minorNumber,
-          byte[] name,
-          byte[] callSign,
-          byte[] affiliateCallSign) {
+          String name,
+          String callSign,
+          String affiliateCallSign) {
         this.majorNumber = majorNumber;
         this.minorNumber = minorNumber;
         this.name = name;
@@ -5316,9 +5316,9 @@ public class ChipClusters {
 
     public static class TargetNavigatorListAttribute {
       public int identifier;
-      public byte[] name;
+      public String name;
 
-      public TargetNavigatorListAttribute(int identifier, byte[] name) {
+      public TargetNavigatorListAttribute(int identifier, String name) {
         this.identifier = identifier;
         this.name = name;
       }

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -176,7 +176,7 @@ static void OnAudioOutputAudioOutputListListAttributeResponse(
         ChipLogProgress(Zcl, "    {");
         ChipLogProgress(Zcl, "      index: %" PRIu8 ",", entry.index);
         ChipLogProgress(Zcl, "      outputType: %" PRIu8 ",", entry.outputType);
-        ChipLogProgress(Zcl, "      name: %s,", ByteSpanToString(entry.name).c_str());
+        ChipLogProgress(Zcl, "      name: %.*s,", static_cast<int>(entry.name.size()), entry.name.data());
         ChipLogProgress(Zcl, "    },");
     }
 
@@ -464,8 +464,8 @@ static void OnFixedLabelLabelListListAttributeResponse(
         auto & entry = iter.GetValue();
 #endif // CHIP_PROGRESS_LOGGING
         ChipLogProgress(Zcl, "    {");
-        ChipLogProgress(Zcl, "      label: %s,", ByteSpanToString(entry.label).c_str());
-        ChipLogProgress(Zcl, "      value: %s,", ByteSpanToString(entry.value).c_str());
+        ChipLogProgress(Zcl, "      label: %.*s,", static_cast<int>(entry.label.size()), entry.label.data());
+        ChipLogProgress(Zcl, "      value: %.*s,", static_cast<int>(entry.value.size()), entry.value.data());
         ChipLogProgress(Zcl, "    },");
     }
 
@@ -555,7 +555,7 @@ static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(
         auto & entry = iter.GetValue();
 #endif // CHIP_PROGRESS_LOGGING
         ChipLogProgress(Zcl, "    {");
-        ChipLogProgress(Zcl, "      Name: %s,", ByteSpanToString(entry.name).c_str());
+        ChipLogProgress(Zcl, "      Name: %.*s,", static_cast<int>(entry.name.size()), entry.name.data());
         ChipLogProgress(Zcl, "      FabricConnected: %d,", entry.fabricConnected);
         ChipLogProgress(Zcl, "      OffPremiseServicesReachableIPv4: %d,", entry.offPremiseServicesReachableIPv4);
         ChipLogProgress(Zcl, "      OffPremiseServicesReachableIPv6: %d,", entry.offPremiseServicesReachableIPv6);
@@ -699,8 +699,8 @@ static void OnMediaInputMediaInputListListAttributeResponse(
         ChipLogProgress(Zcl, "    {");
         ChipLogProgress(Zcl, "      index: %" PRIu8 ",", entry.index);
         ChipLogProgress(Zcl, "      inputType: %" PRIu8 ",", entry.inputType);
-        ChipLogProgress(Zcl, "      name: %s,", ByteSpanToString(entry.name).c_str());
-        ChipLogProgress(Zcl, "      description: %s,", ByteSpanToString(entry.description).c_str());
+        ChipLogProgress(Zcl, "      name: %.*s,", static_cast<int>(entry.name.size()), entry.name.data());
+        ChipLogProgress(Zcl, "      description: %.*s,", static_cast<int>(entry.description.size()), entry.description.data());
         ChipLogProgress(Zcl, "    },");
     }
 
@@ -749,7 +749,7 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(
         ChipLogProgress(Zcl, "      VendorId: %" PRIu16 ",", entry.vendorId);
         ChipLogProgress(Zcl, "      FabricId: %" PRIu64 ",", entry.fabricId);
         ChipLogProgress(Zcl, "      NodeId: %" PRIu64 ",", entry.nodeId);
-        ChipLogProgress(Zcl, "      Label: %s,", ByteSpanToString(entry.label).c_str());
+        ChipLogProgress(Zcl, "      Label: %.*s,", static_cast<int>(entry.label.size()), entry.label.data());
         ChipLogProgress(Zcl, "    },");
     }
 
@@ -833,9 +833,10 @@ static void OnTvChannelTvChannelListListAttributeResponse(
         ChipLogProgress(Zcl, "    {");
         ChipLogProgress(Zcl, "      majorNumber: %" PRIu16 ",", entry.majorNumber);
         ChipLogProgress(Zcl, "      minorNumber: %" PRIu16 ",", entry.minorNumber);
-        ChipLogProgress(Zcl, "      name: %s,", ByteSpanToString(entry.name).c_str());
-        ChipLogProgress(Zcl, "      callSign: %s,", ByteSpanToString(entry.callSign).c_str());
-        ChipLogProgress(Zcl, "      affiliateCallSign: %s,", ByteSpanToString(entry.affiliateCallSign).c_str());
+        ChipLogProgress(Zcl, "      name: %.*s,", static_cast<int>(entry.name.size()), entry.name.data());
+        ChipLogProgress(Zcl, "      callSign: %.*s,", static_cast<int>(entry.callSign.size()), entry.callSign.data());
+        ChipLogProgress(Zcl, "      affiliateCallSign: %.*s,", static_cast<int>(entry.affiliateCallSign.size()),
+                        entry.affiliateCallSign.data());
         ChipLogProgress(Zcl, "    },");
     }
 
@@ -880,7 +881,7 @@ static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(
 #endif // CHIP_PROGRESS_LOGGING
         ChipLogProgress(Zcl, "    {");
         ChipLogProgress(Zcl, "      identifier: %" PRIu8 ",", entry.identifier);
-        ChipLogProgress(Zcl, "      name: %s,", ByteSpanToString(entry.name).c_str());
+        ChipLogProgress(Zcl, "      name: %.*s,", static_cast<int>(entry.name.size()), entry.name.data());
         ChipLogProgress(Zcl, "    },");
     }
 

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -122,7 +122,7 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
         {{#if (isOctetString type)}}
         ChipLogProgress(Zcl, "      {{asSymbol label}}: %s,", ByteSpanToString(entry.{{asLowerCamelCase name}}).c_str());
         {{else if (isCharString type)}}
-        // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
+        ChipLogProgress(Zcl, "      {{asSymbol label}}: %.*s,", static_cast<int>(entry.{{asLowerCamelCase name}}.size()), entry.{{asLowerCamelCase name}}.data());
         {{else}}
         ChipLogProgress(Zcl, "      {{asSymbol label}}: {{asPrintFormat type}},", entry.{{asLowerCamelCase name}});
         {{/if}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -104,7 +104,7 @@ void CHIPAudioOutputAudioOutputListListAttributeCallbackBridge::OnSuccessFn(void
         [array addObject:@ {
             @"index" : [NSNumber numberWithUnsignedChar:entry.index],
             @"outputType" : [NSNumber numberWithUnsignedChar:entry.outputType],
-            @"name" : [NSData dataWithBytes:entry.name.data() length:entry.name.size()],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -228,8 +228,8 @@ void CHIPFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * cont
     while (iter.Next()) {
         auto & entry = iter.GetValue();
         [array addObject:@ {
-            @"label" : [NSData dataWithBytes:entry.label.data() length:entry.label.size()],
-            @"value" : [NSData dataWithBytes:entry.value.data() length:entry.value.size()],
+            @"label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
+            @"value" : [[NSString alloc] initWithBytes:entry.value.data() length:entry.value.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -269,7 +269,7 @@ void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucce
     while (iter.Next()) {
         auto & entry = iter.GetValue();
         [array addObject:@ {
-            @"Name" : [NSData dataWithBytes:entry.name.data() length:entry.name.size()],
+            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
             @"FabricConnected" : [NSNumber numberWithBool:entry.fabricConnected],
             @"OffPremiseServicesReachableIPv4" : [NSNumber numberWithBool:entry.offPremiseServicesReachableIPv4],
             @"OffPremiseServicesReachableIPv6" : [NSNumber numberWithBool:entry.offPremiseServicesReachableIPv6],
@@ -339,8 +339,10 @@ void CHIPMediaInputMediaInputListListAttributeCallbackBridge::OnSuccessFn(void *
         [array addObject:@ {
             @"index" : [NSNumber numberWithUnsignedChar:entry.index],
             @"inputType" : [NSNumber numberWithUnsignedChar:entry.inputType],
-            @"name" : [NSData dataWithBytes:entry.name.data() length:entry.name.size()],
-            @"description" : [NSData dataWithBytes:entry.description.data() length:entry.description.size()],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"description" : [[NSString alloc] initWithBytes:entry.description.data()
+                                                      length:entry.description.size()
+                                                    encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -365,7 +367,7 @@ void CHIPOperationalCredentialsFabricsListListAttributeCallbackBridge::OnSuccess
             @"VendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
             @"FabricId" : [NSNumber numberWithUnsignedLongLong:entry.fabricId],
             @"NodeId" : [NSNumber numberWithUnsignedLongLong:entry.nodeId],
-            @"Label" : [NSData dataWithBytes:entry.label.data() length:entry.label.size()],
+            @"Label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -403,9 +405,13 @@ void CHIPTvChannelTvChannelListListAttributeCallbackBridge::OnSuccessFn(void * c
         [array addObject:@ {
             @"majorNumber" : [NSNumber numberWithUnsignedShort:entry.majorNumber],
             @"minorNumber" : [NSNumber numberWithUnsignedShort:entry.minorNumber],
-            @"name" : [NSData dataWithBytes:entry.name.data() length:entry.name.size()],
-            @"callSign" : [NSData dataWithBytes:entry.callSign.data() length:entry.callSign.size()],
-            @"affiliateCallSign" : [NSData dataWithBytes:entry.affiliateCallSign.data() length:entry.affiliateCallSign.size()],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"callSign" : [[NSString alloc] initWithBytes:entry.callSign.data()
+                                                   length:entry.callSign.size()
+                                                 encoding:NSUTF8StringEncoding],
+            @"affiliateCallSign" : [[NSString alloc] initWithBytes:entry.affiliateCallSign.data()
+                                                            length:entry.affiliateCallSign.size()
+                                                          encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -426,7 +432,7 @@ void CHIPTargetNavigatorTargetNavigatorListListAttributeCallbackBridge::OnSucces
         auto & entry = iter.GetValue();
         [array addObject:@ {
             @"identifier" : [NSNumber numberWithUnsignedChar:entry.identifier],
-            @"name" : [NSData dataWithBytes:entry.name.data() length:entry.name.size()],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -1127,12 +1133,12 @@ void CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge::On
 };
 
 void CHIPOperationalCredentialsClusterNOCResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t StatusCode, uint8_t FabricIndex, chip::ByteSpan DebugText)
+    void * context, uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText)
 {
     DispatchSuccess(context, @ {
         @"StatusCode" : [NSNumber numberWithUnsignedChar:StatusCode],
         @"FabricIndex" : [NSNumber numberWithUnsignedChar:FabricIndex],
-        @"DebugText" : [NSData dataWithBytes:DebugText.data() length:DebugText.size()],
+        @"DebugText" : [[NSString alloc] initWithBytes:DebugText.data() length:DebugText.size() encoding:NSUTF8StringEncoding],
     });
 };
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -1142,7 +1142,7 @@ public:
                                                                CHIPActionBlock action, bool keepAlive = false) :
         CHIPCallbackBridge<OperationalCredentialsClusterNOCResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t StatusCode, uint8_t FabricIndex, chip::ByteSpan DebugText);
+    static void OnSuccessFn(void * context, uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText);
 };
 
 class CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge

--- a/zzz_generated/all-clusters-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -117,8 +118,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
-                           &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->outputType));                                  // AudioOutputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -255,15 +257,17 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan labelSpanStorage(Uint8::from_const_char(entry->label.data()), entry->label.size()); // CHAR_STRING
+            ByteSpan * labelSpan = &labelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 18);
+            ByteSpan valueSpanStorage(Uint8::from_const_char(entry->value.data()), entry->value.size()); // CHAR_STRING
+            ByteSpan * valueSpan = &valueSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -316,7 +320,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -426,16 +431,19 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
-                           &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+                           &entryOffset, sizeof(entry->inputType));                                   // MediaInputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan descriptionSpanStorage(Uint8::from_const_char(entry->description.data()),
+                                            entry->description.size()); // CHAR_STRING
+            ByteSpan * descriptionSpan = &descriptionSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -481,8 +489,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -561,24 +570,28 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->majorNumber, write ? (uint8_t *) &entry->majorNumber : src, write,
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
-                           &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+                           &entryOffset, sizeof(entry->minorNumber));                                 // INT16U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan callSignSpanStorage(Uint8::from_const_char(entry->callSign.data()), entry->callSign.size()); // CHAR_STRING
+            ByteSpan * callSignSpan = &callSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan affiliateCallSignSpanStorage(Uint8::from_const_char(entry->affiliateCallSign.data()),
+                                                  entry->affiliateCallSign.size()); // CHAR_STRING
+            ByteSpan * affiliateCallSignSpan = &affiliateCallSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -609,8 +622,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             // Struct _NavigateTargetTargetInfo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
-                           &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->identifier));                                  // INT8U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -92,7 +92,7 @@ typedef struct _AudioOutputInfo
 {
     uint8_t index;
     uint8_t outputType;
-    chip::ByteSpan name;
+    chip::CharSpan name;
 } AudioOutputInfo;
 
 // Struct for BasicCommissioningInfoType
@@ -172,7 +172,7 @@ typedef struct _FabricDescriptor
     uint16_t VendorId;
     chip::FabricId FabricId;
     chip::NodeId NodeId;
-    chip::ByteSpan Label;
+    chip::CharSpan Label;
 } FabricDescriptor;
 
 // Struct for GroupKey
@@ -203,8 +203,8 @@ typedef struct _IasAceZoneStatusResult
 // Struct for LabelStruct
 typedef struct _LabelStruct
 {
-    chip::ByteSpan label;
-    chip::ByteSpan value;
+    chip::CharSpan label;
+    chip::CharSpan value;
 } LabelStruct;
 
 // Struct for MediaInputInfo
@@ -212,8 +212,8 @@ typedef struct _MediaInputInfo
 {
     uint8_t index;
     uint8_t inputType;
-    chip::ByteSpan name;
-    chip::ByteSpan description;
+    chip::CharSpan name;
+    chip::CharSpan description;
 } MediaInputInfo;
 
 // Struct for MediaPlaybackPosition
@@ -234,7 +234,7 @@ typedef struct _NOCStruct
 typedef struct _NavigateTargetTargetInfo
 {
     uint8_t identifier;
-    chip::ByteSpan name;
+    chip::CharSpan name;
 } NavigateTargetTargetInfo;
 
 // Struct for NeighborTable
@@ -259,7 +259,7 @@ typedef struct _NeighborTable
 // Struct for NetworkInterfaceType
 typedef struct _NetworkInterfaceType
 {
-    chip::ByteSpan Name;
+    chip::CharSpan Name;
     bool FabricConnected;
     bool OffPremiseServicesReachableIPv4;
     bool OffPremiseServicesReachableIPv6;
@@ -378,7 +378,7 @@ typedef struct _ThreadInterfaceScanResult
 typedef struct _ThreadMetrics
 {
     uint64_t Id;
-    chip::ByteSpan Name;
+    chip::CharSpan Name;
     uint32_t StackFreeCurrent;
     uint32_t StackFreeMinimum;
     uint32_t StackSize;
@@ -400,9 +400,9 @@ typedef struct _TvChannelInfo
 {
     uint16_t majorNumber;
     uint16_t minorNumber;
-    chip::ByteSpan name;
-    chip::ByteSpan callSign;
-    chip::ByteSpan affiliateCallSign;
+    chip::CharSpan name;
+    chip::CharSpan callSign;
+    chip::CharSpan affiliateCallSign;
 } TvChannelInfo;
 
 // Struct for TvChannelLineupInfo

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -12867,7 +12867,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(
  * @brief Operational Credentials Cluster NOCResponse Command callback (from server)
  */
 bool emberAfOperationalCredentialsClusterNOCResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                             uint8_t StatusCode, uint8_t FabricIndex, chip::ByteSpan DebugText);
+                                                             uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText);
 /**
  * @brief Operational Credentials Cluster UpdateFabricLabel Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -6719,7 +6719,7 @@ enum class Fields
 struct Type
 {
 public:
-    chip::ByteSpan name;
+    chip::CharSpan name;
     bool fabricConnected;
     bool offPremiseServicesReachableIPv4;
     bool offPremiseServicesReachableIPv6;
@@ -6835,7 +6835,7 @@ struct Type
 {
 public:
     uint64_t id;
-    chip::ByteSpan name;
+    chip::CharSpan name;
     uint32_t stackFreeCurrent;
     uint32_t stackFreeMinimum;
     uint32_t stackSize;
@@ -8526,7 +8526,7 @@ public:
     uint16_t vendorId;
     chip::FabricId fabricId;
     chip::NodeId nodeId;
-    chip::ByteSpan label;
+    chip::CharSpan label;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -8820,7 +8820,7 @@ public:
 
     uint8_t statusCode;
     uint8_t fabricIndex;
-    chip::ByteSpan debugText;
+    chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8833,7 +8833,7 @@ public:
 
     uint8_t statusCode;
     uint8_t fabricIndex;
-    chip::ByteSpan debugText;
+    chip::CharSpan debugText;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace NOCResponse
@@ -9007,8 +9007,8 @@ enum class Fields
 struct Type
 {
 public:
-    chip::ByteSpan label;
-    chip::ByteSpan value;
+    chip::CharSpan label;
+    chip::CharSpan value;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -18301,9 +18301,9 @@ struct Type
 public:
     uint16_t majorNumber;
     uint16_t minorNumber;
-    chip::ByteSpan name;
-    chip::ByteSpan callSign;
-    chip::ByteSpan affiliateCallSign;
+    chip::CharSpan name;
+    chip::CharSpan callSign;
+    chip::CharSpan affiliateCallSign;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -18519,7 +18519,7 @@ struct Type
 {
 public:
     uint8_t identifier;
-    chip::ByteSpan name;
+    chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -19382,8 +19382,8 @@ struct Type
 public:
     uint8_t index;
     MediaInputType inputType;
-    chip::ByteSpan name;
-    chip::ByteSpan description;
+    chip::CharSpan name;
+    chip::CharSpan description;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20093,7 +20093,7 @@ struct Type
 public:
     uint8_t index;
     AudioOutputType outputType;
-    chip::ByteSpan name;
+    chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
     CHIP_ERROR Decode(TLV::TLVReader & reader);

--- a/zzz_generated/bridge-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/bridge-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -155,15 +156,17 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan labelSpanStorage(Uint8::from_const_char(entry->label.data()), entry->label.size()); // CHAR_STRING
+            ByteSpan * labelSpan = &labelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 18);
+            ByteSpan valueSpanStorage(Uint8::from_const_char(entry->value.data()), entry->value.size()); // CHAR_STRING
+            ByteSpan * valueSpan = &valueSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -216,7 +219,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -280,8 +284,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -219,7 +219,7 @@ static void OnAudioOutputAudioOutputListListAttributeResponse(
         ChipLogProgress(chipTool, "AudioOutputInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  index: %" PRIu8 "", entry.index);
         ChipLogProgress(chipTool, "  outputType: %" PRIu8 "", entry.outputType);
-        ChipLogProgress(Zcl, "  name: %zu", entry.name.size());
+        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
     }
 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -464,8 +464,8 @@ static void OnFixedLabelLabelListListAttributeResponse(
 #endif // CHIP_PROGRESS_LOGGING
         ++i;
         ChipLogProgress(chipTool, "LabelStruct[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  label: %zu", entry.label.size());
-        ChipLogProgress(Zcl, "  value: %zu", entry.value.size());
+        ChipLogProgress(Zcl, "  label: %.*s", static_cast<int>(entry.label.size()), entry.label.data());
+        ChipLogProgress(Zcl, "  value: %.*s", static_cast<int>(entry.value.size()), entry.value.data());
     }
 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -539,7 +539,7 @@ static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(
 #endif // CHIP_PROGRESS_LOGGING
         ++i;
         ChipLogProgress(chipTool, "NetworkInterfaceType[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  Name: %zu", entry.name.size());
+        ChipLogProgress(Zcl, "  Name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
         ChipLogProgress(chipTool, "  fabricConnected: %d", entry.fabricConnected);
         ChipLogProgress(chipTool, "  offPremiseServicesReachableIPv4: %d", entry.offPremiseServicesReachableIPv4);
         ChipLogProgress(chipTool, "  offPremiseServicesReachableIPv6: %d", entry.offPremiseServicesReachableIPv6);
@@ -660,8 +660,8 @@ static void OnMediaInputMediaInputListListAttributeResponse(
         ChipLogProgress(chipTool, "MediaInputInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  index: %" PRIu8 "", entry.index);
         ChipLogProgress(chipTool, "  inputType: %" PRIu8 "", entry.inputType);
-        ChipLogProgress(Zcl, "  name: %zu", entry.name.size());
-        ChipLogProgress(Zcl, "  description: %zu", entry.description.size());
+        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
+        ChipLogProgress(Zcl, "  description: %.*s", static_cast<int>(entry.description.size()), entry.description.data());
     }
 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -703,7 +703,7 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(
         ChipLogProgress(chipTool, "  vendorId: %" PRIu16 "", entry.vendorId);
         ChipLogProgress(chipTool, "  fabricId: %" PRIu64 "", entry.fabricId);
         ChipLogProgress(chipTool, "  nodeId: %" PRIu64 "", entry.nodeId);
-        ChipLogProgress(Zcl, "  Label: %zu", entry.label.size());
+        ChipLogProgress(Zcl, "  Label: %.*s", static_cast<int>(entry.label.size()), entry.label.data());
     }
 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -775,9 +775,10 @@ static void OnTvChannelTvChannelListListAttributeResponse(
         ChipLogProgress(chipTool, "TvChannelInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  majorNumber: %" PRIu16 "", entry.majorNumber);
         ChipLogProgress(chipTool, "  minorNumber: %" PRIu16 "", entry.minorNumber);
-        ChipLogProgress(Zcl, "  name: %zu", entry.name.size());
-        ChipLogProgress(Zcl, "  callSign: %zu", entry.callSign.size());
-        ChipLogProgress(Zcl, "  affiliateCallSign: %zu", entry.affiliateCallSign.size());
+        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
+        ChipLogProgress(Zcl, "  callSign: %.*s", static_cast<int>(entry.callSign.size()), entry.callSign.data());
+        ChipLogProgress(Zcl, "  affiliateCallSign: %.*s", static_cast<int>(entry.affiliateCallSign.size()),
+                        entry.affiliateCallSign.data());
     }
 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -815,7 +816,7 @@ static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(
         ++i;
         ChipLogProgress(chipTool, "NavigateTargetTargetInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  identifier: %" PRIu8 "", entry.identifier);
-        ChipLogProgress(Zcl, "  name: %zu", entry.name.size());
+        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
     }
 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -1812,7 +1813,7 @@ static void OnOperationalCredentialsNOCResponseSuccess(
     ChipLogProgress(Zcl, "Received NOCResponse:");
     ChipLogProgress(Zcl, "  StatusCode: %" PRIu8 "", data.statusCode);
     ChipLogProgress(Zcl, "  FabricIndex: %" PRIu8 "", data.fabricIndex);
-    ChipLogProgress(Zcl, "  DebugText: %zu", data.debugText.size());
+    ChipLogProgress(Zcl, "  DebugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
     command->SetCommandExitStatus(CHIP_NO_ERROR);

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -1734,12 +1734,12 @@ bool emberAfOperationalCredentialsClusterCertificateChainResponseCallback(Endpoi
 }
 
 bool emberAfOperationalCredentialsClusterNOCResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                             uint8_t StatusCode, uint8_t FabricIndex, chip::ByteSpan DebugText)
+                                                             uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText)
 {
     ChipLogProgress(Zcl, "NOCResponse:");
     ChipLogProgress(Zcl, "  StatusCode: %" PRIu8 "", StatusCode);
     ChipLogProgress(Zcl, "  FabricIndex: %" PRIu8 "", FabricIndex);
-    ChipLogProgress(Zcl, "  DebugText: %zu", DebugText.size());
+    ChipLogProgress(Zcl, "  DebugText: %.*s", static_cast<int>(DebugText.size()), DebugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("OperationalCredentialsClusterNOCResponseCallback");
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
@@ -123,7 +123,7 @@ typedef void (*OperationalCredentialsClusterAttestationResponseCallback)(void * 
                                                                          chip::ByteSpan Signature);
 typedef void (*OperationalCredentialsClusterCertificateChainResponseCallback)(void * context, chip::ByteSpan Certificate);
 typedef void (*OperationalCredentialsClusterNOCResponseCallback)(void * context, uint8_t StatusCode, uint8_t FabricIndex,
-                                                                 chip::ByteSpan DebugText);
+                                                                 chip::CharSpan DebugText);
 typedef void (*OperationalCredentialsClusterOpCSRResponseCallback)(void * context, chip::ByteSpan NOCSRElements,
                                                                    chip::ByteSpan AttestationSignature);
 typedef void (*ScenesClusterAddSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);

--- a/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
@@ -4233,7 +4233,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             expectArgumentCount = 3;
             uint8_t StatusCode;
             uint8_t FabricIndex;
-            chip::ByteSpan DebugText;
+            chip::CharSpan DebugText;
             bool argExists[3];
 
             memset(argExists, 0, sizeof argExists);

--- a/zzz_generated/controller-clusters/zap-generated/attribute-size.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 

--- a/zzz_generated/lighting-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/lighting-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -179,7 +180,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -243,8 +245,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/lock-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/lock-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -179,7 +180,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -243,8 +245,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/ota-provider-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/ota-provider-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -134,8 +135,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/ota-requestor-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -134,8 +135,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/pump-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/pump-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -179,7 +180,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -243,8 +245,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/pump-controller-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -179,7 +180,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -243,8 +245,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/temperature-measurement-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/temperature-measurement-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -179,7 +180,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -243,8 +245,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/zzz_generated/thermostat/zap-generated/attribute-size.cpp
+++ b/zzz_generated/thermostat/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -117,8 +118,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
-                           &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->outputType));                                  // AudioOutputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -255,15 +257,17 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan labelSpanStorage(Uint8::from_const_char(entry->label.data()), entry->label.size()); // CHAR_STRING
+            ByteSpan * labelSpan = &labelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 18);
+            ByteSpan valueSpanStorage(Uint8::from_const_char(entry->value.data()), entry->value.size()); // CHAR_STRING
+            ByteSpan * valueSpan = &valueSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -316,7 +320,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -426,16 +431,19 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
-                           &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+                           &entryOffset, sizeof(entry->inputType));                                   // MediaInputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan descriptionSpanStorage(Uint8::from_const_char(entry->description.data()),
+                                            entry->description.size()); // CHAR_STRING
+            ByteSpan * descriptionSpan = &descriptionSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -481,8 +489,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -541,24 +550,28 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->majorNumber, write ? (uint8_t *) &entry->majorNumber : src, write,
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
-                           &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+                           &entryOffset, sizeof(entry->minorNumber));                                 // INT16U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan callSignSpanStorage(Uint8::from_const_char(entry->callSign.data()), entry->callSign.size()); // CHAR_STRING
+            ByteSpan * callSignSpan = &callSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan affiliateCallSignSpanStorage(Uint8::from_const_char(entry->affiliateCallSign.data()),
+                                                  entry->affiliateCallSign.size()); // CHAR_STRING
+            ByteSpan * affiliateCallSignSpan = &affiliateCallSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -589,8 +602,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             // Struct _NavigateTargetTargetInfo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
-                           &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->identifier));                                  // INT8U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.cpp
@@ -487,12 +487,12 @@ bool emberAfOperationalCredentialsClusterCertificateChainResponseCallback(Endpoi
 }
 
 bool emberAfOperationalCredentialsClusterNOCResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                             uint8_t StatusCode, uint8_t FabricIndex, chip::ByteSpan DebugText)
+                                                             uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText)
 {
     ChipLogProgress(Zcl, "NOCResponse:");
     ChipLogProgress(Zcl, "  StatusCode: %" PRIu8 "", StatusCode);
     ChipLogProgress(Zcl, "  FabricIndex: %" PRIu8 "", FabricIndex);
-    ChipLogProgress(Zcl, "  DebugText: %zu", DebugText.size());
+    ChipLogProgress(Zcl, "  DebugText: %.*s", static_cast<int>(DebugText.size()), DebugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("OperationalCredentialsClusterNOCResponseCallback");
 

--- a/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.h
@@ -63,7 +63,7 @@ typedef void (*OperationalCredentialsClusterAttestationResponseCallback)(void * 
                                                                          chip::ByteSpan Signature);
 typedef void (*OperationalCredentialsClusterCertificateChainResponseCallback)(void * context, chip::ByteSpan Certificate);
 typedef void (*OperationalCredentialsClusterNOCResponseCallback)(void * context, uint8_t StatusCode, uint8_t FabricIndex,
-                                                                 chip::ByteSpan DebugText);
+                                                                 chip::CharSpan DebugText);
 typedef void (*OperationalCredentialsClusterOpCSRResponseCallback)(void * context, chip::ByteSpan NOCSRElements,
                                                                    chip::ByteSpan AttestationSignature);
 

--- a/zzz_generated/tv-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/tv-app/zap-generated/IMClusterCommandHandler.cpp
@@ -2016,7 +2016,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             expectArgumentCount = 3;
             uint8_t StatusCode;
             uint8_t FabricIndex;
-            chip::ByteSpan DebugText;
+            chip::CharSpan DebugText;
             bool argExists[3];
 
             memset(argExists, 0, sizeof argExists);

--- a/zzz_generated/tv-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/tv-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -117,8 +118,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
-                           &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->outputType));                                  // AudioOutputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -279,7 +281,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -389,16 +392,19 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
-                           &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+                           &entryOffset, sizeof(entry->inputType));                                   // MediaInputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan descriptionSpanStorage(Uint8::from_const_char(entry->description.data()),
+                                            entry->description.size()); // CHAR_STRING
+            ByteSpan * descriptionSpan = &descriptionSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -444,8 +450,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -504,24 +511,28 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->majorNumber, write ? (uint8_t *) &entry->majorNumber : src, write,
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
-                           &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+                           &entryOffset, sizeof(entry->minorNumber));                                 // INT16U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan callSignSpanStorage(Uint8::from_const_char(entry->callSign.data()), entry->callSign.size()); // CHAR_STRING
+            ByteSpan * callSignSpan = &callSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan affiliateCallSignSpanStorage(Uint8::from_const_char(entry->affiliateCallSign.data()),
+                                                  entry->affiliateCallSign.size()); // CHAR_STRING
+            ByteSpan * affiliateCallSignSpan = &affiliateCallSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -552,8 +563,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             // Struct _NavigateTargetTargetInfo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
-                           &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->identifier));                                  // INT8U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/zzz_generated/tv-casting-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/tv-casting-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -117,8 +118,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
-                           &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->outputType));                                  // AudioOutputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -255,15 +257,17 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan labelSpanStorage(Uint8::from_const_char(entry->label.data()), entry->label.size()); // CHAR_STRING
+            ByteSpan * labelSpan = &labelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 18);
+            ByteSpan valueSpanStorage(Uint8::from_const_char(entry->value.data()), entry->value.size()); // CHAR_STRING
+            ByteSpan * valueSpan = &valueSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -316,7 +320,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -426,16 +431,19 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->index, write ? (uint8_t *) &entry->index : src, write, &entryOffset,
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
-                           &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+                           &entryOffset, sizeof(entry->inputType));                                   // MediaInputType
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan descriptionSpanStorage(Uint8::from_const_char(entry->description.data()),
+                                            entry->description.size()); // CHAR_STRING
+            ByteSpan * descriptionSpan = &descriptionSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -481,8 +489,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -514,24 +523,28 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->majorNumber, write ? (uint8_t *) &entry->majorNumber : src, write,
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
-                           &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+                           &entryOffset, sizeof(entry->minorNumber));                                 // INT16U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan callSignSpanStorage(Uint8::from_const_char(entry->callSign.data()), entry->callSign.size()); // CHAR_STRING
+            ByteSpan * callSignSpan = &callSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                 return 0;
             }
-            entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+            ByteSpan affiliateCallSignSpanStorage(Uint8::from_const_char(entry->affiliateCallSign.data()),
+                                                  entry->affiliateCallSign.size()); // CHAR_STRING
+            ByteSpan * affiliateCallSignSpan = &affiliateCallSignSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -562,8 +575,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             // Struct _NavigateTargetTargetInfo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
-                           &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+                           &entryOffset, sizeof(entry->identifier));                                  // INT8U
+            ByteSpan nameSpanStorage(Uint8::from_const_char(entry->name.data()), entry->name.size()); // CHAR_STRING
+            ByteSpan * nameSpan = &nameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/zzz_generated/window-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/window-app/zap-generated/attribute-size.cpp
@@ -21,6 +21,7 @@
 #include <app/util/af.h>
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -179,7 +180,8 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan NameSpanStorage(Uint8::from_const_char(entry->Name.data()), entry->Name.size()); // CHAR_STRING
+            ByteSpan * NameSpan = &NameSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -243,8 +245,9 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->FabricId, write ? (uint8_t *) &entry->FabricId : src, write,
                            &entryOffset, sizeof(entry->FabricId)); // FABRIC_ID
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+                           sizeof(entry->NodeId));                                                       // NODE_ID
+            ByteSpan LabelSpanStorage(Uint8::from_const_char(entry->Label.data()), entry->Label.size()); // CHAR_STRING
+            ByteSpan * LabelSpan = &LabelSpanStorage;
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {


### PR DESCRIPTION
#### Problem
Various XML uses OCTET_STRING for historical reasons when it should use CHAR_STRING.

#### Change overview
Fix XML to use CHAR_STRING as needed, fix up a few zapt files to correctly log CHAR_STRING, fix resulting compile errors.

Fixes https://github.com/project-chip/connectedhomeip/issues/5542
Fixes https://github.com/project-chip/connectedhomeip/issues/6112
Fixes https://github.com/project-chip/connectedhomeip/issues/7322
Fixes https://github.com/project-chip/connectedhomeip/issues/7654
Fixes https://github.com/project-chip/connectedhomeip/issues/7655
Fixes https://github.com/project-chip/connectedhomeip/issues/8704
Fixes https://github.com/project-chip/connectedhomeip/issues/8705
Fixes https://github.com/project-chip/connectedhomeip/issues/8706
Fixes https://github.com/project-chip/connectedhomeip/issues/8707
Fixes https://github.com/project-chip/connectedhomeip/issues/9797
Fixes https://github.com/project-chip/connectedhomeip/issues/9798
Fixes https://github.com/project-chip/connectedhomeip/issues/10508
Fixes https://github.com/project-chip/connectedhomeip/issues/10509

#### Testing
Compiled the tree.