### PR TITLE
Add a Base Application Example device type to chip-devices.xml with t…

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/chip-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-devices.xml
@@ -16,6 +16,20 @@ limitations under the License.
 -->
 <configurator>
   <deviceType>
+    <name>Base Application Example</name>
+    <domain>CHIP</domain>
+    <typeName>Root Node Device Type</typeName>
+    <profileId editable="false">0x0103</profileId>
+    <deviceId editable="false">0xFF00</deviceId>
+    <clusters>
+      <include cluster="Basic" server="true" serverLocked="true"></include>
+      <include cluster="Descriptor" server="true" serverLocked="true"></include>
+      <include cluster="General Commissioning" server="true" serverLocked="true"></include>
+      <include cluster="Operational Credentials" server="true" serverLocked="true"></include>
+    </clusters>
+  </deviceType>
+
+  <deviceType>
     <name>CHIP-All-Clusters-Server</name>
     <domain>CHIP</domain>
     <typeName>CHIP all-clusters-app server example</typeName>


### PR DESCRIPTION
…he minimal clusters needed onto endpoint 0 to commission a device

#### Problem

Creating a new ZAP configuration from scratch is not easy as one needs to figure out what needs to go onto endpoint `0`.

#### Change overview
* Add a simple "Base Application Example" device type to `chip-devices.xml` so it can be selected for endpoint `0` when creating a new file.

#### Testing
 I have built a few new zap files with it.