### PR TITLE
Separate FabricTable storage from Persistent Storage Delegate

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -37,6 +37,7 @@ CHIP_ERROR CHIPCommand::Run()
 
     ReturnLogErrorOnFailure(mStorage.Init());
     ReturnLogErrorOnFailure(mOpCredsIssuer.Initialize(mStorage));
+    ReturnLogErrorOnFailure(mFabricStorage.Initialize(&mStorage));
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
     chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
@@ -64,6 +65,7 @@ CHIP_ERROR CHIPCommand::Run()
 
     chip::Controller::FactoryInitParams factoryInitParams;
     factoryInitParams.storageDelegate = &mStorage;
+    factoryInitParams.fabricStorage   = &mFabricStorage;
     factoryInitParams.listenPort      = mStorage.GetListenPort();
 
     chip::Controller::SetupParams commissionerParams;

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -64,11 +64,11 @@ CHIP_ERROR CHIPCommand::Run()
                                                                            rcacSpan, icacSpan, nocSpan));
 
     chip::Controller::FactoryInitParams factoryInitParams;
-    factoryInitParams.storageDelegate = &mStorage;
-    factoryInitParams.fabricStorage   = &mFabricStorage;
-    factoryInitParams.listenPort      = mStorage.GetListenPort();
+    factoryInitParams.fabricStorage = &mFabricStorage;
+    factoryInitParams.listenPort    = mStorage.GetListenPort();
 
     chip::Controller::SetupParams commissionerParams;
+    commissionerParams.storageDelegate                = &mStorage;
     commissionerParams.operationalCredentialsDelegate = &mOpCredsIssuer;
     commissionerParams.ephemeralKeypair               = &ephemeralKey;
     commissionerParams.controllerRCAC                 = rcacSpan;

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -65,6 +65,7 @@ protected:
 
     ChipDeviceCommissioner mController;
     PersistentStorage mStorage;
+    chip::SimpleFabricStorage mFabricStorage;
 
 private:
     static void RunQueuedCommand(intptr_t commandArg);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -209,6 +209,7 @@ class MyServerStorageDelegate : public PersistentStorageDelegate
 
 DeviceCommissioner gCommissioner;
 MyServerStorageDelegate gServerStorage;
+chip::SimpleFabricStorage gFabricStorage;
 ExampleOperationalCredentialsIssuer gOpCredsIssuer;
 
 CHIP_ERROR InitCommissioner()
@@ -218,7 +219,10 @@ CHIP_ERROR InitCommissioner()
     chip::Controller::FactoryInitParams factoryParams;
     chip::Controller::SetupParams params;
 
+    ReturnErrorOnFailure(gFabricStorage.Initialize(&gServerStorage));
+
     factoryParams.storageDelegate = &gServerStorage;
+    factoryParams.fabricStorage   = &gFabricStorage;
     // use a different listen port for the commissioner.
     factoryParams.listenPort              = LinuxDeviceOptions::GetInstance().securedCommissionerPort;
     params.deviceAddressUpdateDelegate    = nullptr;

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -221,10 +221,10 @@ CHIP_ERROR InitCommissioner()
 
     ReturnErrorOnFailure(gFabricStorage.Initialize(&gServerStorage));
 
-    factoryParams.storageDelegate = &gServerStorage;
-    factoryParams.fabricStorage   = &gFabricStorage;
+    factoryParams.fabricStorage = &gFabricStorage;
     // use a different listen port for the commissioner.
     factoryParams.listenPort              = LinuxDeviceOptions::GetInstance().securedCommissionerPort;
+    params.storageDelegate                = &gServerStorage;
     params.deviceAddressUpdateDelegate    = nullptr;
     params.operationalCredentialsDelegate = &gOpCredsIssuer;
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -86,7 +86,7 @@ private:
 
     static Server sServer;
 
