### PR TITLE
Use CharSpan in a few remaining places for CHAR_STRING.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -340,7 +340,7 @@ public:
 private:
     chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback = new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    {{#if (isCharString type)}}chip::ByteSpan{{else}}{{chipType}}{{/if}} mValue;
+    {{chipType}} mValue;
 };
 
 {{/if}}

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -128,7 +128,14 @@ class {{filename}}: public TestCommand
         {{#if async}}ReturnErrorOnFailure({{else}}return {{/if}}cluster.InvokeCommand<requestType, responseType>(request, this, success, failure){{#if async}}){{/if}};
         {{else}}
         {{#chip_tests_item_parameters}}
-        {{chipType}} {{asLowerCamelCase name}}Argument = {{#if (isString type)}}chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}")){{else}}{{definedValue}}{{asTypeLiteralSuffix type}}{{/if}};
+        {{chipType}} {{asLowerCamelCase name}}Argument =
+          {{#if (isOctetString type)}}
+            chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}"))
+          {{else if (isCharString type)}}
+            chip::CharSpan("{{definedValue}}", strlen("{{definedValue}}"))
+          {{else}}
+            {{definedValue}}{{asTypeLiteralSuffix type}}
+          {{/if}};
         {{/chip_tests_item_parameters}}
 
         {{~#*inline "commandName"}}{{asUpperCamelCase commandName}}{{#if isAttribute}}Attribute{{asUpperCamelCase attribute}}{{/if}}{{/inline}}

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -123,8 +123,8 @@ void OnConnection(void * context, Device * device)
     constexpr uint16_t kExampleSoftwareVersion = 0;
     constexpr uint8_t kExampleProtocolsSupported =
         EMBER_ZCL_OTA_DOWNLOAD_PROTOCOL_BDX_SYNCHRONOUS; // TODO: support this as a list once ember adds list support
-    const uint8_t locationBuf[] = { 'U', 'S' };
-    ByteSpan exampleLocation(locationBuf);
+    const char locationBuf[] = { 'U', 'S' };
+    CharSpan exampleLocation(locationBuf);
     constexpr bool kExampleClientCanConsent = false;
     ByteSpan metadata;
 

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -251,9 +251,13 @@ function handleString(item, [ atomics, enums, bitmaps, structs ])
   const kLengthSizeInBytes = 2;
 
   item.atomicTypeId = atomic.atomicId;
-  item.chipType     = 'chip::ByteSpan';
-  item.size         = kLengthSizeInBytes + item.maxLength;
-  item.name         = item.name || item.label;
+  if (StringHelper.isOctetString(item.type)) {
+    item.chipType = 'chip::ByteSpan';
+  } else {
+    item.chipType = 'chip::CharSpan';
+  }
+  item.size = kLengthSizeInBytes + item.maxLength;
+  item.name = item.name || item.label;
   return true;
 }
 

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -65,9 +65,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
 {{/first}}
     // {{asLowerCamelCase label}}: {{asLowerCamelCase type}}
 {{#if (isCharString type)}}
-    {{! The server expects to get a UTF-8 string, but we have ByteSpan.  Do
-        some conversion to get the right thing to happen. }}
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char({{asLowerCamelCase label}}.data()), {{asLowerCamelCase label}}.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), {{asLowerCamelCase label}}.data()));
 {{else}}
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), {{asLowerCamelCase label}}));
 {{/if}}

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1950,7 +1950,7 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
         {
             ChipLogError(Controller, "Unable to find country code, defaulting to WW");
         }
-        chip::ByteSpan countryCode(reinterpret_cast<uint8_t *>(countryCodeStr), actualCountryCodeSize);
+        chip::CharSpan countryCode(countryCodeStr, actualCountryCodeSize);
 
         GeneralCommissioningCluster genCom;
         genCom.Associate(device, 0);

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -554,7 +554,7 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})
     cppCluster = reinterpret_cast<{{asUpperCamelCase ../name}}Cluster *>(clusterPtr);
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asLowerCamelCase label}}, strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::CharSpan({{asLowerCamelCase label}}Str.c_str(), strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     SuccessOrExit(err);
 
 exit: 
@@ -627,7 +627,7 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase na
     err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*) jniArr.data(), jniArr.size()));
     {{else if (isCharString type)}}
     JniUtfString valueStr(env, value);
