### PR TITLE
Revisions to Inet::IPAddress

### DIFF
--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -107,7 +107,7 @@ bool IPAddress::FromString(const char * str, IPAddress & output)
         if (inet_pton(AF_INET, str, &ipv4Addr) < 1)
             return false;
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
-        output = FromIPv4(ipv4Addr);
+        output = IPAddress(ipv4Addr);
     }
     else
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -121,7 +121,7 @@ bool IPAddress::FromString(const char * str, IPAddress & output)
         if (inet_pton(AF_INET6, str, &ipv6Addr) < 1)
             return false;
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
-        output = FromIPv6(ipv6Addr);
+        output = IPAddress(ipv6Addr);
     }
 
     return true;

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -23,7 +23,7 @@
  *      related enumerated constants. The CHIP Inet Layer uses objects
  *      of this class to represent Internet protocol addresses of both
  *      IPv4 and IPv6 address families. (IPv4 addresses are stored
- *      internally in the V4COMPAT format, reserved for that purpose.)
+ *      internally as IPv4-Mapped IPv6 addresses.)
  *
  */
 
@@ -70,6 +70,51 @@ IPAddress & IPAddress::operator=(const IPAddress & other)
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
+IPAddress::IPAddress(const ip6_addr_t & ipv6Addr)
+{
+    static_assert(sizeof(*this) == sizeof(Addr), "ip6_addr_t size mismatch");
+    memcpy(Addr, &ipv6Addr, sizeof(ipv6Addr));
+}
+
+#if INET_CONFIG_ENABLE_IPV4
+
+IPAddress::IPAddress(const ip4_addr_t & ipv4Addr)
+{
+    Addr[0] = 0;
+    Addr[1] = 0;
+    Addr[2] = htonl(0xFFFF);
+    Addr[3] = ipv4Addr.addr;
+}
+
+IPAddress::IPAddress(const ip_addr_t & addr)
+{
+    switch (IP_GET_TYPE(&addr))
+    {
+#if INET_CONFIG_ENABLE_IPV4
+    case IPADDR_TYPE_V4:
+        *this = IPAddress(*ip_2_ip4(&addr));
+        break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    case IPADDR_TYPE_V6:
+        *this = IPAddress(*ip_2_ip6(&addr));
+        break;
+
+    default:
+        *this = Any;
+        break;
+    }
+}
+
+ip4_addr_t IPAddress::ToIPv4() const
+{
+    ip4_addr_t ipAddr;
+    memcpy(&ipAddr, &Addr[3], sizeof(ipAddr));
+    return ipAddr;
+}
+
+#endif // INET_CONFIG_ENABLE_IPV4
+
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 ip_addr_t IPAddress::ToLwIPAddr(void) const
 {
@@ -101,30 +146,6 @@ ip_addr_t IPAddress::ToLwIPAddr(void) const
     return ret;
 }
 
-IPAddress IPAddress::FromLwIPAddr(const ip_addr_t & addr)
-{
-    IPAddress ret;
-
-    switch (IP_GET_TYPE(&addr))
-    {
-#if INET_CONFIG_ENABLE_IPV4
-    case IPADDR_TYPE_V4:
-        ret = IPAddress::FromIPv4(*ip_2_ip4(&addr));
-        break;
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    case IPADDR_TYPE_V6:
-        ret = IPAddress::FromIPv6(*ip_2_ip6(&addr));
-        break;
-
-    default:
-        ret = Any;
-        break;
-    }
-
-    return ret;
-}
-
 lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 {
     lwip_ip_addr_type ret;
@@ -150,25 +171,6 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 }
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
-#if INET_CONFIG_ENABLE_IPV4
-ip4_addr_t IPAddress::ToIPv4() const
-{
-    ip4_addr_t ipAddr;
-    memcpy(&ipAddr, &Addr[3], sizeof(ipAddr));
-    return ipAddr;
-}
-
-IPAddress IPAddress::FromIPv4(const ip4_addr_t & ipv4Addr)
-{
-    IPAddress ipAddr;
-    ipAddr.Addr[0] = 0;
-    ipAddr.Addr[1] = 0;
-    ipAddr.Addr[2] = htonl(0xFFFF);
-    ipAddr.Addr[3] = ipv4Addr.addr;
-    return ipAddr;
-}
-#endif // INET_CONFIG_ENABLE_IPV4
-
 ip6_addr_t IPAddress::ToIPv6() const
 {
     ip6_addr_t ipAddr;
@@ -177,17 +179,25 @@ ip6_addr_t IPAddress::ToIPv6() const
     return ipAddr;
 }
 
-IPAddress IPAddress::FromIPv6(const ip6_addr_t & ipv6Addr)
-{
-    IPAddress ipAddr;
-    static_assert(sizeof(ipAddr) == sizeof(Addr), "ip6_addr_t size mismatch");
-    memcpy(ipAddr.Addr, &ipv6Addr, sizeof(ipv6Addr));
-    return ipAddr;
-}
-
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+#if INET_CONFIG_ENABLE_IPV4
+IPAddress::IPAddress(const struct in_addr & ipv4Addr)
+{
+    Addr[0] = 0;
+    Addr[1] = 0;
+    Addr[2] = htonl(0xFFFF);
+    Addr[3] = ipv4Addr.s_addr;
+}
+#endif // INET_CONFIG_ENABLE_IPV4
+
+IPAddress::IPAddress(const struct in6_addr & ipv6Addr)
+{
+    static_assert(sizeof(*this) == sizeof(ipv6Addr), "in6_addr size mismatch");
+    memcpy(Addr, &ipv6Addr, sizeof(ipv6Addr));
+}
 
 #if INET_CONFIG_ENABLE_IPV4
 struct in_addr IPAddress::ToIPv4() const