-    class ServerStorageDelegate : public PersistentStorageDelegate
+    class ServerStorageDelegate : public PersistentStorageDelegate, public FabricStorage
     {
         CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
         {
@@ -108,6 +108,18 @@ private:
             ChipLogProgress(AppServer, "Deleted from server storage: %s", key);
             return CHIP_NO_ERROR;
         }
+
+        CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
+        {
+            return SyncSetKeyValue(key, buffer, size);
+        };
+
+        CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
+        {
+            return SyncGetKeyValue(key, buffer, size);
+        };
+
+        CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
     };
 
     // Messaging::ExchangeDelegate

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -49,9 +49,8 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
         return CHIP_NO_ERROR;
     }
 
-    mListenPort      = params.listenPort;
-    mStorageDelegate = params.storageDelegate;
-    mFabricStorage   = params.fabricStorage;
+    mListenPort    = params.listenPort;
+    mFabricStorage = params.fabricStorage;
 
     CHIP_ERROR err = InitSystemState(params);
 
@@ -161,9 +160,9 @@ void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controll
     controllerParams.controllerICAC                 = params.controllerICAC;
     controllerParams.controllerRCAC                 = params.controllerRCAC;
     controllerParams.fabricId                       = params.fabricId;
+    controllerParams.storageDelegate                = params.storageDelegate;
 
     controllerParams.systemState        = mSystemState;
-    controllerParams.storageDelegate    = mStorageDelegate;
     controllerParams.controllerVendorId = params.controllerVendorId;
 }
 
@@ -211,8 +210,7 @@ DeviceControllerFactory::~DeviceControllerFactory()
         chip::Platform::Delete(mSystemState);
         mSystemState = nullptr;
     }
-    mStorageDelegate = nullptr;
-    mFabricStorage   = nullptr;
+    mFabricStorage = nullptr;
 }
 
 CHIP_ERROR DeviceControllerSystemState::Shutdown()

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -51,6 +51,7 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
 
     mListenPort      = params.listenPort;
     mStorageDelegate = params.storageDelegate;
+    mFabricStorage   = params.fabricStorage;
 
     CHIP_ERROR err = InitSystemState(params);
 
@@ -134,7 +135,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.exchangeMgr           = chip::Platform::New<Messaging::ExchangeManager>();
     stateParams.messageCounterManager = chip::Platform::New<secure_channel::MessageCounterManager>();
 
-    ReturnErrorOnFailure(stateParams.fabricTable->Init(mStorageDelegate));
+    ReturnErrorOnFailure(stateParams.fabricTable->Init(mFabricStorage));
     ReturnErrorOnFailure(
         stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr, stateParams.messageCounterManager));
     ReturnErrorOnFailure(stateParams.exchangeMgr->Init(stateParams.sessionMgr));
@@ -211,6 +212,7 @@ DeviceControllerFactory::~DeviceControllerFactory()
         mSystemState = nullptr;
     }
     mStorageDelegate = nullptr;
+    mFabricStorage   = nullptr;
 }
 
 CHIP_ERROR DeviceControllerSystemState::Shutdown()

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -65,6 +65,7 @@ struct SetupParams
 struct FactoryInitParams
 {
     PersistentStorageDelegate * storageDelegate           = nullptr;
+    FabricStorage * fabricStorage                         = nullptr;
     System::Layer * systemLayer                           = nullptr;
     Inet::InetLayer * inetLayer                           = nullptr;
     DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
@@ -110,6 +111,7 @@ private:
 
     uint16_t mListenPort;
     PersistentStorageDelegate * mStorageDelegate = nullptr;
+    FabricStorage * mFabricStorage               = nullptr;
     DeviceControllerSystemState * mSystemState   = nullptr;
 };
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -43,6 +43,8 @@ struct SetupParams
 #endif
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
 
+    PersistentStorageDelegate * storageDelegate = nullptr;
+
     /* The following keypair must correspond to the public key used for generating
     controllerNOC. It's used by controller to establish CASE sessions with devices */
     Crypto::P256Keypair * ephemeralKeypair = nullptr;
@@ -60,11 +62,10 @@ struct SetupParams
     DevicePairingDelegate * pairingDelegate = nullptr;
 };
 