-    err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*) valueStr.c_str(), strlen(valueStr.c_str())));
+    err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::CharSpan(valueStr.c_str(), strlen(valueStr.c_str())));
     {{else}}
     err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), static_cast<{{chipCallback.type}}>(value));
     {{/if}}

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -8270,9 +8270,8 @@ JNI_METHOD(void, AccountLoginCluster, getSetupPIN)
     cppCluster = reinterpret_cast<AccountLoginCluster *>(clusterPtr);
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err =
-        cppCluster->GetSetupPIN(onSuccess->Cancel(), onFailure->Cancel(),
-                                chip::ByteSpan((const uint8_t *) tempAccountIdentifier, strlen(tempAccountIdentifierStr.c_str())));
+    err = cppCluster->GetSetupPIN(onSuccess->Cancel(), onFailure->Cancel(),
+                                  chip::CharSpan(tempAccountIdentifierStr.c_str(), strlen(tempAccountIdentifierStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -8323,8 +8322,8 @@ JNI_METHOD(void, AccountLoginCluster, login)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->Login(onSuccess->Cancel(), onFailure->Cancel(),
-                            chip::ByteSpan((const uint8_t *) tempAccountIdentifier, strlen(tempAccountIdentifierStr.c_str())),
-                            chip::ByteSpan((const uint8_t *) setupPIN, strlen(setupPINStr.c_str())));
+                            chip::CharSpan(tempAccountIdentifierStr.c_str(), strlen(tempAccountIdentifierStr.c_str())),
+                            chip::CharSpan(setupPINStr.c_str(), strlen(setupPINStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -8853,9 +8852,8 @@ JNI_METHOD(void, ApplicationLauncherCluster, launchApp)
     cppCluster = reinterpret_cast<ApplicationLauncherCluster *>(clusterPtr);
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->LaunchApp(onSuccess->Cancel(), onFailure->Cancel(),
-                                chip::ByteSpan((const uint8_t *) data, strlen(dataStr.c_str())), catalogVendorId,
-                                chip::ByteSpan((const uint8_t *) applicationId, strlen(applicationIdStr.c_str())));
+    err = cppCluster->LaunchApp(onSuccess->Cancel(), onFailure->Cancel(), chip::CharSpan(dataStr.c_str(), strlen(dataStr.c_str())),
+                                catalogVendorId, chip::CharSpan(applicationIdStr.c_str(), strlen(applicationIdStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -9020,7 +9018,7 @@ JNI_METHOD(void, AudioOutputCluster, renameOutput)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->RenameOutput(onSuccess->Cancel(), onFailure->Cancel(), index,
-                                   chip::ByteSpan((const uint8_t *) name, strlen(nameStr.c_str())));
+                                   chip::CharSpan(nameStr.c_str(), strlen(nameStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -9632,7 +9630,7 @@ JNI_METHOD(void, BasicCluster, writeUserLabelAttribute)
 
     JniUtfString valueStr(env, value);
     err = cppCluster->WriteAttributeUserLabel(onSuccess->Cancel(), onFailure->Cancel(),
-                                              chip::ByteSpan((const uint8_t *) valueStr.c_str(), strlen(valueStr.c_str())));
+                                              chip::CharSpan(valueStr.c_str(), strlen(valueStr.c_str())));
     VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error writing attribute", err));
 
     onSuccess.release();
@@ -9685,7 +9683,7 @@ JNI_METHOD(void, BasicCluster, writeLocationAttribute)
 
     JniUtfString valueStr(env, value);
     err = cppCluster->WriteAttributeLocation(onSuccess->Cancel(), onFailure->Cancel(),
-                                             chip::ByteSpan((const uint8_t *) valueStr.c_str(), strlen(valueStr.c_str())));
+                                             chip::CharSpan(valueStr.c_str(), strlen(valueStr.c_str())));
     VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error writing attribute", err));
 
     onSuccess.release();
@@ -10533,7 +10531,7 @@ JNI_METHOD(void, BridgedDeviceBasicCluster, writeUserLabelAttribute)
 
     JniUtfString valueStr(env, value);
     err = cppCluster->WriteAttributeUserLabel(onSuccess->Cancel(), onFailure->Cancel(),
-                                              chip::ByteSpan((const uint8_t *) valueStr.c_str(), strlen(valueStr.c_str())));
+                                              chip::CharSpan(valueStr.c_str(), strlen(valueStr.c_str())));
     VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error writing attribute", err));
 
     onSuccess.release();
@@ -13707,7 +13705,7 @@ JNI_METHOD(void, ContentLauncherCluster, launchContent)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->LaunchContent(onSuccess->Cancel(), onFailure->Cancel(), autoPlay,
-                                    chip::ByteSpan((const uint8_t *) data, strlen(dataStr.c_str())));
+                                    chip::CharSpan(dataStr.c_str(), strlen(dataStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -13760,8 +13758,8 @@ JNI_METHOD(void, ContentLauncherCluster, launchURL)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->LaunchURL(onSuccess->Cancel(), onFailure->Cancel(),
-                                chip::ByteSpan((const uint8_t *) contentURL, strlen(contentURLStr.c_str())),
-                                chip::ByteSpan((const uint8_t *) displayString, strlen(displayStringStr.c_str())));
+                                chip::CharSpan(contentURLStr.c_str(), strlen(contentURLStr.c_str())),
+                                chip::CharSpan(displayStringStr.c_str(), strlen(displayStringStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -16286,7 +16284,7 @@ JNI_METHOD(void, GeneralCommissioningCluster, setRegulatoryConfig)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->SetRegulatoryConfig(onSuccess->Cancel(), onFailure->Cancel(), location,
-                                          chip::ByteSpan((const uint8_t *) countryCode, strlen(countryCodeStr.c_str())), breadcrumb,
+                                          chip::CharSpan(countryCodeStr.c_str(), strlen(countryCodeStr.c_str())), breadcrumb,
                                           timeoutMs);
     SuccessOrExit(err);
 
@@ -16704,7 +16702,7 @@ JNI_METHOD(void, GroupsCluster, addGroup)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->AddGroup(onSuccess->Cancel(), onFailure->Cancel(), groupId,
-                               chip::ByteSpan((const uint8_t *) groupName, strlen(groupNameStr.c_str())));
+                               chip::CharSpan(groupNameStr.c_str(), strlen(groupNameStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -16754,7 +16752,7 @@ JNI_METHOD(void, GroupsCluster, addGroupIfIdentifying)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->AddGroupIfIdentifying(onSuccess->Cancel(), onFailure->Cancel(), groupId,
-                                            chip::ByteSpan((const uint8_t *) groupName, strlen(groupNameStr.c_str())));
+                                            chip::CharSpan(groupNameStr.c_str(), strlen(groupNameStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -18503,7 +18501,7 @@ JNI_METHOD(void, MediaInputCluster, renameInput)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->RenameInput(onSuccess->Cancel(), onFailure->Cancel(), index,
-                                  chip::ByteSpan((const uint8_t *) name, strlen(nameStr.c_str())));
+                                  chip::CharSpan(nameStr.c_str(), strlen(nameStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -20138,7 +20136,7 @@ JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, queryImage)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->QueryImage(onSuccess->Cancel(), onFailure->Cancel(), vendorId, productId, hardwareVersion, softwareVersion,
-                                 protocolsSupported, chip::ByteSpan((const uint8_t *) location, strlen(locationStr.c_str())),
+                                 protocolsSupported, chip::CharSpan(locationStr.c_str(), strlen(locationStr.c_str())),
                                  requestorCanConsent,
                                  chip::ByteSpan((const uint8_t *) metadataForProviderArr.data(), metadataForProviderArr.size()));
     SuccessOrExit(err);
@@ -21613,7 +21611,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, updateFabricLabel)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->UpdateFabricLabel(onSuccess->Cancel(), onFailure->Cancel(),
-                                        chip::ByteSpan((const uint8_t *) label, strlen(labelStr.c_str())));
+                                        chip::CharSpan(labelStr.c_str(), strlen(labelStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -23224,7 +23222,7 @@ JNI_METHOD(void, ScenesCluster, addScene)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->AddScene(onSuccess->Cancel(), onFailure->Cancel(), groupId, sceneId, transitionTime,
-                               chip::ByteSpan((const uint8_t *) sceneName, strlen(sceneNameStr.c_str())), clusterId, length, value);
+                               chip::CharSpan(sceneNameStr.c_str(), strlen(sceneNameStr.c_str())), clusterId, length, value);
     SuccessOrExit(err);
 
 exit:
@@ -24009,7 +24007,7 @@ JNI_METHOD(void, TvChannelCluster, changeChannel)(JNIEnv * env, jobject self, jl
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->ChangeChannel(onSuccess->Cancel(), onFailure->Cancel(),
-                                    chip::ByteSpan((const uint8_t *) match, strlen(matchStr.c_str())));
+                                    chip::CharSpan(matchStr.c_str(), strlen(matchStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -24264,7 +24262,7 @@ JNI_METHOD(void, TargetNavigatorCluster, navigateTarget)
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->NavigateTarget(onSuccess->Cancel(), onFailure->Cancel(), target,
-                                     chip::ByteSpan((const uint8_t *) data, strlen(dataStr.c_str())));
+                                     chip::CharSpan(dataStr.c_str(), strlen(dataStr.c_str())));
     SuccessOrExit(err);
 
 exit:
@@ -24730,7 +24728,7 @@ JNI_METHOD(void, TestClusterCluster, testListStructArgumentRequest)
 
     err = cppCluster->TestListStructArgumentRequest(onSuccess->Cancel(), onFailure->Cancel(), a, b, c,
                                                     chip::ByteSpan((const uint8_t *) dArr.data(), dArr.size()),
-                                                    chip::ByteSpan((const uint8_t *) e, strlen(eStr.c_str())), f);
+                                                    chip::CharSpan(eStr.c_str(), strlen(eStr.c_str())), f);
     SuccessOrExit(err);
 
 exit:
@@ -24876,7 +24874,7 @@ JNI_METHOD(void, TestClusterCluster, testStructArgumentRequest)
 
     err = cppCluster->TestStructArgumentRequest(onSuccess->Cancel(), onFailure->Cancel(), a, b, c,
                                                 chip::ByteSpan((const uint8_t *) dArr.data(), dArr.size()),
-                                                chip::ByteSpan((const uint8_t *) e, strlen(eStr.c_str())), f);
+                                                chip::CharSpan(eStr.c_str(), strlen(eStr.c_str())), f);
     SuccessOrExit(err);
 
 exit:
@@ -25950,7 +25948,7 @@ JNI_METHOD(void, TestClusterCluster, writeCharStringAttribute)
 
     JniUtfString valueStr(env, value);
     err = cppCluster->WriteAttributeCharString(onSuccess->Cancel(), onFailure->Cancel(),
-                                               chip::ByteSpan((const uint8_t *) valueStr.c_str(), strlen(valueStr.c_str())));
+                                               chip::CharSpan(valueStr.c_str(), strlen(valueStr.c_str())));
     VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error writing attribute", err));
 
     onSuccess.release();
@@ -26003,7 +26001,7 @@ JNI_METHOD(void, TestClusterCluster, writeLongCharStringAttribute)
 
     JniUtfString valueStr(env, value);
     err = cppCluster->WriteAttributeLongCharString(onSuccess->Cancel(), onFailure->Cancel(),
-                                                   chip::ByteSpan((const uint8_t *) valueStr.c_str(), strlen(valueStr.c_str())));
+                                                   chip::CharSpan(valueStr.c_str(), strlen(valueStr.c_str())));
     VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error writing attribute", err));
 
     onSuccess.release();

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -1311,7 +1311,10 @@ chip::ChipError::StorageType chip_ime_AppendCommand_AccountLogin_GetSetupPIN(chi
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::AccountLoginCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.GetSetupPIN(nullptr, nullptr, chip::ByteSpan(tempAccountIdentifier, tempAccountIdentifier_Len)).AsInteger();
+    return cluster
+        .GetSetupPIN(nullptr, nullptr,
+                     chip::CharSpan(reinterpret_cast<const char *>(tempAccountIdentifier), tempAccountIdentifier_Len))
+        .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_AccountLogin_Login(chip::Controller::Device * device,
                                                                        chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -1323,8 +1326,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_AccountLogin_Login(chip::Con
     chip::Controller::AccountLoginCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .Login(nullptr, nullptr, chip::ByteSpan(tempAccountIdentifier, tempAccountIdentifier_Len),
-               chip::ByteSpan(setupPIN, setupPIN_Len))
+        .Login(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(tempAccountIdentifier), tempAccountIdentifier_Len),
+               chip::CharSpan(reinterpret_cast<const char *>(setupPIN), setupPIN_Len))
         .AsInteger();
 }
 
@@ -1487,8 +1490,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_ApplicationLauncher_LaunchAp
     chip::Controller::ApplicationLauncherCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .LaunchApp(nullptr, nullptr, chip::ByteSpan(data, data_Len), catalogVendorId,
-                   chip::ByteSpan(applicationId, applicationId_Len))
+        .LaunchApp(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(data), data_Len), catalogVendorId,
+                   chip::CharSpan(reinterpret_cast<const char *>(applicationId), applicationId_Len))
         .AsInteger();
 }
 
@@ -1545,7 +1548,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_AudioOutput_RenameOutput(chi
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::AudioOutputCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.RenameOutput(nullptr, nullptr, index, chip::ByteSpan(name, name_Len)).AsInteger();
+    return cluster.RenameOutput(nullptr, nullptr, index, chip::CharSpan(reinterpret_cast<const char *>(name), name_Len))
+        .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_AudioOutput_SelectOutput(chip::Controller::Device * device,
                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -1738,7 +1742,8 @@ chip::ChipError::StorageType chip_ime_WriteAttribute_Basic_UserLabel(chip::Contr
     chip::Controller::BasicCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .WriteAttributeUserLabel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), chip::ByteSpan(value, len))
+        .WriteAttributeUserLabel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
+                                 chip::CharSpan(reinterpret_cast<const char *>(value), len))
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_Location(chip::Controller::Device * device,
@@ -1758,7 +1763,8 @@ chip::ChipError::StorageType chip_ime_WriteAttribute_Basic_Location(chip::Contro
     chip::Controller::BasicCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .WriteAttributeLocation(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), chip::ByteSpan(value, len))
+        .WriteAttributeLocation(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
+                                chip::CharSpan(reinterpret_cast<const char *>(value), len))
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_HardwareVersion(chip::Controller::Device * device,
@@ -2064,7 +2070,8 @@ chip::ChipError::StorageType chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabe
     chip::Controller::BridgedDeviceBasicCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .WriteAttributeUserLabel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), chip::ByteSpan(value, len))
+        .WriteAttributeUserLabel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
+                                 chip::CharSpan(reinterpret_cast<const char *>(value), len))
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion(chip::Controller::Device * device,
@@ -3130,7 +3137,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_ContentLauncher_LaunchConten
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ContentLauncherCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.LaunchContent(nullptr, nullptr, autoPlay, chip::ByteSpan(data, data_Len)).AsInteger();
+    return cluster.LaunchContent(nullptr, nullptr, autoPlay, chip::CharSpan(reinterpret_cast<const char *>(data), data_Len))
+        .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_ContentLauncher_LaunchURL(chip::Controller::Device * device,
                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -3142,7 +3150,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_ContentLauncher_LaunchURL(ch
     chip::Controller::ContentLauncherCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .LaunchURL(nullptr, nullptr, chip::ByteSpan(contentURL, contentURL_Len), chip::ByteSpan(displayString, displayString_Len))
+        .LaunchURL(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(contentURL), contentURL_Len),
+                   chip::CharSpan(reinterpret_cast<const char *>(displayString), displayString_Len))
         .AsInteger();
 }
 
@@ -3857,7 +3866,8 @@ chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(chip::Controller
     chip::Controller::GeneralCommissioningCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .SetRegulatoryConfig(nullptr, nullptr, location, chip::ByteSpan(countryCode, countryCode_Len), breadcrumb, timeoutMs)
+        .SetRegulatoryConfig(nullptr, nullptr, location,
+                             chip::CharSpan(reinterpret_cast<const char *>(countryCode), countryCode_Len), breadcrumb, timeoutMs)
         .AsInteger();
 }
 
@@ -4015,7 +4025,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_Groups_AddGroup(chip::Contro
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::GroupsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.AddGroup(nullptr, nullptr, groupId, chip::ByteSpan(groupName, groupName_Len)).AsInteger();
+    return cluster.AddGroup(nullptr, nullptr, groupId, chip::CharSpan(reinterpret_cast<const char *>(groupName), groupName_Len))
+        .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(chip::Controller::Device * device,
                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -4025,7 +4036,9 @@ chip::ChipError::StorageType chip_ime_AppendCommand_Groups_AddGroupIfIdentifying
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::GroupsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.AddGroupIfIdentifying(nullptr, nullptr, groupId, chip::ByteSpan(groupName, groupName_Len)).AsInteger();
+    return cluster
+        .AddGroupIfIdentifying(nullptr, nullptr, groupId, chip::CharSpan(reinterpret_cast<const char *>(groupName), groupName_Len))
+        .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_Groups_GetGroupMembership(chip::Controller::Device * device,
                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -4527,7 +4540,7 @@ chip::ChipError::StorageType chip_ime_AppendCommand_MediaInput_RenameInput(chip:
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::MediaInputCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.RenameInput(nullptr, nullptr, index, chip::ByteSpan(name, name_Len)).AsInteger();
+    return cluster.RenameInput(nullptr, nullptr, index, chip::CharSpan(reinterpret_cast<const char *>(name), name_Len)).AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_MediaInput_SelectInput(chip::Controller::Device * device,
                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -4916,7 +4929,7 @@ chip::ChipError::StorageType chip_ime_AppendCommand_OtaSoftwareUpdateProvider_Qu
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .QueryImage(nullptr, nullptr, vendorId, productId, hardwareVersion, softwareVersion, protocolsSupported,
-                    chip::ByteSpan(location, location_Len), requestorCanConsent,
+                    chip::CharSpan(reinterpret_cast<const char *>(location), location_Len), requestorCanConsent,
                     chip::ByteSpan(metadataForProvider, metadataForProvider_Len))
         .AsInteger();
 }
@@ -5333,7 +5346,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_Updat
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OperationalCredentialsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.UpdateFabricLabel(nullptr, nullptr, chip::ByteSpan(label, label_Len)).AsInteger();
+    return cluster.UpdateFabricLabel(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(label), label_Len))
+        .AsInteger();
 }
 chip::ChipError::StorageType
 chip_ime_AppendCommand_OperationalCredentials_UpdateNOC(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
@@ -5921,8 +5935,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_AddScene(chip::Contro
     chip::Controller::ScenesCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .AddScene(nullptr, nullptr, groupId, sceneId, transitionTime, chip::ByteSpan(sceneName, sceneName_Len), clusterId, length,
-                  value)
+        .AddScene(nullptr, nullptr, groupId, sceneId, transitionTime,
+                  chip::CharSpan(reinterpret_cast<const char *>(sceneName), sceneName_Len), clusterId, length, value)
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_GetSceneMembership(chip::Controller::Device * device,
@@ -6150,7 +6164,7 @@ chip::ChipError::StorageType chip_ime_AppendCommand_TvChannel_ChangeChannel(chip
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TvChannelCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.ChangeChannel(nullptr, nullptr, chip::ByteSpan(match, match_Len)).AsInteger();
+    return cluster.ChangeChannel(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(match), match_Len)).AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(chip::Controller::Device * device,
                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
@@ -6226,7 +6240,8 @@ chip::ChipError::StorageType chip_ime_AppendCommand_TargetNavigator_NavigateTarg
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TargetNavigatorCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.NavigateTarget(nullptr, nullptr, target, chip::ByteSpan(data, data_Len)).AsInteger();
+    return cluster.NavigateTarget(nullptr, nullptr, target, chip::CharSpan(reinterpret_cast<const char *>(data), data_Len))
+        .AsInteger();
 }
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList(chip::Controller::Device * device,
@@ -6355,7 +6370,9 @@ chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest(chip::Controlle
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TestClusterCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.TestListStructArgumentRequest(nullptr, nullptr, a, b, c, chip::ByteSpan(d, d_Len), chip::ByteSpan(e, e_Len), f)
+    return cluster
+        .TestListStructArgumentRequest(nullptr, nullptr, a, b, c, chip::ByteSpan(d, d_Len),
+                                       chip::CharSpan(reinterpret_cast<const char *>(e), e_Len), f)
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestNotHandled(chip::Controller::Device * device,
@@ -6382,7 +6399,9 @@ chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest(chip::Controller::D
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TestClusterCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.TestStructArgumentRequest(nullptr, nullptr, a, b, c, chip::ByteSpan(d, d_Len), chip::ByteSpan(e, e_Len), f)
+    return cluster
+        .TestStructArgumentRequest(nullptr, nullptr, a, b, c, chip::ByteSpan(d, d_Len),
+                                   chip::CharSpan(reinterpret_cast<const char *>(e), e_Len), f)
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestUnknownCommand(chip::Controller::Device * device,
@@ -6773,7 +6792,8 @@ chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_CharString(chip
     chip::Controller::TestClusterCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .WriteAttributeCharString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), chip::ByteSpan(value, len))
+        .WriteAttributeCharString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
+                                  chip::CharSpan(reinterpret_cast<const char *>(value), len))
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_LongCharString(chip::Controller::Device * device,
@@ -6795,7 +6815,7 @@ chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_LongCharString(
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .WriteAttributeLongCharString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                      chip::ByteSpan(value, len))
+                                      chip::CharSpan(reinterpret_cast<const char *>(value), len))
         .AsInteger();
 }
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_EpochUs(chip::Controller::Device * device,

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -4199,14 +4199,14 @@ class ChipClusters:
 
     # Cluster commands
 
-    def ClusterAccountLogin_CommandGetSetupPIN(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: bytes):
+    def ClusterAccountLogin_CommandGetSetupPIN(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: str):
         tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN(
             device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(
                 tempAccountIdentifier)
         )
 
-    def ClusterAccountLogin_CommandLogin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: bytes, setupPIN: bytes):
+    def ClusterAccountLogin_CommandLogin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: str, setupPIN: str):
         tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
         setupPIN = setupPIN.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AccountLogin_Login(
@@ -4235,7 +4235,7 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid, status
         )
 
-    def ClusterApplicationLauncher_CommandLaunchApp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, data: bytes, catalogVendorId: int, applicationId: bytes):
+    def ClusterApplicationLauncher_CommandLaunchApp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, data: str, catalogVendorId: int, applicationId: str):
         data = data.encode("utf-8") + b'\x00'
         applicationId = applicationId.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(
@@ -4243,7 +4243,7 @@ class ChipClusters:
                 data), catalogVendorId, applicationId, len(applicationId)
         )
 
-    def ClusterAudioOutput_CommandRenameOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: bytes):
+    def ClusterAudioOutput_CommandRenameOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: str):
         name = name.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput(
             device, ZCLendpoint, ZCLgroupid, index, name, len(name)
@@ -4374,13 +4374,13 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
         )
 
-    def ClusterContentLauncher_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: bool, data: bytes):
+    def ClusterContentLauncher_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: bool, data: str):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent(
             device, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
         )
 
-    def ClusterContentLauncher_CommandLaunchURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, contentURL: bytes, displayString: bytes):
+    def ClusterContentLauncher_CommandLaunchURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, contentURL: str, displayString: str):
         contentURL = contentURL.encode("utf-8") + b'\x00'
         displayString = displayString.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL(
@@ -4526,20 +4526,20 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid
         )
 
-    def ClusterGeneralCommissioning_CommandSetRegulatoryConfig(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, location: int, countryCode: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterGeneralCommissioning_CommandSetRegulatoryConfig(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, location: int, countryCode: str, breadcrumb: int, timeoutMs: int):
         countryCode = countryCode.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(
             device, ZCLendpoint, ZCLgroupid, location, countryCode, len(
                 countryCode), breadcrumb, timeoutMs
         )
 
-    def ClusterGroups_CommandAddGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: bytes):
+    def ClusterGroups_CommandAddGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: str):
         groupName = groupName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Groups_AddGroup(
             device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
         )
 
-    def ClusterGroups_CommandAddGroupIfIdentifying(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: bytes):
+    def ClusterGroups_CommandAddGroupIfIdentifying(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: str):
         groupName = groupName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(
             device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
@@ -4635,7 +4635,7 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid
         )
 
-    def ClusterMediaInput_CommandRenameInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: bytes):
+    def ClusterMediaInput_CommandRenameInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: str):
         name = name.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput(
             device, ZCLendpoint, ZCLgroupid, index, name, len(name)
@@ -4771,7 +4771,7 @@ class ChipClusters:
                 updateToken), softwareVersion
         )
 
-    def ClusterOtaSoftwareUpdateProvider_CommandQueryImage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int, productId: int, hardwareVersion: int, softwareVersion: int, protocolsSupported: int, location: bytes, requestorCanConsent: bool, metadataForProvider: bytes):
+    def ClusterOtaSoftwareUpdateProvider_CommandQueryImage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int, productId: int, hardwareVersion: int, softwareVersion: int, protocolsSupported: int, location: str, requestorCanConsent: bool, metadataForProvider: bytes):
         location = location.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage(
             device, ZCLendpoint, ZCLgroupid, vendorId, productId, hardwareVersion, softwareVersion, protocolsSupported, location, len(
@@ -4853,7 +4853,7 @@ class ChipClusters:
                 trustedRootIdentifier)
         )
 
-    def ClusterOperationalCredentials_CommandUpdateFabricLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, label: bytes):
+    def ClusterOperationalCredentials_CommandUpdateFabricLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, label: str):
         label = label.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(
             device, ZCLendpoint, ZCLgroupid, label, len(label)
@@ -4865,7 +4865,7 @@ class ChipClusters:
                 NOCValue), ICACValue, len(ICACValue)
         )
 
-    def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: bytes, clusterId: int, length: int, value: int):
+    def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: str, clusterId: int, length: int, value: int):
         sceneName = sceneName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Scenes_AddScene(
             device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime, sceneName, len(
@@ -4907,7 +4907,7 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid
         )
 
-    def ClusterTvChannel_CommandChangeChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, match: bytes):
+    def ClusterTvChannel_CommandChangeChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, match: str):
         match = match.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel(
             device, ZCLendpoint, ZCLgroupid, match, len(match)
@@ -4923,7 +4923,7 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid, count
         )
 
