### PR TITLE
Fix cirque - update int/pointer casting and reset subscription counts in tests.

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -317,7 +317,7 @@ class ChipDeviceController(object):
             nonlocal returnDevice
             nonlocal deviceAvailableCV
             with deviceAvailableCV:
-                returnDevice = device
+                returnDevice = c_void_p(device)
                 deviceAvailableCV.notify_all()
             if err != 0:
                 print("Failed in getting the connected device: {}".format(err))
@@ -330,11 +330,11 @@ class ChipDeviceController(object):
 
         # The callback might have been received synchronously (during self._ChipStack.Call()).
         # Check if the device is already set before waiting for the callback.
-        if returnDevice == c_void_p(None):
+        if returnDevice.value == None:
             with deviceAvailableCV:
                 deviceAvailableCV.wait()
 
-        if returnDevice == c_void_p(None):
+        if returnDevice.value == None:
             raise self._ChipStack.ErrorToException(CHIP_ERROR_INTERNAL)
         return returnDevice
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -344,11 +344,14 @@ class BaseTestHelper:
                 "OnOff", "OnOff", nodeid, endpoint, 1, 10)
             changeThread = _conductAttributeChange(
                 self.devCtrl, nodeid, endpoint)
+            # Reset the number of subscriptions received as subscribing causes a callback.
+            handler.subscriptionReceived = 0
             changeThread.start()
             with handler.cv:
                 while handler.subscriptionReceived < 5:
                     # We should observe 10 attribute changes
                     handler.cv.wait()
+            changeThread.join()
             return True
         except Exception as ex:
             self.logger.exception(f"Failed to finish API test: {ex}")


### PR DESCRIPTION
#### Problem
Two commits
1) GetConnectedDeviceSync - Returned device pointer is actually an int type, which meant that the function never actually waited for a callback and was racing on the device resolve when it attempted to send commands.
2) Subscription test - The subscription itself causes a callback, which throws off the count between the number of commands and the check. The result is that the check ends, but the change thread continues on and causes weird races with the remaining tests.

#### Change overview
1) Fixes GetConnectedDeviceSync to check against the pointer type
2) Resets count on subscription test and joins the thread before exiting.

#### Testing
- 1) Saw GetConnectedDeviceSync wait for a device callback when running the MobileDeviceTest
- 2) No longer see the subscription send logs interspersed with the remaining test commands.