-// TODO everything other than the storage delegate here should be removed.
+// TODO everything other than the fabric storage here should be removed.
 // We're blocked because of the need to support !CHIP_DEVICE_LAYER
 struct FactoryInitParams
 {
-    PersistentStorageDelegate * storageDelegate           = nullptr;
     FabricStorage * fabricStorage                         = nullptr;
     System::Layer * systemLayer                           = nullptr;
     Inet::InetLayer * inetLayer                           = nullptr;
@@ -110,9 +111,8 @@ private:
     CHIP_ERROR InitSystemState();
 
     uint16_t mListenPort;
-    PersistentStorageDelegate * mStorageDelegate = nullptr;
-    FabricStorage * mFabricStorage               = nullptr;
-    DeviceControllerSystemState * mSystemState   = nullptr;
+    FabricStorage * mFabricStorage             = nullptr;
+    DeviceControllerSystemState * mSystemState = nullptr;
 };
 
 } // namespace Controller

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -209,12 +209,13 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
     chip::Controller::FactoryInitParams initParams;
     chip::Controller::SetupParams setupParams;
 
-    initParams.storageDelegate = wrapper.get();
-    initParams.systemLayer     = systemLayer;
-    initParams.inetLayer       = inetLayer;
+    initParams.systemLayer   = systemLayer;
+    initParams.inetLayer     = inetLayer;
+    initParams.fabricStorage = wrapper.get();
     // move bleLayer into platform/android to share with app server
     initParams.bleLayer                        = DeviceLayer::ConnectivityMgr().GetBleLayer();
     initParams.listenPort                      = CHIP_PORT + 1;
+    setupParams.storageDelegate                = wrapper.get();
     setupParams.pairingDelegate                = wrapper.get();
     setupParams.operationalCredentialsDelegate = wrapper.get();
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -352,3 +352,20 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
     ChipLogProgress(chipTool, "KVS: Deleting key %s", key);
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
 }
+
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer,
+                                                     uint16_t size) override
+{
+    return SyncSetKeyValue(key, buffer, size);
+};
+
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer,
+                                                    uint16_t & size) override
+{
+    return SyncGetKeyValue(key, buffer, size);
+};
+
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncDelete(FabricIndex fabricIndex, const char * key) override
+{
+    return SyncDeleteKeyValue(key);
+};

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -353,19 +353,19 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
 }
 
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer,
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncStore(chip::FabricIndex fabricIndex, const char * key, const void * buffer,
                                                      uint16_t size) override
 {
     return SyncSetKeyValue(key, buffer, size);
 };
 
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer,
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncLoad(chip::FabricIndex fabricIndex, const char * key, void * buffer,
                                                     uint16_t & size) override
 {
     return SyncGetKeyValue(key, buffer, size);
 };
 
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncDelete(FabricIndex fabricIndex, const char * key) override
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncDelete(chip::FabricIndex fabricIndex, const char * key) override
 {
     return SyncDeleteKeyValue(key);
 };

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -354,18 +354,17 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
 }
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncStore(chip::FabricIndex fabricIndex, const char * key, const void * buffer,
-                                                     uint16_t size) override
+                                                     uint16_t size)
 {
     return SyncSetKeyValue(key, buffer, size);
 };
 
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncLoad(chip::FabricIndex fabricIndex, const char * key, void * buffer,
-                                                    uint16_t & size) override
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncLoad(chip::FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size)
 {
     return SyncGetKeyValue(key, buffer, size);
 };
 
-CHIP_ERROR AndroidDeviceControllerWrapper::SyncDelete(chip::FabricIndex fabricIndex, const char * key) override
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncDelete(chip::FabricIndex fabricIndex, const char * key)
 {
     return SyncDeleteKeyValue(key);
 };

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -80,9 +80,9 @@ public:
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
 
     // FabricStorage implementation