-    def ClusterTargetNavigator_CommandNavigateTarget(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, target: int, data: bytes):
+    def ClusterTargetNavigator_CommandNavigateTarget(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, target: int, data: str):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget(
             device, ZCLendpoint, ZCLgroupid, target, data, len(data)
@@ -4949,7 +4949,7 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid, arg1
         )
 
-    def ClusterTestCluster_CommandTestListStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: bytes, f: int):
+    def ClusterTestCluster_CommandTestListStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: str, f: int):
         e = e.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest(
             device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
@@ -4965,7 +4965,7 @@ class ChipClusters:
             device, ZCLendpoint, ZCLgroupid
         )
 
-    def ClusterTestCluster_CommandTestStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: bytes, f: int):
+    def ClusterTestCluster_CommandTestStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: str, f: int):
         e = e.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest(
             device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
@@ -5132,14 +5132,14 @@ class ChipClusters:
     def ClusterBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
+    def ClusterBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterBasic_ReadAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterBasic_WriteAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
+    def ClusterBasic_WriteAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
@@ -5221,7 +5221,7 @@ class ChipClusters:
     def ClusterBridgedDeviceBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterBridgedDeviceBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
+    def ClusterBridgedDeviceBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
@@ -6191,14 +6191,14 @@ class ChipClusters:
     def ClusterTestCluster_ReadAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
+    def ClusterTestCluster_WriteAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterTestCluster_ReadAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
+    def ClusterTestCluster_WriteAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
 

--- a/src/controller/python/templates/helper.js
+++ b/src/controller/python/templates/helper.js
@@ -41,7 +41,9 @@ function asPythonType(zclType)
     return 'str';
   case 'uint8_t *':
   case 'chip::ByteSpan':
-    return 'bytes'
+    return 'bytes';
+  case 'chip::CharSpan':
+    return 'str';
   }
 }
 

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -185,7 +185,7 @@ chip::ChipError::StorageType chip_ime_AppendCommand_{{asUpperCamelCase clusterNa
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::{{asUpperCamelCase clusterName}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.{{asUpperCamelCase name}}(nullptr, nullptr{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isString type)}}chip::ByteSpan({{asLowerCamelCase label}}, {{asLowerCamelCase label}}_Len){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}).AsInteger();
+    return cluster.{{asUpperCamelCase name}}(nullptr, nullptr{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isOctetString type)}}chip::ByteSpan({{asLowerCamelCase label}}, {{asLowerCamelCase label}}_Len){{else if (isCharString type)}}chip::CharSpan(reinterpret_cast<const char*>({{asLowerCamelCase label}}), {{asLowerCamelCase label}}_Len){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}).AsInteger();
 }
 {{/chip_cluster_commands}}
 