@@ -195,16 +205,6 @@ struct in_addr IPAddress::ToIPv4() const
     struct in_addr ipv4Addr;
     ipv4Addr.s_addr = Addr[3];
     return ipv4Addr;
-}
-
-IPAddress IPAddress::FromIPv4(const struct in_addr & ipv4Addr)
-{
-    IPAddress ipAddr;
-    ipAddr.Addr[0] = 0;
-    ipAddr.Addr[1] = 0;
-    ipAddr.Addr[2] = htonl(0xFFFF);
-    ipAddr.Addr[3] = ipv4Addr.s_addr;
-    return ipAddr;
 }
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -216,22 +216,14 @@ struct in6_addr IPAddress::ToIPv6() const
     return ipAddr;
 }
 
-IPAddress IPAddress::FromIPv6(const struct in6_addr & ipv6Addr)
-{
-    IPAddress ipAddr;
-    static_assert(sizeof(ipAddr) == sizeof(ipv6Addr), "in6_addr size mismatch");
-    memcpy(ipAddr.Addr, &ipv6Addr, sizeof(ipv6Addr));
-    return ipAddr;
-}
-
-IPAddress IPAddress::FromSockAddr(const struct sockaddr & sockaddr)
+IPAddress IPAddress::FromSockAddr(const SockAddr & sockaddr)
 {
 #if INET_CONFIG_ENABLE_IPV4
-    if (sockaddr.sa_family == AF_INET)
-        return FromIPv4(reinterpret_cast<const sockaddr_in *>(&sockaddr)->sin_addr);
+    if (sockaddr.any.sa_family == AF_INET)
+        return FromSockAddr(sockaddr.in);
 #endif // INET_CONFIG_ENABLE_IPV4
-    if (sockaddr.sa_family == AF_INET6)
-        return FromIPv6(reinterpret_cast<const sockaddr_in6 *>(&sockaddr)->sin6_addr);
+    if (sockaddr.any.sa_family == AF_INET6)
+        return FromSockAddr(sockaddr.in6);
     return Any;
 }
 

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -72,7 +72,7 @@ IPAddress & IPAddress::operator=(const IPAddress & other)
 
 IPAddress::IPAddress(const ip6_addr_t & ipv6Addr)
 {
-    static_assert(sizeof(*this) == sizeof(Addr), "ip6_addr_t size mismatch");
+    static_assert(sizeof(ip6_addr_t) == sizeof(Addr), "ip6_addr_t size mismatch");
     memcpy(Addr, &ipv6Addr, sizeof(ipv6Addr));
 }
 

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -117,6 +117,7 @@ union SockAddr
     sockaddr any;
     sockaddr_in in;
     sockaddr_in6 in6;
+    sockaddr_storage storage;
 };
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -23,13 +23,15 @@
  *      related enumerated constants. The CHIP Inet Layer uses objects
  *      of this class to represent Internet protocol addresses of both
  *      IPv4 and IPv6 address families. (IPv4 addresses are stored
- *      internally in the V4COMPAT format, reserved for that purpose.)
+ *      internally as IPv4-Mapped IPv6 addresses.)
  */
 
 #pragma once
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+#include <type_traits>
 
 #include <lib/support/BitFlags.h>
 #include <lib/support/DLLUtil.h>
@@ -109,9 +111,19 @@ enum class IPv6MulticastFlag : uint8_t
 };
 using IPv6MulticastFlags = BitFlags<IPv6MulticastFlag>;
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+union SockAddr
+{
+    sockaddr any;
+    sockaddr_in in;
+    sockaddr_in6 in6;
+};
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
 /**
- * Internet protocol address
+ * @brief   Internet protocol address
  *
+ * @details
  *  The CHIP Inet Layer uses objects of this class to represent Internet
  *  protocol addresses (independent of protocol version).
  */
@@ -128,21 +140,33 @@ public:
     static constexpr uint16_t kMaxStringLength = INET6_ADDRSTRLEN;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-    IPAddress() = default;
-
-    /**
-     *  Copy constructor for the IPAddress class.
-     *
-     */
+public:
+    IPAddress()                        = default;
     IPAddress(const IPAddress & other) = default;
+
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    explicit IPAddress(const ip6_addr_t & ipv6Addr);
+#if INET_CONFIG_ENABLE_IPV4
+    explicit IPAddress(const ip4_addr_t & ipv4Addr);
+    explicit IPAddress(const ip_addr_t & addr);
+#endif // INET_CONFIG_ENABLE_IPV4
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+    explicit IPAddress(const struct in6_addr & ipv6Addr);
+#if INET_CONFIG_ENABLE_IPV4
+    explicit IPAddress(const struct in_addr & ipv4Addr);
+#endif // INET_CONFIG_ENABLE_IPV4
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     /**
      * @brief   Opaque word array to contain IP addresses (independent of protocol version)
      *
      * @details
      *  IPv6 address use all 128-bits split into four 32-bit network byte
-     *  ordered unsigned integers. IPv4 addresses are V4COMPAT, i.e. the
-     *  first three words are zero, and the fourth word contains the IPv4
+     *  ordered unsigned integers. IPv4 addresses are IPv4-Mapped IPv6 addresses,
+     *  i.e. the first two words are zero, the third word contains 0xFFFF in
+     *  network byte order, and the fourth word contains the IPv4
      *  address in network byte order.
      */
     uint32_t Addr[4];