-    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override;
-    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override;
-    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override;
+    CHIP_ERROR SyncStore(chip::FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override;
+    CHIP_ERROR SyncLoad(chip::FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncDelete(chip::FabricIndex fabricIndex, const char * key) override;
 
     static AndroidDeviceControllerWrapper * FromJNIHandle(jlong handle)
     {

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -37,7 +37,8 @@
 class AndroidDeviceControllerWrapper : public chip::Controller::DevicePairingDelegate,
                                        public chip::Controller::DeviceStatusDelegate,
                                        public chip::Controller::OperationalCredentialsDelegate,
-                                       public chip::PersistentStorageDelegate
+                                       public chip::PersistentStorageDelegate,
+                                       public chip::FabricStorage
 {
 public:
     ~AndroidDeviceControllerWrapper();
@@ -77,6 +78,11 @@ public:
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+
+    // FabricStorage implementation
+    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override;
+    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override;
 
     static AndroidDeviceControllerWrapper * FromJNIHandle(jlong handle)
     {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -86,6 +86,7 @@ chip::Controller::PythonPersistentStorageDelegate sStorageDelegate;
 chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
 chip::Controller::ScriptDeviceAddressUpdateDelegate sDeviceAddressUpdateDelegate;
 chip::Controller::ExampleOperationalCredentialsIssuer sOperationalCredentialsIssuer;
+chip::SimpleFabricStorage sFabricStorage;
 } // namespace
 
 // NOTE: Remote device ID is in sync with the echo server device id
@@ -186,6 +187,9 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
     CHIP_ERROR err = sOperationalCredentialsIssuer.Initialize(sStorageDelegate);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
+    err = sFabricStorage.Initialize(&sStorageDelegate);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
+
     chip::Crypto::P256Keypair ephemeralKey;
     err = ephemeralKey.Initialize();
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
@@ -208,6 +212,7 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
 
     FactoryInitParams factoryParams;
     factoryParams.storageDelegate = &sStorageDelegate;
+    factoryParams.fabricStorage   = &sFabricStorage;
     factoryParams.imDelegate      = &PythonInteractionModelDelegate::Instance();
 
     SetupParams initParams;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -211,11 +211,11 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
     FactoryInitParams factoryParams;
-    factoryParams.storageDelegate = &sStorageDelegate;
-    factoryParams.fabricStorage   = &sFabricStorage;
-    factoryParams.imDelegate      = &PythonInteractionModelDelegate::Instance();
+    factoryParams.fabricStorage = &sFabricStorage;
+    factoryParams.imDelegate    = &PythonInteractionModelDelegate::Instance();
 
     SetupParams initParams;
+    initParams.storageDelegate                = &sStorageDelegate;
     initParams.deviceAddressUpdateDelegate    = &sDeviceAddressUpdateDelegate;
     initParams.pairingDelegate                = &sPairingDelegate;
     initParams.operationalCredentialsDelegate = &sOperationalCredentialsIssuer;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -79,6 +79,7 @@ private:
 };
 
 ServerStorageDelegate gServerStorage;
+chip::SimpleFabricStorage gFabricStorage;
 ScriptDevicePairingDelegate gPairingDelegate;
 chip::Controller::ExampleOperationalCredentialsIssuer gOperationalCredentialsIssuer;
 
@@ -102,18 +103,21 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         // already assumed initialized
         chip::Controller::SetupParams commissionerParams;
         chip::Controller::FactoryInitParams factoryParams;
-
-        commissionerParams.pairingDelegate = &gPairingDelegate;
-        factoryParams.storageDelegate      = &gServerStorage;
-
         chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
         chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
         chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
+        chip::Crypto::P256Keypair ephemeralKey;
+
+        err = gFabricStorage.Initialize(&gServerStorage);
+        SuccessOrExit(err);
+
+        commissionerParams.pairingDelegate = &gPairingDelegate;
+        factoryParams.storageDelegate      = &gServerStorage;
+        factoryParams.fabricStorage        = &gFabricStorage;
 
         // Initialize device attestation verifier
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
 
-        chip::Crypto::P256Keypair ephemeralKey;
         err = ephemeralKey.Initialize();
         SuccessOrExit(err);
 

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -111,9 +111,10 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         err = gFabricStorage.Initialize(&gServerStorage);
         SuccessOrExit(err);
 
+        factoryParams.fabricStorage = &gFabricStorage;
+
         commissionerParams.pairingDelegate = &gPairingDelegate;
-        factoryParams.storageDelegate      = &gServerStorage;
-        factoryParams.fabricStorage        = &gFabricStorage;
+        commissionerParams.storageDelegate = &gServerStorage;
 
         // Initialize device attestation verifier
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -125,10 +125,6 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
             delete self->_cppCommissioner;
             self->_cppCommissioner = nullptr;
         }
-        if (self->_fabricStorage) {
-            delete self->_fabricStorage;
-            self->_fabricStorage = nullptr;
-        }
     });
 
     // StopEventLoopTask will block until blocks are executed