@@ -223,7 +223,7 @@ chip::ChipError::StorageType chip_ime_WriteAttribute_{{asUpperCamelCase parent.n
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttribute{{asUpperCamelCase name}}(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), {{#if (isString type)}} chip::ByteSpan(value, len){{else}}value{{/if}}).AsInteger();
+    return cluster.WriteAttribute{{asUpperCamelCase name}}(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), {{#if (isOctetString type)}} chip::ByteSpan(value, len){{else if (isCharString type)}} chip::CharSpan(reinterpret_cast<const char*>(value), len){{else}}value{{/if}}).AsInteger();
 }
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/CHIPCluster.mm
+++ b/src/darwin/Framework/CHIP/CHIPCluster.mm
@@ -48,15 +48,14 @@ using namespace ::chip;
     return nullptr;
 }
 
-- (chip::ByteSpan)asSpan:(id)value
+- (chip::ByteSpan)asByteSpan:(NSData *)value
 {
-    if ([value isKindOfClass:[NSData class]]) {
-        NSData * v = (NSData *) value;
-        return chip::ByteSpan((const uint8_t *) v.bytes, v.length);
-    } else {
-        NSString * v = (NSString *) value;
-        return chip::ByteSpan((const uint8_t *) [v dataUsingEncoding:NSUTF8StringEncoding].bytes,
-            [v lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
-    }
+    return chip::ByteSpan(static_cast<const uint8_t *>(value.bytes), value.length);
+}
+
+- (chip::CharSpan)asCharSpan:(NSString *)value
+{
+    return chip::CharSpan(static_cast<const char *>([value dataUsingEncoding:NSUTF8StringEncoding].bytes),
+        [value lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
 }
 @end

--- a/src/darwin/Framework/CHIP/CHIPCluster_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPCluster_internal.h
@@ -27,5 +27,6 @@
 @interface CHIPCluster ()
 @property (readonly, nonatomic) dispatch_queue_t callbackQueue;
 - (chip::Controller::ClusterBase *)getCluster;
-- (chip::ByteSpan)asSpan:(id)value;
+- (chip::ByteSpan)asByteSpan:(NSData *)value;
+- (chip::CharSpan)asCharSpan:(NSString *)value;
 @end

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -22,7 +22,15 @@ using chip::Callback::Cancelable;
 
 {{#chip_cluster_commands}}
 {{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}DefaultSuccess{{/if}}{{/inline}}
-{{#*inline "callbackParams"}}{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isString type)}}[self asSpan:{{/if}}{{asLowerCamelCase label}}{{#if (isString type)}}]{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}{{/inline}}
+{{#*inline "callbackParams"}}{{#chip_cluster_command_arguments_with_structs_expanded}},
+  {{#if (isOctetString type)}}
+    [self asByteSpan:{{asLowerCamelCase label}}]
+  {{else if (isCharString type)}}
+    [self asCharSpan:{{asLowerCamelCase label}}]
+  {{else}}
+    {{asLowerCamelCase label}}
+  {{/if}}
+{{/chip_cluster_command_arguments_with_structs_expanded}}{{/inline}}
 {{#if (zcl_command_arguments_count this.id)}}
 - (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments_with_structs_expanded}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments_with_structs_expanded}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
@@ -47,7 +55,15 @@ using chip::Callback::Cancelable;
 
 {{#if isWritableAttribute}}
 {{#*inline "callbackName"}}DefaultSuccess{{/inline}}
-{{#*inline "callbackParams"}}, {{#if (isString type)}}[self asSpan:{{/if}}value{{#if (isString type)}}]{{/if}}{{/inline}}
+{{#*inline "callbackParams"}},
+  {{#if (isOctetString type)}}
+    [self asByteSpan:value]
+  {{else if (isCharString type)}}
+    [self asCharSpan:value]
+  {{else}}
+    value
+  {{/if}}
+{{/inline}}
 - (void)write{{>attribute}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/darwin/Framework/CHIP/templates/CHIPTestClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPTestClustersObjc-src.zapt
@@ -31,7 +31,15 @@ using chip::Callback::Cancelable;
 {{#unless isStruct}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
 {{#*inline "callbackName"}}DefaultSuccess{{/inline}}
-{{#*inline "callbackParams"}}, {{#if (isString type)}}[self asSpan:{{/if}}value{{#if (isString type)}}]{{/if}}{{/inline}}
+{{#*inline "callbackParams"}},
+  {{#if (isOctetString type)}}
+    [self asByteSpan:value]
+  {{else if (isCharString type)}}
+    [self asCharSpan:value]
+  {{else}}
+    value
+  {{/if}}
+{{/inline}}
 - (void)write{{>attribute}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -38,14 +38,14 @@ using chip::Callback::Cancelable;
 {
     new CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetSetupPIN(success, failure, [self asSpan:tempAccountIdentifier]);
+            return self.cppCluster.GetSetupPIN(success, failure, [self asCharSpan:tempAccountIdentifier]);
         });
 }
 
 - (void)login:(NSString *)tempAccountIdentifier setupPIN:(NSString *)setupPIN responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Login(success, failure, [self asSpan:tempAccountIdentifier], [self asSpan:setupPIN]);
+        return self.cppCluster.Login(success, failure, [self asCharSpan:tempAccountIdentifier], [self asCharSpan:setupPIN]);
     });
 }
 
@@ -81,8 +81,8 @@ using chip::Callback::Cancelable;
                 responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OpenCommissioningWindow(success, failure, commissioningTimeout, [self asSpan:PAKEVerifier],
-            discriminator, iterations, [self asSpan:salt], passcodeID);
+        return self.cppCluster.OpenCommissioningWindow(success, failure, commissioningTimeout, [self asByteSpan:PAKEVerifier],
+            discriminator, iterations, [self asByteSpan:salt], passcodeID);
     });
 }
 
@@ -188,7 +188,8 @@ using chip::Callback::Cancelable;
 {
     new CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LaunchApp(success, failure, [self asSpan:data], catalogVendorId, [self asSpan:applicationId]);
+            return self.cppCluster.LaunchApp(
+                success, failure, [self asCharSpan:data], catalogVendorId, [self asCharSpan:applicationId]);
         });
 }
 
@@ -233,7 +234,7 @@ using chip::Callback::Cancelable;
 - (void)renameOutput:(uint8_t)index name:(NSString *)name responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RenameOutput(success, failure, index, [self asSpan:name]);
+        return self.cppCluster.RenameOutput(success, failure, index, [self asCharSpan:name]);
     });
 }
 
@@ -385,7 +386,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeUserLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUserLabel(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeUserLabel(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -399,7 +400,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeLocationWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLocation(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeLocation(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -661,7 +662,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeUserLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUserLabel(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeUserLabel(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -1550,7 +1551,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPContentLauncherClusterLaunchContentResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LaunchContent(success, failure, autoPlay, [self asSpan:data]);
+            return self.cppCluster.LaunchContent(success, failure, autoPlay, [self asCharSpan:data]);
         });
 }
 
@@ -1558,7 +1559,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPContentLauncherClusterLaunchURLResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LaunchURL(success, failure, [self asSpan:contentURL], [self asSpan:displayString]);
+            return self.cppCluster.LaunchURL(success, failure, [self asCharSpan:contentURL], [self asCharSpan:displayString]);
         });
 }
 
@@ -1649,7 +1650,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         return self.cppCluster.RetrieveLogsRequest(
-            success, failure, intent, requestedProtocol, [self asSpan:transferFileDesignator]);
+            success, failure, intent, requestedProtocol, [self asByteSpan:transferFileDesignator]);
     });
 }
 
@@ -1778,7 +1779,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDoorLockClusterLockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LockDoor(success, failure, [self asSpan:pin]);
+            return self.cppCluster.LockDoor(success, failure, [self asByteSpan:pin]);
         });
 }
 
@@ -1803,7 +1804,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDoorLockClusterSetPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetPin(success, failure, userId, userStatus, userType, [self asSpan:pin]);
+            return self.cppCluster.SetPin(success, failure, userId, userStatus, userType, [self asByteSpan:pin]);
         });
 }
 
@@ -1815,7 +1816,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDoorLockClusterSetRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetRfid(success, failure, userId, userStatus, userType, [self asSpan:id]);
+            return self.cppCluster.SetRfid(success, failure, userId, userStatus, userType, [self asByteSpan:id]);
         });
 }
 
@@ -1859,7 +1860,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDoorLockClusterUnlockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UnlockDoor(success, failure, [self asSpan:pin]);
+            return self.cppCluster.UnlockDoor(success, failure, [self asByteSpan:pin]);
         });
 }
 
@@ -1867,7 +1868,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UnlockWithTimeout(success, failure, timeoutInSeconds, [self asSpan:pin]);
+            return self.cppCluster.UnlockWithTimeout(success, failure, timeoutInSeconds, [self asByteSpan:pin]);
         });
 }
 
@@ -2195,7 +2196,7 @@ using chip::Callback::Cancelable;
     new CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
             return self.cppCluster.SetRegulatoryConfig(
-                success, failure, location, [self asSpan:countryCode], breadcrumb, timeoutMs);
+                success, failure, location, [self asCharSpan:countryCode], breadcrumb, timeoutMs);
         });
 }
 
@@ -2325,14 +2326,14 @@ using chip::Callback::Cancelable;
 {
     new CHIPGroupsClusterAddGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddGroup(success, failure, groupId, [self asSpan:groupName]);
+            return self.cppCluster.AddGroup(success, failure, groupId, [self asCharSpan:groupName]);
         });
 }
 
 - (void)addGroupIfIdentifying:(uint16_t)groupId groupName:(NSString *)groupName responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.AddGroupIfIdentifying(success, failure, groupId, [self asSpan:groupName]);
+        return self.cppCluster.AddGroupIfIdentifying(success, failure, groupId, [self asCharSpan:groupName]);
     });
 }
 
@@ -2762,7 +2763,7 @@ using chip::Callback::Cancelable;
 - (void)renameInput:(uint8_t)index name:(NSString *)name responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RenameInput(success, failure, index, [self asSpan:name]);
+        return self.cppCluster.RenameInput(success, failure, index, [self asCharSpan:name]);
     });
 }
 
@@ -2978,7 +2979,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddThreadNetwork(success, failure, [self asSpan:operationalDataset], breadcrumb, timeoutMs);
+            return self.cppCluster.AddThreadNetwork(success, failure, [self asByteSpan:operationalDataset], breadcrumb, timeoutMs);
         });
 }
 
