### PR TITLE
Fix codegen to handle the int sizes between int32 and int64 correctly.

### DIFF
--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -20,8 +20,14 @@ function atomicType(arg)
   switch (arg.name) {
   case 'boolean':
     return 'bool';
+  case 'int40s':
+  case 'int48s':
+  case 'int56s':
   case 'int64s':
     return 'int64_t';
+  case 'int40u':
+  case 'int48u':
+  case 'int56u':
   case 'int64u':
   case 'bitmap64':
     return 'uint64_t';
@@ -57,7 +63,7 @@ function atomicType(arg)
   case 'long_char_string':
     return 'chip::CharSpan';
   case 'eui64':
-    return 'chip::node_id';
+    return 'chip::NodeId';
   case 'percent':
     return 'chip::Percent';
   case 'percent100ths':

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -21966,8 +21966,8 @@ namespace Attributes {
 namespace BasicIdentification {
 struct TypeInfo
 {
-    using Type          = uint8_t *;
-    using DecodableType = uint8_t *;
+    using Type          = uint64_t;
+    using DecodableType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BasicIdentification::Id; }


### PR DESCRIPTION
Also fixes handling of eui64, not that we should be using that to
start with.

Does not enable Accessors bits for these, though, because it's not
clear how they would be stored in the attribute store.

#### Problem
Generating these types as `uint8_t *`, which is clearly wrong.

#### Change overview
Generate them as `uint64_t`.

#### Testing
The only actual change in the codegen is code we don't actually use yet.