@@ -160,7 +156,9 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         _persistentStorageDelegateBridge->setFrameworkDelegate(storageDelegate);
         // TODO Expose FabricStorage to CHIPFramework consumers.
         _fabricStorage = new chip::SimpleFabricStorage(_persistentStorageDelegateBridge);
-
+        if ([self checkForStartError:(_fabricStorage != nullptr) logMsg:kErrorMemoryInit]) {
+            return;
+        }
         // create a CHIPP256KeypairBridge here and pass it to the operationalCredentialsDelegate
         std::unique_ptr<chip::Crypto::CHIPP256KeypairNativeBridge> nativeBridge;
         if (nocSigner != nil) {
@@ -190,8 +188,8 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         // Initialize device attestation verifier
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
 
-        params.storageDelegate = _persistentStorageDelegateBridge;
         params.fabricStorage = _fabricStorage;
+        commissionerParams.storageDelegate = _persistentStorageDelegateBridge;
         commissionerParams.deviceAddressUpdateDelegate = _pairingDelegateBridge;
         commissionerParams.pairingDelegate = _pairingDelegateBridge;
 
@@ -482,11 +480,6 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         _persistentStorageDelegateBridge = NULL;
     }
 
-    if (_fabricStorage) {
-        delete _fabricStorage;
-        _fabricStorage = nullptr;
-    }
-
     return YES;
 }
 
@@ -501,6 +494,11 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     if (_cppCommissioner) {
         delete _cppCommissioner;
         _cppCommissioner = NULL;
+    }
+
+    if (_fabricStorage) {
+        delete _fabricStorage;
+        _fabricStorage = nullptr;
     }
 
     return YES;
@@ -518,6 +516,14 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     }
 
     return YES;
