### PR TITLE
Fix build error with ambiguous reference to ‘Messaging’

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -313,16 +313,16 @@ void MatterOperationalCredentialsPluginServerInitCallback(void)
 }
 
 namespace {
-class FabricCleanupExchangeDelegate : public Messaging::ExchangeDelegate
+class FabricCleanupExchangeDelegate : public chip::Messaging::ExchangeDelegate
 {
 public:
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
+    CHIP_ERROR OnMessageReceived(chip::Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && payload) override
     {
         return CHIP_NO_ERROR;
     }
-    void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
-    void OnExchangeClosing(Messaging::ExchangeContext * ec) override
+    void OnResponseTimeout(chip::Messaging::ExchangeContext * ec) override {}
+    void OnExchangeClosing(chip::Messaging::ExchangeContext * ec) override
     {
         FabricIndex currentFabricIndex = ec->GetSecureSession().GetFabricIndex();
         ec->GetExchangeMgr()->GetSessionManager()->ExpireAllPairingsForFabric(currentFabricIndex);
@@ -352,8 +352,8 @@ exit:
     emberAfSendImmediateDefaultResponse(status);
     if (err == CHIP_NO_ERROR)
     {
-        Messaging::ExchangeContext * ec = commandObj->GetExchangeContext();
-        FabricIndex currentFabricIndex  = ec->GetSecureSession().GetFabricIndex();
+        chip::Messaging::ExchangeContext * ec = commandObj->GetExchangeContext();
+        FabricIndex currentFabricIndex        = ec->GetSecureSession().GetFabricIndex();
         if (currentFabricIndex == fabricBeingRemoved)
         {
             // If the current fabric is being removed, expiring all the secure sessions causes crashes as


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* There is an ambiguous reference to ‘Messaging’ in app/clusters/operational-credentials-server/operational-credentials-server.cpp

```
../../../examples/lighting-app/linux/third_party/connectedhomeip/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp:355:9: error: reference to ‘Messaging’ is ambiguous
  355 |         Messaging::ExchangeContext * ec = commandObj->GetExchangeContext();
      |         ^~~~~~~~~
In file included from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/messaging/ExchangeMessageDispatch.h:27,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/messaging/ApplicationExchangeDispatch.h:28,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/messaging/ExchangeDelegate.h:27,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/messaging/ExchangeContext.h:31,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/app/util/af-types.h:60,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h:27,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp:26:
../../../examples/lighting-app/linux/third_party/connectedhomeip/src/messaging/Flags.h:30:11: note: candidates are: ‘namespace chip::Messaging { }’
   30 | namespace Messaging {
      |           ^~~~~~~~~
In file included from ../../../examples/lighting-app/linux/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h:24,
                 from ../../../examples/lighting-app/linux/third_party/connectedhomeip/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp:28:
../../../examples/lighting-app/linux/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/ids/Clusters.h:316:11: note:                 ‘namespace chip::app::Clusters::Messaging { }’
  316 | namespace Messaging {
      |           ^~~~~~~~~
```

#### Change overview
Fix build error with ambiguous reference to ‘Messaging’

#### Testing
How was this tested? (at least one bullet point required)
* Tested with build.gn