@@ -375,8 +399,8 @@ public:
      * @details
      *  Use <tt>WriteAddress(uint8_t *&p)</tt> to encode the IP address in
      *  the binary format defined by RFC 4291 for IPv6 addresses.  IPv4
-     *  addresses are encoded according to section 2.5.5.1 "IPv4-Compatible
-     *  IPv6 Address" (V4COMPAT).
+     *  addresses are encoded according to section 2.5.5.2 "IPv4-Mapped
+     *  IPv6 Address".
      */
     void WriteAddress(uint8_t *& p) const;
 
@@ -462,42 +486,6 @@ public:
      *      either unspecified or not an IPv4 address.
      */
 
-    /**
-     * @fn      static IPAddress FromIPv4(const struct in_addr & addr)
-     *
-     * @brief   Inject the IPv4 address from a platform data structure.
-     *
-     * @details
-     *  Use <tt>FromIPv4(const ip4_addr_t &addr)</tt> to inject \c addr as an
-     *  IPv4 address.
-     *
-     *  The argument \c addr is either of type <tt>const struct in_addr&</tt>
-     *  (on POSIX) or <tt>const ip4_addr_t&</tt> (on LwIP).
-     *
-     * @return  The constructed IP address.
-     */
-    /**
-     * @overload static IPAddress FromIPv4(const ip4_addr_t &addr)
-     */
-
-    /**
-     * @fn      static IPAddress FromIPv6(const struct in6_addr& addr)
-     *
-     * @brief   Inject the IPv6 address from a platform data structure.
-     *
-     * @details
-     *  Use <tt>FromIPv6(const ip6_addr_t &addr)</tt> to inject \c addr as an
-     *  IPv6 address.
-     *
-     *  The argument \c addr is either of type <tt>const struct in6_addr&</tt>
-     *  (on POSIX) or <tt>const ip6_addr_t&</tt> (on LwIP).
-     *
-     * @return  The constructed IP address.
-     */
-    /**
-     * @overload     static IPAddress FromIPv6(const ip6_addr_t &addr)
-     */
-
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
@@ -515,21 +503,6 @@ public:
     ip_addr_t ToLwIPAddr(void) const;
 
     /**
-     * @fn      static IPAddress FromLwIPAddr(const ip_addr_t& addr)
-     *
-     * @brief   Inject the IP address from an LwIP ip_addr_t structure.
-     *
-     * @details
-     *  Use <tt>FromLwIPAddr(const ip_addr_t &addr)</tt> to inject \c addr as an
-     *  Inet layer IP address.
-     *
-     *  The argument \c addr is of type <tt>const ip_addr_t&</tt> (on LwIP).
-     *
-     * @return  The constructed IP address.
-     */
-    static IPAddress FromLwIPAddr(const ip_addr_t & addr);
-
-    /**
      * @brief   Convert the INET layer address type to its underlying LwIP type.
      *
      * @details
@@ -540,11 +513,9 @@ public:
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 
     ip6_addr_t ToIPv6(void) const;
-    static IPAddress FromIPv6(const ip6_addr_t & addr);
 
 #if INET_CONFIG_ENABLE_IPV4
     ip4_addr_t ToIPv4(void) const;
-    static IPAddress FromIPv4(const ip4_addr_t & addr);
 #endif // INET_CONFIG_ENABLE_IPV4
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -552,23 +523,20 @@ public:
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     struct in6_addr ToIPv6() const;
-    static IPAddress FromIPv6(const struct in6_addr & addr);
 
 #if INET_CONFIG_ENABLE_IPV4
     struct in_addr ToIPv4() const;
-    static IPAddress FromIPv4(const struct in_addr & addr);
 #endif // INET_CONFIG_ENABLE_IPV4
 
     /**
-     * @brief   Inject the IPv6 address from a POSIX <tt>struct sockaddr&</tt>
-     *
-     * @details
-     *  Use <tt>FromSockAddr(const struct sockaddr& sockaddr)</tt> to inject
-     *  <tt>sockaddr.sa_addr</tt> as an IPv6 address.
-     *
-     * @return  The constructed IP address.
+     * Get the IP address from a SockAddr.
      */
-    static IPAddress FromSockAddr(const struct sockaddr & sockaddr);
+    static IPAddress FromSockAddr(const SockAddr & sockaddr);
+    static IPAddress FromSockAddr(const sockaddr & sockaddr) { return FromSockAddr(reinterpret_cast<const SockAddr &>(sockaddr)); }
+    static IPAddress FromSockAddr(const sockaddr_in6 & sockaddr) { return IPAddress(sockaddr.sin6_addr); }
+#if INET_CONFIG_ENABLE_IPV4
+    static IPAddress FromSockAddr(const sockaddr_in & sockaddr) { return IPAddress(sockaddr.sin_addr); }
+#endif // INET_CONFIG_ENABLE_IPV4
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_USE_NETWORK_FRAMEWORK
 