@@ -2991,7 +2992,7 @@ using chip::Callback::Cancelable;
     new CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
             return self.cppCluster.AddWiFiNetwork(
-                success, failure, [self asSpan:ssid], [self asSpan:credentials], breadcrumb, timeoutMs);
+                success, failure, [self asByteSpan:ssid], [self asByteSpan:credentials], breadcrumb, timeoutMs);
         });
 }
 
@@ -3002,7 +3003,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.DisableNetwork(success, failure, [self asSpan:networkID], breadcrumb, timeoutMs);
+            return self.cppCluster.DisableNetwork(success, failure, [self asByteSpan:networkID], breadcrumb, timeoutMs);
         });
 }
 
@@ -3013,7 +3014,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.EnableNetwork(success, failure, [self asSpan:networkID], breadcrumb, timeoutMs);
+            return self.cppCluster.EnableNetwork(success, failure, [self asByteSpan:networkID], breadcrumb, timeoutMs);
         });
 }
 
@@ -3031,7 +3032,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RemoveNetwork(success, failure, [self asSpan:networkID], breadcrumb, timeoutMs);
+            return self.cppCluster.RemoveNetwork(success, failure, [self asByteSpan:networkID], breadcrumb, timeoutMs);
         });
 }
 
@@ -3042,7 +3043,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ScanNetworks(success, failure, [self asSpan:ssid], breadcrumb, timeoutMs);
+            return self.cppCluster.ScanNetworks(success, failure, [self asByteSpan:ssid], breadcrumb, timeoutMs);
         });
 }
 
@@ -3053,7 +3054,8 @@ using chip::Callback::Cancelable;
 {
     new CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateThreadNetwork(success, failure, [self asSpan:operationalDataset], breadcrumb, timeoutMs);
+            return self.cppCluster.UpdateThreadNetwork(
+                success, failure, [self asByteSpan:operationalDataset], breadcrumb, timeoutMs);
         });
 }
 
@@ -3066,7 +3068,7 @@ using chip::Callback::Cancelable;
     new CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
             return self.cppCluster.UpdateWiFiNetwork(
-                success, failure, [self asSpan:ssid], [self asSpan:credentials], breadcrumb, timeoutMs);
+                success, failure, [self asByteSpan:ssid], [self asByteSpan:credentials], breadcrumb, timeoutMs);
         });
 }
 
@@ -3097,7 +3099,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ApplyUpdateRequest(success, failure, [self asSpan:updateToken], newVersion);
+            return self.cppCluster.ApplyUpdateRequest(success, failure, [self asByteSpan:updateToken], newVersion);
         });
 }
 
@@ -3106,7 +3108,7 @@ using chip::Callback::Cancelable;
             responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.NotifyUpdateApplied(success, failure, [self asSpan:updateToken], softwareVersion);
+        return self.cppCluster.NotifyUpdateApplied(success, failure, [self asByteSpan:updateToken], softwareVersion);
     });
 }
 
@@ -3123,7 +3125,7 @@ using chip::Callback::Cancelable;
     new CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
             return self.cppCluster.QueryImage(success, failure, vendorId, productId, hardwareVersion, softwareVersion,
-                protocolsSupported, [self asSpan:location], requestorCanConsent, [self asSpan:metadataForProvider]);
+                protocolsSupported, [self asCharSpan:location], requestorCanConsent, [self asByteSpan:metadataForProvider]);
         });
 }
 
@@ -3151,7 +3153,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         return self.cppCluster.AnnounceOtaProvider(
-            success, failure, [self asSpan:providerLocation], vendorId, announcementReason, [self asSpan:metadataForNode]);
+            success, failure, [self asByteSpan:providerLocation], vendorId, announcementReason, [self asByteSpan:metadataForNode]);
     });
 }
 
@@ -3165,7 +3167,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeDefaultOtaProviderWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDefaultOtaProvider(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeDefaultOtaProvider(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -3437,15 +3439,15 @@ using chip::Callback::Cancelable;
 {
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddNOC(success, failure, [self asSpan:NOCValue], [self asSpan:ICACValue], [self asSpan:IPKValue],
-                caseAdminNode, adminVendorId);
+            return self.cppCluster.AddNOC(success, failure, [self asByteSpan:NOCValue], [self asByteSpan:ICACValue],
+                [self asByteSpan:IPKValue], caseAdminNode, adminVendorId);
         });
 }
 
 - (void)addTrustedRootCertificate:(NSData *)rootCertificate responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.AddTrustedRootCertificate(success, failure, [self asSpan:rootCertificate]);
+        return self.cppCluster.AddTrustedRootCertificate(success, failure, [self asByteSpan:rootCertificate]);
     });
 }
 
@@ -3453,7 +3455,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AttestationRequest(success, failure, [self asSpan:attestationNonce]);
+            return self.cppCluster.AttestationRequest(success, failure, [self asByteSpan:attestationNonce]);
         });
 }
 
@@ -3469,7 +3471,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.OpCSRRequest(success, failure, [self asSpan:CSRNonce]);
+            return self.cppCluster.OpCSRRequest(success, failure, [self asByteSpan:CSRNonce]);
         });
 }
 
@@ -3484,7 +3486,7 @@ using chip::Callback::Cancelable;
 - (void)removeTrustedRootCertificate:(NSData *)trustedRootIdentifier responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RemoveTrustedRootCertificate(success, failure, [self asSpan:trustedRootIdentifier]);
+        return self.cppCluster.RemoveTrustedRootCertificate(success, failure, [self asByteSpan:trustedRootIdentifier]);
     });
 }
 
@@ -3492,7 +3494,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateFabricLabel(success, failure, [self asSpan:label]);
+            return self.cppCluster.UpdateFabricLabel(success, failure, [self asCharSpan:label]);
         });
 }
 
@@ -3500,7 +3502,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateNOC(success, failure, [self asSpan:NOCValue], [self asSpan:ICACValue]);
+            return self.cppCluster.UpdateNOC(success, failure, [self asByteSpan:NOCValue], [self asByteSpan:ICACValue]);
         });
 }
 
@@ -3982,7 +3984,7 @@ using chip::Callback::Cancelable;
     new CHIPScenesClusterAddSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
             return self.cppCluster.AddScene(
-                success, failure, groupId, sceneId, transitionTime, [self asSpan:sceneName], clusterId, length, value);
+                success, failure, groupId, sceneId, transitionTime, [self asCharSpan:sceneName], clusterId, length, value);
         });
 }
 
@@ -4184,7 +4186,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPTvChannelClusterChangeChannelResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ChangeChannel(success, failure, [self asSpan:match]);
+            return self.cppCluster.ChangeChannel(success, failure, [self asCharSpan:match]);
         });
 }
 
@@ -4246,7 +4248,7 @@ using chip::Callback::Cancelable;
 {
     new CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.NavigateTarget(success, failure, target, [self asSpan:data]);
+            return self.cppCluster.NavigateTarget(success, failure, target, [self asCharSpan:data]);
         });
 }
 
@@ -4369,7 +4371,8 @@ using chip::Callback::Cancelable;
                       responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.TestListStructArgumentRequest(success, failure, a, b, c, [self asSpan:d], [self asSpan:e], f);
+        return self.cppCluster.TestListStructArgumentRequest(
+            success, failure, a, b, c, [self asByteSpan:d], [self asCharSpan:e], f);
     });
 }
 
@@ -4397,7 +4400,7 @@ using chip::Callback::Cancelable;
                   responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.TestStructArgumentRequest(success, failure, a, b, c, [self asSpan:d], [self asSpan:e], f);
+        return self.cppCluster.TestStructArgumentRequest(success, failure, a, b, c, [self asByteSpan:d], [self asCharSpan:e], f);
     });
 }
 
