### PR TITLE
[esp32] Fix the Python dependency issue on macOS

### DIFF
--- a/scripts/requirements.esp32.txt
+++ b/scripts/requirements.esp32.txt
@@ -1,15 +1,15 @@
-setuptools>=21 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-click>=5.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pyserial>=3.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-future>=0.15.2 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-cryptography>=2.1.4 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pyparsing>=2.0.3,<2.4.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pyelftools>=0.22 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-pygdbmi<=0.9.0.2 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-reedsolo>=1.5.3,<=1.5.4 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-bitstring>=3.1.6 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-ecdsa>=0.16.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-kconfiglib==13.7.1 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-construct==2.10.54 ; platform_machine != 'aarch64' and sys_platform == 'linux'
-python-socketio<5 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+setuptools>=21
+click>=5.0
+pyserial>=3.0
+future>=0.15.2
+cryptography>=2.1.4
+pyparsing>=2.0.3,<2.4.0
+pyelftools>=0.22
+gdbgui==0.13.2.0
+pygdbmi<=0.9.0.2
+reedsolo>=1.5.3,<=1.5.4
+bitstring>=3.1.6
+ecdsa>=0.16.0
+kconfiglib==13.7.1
+construct==2.10.54
+python-socketio<5


### PR DESCRIPTION
#### Problem
Build ESP platform on macOS fails due to the error:
```
The following Python requirements are not satisfied:
cryptography>=2.1.4
pyelftools>=0.22
gdbgui==0.13.2.0
pygdbmi<=0.9.0.2
python-socketio<5
kconfiglib==13.7.1
reedsolo>=1.5.3,<=1.5.4
bitstring>=3.1.6
ecdsa>=0.16.0
construct==2.10.54
To install the missing packages, please run "/Users/chenshu/code/esp-idf/install.sh"
```

It's caused by that it didn't install the correct python packages required by ESP-IDF on macOS.

#### Change overview
Remove the Linux OS limitation for ESP's python requirements, so it will work for macOS as well.

#### Testing
Tested locally with esp32 target on macOS.

Note: I didn't update the `constraints.txt` file since it caused some CI issue before. I can apply the update if it's safe now.