@@ -614,7 +582,7 @@ public:
      * @brief   Construct an IPv6 multicast address from its parts.
      *
      * @details
-     *  Use <tt>MakeIPv6Multicast(IPv6MulticastFlag flags, uint8_t scope,
+     *  Use <tt>MakeIPv6Multicast(uint8_t flags, uint8_t scope,
      *  uint32_t groupId)</tt> to construct an IPv6 multicast
      *  address with \c flags for routing scope \c scope and group
      *  identifier \c groupId.
@@ -639,7 +607,7 @@ public:
      * @brief   Construct a transient IPv6 multicast address from its parts.
      *
      * @details
-     *  Use <tt>MakeIPv6TransientMulticast(IPv6MulticastFlag flags, uint8_t scope,
+     *  Use <tt>MakeIPv6TransientMulticast(uint8_t flags, uint8_t scope,
      *  uint8_t groupId[14])</tt> to construct a transient IPv6
      *  multicast address with \c flags for routing scope \c scope and
      *  group identifier octets \c groupId.

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -50,13 +50,6 @@
 #include <lwip/raw.h>
 #include <lwip/udp.h>
 
-#if INET_CONFIG_ENABLE_IPV4
-#define LWIP_IPV4_ADDR_T ip4_addr_t
-#define IPV4_TO_LWIPADDR(aAddress) (aAddress).ToIPv4()
-#endif // INET_CONFIG_ENABLE_IPV4
-#define LWIP_IPV6_ADDR_T ip6_addr_t
-#define IPV6_TO_LWIPADDR(aAddress) (aAddress).ToIPv6()
-
 #if !defined(RAW_FLAGS_MULTICAST_LOOP) || !defined(UDP_FLAGS_MULTICAST_LOOP) || !defined(raw_clear_flags) ||                       \
     !defined(raw_set_flags) || !defined(udp_clear_flags) || !defined(udp_set_flags)
 #define HAVE_LWIP_MULTICAST_LOOP 0
@@ -140,13 +133,13 @@ static CHIP_ERROR CheckMulticastGroupArgs(InterfaceId aInterfaceId, const IPAddr
 #if INET_CONFIG_ENABLE_IPV4
 #if LWIP_IPV4 && LWIP_IGMP
 static CHIP_ERROR LwIPIPv4JoinLeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress,
-                                                  err_t (*aMethod)(struct netif *, const LWIP_IPV4_ADDR_T *))
+                                                  err_t (*aMethod)(struct netif *, const ip4_addr_t *))
 {
     struct netif * const lNetif = IPEndPointBasis::FindNetifFromInterfaceId(aInterfaceId);
     VerifyOrReturnError(lNetif != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
 
-    const LWIP_IPV4_ADDR_T lIPv4Address = IPV4_TO_LWIPADDR(aAddress);
-    const err_t lStatus                 = aMethod(lNetif, &lIPv4Address);
+    const ip4_addr_t lIPv4Address = aAddress.ToIPv4();
+    const err_t lStatus           = aMethod(lNetif, &lIPv4Address);
 
     if (lStatus == ERR_MEM)
     {
@@ -159,13 +152,13 @@ static CHIP_ERROR LwIPIPv4JoinLeaveMulticastGroup(InterfaceId aInterfaceId, cons
 
 #ifdef HAVE_IPV6_MULTICAST
 static CHIP_ERROR LwIPIPv6JoinLeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress,
-                                                  err_t (*aMethod)(struct netif *, const LWIP_IPV6_ADDR_T *))
+                                                  err_t (*aMethod)(struct netif *, const ip6_addr_t *))
 {
     struct netif * const lNetif = IPEndPointBasis::FindNetifFromInterfaceId(aInterfaceId);
     VerifyOrReturnError(lNetif != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
 
-    const LWIP_IPV6_ADDR_T lIPv6Address = IPV6_TO_LWIPADDR(aAddress);
-    const err_t lStatus                 = aMethod(lNetif, &lIPv6Address);
+    const ip6_addr_t lIPv6Address = aAddress.ToIPv6();
+    const err_t lStatus           = aMethod(lNetif, &lIPv6Address);
 
     if (lStatus == ERR_MEM)
     {
@@ -346,13 +339,6 @@ struct netif * IPEndPointBasis::FindNetifFromInterfaceId(InterfaceId aInterfaceI
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-union PeerSockAddr
-{
-    sockaddr any;
-    sockaddr_in in;
-    sockaddr_in6 in6;
-};
 
 #if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 IPEndPointBasis::MulticastGroupHandler IPEndPointBasis::sJoinMulticastGroupHandler;
@@ -639,7 +625,7 @@ CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     msgHeader.msg_iovlen = 1;
 
     // Construct a sockaddr_in/sockaddr_in6 structure containing the destination information.
-    PeerSockAddr peerSockAddr;
+    SockAddr peerSockAddr;
     memset(&peerSockAddr, 0, sizeof(peerSockAddr));
     msgHeader.msg_name = &peerSockAddr;
     if (mAddrType == IPAddressType::kIPv6)
@@ -869,7 +855,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
     if (!lBuffer.IsNull())
     {
         struct iovec msgIOV;
-        PeerSockAddr lPeerSockAddr;
+        SockAddr lPeerSockAddr;
         uint8_t controlData[256];
         struct msghdr msgHeader;
 
@@ -903,13 +889,13 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
 
             if (lPeerSockAddr.any.sa_family == AF_INET6)
             {
-                lPacketInfo.SrcAddress = IPAddress::FromIPv6(lPeerSockAddr.in6.sin6_addr);
+                lPacketInfo.SrcAddress = IPAddress(lPeerSockAddr.in6.sin6_addr);
                 lPacketInfo.SrcPort    = ntohs(lPeerSockAddr.in6.sin6_port);
             }
 #if INET_CONFIG_ENABLE_IPV4
             else if (lPeerSockAddr.any.sa_family == AF_INET)
             {
-                lPacketInfo.SrcAddress = IPAddress::FromIPv4(lPeerSockAddr.in.sin_addr);
+                lPacketInfo.SrcAddress = IPAddress(lPeerSockAddr.in.sin_addr);
                 lPacketInfo.SrcPort    = ntohs(lPeerSockAddr.in.sin_port);
             }
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -935,7 +921,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
                         break;
                     }
                     lPacketInfo.Interface   = static_cast<InterfaceId>(inPktInfo->ipi_ifindex);
-                    lPacketInfo.DestAddress = IPAddress::FromIPv4(inPktInfo->ipi_addr);
+                    lPacketInfo.DestAddress = IPAddress(inPktInfo->ipi_addr);
                     continue;
                 }
 #endif // defined(IP_PKTINFO)
@@ -951,7 +937,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
                         break;
                     }
                     lPacketInfo.Interface   = static_cast<InterfaceId>(in6PktInfo->ipi6_ifindex);
-                    lPacketInfo.DestAddress = IPAddress::FromIPv6(in6PktInfo->ipi6_addr);
+                    lPacketInfo.DestAddress = IPAddress(in6PktInfo->ipi6_addr);
                     continue;
                 }
 #endif // defined(IPV6_PKTINFO)
@@ -1175,7 +1161,7 @@ CHIP_ERROR IPEndPointBasis::GetEndPoint(nw_endpoint_t & aEndPoint, const IPAddre
     // we want if the locale endpoint is IPv4.
     if (aAddressType == IPAddressType::kIPv4 && aAddress.Type() == IPAddressType::kAny)
     {
-        const IPAddress anyAddr = IPAddress::FromIPv4(aAddress.ToIPv4());
+        const IPAddress anyAddr = IPAddress(aAddress.ToIPv4());
         anyAddr.ToString(addrStr, sizeof(addrStr));
     }
     else

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -214,12 +214,12 @@ IPAddress InterfaceAddressIterator::GetAddress()
 
         if (mCurAddrIndex < LWIP_IPV6_NUM_ADDRESSES)
         {
-            return IPAddress::FromIPv6(*netif_ip6_addr(curIntf, mCurAddrIndex));
+            return IPAddress(*netif_ip6_addr(curIntf, mCurAddrIndex));
         }
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
         else
         {
-            return IPAddress::FromIPv4(*netif_ip4_addr(curIntf));
+            return IPAddress(*netif_ip4_addr(curIntf));
         }
 #endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
     }
@@ -844,7 +844,7 @@ IPAddress InterfaceAddressIterator::GetAddress()
 {
     if (HasCurrent())
     {
-        return IPAddress::FromIPv6(mIpv6->unicast[mCurAddrIndex].address.in6_addr);
+        return IPAddress(mIpv6->unicast[mCurAddrIndex].address.in6_addr);
     }
 
     return IPAddress::Any;

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -380,7 +380,7 @@ CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
         {
             if (ip6_addr_isvalid(netif_ip6_addr_state(intf, j)) && ip6_addr_islinklocal(netif_ip6_addr(intf, j)))
             {
-                (*llAddr) = IPAddress::FromIPv6(*netif_ip6_addr(intf, j));
+                (*llAddr) = IPAddress(*netif_ip6_addr(intf, j));
                 return CHIP_NO_ERROR;
             }
         }
@@ -409,7 +409,7 @@ CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
                 struct in6_addr * sin6_addr = &(reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr;
                 if (sin6_addr->s6_addr[0] == 0xfe && (sin6_addr->s6_addr[1] & 0xc0) == 0x80) // Link Local Address
                 {
-                    (*llAddr) = IPAddress::FromIPv6((reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr);
+                    (*llAddr) = IPAddress((reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr);
                     break;
                 }
             }
@@ -425,7 +425,7 @@ CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
     in6_addr * const ip6_addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
     VerifyOrReturnError(ip6_addr != nullptr, INET_ERROR_ADDRESS_NOT_FOUND);
 
-    *llAddr = IPAddress::FromIPv6(*ip6_addr);
+    *llAddr = IPAddress(*ip6_addr);
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
     return CHIP_NO_ERROR;

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -278,12 +278,12 @@ CHIP_ERROR TCPEndPoint::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) con
         *retPort = mTCP->remote_port;
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        *retAddr = IPAddress::FromLwIPAddr(mTCP->remote_ip);
+        *retAddr = IPAddress(mTCP->remote_ip);
 #else // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 #if INET_CONFIG_ENABLE_IPV4
-        *retAddr = PCB_ISIPV6(mTCP) ? IPAddress::FromIPv6(mTCP->remote_ip.ip6) : IPAddress::FromIPv4(mTCP->remote_ip.ip4);
+        *retAddr = PCB_ISIPV6(mTCP) ? IPAddress(mTCP->remote_ip.ip6) : IPAddress(mTCP->remote_ip.ip4);
 #else  // !INET_CONFIG_ENABLE_IPV4
-        *retAddr                    = IPAddress::FromIPv6(mTCP->remote_ip.ip6);
+        *retAddr                    = IPAddress(mTCP->remote_ip.ip6);
 #endif // !INET_CONFIG_ENABLE_IPV4
 #endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
     }
@@ -311,12 +311,12 @@ CHIP_ERROR TCPEndPoint::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort)
         *retPort = mTCP->local_port;
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        *retAddr = IPAddress::FromLwIPAddr(mTCP->local_ip);
+        *retAddr = IPAddress(mTCP->local_ip);
 #else // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 #if INET_CONFIG_ENABLE_IPV4
-        *retAddr = PCB_ISIPV6(mTCP) ? IPAddress::FromIPv6(mTCP->local_ip.ip6) : IPAddress::FromIPv4(mTCP->local_ip.ip4);
+        *retAddr = PCB_ISIPV6(mTCP) ? IPAddress(mTCP->local_ip.ip6) : IPAddress(mTCP->local_ip.ip4);
 #else  // !INET_CONFIG_ENABLE_IPV4
-        *retAddr                    = IPAddress::FromIPv6(mTCP->local_ip.ip6);
+        *retAddr                    = IPAddress(mTCP->local_ip.ip6);
 #endif // !INET_CONFIG_ENABLE_IPV4
 #endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
     }
@@ -1332,14 +1332,7 @@ CHIP_ERROR TCPEndPoint::ConnectImpl(const IPAddress & addr, uint16_t port, Inter
     socklen_t sockaddrsize       = 0;
     const sockaddr * sockaddrptr = nullptr;
 
-    union
-    {
-        sockaddr any;
-        sockaddr_in6 in6;
-#if INET_CONFIG_ENABLE_IPV4
-        sockaddr_in in;
-#endif // INET_CONFIG_ENABLE_IPV4
-    } sa;
+    SockAddr sa;
     memset(&sa, 0, sizeof(sa));
 
     if (addrType == IPAddressType::kIPv6)
@@ -1406,12 +1399,7 @@ CHIP_ERROR TCPEndPoint::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) con
     if (!IsConnected())
         return CHIP_ERROR_INCORRECT_STATE;
 
-    union
-    {
-        sockaddr any;
-        sockaddr_in in;
-        sockaddr_in6 in6;
-    } sa;
+    SockAddr sa;
     memset(&sa, 0, sizeof(sa));
     socklen_t saLen = sizeof(sa);
 
@@ -1420,13 +1408,13 @@ CHIP_ERROR TCPEndPoint::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) con
 
     if (sa.any.sa_family == AF_INET6)
     {
-        *retAddr = IPAddress::FromIPv6(sa.in6.sin6_addr);
+        *retAddr = IPAddress(sa.in6.sin6_addr);
         *retPort = ntohs(sa.in6.sin6_port);
     }
 #if INET_CONFIG_ENABLE_IPV4
     else if (sa.any.sa_family == AF_INET)
     {
-        *retAddr = IPAddress::FromIPv4(sa.in.sin_addr);
+        *retAddr = IPAddress(sa.in.sin_addr);
         *retPort = ntohs(sa.in.sin_port);
     }
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -1443,14 +1431,7 @@ CHIP_ERROR TCPEndPoint::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort)
     if (!IsConnected())
         return CHIP_ERROR_INCORRECT_STATE;
 
-    union
-    {
-        sockaddr any;
-        sockaddr_in6 in6;
-#if INET_CONFIG_ENABLE_IPV4
-        sockaddr_in in;
-#endif // INET_CONFIG_ENABLE_IPV4
-    } sa;
+    SockAddr sa;
 
     memset(&sa, 0, sizeof(sa));
     socklen_t saLen = sizeof(sa);
@@ -1460,13 +1441,13 @@ CHIP_ERROR TCPEndPoint::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort)
 
     if (sa.any.sa_family == AF_INET6)
     {
-        *retAddr = IPAddress::FromIPv6(sa.in6.sin6_addr);
+        *retAddr = IPAddress(sa.in6.sin6_addr);
         *retPort = ntohs(sa.in6.sin6_port);
     }
 #if INET_CONFIG_ENABLE_IPV4
     else if (sa.any.sa_family == AF_INET)
     {
-        *retAddr = IPAddress::FromIPv4(sa.in.sin_addr);
+        *retAddr = IPAddress(sa.in.sin_addr);
         *retPort = ntohs(sa.in.sin_port);
     }
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -1481,15 +1462,7 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
     if (!IsConnected())
         return CHIP_ERROR_INCORRECT_STATE;
 
