### PR TITLE
Remove const for Concrete*Path.h members

### DIFF
--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -37,9 +37,9 @@ struct ConcreteAttributePath
         return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId;
     }
 
-    const EndpointId mEndpointId   = 0;
-    const ClusterId mClusterId     = 0;
-    const AttributeId mAttributeId = 0;
+    EndpointId mEndpointId   = 0;
+    ClusterId mClusterId     = 0;
+    AttributeId mAttributeId = 0;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/ConcreteCommandPath.h
+++ b/src/app/ConcreteCommandPath.h
@@ -38,9 +38,9 @@ struct ConcreteCommandPath
         return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mCommandId == other.mCommandId;
     }
 
-    const EndpointId mEndpointId = 0;
-    const ClusterId mClusterId   = 0;
-    const CommandId mCommandId   = 0;
+    EndpointId mEndpointId = 0;
+    ClusterId mClusterId   = 0;
+    CommandId mCommandId   = 0;
 };
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
#### Problem

The following code does not work because of `Concrete*Path` members beeing `const`.

```
void SomeMethod()
{
    CHIP_ERROR err = CHIP_NO_ERROR;
    chip::app::ConcreteCommandPath commandPath;

    ... some code...
    err = RetrieveEndpointClusterAndCommandIdsInSomeWays();
    SuccessOrExit(err);
    commandPath = chip:app::ConcreteCommandPath(endpointId, clusterId, commandId);

exit:
   ... some code...
}
```

#### Change overview
 * Remove `const` for members

#### Testing
There is no behaviour changed afaict and I have some local changes where I need this so that's how I have checked that it works.