+}
+
+- (void)dealloc
+{
+    if (_fabricStorage) {
+        delete _fabricStorage;
+        _fabricStorage = nullptr;
+    }
 }
 
 @end

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -251,7 +251,7 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
-class TestPersistentStorageDelegate : public PersistentStorageDelegate
+class TestPersistentStorageDelegate : public PersistentStorageDelegate, public FabricStorage
 {
 public:
     TestPersistentStorageDelegate()
@@ -318,6 +318,18 @@ public:
     }
 
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override { return CHIP_NO_ERROR; }
+
+    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
+    {
+        return SyncSetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
+    {
+        return SyncGetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
 
 private:
     char * keys[16];

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -207,7 +207,7 @@ CHIP_ERROR FabricInfo::DeleteFromStorage(FabricStorage * storage, FabricIndex fa
     err = storage->SyncDelete(fabricIndex, key);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogDetail(Discovery, "Fabric %d is not yet configured", ifabricIndexd);
+        ChipLogDetail(Discovery, "Fabric %d is not yet configured", fabricIndex);
     }
     return err;
 }
@@ -598,6 +598,15 @@ CHIP_ERROR FabricTable::SetFabricDelegate(FabricTableDelegate * delegate)
     mDelegate = delegate;
     ChipLogDetail(Discovery, "Set the fabric pairing table delegate");
     return CHIP_NO_ERROR;
+}
+
+std::string SimpleFabricStorage::formatKey(FabricIndex fabricIndex, const char * key)
+{
+    char fabricPrefix[fabricPrefixSize];
+    snprintf(fabricPrefix, fabricPrefixSize, "F%02X/", fabricIndex);
+    std::string formattedKey = fabricPrefix;
+    formattedKey += key;
+    return formattedKey;
 }
 
 } // namespace chip

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -384,11 +384,6 @@ FabricInfo * FabricTable::FindFabricWithIndex(FabricIndex fabricIndex)
 
 FabricInfo * FabricTable::FindFabricWithCompressedId(CompressedFabricId fabricId)
 {
-    if (fabricId == kUndefinedCompressedFabricId)
-    {
-        return nullptr;
-    }
-
     static_assert(kMaxValidFabricIndex <= UINT8_MAX, "Cannot create more fabrics than UINT8_MAX");
     for (FabricIndex i = kMinValidFabricIndex; i <= kMaxValidFabricIndex; i++)
     {

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -600,7 +600,7 @@ CHIP_ERROR FabricTable::SetFabricDelegate(FabricTableDelegate * delegate)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR formatKey(FabricIndex fabricIndex, MutableCharSpan & formattedKey, const char * key)
+CHIP_ERROR formatKey(FabricIndex fabricIndex, MutableCharSpan formattedKey, const char * key)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -617,8 +617,7 @@ CHIP_ERROR SimpleFabricStorage::SyncStore(FabricIndex fabricIndex, const char * 
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
     char formattedKey[MAX_KEY_SIZE] = "";
-    MutableCharSpan keySpan         = MutableCharSpan(formattedKey, MAX_KEY_SIZE);
-    ReturnErrorOnFailure(formatKey(fabricIndex, keySpan, key));
+    ReturnErrorOnFailure(formatKey(fabricIndex, MutableCharSpan(formattedKey, MAX_KEY_SIZE), key));
     return mStorage->SyncSetKeyValue(formattedKey, buffer, size);
 };
 
@@ -626,8 +625,7 @@ CHIP_ERROR SimpleFabricStorage::SyncLoad(FabricIndex fabricIndex, const char * k
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
     char formattedKey[MAX_KEY_SIZE] = "";
-    MutableCharSpan keySpan         = MutableCharSpan(formattedKey, MAX_KEY_SIZE);
-    ReturnErrorOnFailure(formatKey(fabricIndex, keySpan, key));
+    ReturnErrorOnFailure(formatKey(fabricIndex, MutableCharSpan(formattedKey, MAX_KEY_SIZE), key));
     return mStorage->SyncGetKeyValue(formattedKey, buffer, size);
 };
 
@@ -635,8 +633,7 @@ CHIP_ERROR SimpleFabricStorage::SyncDelete(FabricIndex fabricIndex, const char *
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
     char formattedKey[MAX_KEY_SIZE] = "";
-    MutableCharSpan keySpan         = MutableCharSpan(formattedKey, MAX_KEY_SIZE);
-    ReturnErrorOnFailure(formatKey(fabricIndex, keySpan, key));
+    ReturnErrorOnFailure(formatKey(fabricIndex, MutableCharSpan(formattedKey, MAX_KEY_SIZE), key));
     return mStorage->SyncDeleteKeyValue(formattedKey);
 };
 

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -403,7 +403,6 @@ FabricInfo * FabricTable::FindFabricWithCompressedId(CompressedFabricId fabricId
     return nullptr;
 }
 
-
 void FabricTable::Reset()
 {
     static_assert(kMaxValidFabricIndex <= UINT8_MAX, "Cannot create more fabrics than UINT8_MAX");

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -91,32 +91,14 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
-    {
-        VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        std::string formattedKey = formatKey(fabricIndex, key);
-        return mStorage->SyncSetKeyValue(formattedKey.c_str(), buffer, size);
-    };
+    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override;
 
-    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
-    {
-        VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        std::string formattedKey = formatKey(fabricIndex, key);
-        return mStorage->SyncGetKeyValue(formattedKey.c_str(), buffer, size);
-    };
+    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override;
 
-    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override
-    {
-        VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        std::string formattedKey = formatKey(fabricIndex, key);
-        return mStorage->SyncDeleteKeyValue(formattedKey.c_str());
-    };
+    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override;
 
 private:
-    // FabricPrefix is of the format "F%02X/"
-    const static int fabricPrefixSize = 5;
-    // Returns a string that adds a FabricIndex prefix to the Key
-    std::string formatKey(FabricIndex fabricIndex, const char * key);
+    const static int MAX_KEY_SIZE = 32;
 
     PersistentStorageDelegate * mStorage = nullptr;
 };

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -271,9 +271,9 @@ private:
 
     static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 
-    CHIP_ERROR StoreIntoKVS(FabricStorage * kvs);
-    CHIP_ERROR FetchFromKVS(FabricStorage * kvs);
-    static CHIP_ERROR DeleteFromKVS(FabricStorage * kvs, FabricIndex id);
+    CHIP_ERROR CommitToStorage(FabricStorage * storage);
+    CHIP_ERROR LoadFromStorage(FabricStorage * storage);
+    static CHIP_ERROR DeleteFromStorage(FabricStorage * storage, FabricIndex fabricIndex);
 
     void ReleaseCert(MutableByteSpan & cert);
     void ReleaseOperationalCerts()

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -48,6 +48,68 @@ static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 constexpr char kFabricTableKeyPrefix[] = "Fabric";
 constexpr char kFabricTableCountKey[]  = "NumFabrics";
 
+class DLL_EXPORT FabricStorage
+{
+public:
+    virtual ~FabricStorage() {}
+
+    /**
+     * Gets called when fabric data needs to be stored.
+     **/
+    virtual CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) = 0;
+
+    /**
+     * Gets called when fabric data needs to be loaded.
+     **/
+    virtual CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) = 0;
+
+    /**
+     * Gets called when fabric data needs to be removed.
+     **/
+    virtual CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) = 0;
+};
+
+/**
+ * @brief A default implementation of Fabric storage that preserves legacy behavior of using
+ *        the Persistent storage delegate directly.
+ *
+ */
+class DLL_EXPORT SimpleFabricStorage : public FabricStorage
+{
+public:
+    SimpleFabricStorage(){};
+    SimpleFabricStorage(PersistentStorageDelegate * storage) : mStorage(storage){};
+    ~SimpleFabricStorage() override { mStorage = nullptr; };
+
+    CHIP_ERROR Initialize(PersistentStorageDelegate * storage)
+    {
+        VerifyOrReturnError(mStorage == nullptr || storage == mStorage, CHIP_ERROR_INCORRECT_STATE);
+        mStorage = storage;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
+    {
+        VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mStorage->SyncSetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
+    {
+        VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mStorage->SyncGetKeyValue(key, buffer, size);
+    };
+
+    CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override
+    {
+        VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return mStorage->SyncDeleteKeyValue(key);
+    };
+
+private:
+    PersistentStorageDelegate * mStorage = nullptr;
+};
+
 /**
  * Defines state of a pairing established by a fabric.
  * Node ID is only settable using the device operational credentials.
@@ -209,9 +271,9 @@ private:
 
     static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 
-    CHIP_ERROR StoreIntoKVS(PersistentStorageDelegate * kvs);
-    CHIP_ERROR FetchFromKVS(PersistentStorageDelegate * kvs);
-    static CHIP_ERROR DeleteFromKVS(PersistentStorageDelegate * kvs, FabricIndex id);
+    CHIP_ERROR StoreIntoKVS(FabricStorage * kvs);
+    CHIP_ERROR FetchFromKVS(FabricStorage * kvs);
+    static CHIP_ERROR DeleteFromKVS(FabricStorage * kvs, FabricIndex id);
 
     void ReleaseCert(MutableByteSpan & cert);
     void ReleaseOperationalCerts()
@@ -356,13 +418,14 @@ public:
     void ReleaseFabricIndex(FabricIndex fabricIndex);
 
     FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex);
+    FabricInfo * FindFabricWithCompressedId(CompressedFabricId fabricId);
 
     FabricIndex FindDestinationIDCandidate(const ByteSpan & destinationId, const ByteSpan & initiatorRandom,
                                            const ByteSpan * ipkList, size_t ipkListEntries);
 
     void Reset();
 
-    CHIP_ERROR Init(PersistentStorageDelegate * storage);
+    CHIP_ERROR Init(FabricStorage * storage);
     CHIP_ERROR SetFabricDelegate(FabricTableDelegate * delegate);
 
     uint8_t FabricCount() const { return mFabricCount; }
@@ -377,7 +440,7 @@ public:
 
 private:
     FabricInfo mStates[CHIP_CONFIG_MAX_DEVICE_ADMINS];
-    PersistentStorageDelegate * mStorage = nullptr;
+    FabricStorage * mStorage = nullptr;
 
     // TODO: Fabric table should be backed by a single backing store (attribute store), remove delegate callbacks #6419
     FabricTableDelegate * mDelegate = nullptr;

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -73,6 +73,9 @@ public:
  * @brief A default implementation of Fabric storage that preserves legacy behavior of using
  *        the Persistent storage delegate directly.
  *
+ *        This class automatically prefixes the Fabric Storage Keys with the FabricIndex.
+ *        The keys are formatted like so: "F%02X/" + key.
+ *
  */
 class DLL_EXPORT SimpleFabricStorage : public FabricStorage
 {
@@ -91,22 +94,30 @@ public:
     CHIP_ERROR SyncStore(FabricIndex fabricIndex, const char * key, const void * buffer, uint16_t size) override
     {
         VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mStorage->SyncSetKeyValue(key, buffer, size);
+        std::string formattedKey = formatKey(fabricIndex, key);
+        return mStorage->SyncSetKeyValue(formattedKey.c_str(), buffer, size);
     };
 
     CHIP_ERROR SyncLoad(FabricIndex fabricIndex, const char * key, void * buffer, uint16_t & size) override
     {
         VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mStorage->SyncGetKeyValue(key, buffer, size);
+        std::string formattedKey = formatKey(fabricIndex, key);
+        return mStorage->SyncGetKeyValue(formattedKey.c_str(), buffer, size);
     };
 
     CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override
     {
         VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        return mStorage->SyncDeleteKeyValue(key);
+        std::string formattedKey = formatKey(fabricIndex, key);
+        return mStorage->SyncDeleteKeyValue(formattedKey.c_str());
     };
 
 private:
+    // FabricPrefix is of the format "F%02X/"
+    const static int fabricPrefixSize = 5;
+    // Returns a string that adds a FabricIndex prefix to the Key
+    std::string formatKey(FabricIndex fabricIndex, const char * key);
+
     PersistentStorageDelegate * mStorage = nullptr;
 };
 


### PR DESCRIPTION
#### Problem
Nearly all the operational data required by a Controller/Commissioner can be scoped to a single Fabric. To support multiple Nodes in a single process, we need to be able to section off their storage. 
The DeviceControllerFactory class already allows providing different storage delegates to each Controller/Commissioner object but our FabricTable makes a true separation of storage difficult since it assumes direct access to a "global" storage.

#### Change overview
Separate out the Storage interface for the Fabric Table into something that describes which FabricIndex is being accessed in storage. That way it's up to the fabric storage implementation to choose how much or how little separation it wants between its storage. 

We should now have all the pieces to store all operational data for a Node under a Fabric Index section in storage if needed.
We can also provide Controller/Commissioner objects with access to data for their Fabric only and all the data they generate can be sectioned off by Fabric Index as well as required by the Application logic.  

I wish I could give more structure to the FabricStorage but since we intend to split the FabricInfo into some kind of on-demand object I elected to make it mirror the generic Key/Value API so that we can split up the FabricInfo in the future without fully rewriting the FabricStorage interface.

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
I have not yet tested this, but will test it with the chip-tool CLI, CHIPTool iOS app, and an M5Stack before it goes in. 