@@ -4628,7 +4631,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOctetString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeOctetString(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -4666,7 +4669,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeLongOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLongOctetString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeLongOctetString(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -4680,7 +4683,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCharString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeCharString(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -4694,7 +4697,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeLongCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLongCharString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeLongCharString(success, failure, [self asCharSpan:value]);
     });
 }
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -82,7 +82,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -96,7 +96,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeApplicationNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeApplicationName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeApplicationName(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -110,7 +110,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeApplicationIdWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeApplicationId(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeApplicationId(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -267,7 +267,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -281,7 +281,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeProductNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeProductName(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -302,7 +302,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeHardwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeHardwareVersionString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeHardwareVersionString(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -316,42 +316,42 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeSoftwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSoftwareVersionString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeSoftwareVersionString(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeManufacturingDateWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeManufacturingDate(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeManufacturingDate(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributePartNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePartNumber(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributePartNumber(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeProductURLWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductURL(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeProductURL(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeProductLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductLabel(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeProductLabel(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeSerialNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSerialNumber(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeSerialNumber(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -432,7 +432,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -446,7 +446,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeProductNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeProductName(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -460,7 +460,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeHardwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeHardwareVersionString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeHardwareVersionString(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -474,42 +474,42 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeSoftwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSoftwareVersionString(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeSoftwareVersionString(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeManufacturingDateWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeManufacturingDate(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeManufacturingDate(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributePartNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePartNumber(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributePartNumber(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeProductURLWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductURL(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeProductURL(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeProductLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductLabel(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeProductLabel(success, failure, [self asCharSpan:value]);
     });
 }
 
 - (void)writeAttributeSerialNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSerialNumber(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeSerialNumber(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -585,7 +585,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeCompensationTextWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCompensationText(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeCompensationText(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -1756,7 +1756,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeDescriptionWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDescription(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeDescription(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -2204,14 +2204,14 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeTvChannelLineupWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTvChannelLineup(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeTvChannelLineup(success, failure, [self asByteSpan:value]);
     });
 }
 
 - (void)writeAttributeCurrentTvChannelWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentTvChannel(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeCurrentTvChannel(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -2436,7 +2436,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeNetworkNameWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNetworkName(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeNetworkName(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -2457,7 +2457,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeMeshLocalPrefixWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeshLocalPrefix(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeMeshLocalPrefix(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -2821,7 +2821,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeChannelMaskWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeChannelMask(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeChannelMask(success, failure, [self asByteSpan:value]);
     });
 }
 
@@ -2848,7 +2848,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeWakeOnLanMacAddressWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeWakeOnLanMacAddress(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeWakeOnLanMacAddress(success, failure, [self asCharSpan:value]);
     });
 }
 
@@ -2875,7 +2875,7 @@ using chip::Callback::Cancelable;
 - (void)writeAttributeBssidWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBssid(success, failure, [self asSpan:value]);
+        return self.cppCluster.WriteAttributeBssid(success, failure, [self asByteSpan:value]);
     });
 }
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -3410,7 +3410,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    chip::ByteSpan mValue;
+    chip::CharSpan mValue;
 };
 
 /*
@@ -3477,7 +3477,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    chip::ByteSpan mValue;
+    chip::CharSpan mValue;
 };
 
 /*
@@ -4517,7 +4517,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    chip::ByteSpan mValue;
+    chip::CharSpan mValue;
 };
 
 /*
@@ -19735,7 +19735,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    chip::ByteSpan mValue;
+    chip::CharSpan mValue;
 };
 
 /*
@@ -19802,7 +19802,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    chip::ByteSpan mValue;
+    chip::CharSpan mValue;
 };
 
 /*

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -15624,7 +15624,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::ByteSpan charStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("☉T☉"), strlen("☉T☉"));
+        chip::CharSpan charStringArgument = chip::CharSpan("☉T☉", strlen("☉T☉"));
 
         return cluster.WriteAttributeCharString(mOnSuccessCallback_99.Cancel(), mOnFailureCallback_99.Cancel(), charStringArgument);
     }
@@ -15638,8 +15638,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::ByteSpan charStringArgument =
-            chip::ByteSpan(chip::Uint8::from_const_char("☉TestValueLongerThan10☉"), strlen("☉TestValueLongerThan10☉"));
+        chip::CharSpan charStringArgument = chip::CharSpan("☉TestValueLongerThan10☉", strlen("☉TestValueLongerThan10☉"));
 
         return cluster.WriteAttributeCharString(mOnSuccessCallback_100.Cancel(), mOnFailureCallback_100.Cancel(),
                                                 charStringArgument);
@@ -15654,7 +15653,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::ByteSpan charStringArgument = chip::ByteSpan(chip::Uint8::from_const_char(""), strlen(""));
+        chip::CharSpan charStringArgument = chip::CharSpan("", strlen(""));
 
         return cluster.WriteAttributeCharString(mOnSuccessCallback_101.Cancel(), mOnFailureCallback_101.Cancel(),
                                                 charStringArgument);
@@ -15685,11 +15684,10 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::ByteSpan longCharStringArgument = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-                "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-                "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"),
+        chip::CharSpan longCharStringArgument = chip::CharSpan(
+            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
+            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
+            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉",
             strlen("☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
                    "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
                    "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"));
@@ -15727,7 +15725,7 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::ByteSpan longCharStringArgument = chip::ByteSpan(chip::Uint8::from_const_char(""), strlen(""));
+        chip::CharSpan longCharStringArgument = chip::CharSpan("", strlen(""));
 
         return cluster.WriteAttributeLongCharString(mOnSuccessCallback_105.Cancel(), mOnFailureCallback_105.Cancel(),
                                                     longCharStringArgument);

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -51,7 +51,7 @@ namespace Controller {
 
 // AccountLogin Cluster Commands
 CHIP_ERROR AccountLoginCluster::GetSetupPIN(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                            chip::ByteSpan tempAccountIdentifier)
+                                            chip::CharSpan tempAccountIdentifier)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -75,9 +75,7 @@ CHIP_ERROR AccountLoginCluster::GetSetupPIN(Callback::Cancelable * onSuccessCall
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // tempAccountIdentifier: charString
-    SuccessOrExit(err = writer->PutString(
-                      TLV::ContextTag(argSeqNumber++),
-                      Span<const char>(Uint8::to_const_char(tempAccountIdentifier.data()), tempAccountIdentifier.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), tempAccountIdentifier.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -94,7 +92,7 @@ exit:
 }
 
 CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                      chip::ByteSpan tempAccountIdentifier, chip::ByteSpan setupPIN)
+                                      chip::CharSpan tempAccountIdentifier, chip::CharSpan setupPIN)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -118,12 +116,9 @@ CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, 
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // tempAccountIdentifier: charString
-    SuccessOrExit(err = writer->PutString(
-                      TLV::ContextTag(argSeqNumber++),
-                      Span<const char>(Uint8::to_const_char(tempAccountIdentifier.data()), tempAccountIdentifier.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), tempAccountIdentifier.data()));
     // setupPIN: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(setupPIN.data()), setupPIN.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), setupPIN.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -478,7 +473,7 @@ template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ApplicationB
 
 // ApplicationLauncher Cluster Commands
 CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 chip::ByteSpan data, uint16_t catalogVendorId, chip::ByteSpan applicationId)
+                                                 chip::CharSpan data, uint16_t catalogVendorId, chip::CharSpan applicationId)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -502,13 +497,11 @@ CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSucces
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // data: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(data.data()), data.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), data.data()));
     // catalogVendorId: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), catalogVendorId));
     // applicationId: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(applicationId.data()), applicationId.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), applicationId.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -582,7 +575,7 @@ ClusterBase::InvokeCommand<chip::app::Clusters::ApplicationLauncher::Commands::L
 
 // AudioOutput Cluster Commands
 CHIP_ERROR AudioOutputCluster::RenameOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                            uint8_t index, chip::ByteSpan name)
+                                            uint8_t index, chip::CharSpan name)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -608,8 +601,7 @@ CHIP_ERROR AudioOutputCluster::RenameOutput(Callback::Cancelable * onSuccessCall
     // index: int8u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), index));
     // name: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(name.data()), name.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), name.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -975,7 +967,7 @@ CHIP_ERROR BasicCluster::ReadAttributeUserLabel(Callback::Cancelable * onSuccess
 }
 
 CHIP_ERROR BasicCluster::WriteAttributeUserLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 chip::ByteSpan value)
+                                                 chip::CharSpan value)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -1003,7 +995,7 @@ CHIP_ERROR BasicCluster::ReadAttributeLocation(Callback::Cancelable * onSuccessC
 }
 
 CHIP_ERROR BasicCluster::WriteAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                chip::ByteSpan value)
+                                                chip::CharSpan value)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -1472,7 +1464,7 @@ CHIP_ERROR BridgedDeviceBasicCluster::ReadAttributeUserLabel(Callback::Cancelabl
 }
 
 CHIP_ERROR BridgedDeviceBasicCluster::WriteAttributeUserLabel(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
+                                                              Callback::Cancelable * onFailureCallback, chip::CharSpan value)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -3610,7 +3602,7 @@ ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StopMove
 
 // ContentLauncher Cluster Commands
 CHIP_ERROR ContentLauncherCluster::LaunchContent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 bool autoPlay, chip::ByteSpan data)
+                                                 bool autoPlay, chip::CharSpan data)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -3636,8 +3628,7 @@ CHIP_ERROR ContentLauncherCluster::LaunchContent(Callback::Cancelable * onSucces
     // autoPlay: boolean
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), autoPlay));
     // data: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(data.data()), data.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), data.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -3654,7 +3645,7 @@ exit:
 }
 
 CHIP_ERROR ContentLauncherCluster::LaunchURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                             chip::ByteSpan contentURL, chip::ByteSpan displayString)
+                                             chip::CharSpan contentURL, chip::CharSpan displayString)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -3678,11 +3669,9 @@ CHIP_ERROR ContentLauncherCluster::LaunchURL(Callback::Cancelable * onSuccessCal
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // contentURL: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(contentURL.data()), contentURL.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), contentURL.data()));
     // displayString: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(displayString.data()), displayString.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), displayString.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -5538,7 +5527,7 @@ exit:
 
 CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint8_t location,
-                                                            chip::ByteSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs)
+                                                            chip::CharSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -5565,8 +5554,7 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     // location: regulatoryLocationType
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), location));
     // countryCode: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(countryCode.data()), countryCode.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), countryCode.data()));
     // breadcrumb: int64u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), breadcrumb));
     // timeoutMs: int32u
@@ -5776,7 +5764,7 @@ CHIP_ERROR GroupKeyManagementCluster::ReadAttributeClusterRevision(Callback::Can
 
 // Groups Cluster Commands
 CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                   uint16_t groupId, chip::ByteSpan groupName)
+                                   uint16_t groupId, chip::CharSpan groupName)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -5802,8 +5790,7 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
     // groupId: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(groupName.data()), groupName.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), groupName.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -5820,7 +5807,7 @@ exit:
 }
 
 CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                uint16_t groupId, chip::ByteSpan groupName)
+                                                uint16_t groupId, chip::CharSpan groupName)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -5846,8 +5833,7 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
     // groupId: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(groupName.data()), groupName.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), groupName.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -7152,7 +7138,7 @@ exit:
 }
 
 CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint8_t index, chip::ByteSpan name)
+                                          uint8_t index, chip::CharSpan name)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -7178,8 +7164,7 @@ CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallba
     // index: int8u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), index));
     // name: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(name.data()), name.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), name.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -8541,7 +8526,7 @@ exit:
 CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t vendorId,
                                                         uint16_t productId, uint16_t hardwareVersion, uint32_t softwareVersion,
-                                                        uint8_t protocolsSupported, chip::ByteSpan location,
+                                                        uint8_t protocolsSupported, chip::CharSpan location,
                                                         bool requestorCanConsent, chip::ByteSpan metadataForProvider)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
@@ -8577,8 +8562,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
     // protocolsSupported: OTADownloadProtocol
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), protocolsSupported));
     // location: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(location.data()), location.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), location.data()));
     // requestorCanConsent: boolean
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), requestorCanConsent));
     // metadataForProvider: octetString
@@ -9593,7 +9577,7 @@ exit:
 }
 
 CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback, chip::ByteSpan label)
+                                                            Callback::Cancelable * onFailureCallback, chip::CharSpan label)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -9618,8 +9602,7 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // label: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(label.data()), label.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), label.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -10416,7 +10399,7 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeClusterRevision(Call
 
 // Scenes Cluster Commands
 CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, chip::ByteSpan sceneName,
+                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, chip::CharSpan sceneName,
                                    chip::ClusterId clusterId, uint8_t length, uint8_t value)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
@@ -10447,8 +10430,7 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     // transitionTime: int16u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
     // sceneName: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(sceneName.data()), sceneName.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), sceneName.data()));
     // clusterId: clusterId
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
     // length: int8u
@@ -10993,7 +10975,7 @@ CHIP_ERROR SwitchCluster::ReadAttributeClusterRevision(Callback::Cancelable * on
 
 // TvChannel Cluster Commands
 CHIP_ERROR TvChannelCluster::ChangeChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                           chip::ByteSpan match)
+                                           chip::CharSpan match)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -11017,8 +10999,7 @@ CHIP_ERROR TvChannelCluster::ChangeChannel(Callback::Cancelable * onSuccessCallb
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // match: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(match.data()), match.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), match.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -11186,7 +11167,7 @@ ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::SkipChannel
 
 // TargetNavigator Cluster Commands
 CHIP_ERROR TargetNavigatorCluster::NavigateTarget(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback, uint8_t target, chip::ByteSpan data)
+                                                  Callback::Cancelable * onFailureCallback, uint8_t target, chip::CharSpan data)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -11212,8 +11193,7 @@ CHIP_ERROR TargetNavigatorCluster::NavigateTarget(Callback::Cancelable * onSucce
     // target: int8u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), target));
     // data: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(data.data()), data.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), data.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -11497,7 +11477,7 @@ exit:
 
 CHIP_ERROR TestClusterCluster::TestListStructArgumentRequest(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint8_t a, bool b, uint8_t c,
-                                                             chip::ByteSpan d, chip::ByteSpan e, uint8_t f)
+                                                             chip::ByteSpan d, chip::CharSpan e, uint8_t f)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -11530,8 +11510,7 @@ CHIP_ERROR TestClusterCluster::TestListStructArgumentRequest(Callback::Cancelabl
     // d: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), d));
     // e: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(e.data()), e.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), e.data()));
     // f: simpleBitmap
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), f));
 
@@ -11627,7 +11606,7 @@ exit:
 
 CHIP_ERROR TestClusterCluster::TestStructArgumentRequest(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback, uint8_t a, bool b, uint8_t c,
-                                                         chip::ByteSpan d, chip::ByteSpan e, uint8_t f)
+                                                         chip::ByteSpan d, chip::CharSpan e, uint8_t f)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -11660,8 +11639,7 @@ CHIP_ERROR TestClusterCluster::TestStructArgumentRequest(Callback::Cancelable * 
     // d: octetString
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), d));
     // e: charString
-    SuccessOrExit(
-        err = writer->PutString(TLV::ContextTag(argSeqNumber++), Span<const char>(Uint8::to_const_char(e.data()), e.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), e.data()));
     // f: simpleBitmap
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), f));
 
@@ -12261,7 +12239,7 @@ CHIP_ERROR TestClusterCluster::ReadAttributeCharString(Callback::Cancelable * on
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeCharString(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
+                                                        Callback::Cancelable * onFailureCallback, chip::CharSpan value)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -12290,7 +12268,7 @@ CHIP_ERROR TestClusterCluster::ReadAttributeLongCharString(Callback::Cancelable 
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeLongCharString(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
+                                                            Callback::Cancelable * onFailureCallback, chip::CharSpan value)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -38,9 +38,9 @@ public:
 
     // Cluster Commands
     CHIP_ERROR GetSetupPIN(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                           chip::ByteSpan tempAccountIdentifier);
+                           chip::CharSpan tempAccountIdentifier);
     CHIP_ERROR Login(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                     chip::ByteSpan tempAccountIdentifier, chip::ByteSpan setupPIN);
+                     chip::CharSpan tempAccountIdentifier, chip::CharSpan setupPIN);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -97,8 +97,8 @@ public:
     ~ApplicationLauncherCluster() {}
 
     // Cluster Commands
-    CHIP_ERROR LaunchApp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, chip::ByteSpan data,
-                         uint16_t catalogVendorId, chip::ByteSpan applicationId);
+    CHIP_ERROR LaunchApp(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, chip::CharSpan data,
+                         uint16_t catalogVendorId, chip::CharSpan applicationId);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeApplicationLauncherList(Callback::Cancelable * onSuccessCallback,
@@ -118,7 +118,7 @@ public:
 
     // Cluster Commands
     CHIP_ERROR RenameOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t index,
-                            chip::ByteSpan name);
+                            chip::CharSpan name);
     CHIP_ERROR SelectOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t index);
 
     // Cluster Attributes
@@ -183,9 +183,9 @@ public:
     CHIP_ERROR ReadAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR WriteAttributeUserLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                       chip::ByteSpan value);
+                                       chip::CharSpan value);
     CHIP_ERROR WriteAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                      chip::ByteSpan value);
+                                      chip::CharSpan value);
     CHIP_ERROR WriteAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  bool value);
 
@@ -258,7 +258,7 @@ public:
     CHIP_ERROR ReadAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR WriteAttributeUserLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                       chip::ByteSpan value);
+                                       chip::CharSpan value);
 };
 
 class DLL_EXPORT ColorControlCluster : public ClusterBase
@@ -432,9 +432,9 @@ public:
 
     // Cluster Commands
     CHIP_ERROR LaunchContent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, bool autoPlay,
-                             chip::ByteSpan data);
+                             chip::CharSpan data);
     CHIP_ERROR LaunchURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                         chip::ByteSpan contentURL, chip::ByteSpan displayString);
+                         chip::CharSpan contentURL, chip::CharSpan displayString);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeAcceptsHeaderList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -612,7 +612,7 @@ public:
                            uint16_t expiryLengthSeconds, uint64_t breadcrumb, uint32_t timeoutMs);
     CHIP_ERROR CommissioningComplete(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                   uint8_t location, chip::ByteSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
+                                   uint8_t location, chip::CharSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -661,9 +661,9 @@ public:
 
     // Cluster Commands
     CHIP_ERROR AddGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t groupId,
-                        chip::ByteSpan groupName);
+                        chip::CharSpan groupName);
     CHIP_ERROR AddGroupIfIdentifying(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                     uint16_t groupId, chip::ByteSpan groupName);
+                                     uint16_t groupId, chip::CharSpan groupName);
     CHIP_ERROR GetGroupMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                   uint8_t groupCount, uint16_t groupList);
     CHIP_ERROR RemoveAllGroups(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -798,7 +798,7 @@ public:
     // Cluster Commands
     CHIP_ERROR HideInputStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR RenameInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t index,
-                           chip::ByteSpan name);
+                           chip::CharSpan name);
     CHIP_ERROR SelectInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t index);
     CHIP_ERROR ShowInputStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
@@ -891,7 +891,7 @@ public:
                                    chip::ByteSpan updateToken, uint32_t softwareVersion);
     CHIP_ERROR QueryImage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t vendorId,
                           uint16_t productId, uint16_t hardwareVersion, uint32_t softwareVersion, uint8_t protocolsSupported,
-                          chip::ByteSpan location, bool requestorCanConsent, chip::ByteSpan metadataForProvider);
+                          chip::CharSpan location, bool requestorCanConsent, chip::ByteSpan metadataForProvider);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -1010,7 +1010,7 @@ public:
     CHIP_ERROR RemoveTrustedRootCertificate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             chip::ByteSpan trustedRootIdentifier);
     CHIP_ERROR UpdateFabricLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                 chip::ByteSpan label);
+                                 chip::CharSpan label);
     CHIP_ERROR UpdateNOC(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                          chip::ByteSpan NOCValue, chip::ByteSpan ICACValue);
 
@@ -1131,7 +1131,7 @@ public:
 
     // Cluster Commands
     CHIP_ERROR AddScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t groupId,
-                        uint8_t sceneId, uint16_t transitionTime, chip::ByteSpan sceneName, chip::ClusterId clusterId,
+                        uint8_t sceneId, uint16_t transitionTime, chip::CharSpan sceneName, chip::ClusterId clusterId,
                         uint8_t length, uint8_t value);
     CHIP_ERROR GetSceneMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                   uint16_t groupId);
@@ -1199,7 +1199,7 @@ public:
 
     // Cluster Commands
     CHIP_ERROR ChangeChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                             chip::ByteSpan match);
+                             chip::CharSpan match);
     CHIP_ERROR ChangeChannelByNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                      uint16_t majorNumber, uint16_t minorNumber);
     CHIP_ERROR SkipChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t count);
@@ -1221,7 +1221,7 @@ public:
 
     // Cluster Commands
     CHIP_ERROR NavigateTarget(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t target,
-                              chip::ByteSpan data);
+                              chip::CharSpan data);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeTargetNavigatorList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -1261,11 +1261,11 @@ public:
     CHIP_ERROR TestListInt8UReverseRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint8_t arg1);
     CHIP_ERROR TestListStructArgumentRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                             uint8_t a, bool b, uint8_t c, chip::ByteSpan d, chip::ByteSpan e, uint8_t f);
+                                             uint8_t a, bool b, uint8_t c, chip::ByteSpan d, chip::CharSpan e, uint8_t f);
     CHIP_ERROR TestNotHandled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR TestSpecific(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR TestStructArgumentRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                         uint8_t a, bool b, uint8_t c, chip::ByteSpan d, chip::ByteSpan e, uint8_t f);
+                                         uint8_t a, bool b, uint8_t c, chip::ByteSpan d, chip::CharSpan e, uint8_t f);
     CHIP_ERROR TestUnknownCommand(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
@@ -1331,9 +1331,9 @@ public:
     CHIP_ERROR WriteAttributeLongOctetString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              chip::ByteSpan value);
     CHIP_ERROR WriteAttributeCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeLongCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                            chip::ByteSpan value);
+                                            chip::CharSpan value);
     CHIP_ERROR WriteAttributeEpochUs(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                      uint64_t value);
     CHIP_ERROR WriteAttributeEpochS(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,

--- a/zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.cpp
@@ -70,7 +70,7 @@ CHIP_ERROR AdministratorCommissioningClusterTest::WriteAttributeClusterRevision(
 
 CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeVendorName(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback,
-                                                                 chip::ByteSpan vendorName)
+                                                                 chip::CharSpan vendorName)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -105,7 +105,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeVendorId(Callback::Cancela
 
 CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeApplicationName(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
-                                                                      chip::ByteSpan applicationName)
+                                                                      chip::CharSpan applicationName)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -140,7 +140,7 @@ CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeProductId(Callback::Cancel
 
 CHIP_ERROR ApplicationBasicClusterTest::WriteAttributeApplicationId(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback,
-                                                                    chip::ByteSpan applicationId)
+                                                                    chip::CharSpan applicationId)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -408,7 +408,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeInteractionModelVersion(Callback::Can
 }
 
 CHIP_ERROR BasicClusterTest::WriteAttributeVendorName(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback, chip::ByteSpan vendorName)
+                                                      Callback::Cancelable * onFailureCallback, chip::CharSpan vendorName)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -442,7 +442,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeVendorID(Callback::Cancelable * onSuc
 }
 
 CHIP_ERROR BasicClusterTest::WriteAttributeProductName(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback, chip::ByteSpan productName)
+                                                       Callback::Cancelable * onFailureCallback, chip::CharSpan productName)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -494,7 +494,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeHardwareVersion(Callback::Cancelable 
 
 CHIP_ERROR BasicClusterTest::WriteAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback,
-                                                                 chip::ByteSpan hardwareVersionString)
+                                                                 chip::CharSpan hardwareVersionString)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -529,7 +529,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeSoftwareVersion(Callback::Cancelable 
 
 CHIP_ERROR BasicClusterTest::WriteAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback,
-                                                                 chip::ByteSpan softwareVersionString)
+                                                                 chip::CharSpan softwareVersionString)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -547,7 +547,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeSoftwareVersionString(Callback::Cance
 
 CHIP_ERROR BasicClusterTest::WriteAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback,
-                                                             chip::ByteSpan manufacturingDate)
+                                                             chip::CharSpan manufacturingDate)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -564,7 +564,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeManufacturingDate(Callback::Cancelabl
 }
 
 CHIP_ERROR BasicClusterTest::WriteAttributePartNumber(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback, chip::ByteSpan partNumber)
+                                                      Callback::Cancelable * onFailureCallback, chip::CharSpan partNumber)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -581,7 +581,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributePartNumber(Callback::Cancelable * onS
 }
 
 CHIP_ERROR BasicClusterTest::WriteAttributeProductURL(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback, chip::ByteSpan productURL)
+                                                      Callback::Cancelable * onFailureCallback, chip::CharSpan productURL)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -598,7 +598,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeProductURL(Callback::Cancelable * onS
 }
 
 CHIP_ERROR BasicClusterTest::WriteAttributeProductLabel(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback, chip::ByteSpan productLabel)
+                                                        Callback::Cancelable * onFailureCallback, chip::CharSpan productLabel)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -615,7 +615,7 @@ CHIP_ERROR BasicClusterTest::WriteAttributeProductLabel(Callback::Cancelable * o
 }
 
 CHIP_ERROR BasicClusterTest::WriteAttributeSerialNumber(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback, chip::ByteSpan serialNumber)
+                                                        Callback::Cancelable * onFailureCallback, chip::CharSpan serialNumber)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -719,7 +719,7 @@ CHIP_ERROR BindingClusterTest::WriteAttributeClusterRevision(Callback::Cancelabl
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeVendorName(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback,
-                                                                   chip::ByteSpan vendorName)
+                                                                   chip::CharSpan vendorName)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -754,7 +754,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeVendorID(Callback::Cance
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductName(Callback::Cancelable * onSuccessCallback,
                                                                     Callback::Cancelable * onFailureCallback,
-                                                                    chip::ByteSpan productName)
+                                                                    chip::CharSpan productName)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -790,7 +790,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeHardwareVersion(Callback
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
-                                                                              chip::ByteSpan hardwareVersionString)
+                                                                              chip::CharSpan hardwareVersionString)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -826,7 +826,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSoftwareVersion(Callback
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
                                                                               Callback::Cancelable * onFailureCallback,
-                                                                              chip::ByteSpan softwareVersionString)
+                                                                              chip::CharSpan softwareVersionString)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -844,7 +844,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSoftwareVersionString(Ca
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
-                                                                          chip::ByteSpan manufacturingDate)
+                                                                          chip::CharSpan manufacturingDate)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -862,7 +862,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeManufacturingDate(Callba
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributePartNumber(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback,
-                                                                   chip::ByteSpan partNumber)
+                                                                   chip::CharSpan partNumber)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -880,7 +880,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributePartNumber(Callback::Can
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductURL(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback,
-                                                                   chip::ByteSpan productURL)
+                                                                   chip::CharSpan productURL)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -898,7 +898,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductURL(Callback::Can
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductLabel(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback,
-                                                                     chip::ByteSpan productLabel)
+                                                                     chip::CharSpan productLabel)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -916,7 +916,7 @@ CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeProductLabel(Callback::C
 
 CHIP_ERROR BridgedDeviceBasicClusterTest::WriteAttributeSerialNumber(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback,
-                                                                     chip::ByteSpan serialNumber)
+                                                                     chip::CharSpan serialNumber)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -1073,7 +1073,7 @@ CHIP_ERROR ColorControlClusterTest::WriteAttributeDriftCompensation(Callback::Ca
 
 CHIP_ERROR ColorControlClusterTest::WriteAttributeCompensationText(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback,
-                                                                   chip::ByteSpan compensationText)
+                                                                   chip::CharSpan compensationText)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -3158,7 +3158,7 @@ CHIP_ERROR PowerSourceClusterTest::WriteAttributeOrder(Callback::Cancelable * on
 }
 
 CHIP_ERROR PowerSourceClusterTest::WriteAttributeDescription(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback, chip::ByteSpan description)
+                                                             Callback::Cancelable * onFailureCallback, chip::CharSpan description)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;
@@ -5472,7 +5472,7 @@ CHIP_ERROR ThreadNetworkDiagnosticsClusterTest::WriteAttributeClusterRevision(Ca
 
 CHIP_ERROR WakeOnLanClusterTest::WriteAttributeWakeOnLanMacAddress(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback,
-                                                                   chip::ByteSpan wakeOnLanMacAddress)
+                                                                   chip::CharSpan wakeOnLanMacAddress)
 {
     app::WriteClientHandle handle;
     chip::app::AttributePathParams attributePath;

--- a/zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.h
+++ b/zzz_generated/controller-clusters/zap-generated/tests/CHIPClustersTest.h
@@ -51,15 +51,15 @@ public:
     ~ApplicationBasicClusterTest() {}
 
     CHIP_ERROR WriteAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       uint16_t value);
     CHIP_ERROR WriteAttributeApplicationName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                             chip::ByteSpan value);
+                                             chip::CharSpan value);
     CHIP_ERROR WriteAttributeProductId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t value);
     CHIP_ERROR WriteAttributeApplicationId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                           chip::ByteSpan value);
+                                           chip::CharSpan value);
     CHIP_ERROR WriteAttributeCatalogVendorId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t value);
     CHIP_ERROR WriteAttributeApplicationStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -121,31 +121,31 @@ public:
     CHIP_ERROR WriteAttributeInteractionModelVersion(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback, uint16_t value);
     CHIP_ERROR WriteAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeVendorID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       uint16_t value);
     CHIP_ERROR WriteAttributeProductName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                         chip::ByteSpan value);
+                                         chip::CharSpan value);
     CHIP_ERROR WriteAttributeProductID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        uint16_t value);
     CHIP_ERROR WriteAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t value);
     CHIP_ERROR WriteAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, chip::ByteSpan value);
+                                                   Callback::Cancelable * onFailureCallback, chip::CharSpan value);
     CHIP_ERROR WriteAttributeSoftwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint32_t value);
     CHIP_ERROR WriteAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, chip::ByteSpan value);
+                                                   Callback::Cancelable * onFailureCallback, chip::CharSpan value);
     CHIP_ERROR WriteAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               chip::ByteSpan value);
+                                               chip::CharSpan value);
     CHIP_ERROR WriteAttributePartNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeProductURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeProductLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          chip::ByteSpan value);
+                                          chip::CharSpan value);
     CHIP_ERROR WriteAttributeSerialNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          chip::ByteSpan value);
+                                          chip::CharSpan value);
     CHIP_ERROR WriteAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        bool value);
     CHIP_ERROR WriteAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -181,29 +181,29 @@ public:
     ~BridgedDeviceBasicClusterTest() {}
 
     CHIP_ERROR WriteAttributeVendorName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeVendorID(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       uint16_t value);
     CHIP_ERROR WriteAttributeProductName(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                         chip::ByteSpan value);
+                                         chip::CharSpan value);
     CHIP_ERROR WriteAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t value);
     CHIP_ERROR WriteAttributeHardwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, chip::ByteSpan value);
+                                                   Callback::Cancelable * onFailureCallback, chip::CharSpan value);
     CHIP_ERROR WriteAttributeSoftwareVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint32_t value);
     CHIP_ERROR WriteAttributeSoftwareVersionString(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, chip::ByteSpan value);
+                                                   Callback::Cancelable * onFailureCallback, chip::CharSpan value);
     CHIP_ERROR WriteAttributeManufacturingDate(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               chip::ByteSpan value);
+                                               chip::CharSpan value);
     CHIP_ERROR WriteAttributePartNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeProductURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                        chip::ByteSpan value);
+                                        chip::CharSpan value);
     CHIP_ERROR WriteAttributeProductLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          chip::ByteSpan value);
+                                          chip::CharSpan value);
     CHIP_ERROR WriteAttributeSerialNumber(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          chip::ByteSpan value);
+                                          chip::CharSpan value);
     CHIP_ERROR WriteAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                        bool value);
     CHIP_ERROR WriteAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -229,7 +229,7 @@ public:
     CHIP_ERROR WriteAttributeDriftCompensation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                uint8_t value);
     CHIP_ERROR WriteAttributeCompensationText(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                              chip::ByteSpan value);
+                                              chip::CharSpan value);
     CHIP_ERROR WriteAttributeColorTemperature(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t value);
     CHIP_ERROR WriteAttributeColorMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -673,7 +673,7 @@ public:
     CHIP_ERROR WriteAttributeOrder(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                    uint8_t value);
     CHIP_ERROR WriteAttributeDescription(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                         chip::ByteSpan value);
+                                         chip::CharSpan value);
     CHIP_ERROR WriteAttributeBatteryVoltage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             uint32_t value);
     CHIP_ERROR WriteAttributeBatteryPercentRemaining(Callback::Cancelable * onSuccessCallback,
@@ -1045,7 +1045,7 @@ public:
     ~WakeOnLanClusterTest() {}
 
     CHIP_ERROR WriteAttributeWakeOnLanMacAddress(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 chip::ByteSpan value);
+                                                 chip::CharSpan value);
     CHIP_ERROR WriteAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint16_t value);
 };

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.cpp
@@ -143,7 +143,7 @@ exit:
 CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback, uint16_t vendorId,
                                                         uint16_t productId, uint16_t hardwareVersion, uint32_t softwareVersion,
-                                                        uint8_t protocolsSupported, chip::ByteSpan location,
+                                                        uint8_t protocolsSupported, chip::CharSpan location,
                                                         bool requestorCanConsent, chip::ByteSpan metadataForProvider)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
@@ -179,8 +179,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
     // protocolsSupported: OTADownloadProtocol
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), protocolsSupported));
     // location: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(location.data()), location.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), location.data()));
     // requestorCanConsent: boolean
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), requestorCanConsent));
     // metadataForProvider: octetString

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClusters.h
@@ -43,7 +43,7 @@ public:
                                    chip::ByteSpan updateToken, uint32_t softwareVersion);
     CHIP_ERROR QueryImage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t vendorId,
                           uint16_t productId, uint16_t hardwareVersion, uint32_t softwareVersion, uint8_t protocolsSupported,
-                          chip::ByteSpan location, bool requestorCanConsent, chip::ByteSpan metadataForProvider);
+                          chip::CharSpan location, bool requestorCanConsent, chip::ByteSpan metadataForProvider);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.cpp
@@ -138,7 +138,7 @@ exit:
 
 CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
                                                             Callback::Cancelable * onFailureCallback, uint8_t location,
-                                                            chip::ByteSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs)
+                                                            chip::CharSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -165,8 +165,7 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     // location: regulatoryLocationType
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), location));
     // countryCode: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(countryCode.data()), countryCode.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), countryCode.data()));
     // breadcrumb: int64u
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), breadcrumb));
     // timeoutMs: int32u
@@ -802,7 +801,7 @@ exit:
 }
 
 CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback, chip::ByteSpan label)
+                                                            Callback::Cancelable * onFailureCallback, chip::CharSpan label)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     TLV::TLVWriter * writer = nullptr;
@@ -827,8 +826,7 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
 
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // label: charString
-    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++),
-                                          Span<const char>(Uint8::to_const_char(label.data()), label.size())));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(argSeqNumber++), label.data()));
 
     SuccessOrExit(err = sender->FinishCommand());
 

--- a/zzz_generated/tv-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/tv-app/zap-generated/CHIPClusters.h
@@ -41,7 +41,7 @@ public:
                            uint16_t expiryLengthSeconds, uint64_t breadcrumb, uint32_t timeoutMs);
     CHIP_ERROR CommissioningComplete(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                   uint8_t location, chip::ByteSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
+                                   uint8_t location, chip::CharSpan countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -98,7 +98,7 @@ public:
     CHIP_ERROR RemoveFabric(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                             uint8_t fabricIndex);
     CHIP_ERROR UpdateFabricLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                 chip::ByteSpan label);
+                                 chip::CharSpan label);
 
     // Cluster Attributes
     CHIP_ERROR ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);


### PR DESCRIPTION
These were missed earlier.

#### Problem
Places where we are still using ByteSpan for strings.

#### Change overview
CharSpan in those places.

#### Testing
No behavior changes; tree compiles.