-    union
-    {
-        sockaddr any;
-        sockaddr_in6 in6;
-#if INET_CONFIG_ENABLE_IPV4
-        sockaddr_in in;
-#endif // INET_CONFIG_ENABLE_IPV4
-    } sa;
-
+    SockAddr sa;
     memset(&sa, 0, sizeof(sa));
     socklen_t saLen = sizeof(sa);
 
@@ -1500,7 +1473,7 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
 
     if (sa.any.sa_family == AF_INET6)
     {
-        if (IPAddress::FromIPv6(sa.in6.sin6_addr).IsIPv6LinkLocal())
+        if (IPAddress(sa.in6.sin6_addr).IsIPv6LinkLocal())
         {
             *retInterface = sa.in6.sin6_scope_id;
         }
@@ -2185,12 +2158,7 @@ void TCPEndPoint::HandleIncomingConnection()
     IPAddress peerAddr;
     uint16_t peerPort;
 
-    union
-    {
-        sockaddr any;
-        sockaddr_in in;
-        sockaddr_in6 in6;
-    } sa;
+    SockAddr sa;
     memset(&sa, 0, sizeof(sa));
     socklen_t saLen = sizeof(sa);
 
@@ -2217,13 +2185,13 @@ void TCPEndPoint::HandleIncomingConnection()
     {
         if (sa.any.sa_family == AF_INET6)
         {
-            peerAddr = IPAddress::FromIPv6(sa.in6.sin6_addr);
+            peerAddr = IPAddress(sa.in6.sin6_addr);
             peerPort = ntohs(sa.in6.sin6_port);
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if (sa.any.sa_family == AF_INET)
         {
-            peerAddr = IPAddress::FromIPv4(sa.in.sin_addr);
+            peerAddr = IPAddress(sa.in.sin_addr);
             peerPort = ntohs(sa.in.sin_port);
         }
 #endif // INET_CONFIG_ENABLE_IPV4

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -485,19 +485,19 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
     if (pktInfo != NULL)
     {
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        pktInfo->SrcAddress  = IPAddress::FromLwIPAddr(*addr);
-        pktInfo->DestAddress = IPAddress::FromLwIPAddr(*ip_current_dest_addr());
+        pktInfo->SrcAddress  = IPAddress(*addr);
+        pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
 #else // LWIP_VERSION_MAJOR <= 1
         if (PCB_ISIPV6(pcb))
         {
-            pktInfo->SrcAddress = IPAddress::FromIPv6(*(ip6_addr_t *) addr);
-            pktInfo->DestAddress = IPAddress::FromIPv6(*ip6_current_dest_addr());
+            pktInfo->SrcAddress = IPAddress(*(ip6_addr_t *) addr);
+            pktInfo->DestAddress = IPAddress(*ip6_current_dest_addr());
         }
 #if INET_CONFIG_ENABLE_IPV4
         else
         {
-            pktInfo->SrcAddress = IPAddress::FromIPv4(*addr);
-            pktInfo->DestAddress = IPAddress::FromIPv4(*ip_current_dest_addr());
+            pktInfo->SrcAddress = IPAddress(*addr);
+            pktInfo->DestAddress = IPAddress(*ip_current_dest_addr());
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 #endif // LWIP_VERSION_MAJOR <= 1
@@ -526,12 +526,7 @@ CHIP_ERROR UDPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
     // If an ephemeral port was requested, retrieve the actual bound port.
     if (port == 0)
     {
-        union
-        {
-            struct sockaddr any;
-            struct sockaddr_in in;
-            struct sockaddr_in6 in6;
-        } boundAddr;
+        SockAddr boundAddr;
         socklen_t boundAddrLen = sizeof(boundAddr);
 
         if (getsockname(mSocket, &boundAddr.any, &boundAddrLen) == 0)

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -1053,7 +1053,7 @@ void CheckFromIPv6(nlTestSuite * inSuite, void * inContext)
         struct in6_addr ip_addr;
         ip_addr = *reinterpret_cast<struct in6_addr *>(addr);
 #endif
-        test_addr_2 = IPAddress::FromIPv6(ip_addr);
+        test_addr_2 = IPAddress(ip_addr);
 
         CheckAddressQuartets(inSuite, test_addr_1, test_addr_2);
 
@@ -1186,7 +1186,7 @@ void CheckFromIPv4(nlTestSuite * inSuite, void * inContext)
         ip_addr.s_addr      = htonl(lCurrent->mAddr.mAddrQuartets[3]);
         test_addr_1.Addr[2] = htonl(0xffff);
 #endif
-        test_addr_2 = IPAddress::FromIPv4(ip_addr);
+        test_addr_2 = IPAddress(ip_addr);
 
         CheckAddressQuartets(inSuite, test_addr_1, test_addr_2);
 
@@ -1232,7 +1232,7 @@ void CheckFromSocket(nlTestSuite * inSuite, void * inContext)
             memset(&sock_v4, 0, sizeof(struct sockaddr_in));
             sock_v4.sin_family = AF_INET;
             memcpy(&sock_v4.sin_addr.s_addr, &addr[3], sizeof(struct in_addr));
-            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v4));
+            test_addr_2 = IPAddress::FromSockAddr(sock_v4);
             break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -1240,14 +1240,14 @@ void CheckFromSocket(nlTestSuite * inSuite, void * inContext)
             memset(&sock_v6, 0, sizeof(struct sockaddr_in6));
             sock_v6.sin6_family = AF_INET6;
             memcpy(&sock_v6.sin6_addr.s6_addr, addr, sizeof(struct in6_addr));
-            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v6));
+            test_addr_2 = IPAddress::FromSockAddr(sock_v6);
             break;
 
         case IPAddressType::kAny:
             memset(&sock_v6, 0, sizeof(struct sockaddr_in6));
             sock_v6.sin6_family = 0;
             memcpy(&sock_v6.sin6_addr.s6_addr, addr, sizeof(struct in6_addr));
-            test_addr_2 = IPAddress::FromSockAddr(reinterpret_cast<struct sockaddr &>(sock_v6));
+            test_addr_2 = IPAddress::FromSockAddr(sock_v6);
             break;
 
         default:

--- a/src/inet/tests/TestLwIPDNS.cpp
+++ b/src/inet/tests/TestLwIPDNS.cpp
@@ -88,7 +88,7 @@ static void found_multi(const char * aName, ip_addr_t * aIpAddrs, uint8_t aNumIp
     {
         char addrStr[INET6_ADDRSTRLEN];
 
-        IPAddress::FromIPv4(aIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+        IPAddress(aIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
 
         printf("\t(%d) IPv4: %s\n", i, addrStr);
     }
@@ -145,7 +145,7 @@ static void TestLwIPDNS(void)
         for (uint8_t i = 0; i < sNumIpAddrs; ++i)
         {
             char addrStr[64];
-            IPAddress::FromIPv4(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+            IPAddress(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
             printf("\t(%d) IPv4: %s\n", i, addrStr);
         }
     }
@@ -171,7 +171,7 @@ static void TestLwIPDNS(void)
         for (i = 0; i < sNumIpAddrs; ++i)
         {
             char addrStr[64];
-            IPAddress::FromIPv4(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+            IPAddress(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
             printf("\t(%d) IPv4: %s\n", i, addrStr);
         }
     }
@@ -197,7 +197,7 @@ static void TestLwIPDNS(void)
         for (i = 0; i < sNumIpAddrs; ++i)
         {
             char addrStr[64];
-            IPAddress::FromIPv4(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
+            IPAddress(sIpAddrs[i]).ToString(addrStr, sizeof(addrStr));
             printf("\t(%d) IPv4: %s\n", i, addrStr);
         }
     }

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -40,7 +40,7 @@ struct ResolvedNodeData
     void LogNodeIdResolved()
     {
 #if CHIP_PROGRESS_LOGGING
-        char addrBuffer[Inet::IPAddress::kMaxStringLength + 1];
+        char addrBuffer[Inet::IPAddress::kMaxStringLength];
         mAddress.ToString(addrBuffer);
         // Would be nice to log the interface id, but sorting out how to do so
         // across our differnet InterfaceId implementations is a pain.

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -722,7 +722,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
                 struct in_addr addr4;
 
                 memcpy(&addr4, &(address->data.ipv4), sizeof(addr4));
-                result.mAddress.SetValue(chip::Inet::IPAddress::FromIPv4(addr4));
+                result.mAddress.SetValue(chip::Inet::IPAddress(addr4));
 #else
                 result_err = CHIP_ERROR_INVALID_ADDRESS;
                 ChipLogError(Discovery, "Ignoring IPv4 mDNS address.");
@@ -732,7 +732,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
                 struct in6_addr addr6;
 
                 memcpy(&addr6, &(address->data.ipv6), sizeof(addr6));
-                result.mAddress.SetValue(chip::Inet::IPAddress::FromIPv6(addr6));
+                result.mAddress.SetValue(chip::Inet::IPAddress(addr6));
                 break;
             default:
                 break;

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -181,7 +181,7 @@ bool ThreadStackManagerImpl::_HaveRouteToAddress(const Inet::IPAddress & destAdd
                 continue;
 
             Inet::IPPrefix p;
-            p.IPAddr = Inet::IPAddress::FromIPv6(*reinterpret_cast<const struct in6_addr *>(data));
+            p.IPAddr = Inet::IPAddress(*reinterpret_cast<const struct in6_addr *>(data));
             p.Length = prefixLength;
 
             if (p.MatchAddress(destAddr))

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -247,7 +247,7 @@ void GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::UpdateThreadInter
                 uint8_t state = netif_ip6_addr_state(mNetIf, addrIdx);
                 if (state != IP6_ADDR_INVALID)
                 {
-                    Inet::IPAddress addr = Inet::IPAddress::FromIPv6(*netif_ip6_addr(mNetIf, addrIdx));
+                    Inet::IPAddress addr = Inet::IPAddress(*netif_ip6_addr(mNetIf, addrIdx));
                     char addrStr[50];
                     addr.ToString(addrStr, sizeof(addrStr));
                     const char * typeStr;


### PR DESCRIPTION
#### Problem

`Inet::IPAddress` has some redundancies and outdated comments.

#### Change overview

- Convert `IPAddress::From…()` functions that are semantically
  constructors into constructors.
- Replace several identical `union`s with `IPAddress::SockAddr`.
- Fix outdated documentation regarding IPv4-in-IPv6.
- Fix a use of `IPAddress::kMaxStringLength` (from PR# 10450 review).

#### Testing

CI; no changes to functionality intended.
