### PR TITLE
Move registerCommandsTests outside of the test_cluster.zapt partial as it introduce some dependencies on chip-tool built-in Commands class

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -190,16 +190,3 @@ class {{filename}}: public TestCommand
 };
 
 {{/chip_tests}}
-
-void registerCommandsTests(Commands & commands)
-{
-    const char * clusterName = "Tests";
-
-    commands_list clusterCommands = {
-      {{#chip_tests tests}}
-        make_unique<{{filename}}>(),
-      {{/chip_tests}}
-    };
-
-    commands.Register(clusterName, clusterCommands);
-}

--- a/examples/chip-tool/templates/tests-commands.zapt
+++ b/examples/chip-tool/templates/tests-commands.zapt
@@ -5,3 +5,16 @@
 #include <commands/tests/TestCommand.h>
 
 {{>test_cluster tests=(getTests)}}
+
+void registerCommandsTests(Commands & commands)
+{
+    const char * clusterName = "Tests";
+
+    commands_list clusterCommands = {
+      {{#chip_tests (getTests)}}
+        make_unique<{{filename}}>(),
+      {{/chip_tests}}
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}


### PR DESCRIPTION
#### Problem

The signature `void registerCommandsTests(Commands & commands)` into the partial that generates tests cases introduce a dependency onto `chip-tool` buit-in `Commands` and `Command` objects.

If some other examples wants to reuse the partial, then they need to reimplement those objects, that may not fit for their use cases.

#### Change overview
* Move `registerCommandsTests` from `examples/chip-tool/templates/partials/test_cluster.zapt` to `examples/chip-tool/templates/tests-commands.zapt`. It does not change anything for `chip-tool` itself while making it easier to reuse for others.

#### Testing
 Running codegen show no changes at all.