### PR TITLE
Use attributes accessors into src/app/clusters/basic/basic.cpp

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -18,81 +18,76 @@
 
 #include "basic.h"
 
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <platform/CHIPDeviceLayer.h>
-
-#include <app-common/zap-generated/att-storage.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app/util/af.h>
-#include <app/util/attribute-storage.h>
-#include <lib/support/ZclString.h>
-#include <protocols/interaction_model/Constants.h>
 
 #include <cstring>
 
 using namespace chip;
+using namespace chip::app::Clusters::Basic;
 using namespace chip::DeviceLayer;
 
 void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
 {
-    uint16_t vendorId;
-    uint16_t productId;
-    uint16_t productRevision;
-    uint32_t firmwareRevision;
-    char cString[65];
-    uint8_t bufferMemory[65];
-    MutableByteSpan zclString(bufferMemory);
+    EmberAfStatus status;
 
-    if (ConfigurationMgr().GetVendorName(cString, sizeof(cString)) == CHIP_NO_ERROR)
+    char vendorName[33];
+    if (ConfigurationMgr().GetVendorName(vendorName, sizeof(vendorName)) == CHIP_NO_ERROR)
     {
-        MakeZclCharString(zclString, cString);
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_VENDOR_NAME_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, zclString.data(),
-                              ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+        status = Attributes::VendorName::Set(endpoint, chip::CharSpan(vendorName, strlen(vendorName)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Name: 0x%02x", status));
     }
 
+    uint16_t vendorId;
     if (ConfigurationMgr().GetVendorId(vendorId) == CHIP_NO_ERROR)
     {
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_VENDOR_ID_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                              reinterpret_cast<uint8_t *>(&vendorId), ZCL_INT16U_ATTRIBUTE_TYPE);
+        status = Attributes::VendorID::Set(endpoint, vendorId);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Vendor Id: 0x%02x", status));
     }
 
-    if (ConfigurationMgr().GetProductName(cString, sizeof(cString)) == CHIP_NO_ERROR)
+    char productName[33];
+    if (ConfigurationMgr().GetProductName(productName, sizeof(productName)) == CHIP_NO_ERROR)
     {
-        MakeZclCharString(zclString, cString);
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_PRODUCT_NAME_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, zclString.data(),
-                              ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+        status = Attributes::ProductName::Set(endpoint, chip::CharSpan(productName, strlen(productName)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Name: 0x%02x", status));
     }
 
+    uint16_t productId;
     if (ConfigurationMgr().GetProductId(productId) == CHIP_NO_ERROR)
     {
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_PRODUCT_ID_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                              reinterpret_cast<uint8_t *>(&productId), ZCL_INT16U_ATTRIBUTE_TYPE);
+        status = Attributes::ProductID::Set(endpoint, productId);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Product Id: 0x%02x", status));
     }
 
-    if (ConfigurationMgr().GetProductRevisionString(cString, sizeof(cString)) == CHIP_NO_ERROR)
+    char productRevisionString[65];
+    if (ConfigurationMgr().GetProductRevisionString(productRevisionString, sizeof(productRevisionString)) == CHIP_NO_ERROR)
     {
-        MakeZclCharString(zclString, cString);
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_HARDWARE_VERSION_STRING_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                              zclString.data(), ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+        status =
+            Attributes::HardwareVersionString::Set(endpoint, chip::CharSpan(productRevisionString, strlen(productRevisionString)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+                       ChipLogError(Zcl, "Error setting Hardware Version String: 0x%02x", status));
     }
 
+    uint16_t productRevision;
     if (ConfigurationMgr().GetProductRevision(productRevision) == CHIP_NO_ERROR)
     {
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_HARDWARE_VERSION_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                              reinterpret_cast<uint8_t *>(&productRevision), ZCL_INT16U_ATTRIBUTE_TYPE);
+        status = Attributes::HardwareVersion::Set(endpoint, productRevision);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Hardware Version: 0x%02x", status));
     }
 
-    if (ConfigurationMgr().GetFirmwareRevisionString(cString, sizeof(cString)) == CHIP_NO_ERROR)
+    char firmwareRevisionString[65];
+    if (ConfigurationMgr().GetFirmwareRevisionString(firmwareRevisionString, sizeof(firmwareRevisionString)) == CHIP_NO_ERROR)
     {
-        MakeZclCharString(zclString, cString);
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_SOFTWARE_VERSION_STRING_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                              zclString.data(), ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+        status = Attributes::SoftwareVersionString::Set(endpoint,
+                                                        chip::CharSpan(firmwareRevisionString, strlen(firmwareRevisionString)));
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+                       ChipLogError(Zcl, "Error setting Software Version String: 0x%02x", status));
     }
 
+    uint16_t firmwareRevision;
     if (ConfigurationMgr().GetFirmwareRevision(firmwareRevision) == CHIP_NO_ERROR)
     {
-        emberAfWriteAttribute(endpoint, ZCL_BASIC_CLUSTER_ID, ZCL_SOFTWARE_VERSION_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                              reinterpret_cast<uint8_t *>(&firmwareRevision), ZCL_INT32U_ATTRIBUTE_TYPE);
+        status = Attributes::HardwareVersion::Set(endpoint, firmwareRevision);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version: 0x%02x", status));
     }
 }

--- a/src/app/zap-templates/common/attributes/Accessors.js
+++ b/src/app/zap-templates/common/attributes/Accessors.js
@@ -31,10 +31,6 @@ function isUnsupportedType(type)
 
 function canHaveSimpleAccessors(type)
 {
-  if (StringHelper.isString(type)) {
-    return false;
-  }
-
   if (ListHelper.isList(type)) {
     return false;
   }

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -28,14 +28,34 @@ namespace Attributes {
 {{#if (canHaveSimpleAccessors type)}}
 namespace {{asUpperCamelCase label}} {
 
-EmberAfStatus Get(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}})
-{
-    return emberAfReadServerAttribute(endpoint, Clusters::{{asUpperCamelCase parent.label}}::Id, Id, (uint8_t *) {{asLowerCamelCase label}}, sizeof(*{{asLowerCamelCase label}}));
+{{#*inline "clusterId"}}Clusters::{{asUpperCamelCase parent.label}}::Id{{/inline}}
+{{#*inline "sizingBytes"}}{{#if (isShortString type)}}1{{else}}2{{/if}}{{/inline}}
 
-}
-EmberAfStatus Set(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}})
+EmberAfStatus Get(chip::EndpointId endpoint, {{#if (isCharString type)}}chip::MutableCharSpan{{else if (isOctetString type)}}chip::MutableByteSpan{{else}}{{asUnderlyingZclType type}} *{{/if}} value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::{{asUpperCamelCase parent.label}}::Id, Id, (uint8_t *) &{{asLowerCamelCase label}}, ZCL_{{asDelimitedMacro type}}_ATTRIBUTE_TYPE);
+    {{#if (isString type)}}
+    VerifyOrReturnError(value.size() == {{maxLength}}, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[{{maxLength}} + {{>sizingBytes}}];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, {{>clusterId}}, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[{{>sizingBytes}}], {{maxLength}});
+    value.reduce_size(emberAf{{#if (isLongString type)}}Long{{/if}}StringLength(zclString));
+    return status;
+    {{else}}
+    return emberAfReadServerAttribute(endpoint, {{>clusterId}}, Id, (uint8_t *) value, sizeof(*value));
+    {{/if}}
+}
+EmberAfStatus Set(chip::EndpointId endpoint, {{asUnderlyingZclType type}} value)
+{
+    {{#if (isString type)}}
+    VerifyOrReturnError(value.size() <= {{maxLength}}, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[{{maxLength}} + {{>sizingBytes}}];
+    emberAfCopyInt{{#if (isShortString type)}}8{{else}}16{{/if}}u(zclString, 0, static_cast<uint{{#if (isShortString type)}}8{{else}}16{{/if}}_t>(value.size()));
+    memcpy(&zclString[{{>sizingBytes}}], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, {{>clusterId}}, Id, zclString, ZCL_{{asDelimitedMacro type}}_ATTRIBUTE_TYPE);
+    {{else}}
+    return emberAfWriteServerAttribute(endpoint, {{>clusterId}}, Id, (uint8_t *) &value, ZCL_{{asDelimitedMacro type}}_ATTRIBUTE_TYPE);
+    {{/if}}
 }
 
 } // namespace {{asUpperCamelCase label}}

--- a/src/app/zap-templates/templates/app/attributes/Accessors.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors.zapt
@@ -25,8 +25,8 @@ namespace Attributes {
 {{#if clusterRef}}
 {{#if (canHaveSimpleAccessors type)}}
 namespace {{asUpperCamelCase label}} {
-EmberAfStatus Get(chip::EndpointId endpoint, {{asUnderlyingZclType type}} * {{asLowerCamelCase label}}); // {{type}} {{isArray}}
-EmberAfStatus Set(chip::EndpointId endpoint, {{asUnderlyingZclType type}} {{asLowerCamelCase label}});
+EmberAfStatus Get(chip::EndpointId endpoint, {{#if (isCharString type)}}chip::MutableCharSpan{{else if (isOctetString type)}}chip::MutableByteSpan{{else}}{{asUnderlyingZclType type}} *{{/if}} value); // {{type}} {{isArray}}
+EmberAfStatus Set(chip::EndpointId endpoint, {{asUnderlyingZclType type}} value);
 } // namespace {{asUpperCamelCase label}}
 
 {{/if}}

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -80,7 +80,7 @@ public:
     virtual CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf)                                    = 0;
     virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) = 0;
     virtual CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize)                        = 0;
-    virtual CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev)                                  = 0;
+    virtual CHIP_ERROR GetFirmwareRevision(uint16_t & firmwareRev)                                  = 0;
     virtual CHIP_ERROR GetSetupPinCode(uint32_t & setupPinCode)                                     = 0;
     virtual CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator)                         = 0;
 #if CHIP_ENABLE_ROTATING_DEVICE_ID

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -62,7 +62,7 @@ public:
     CHIP_ERROR GetProductRevision(uint16_t & productRev) override;
     CHIP_ERROR StoreProductRevision(uint16_t productRev) override;
     CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev) override;
+    CHIP_ERROR GetFirmwareRevision(uint16_t & firmwareRev) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) override;
     CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override;
     CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
@@ -134,7 +134,7 @@ inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetProductId(uint1
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevision(uint32_t & firmwareRev)
+inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::GetFirmwareRevision(uint16_t & firmwareRev)
 {
     firmwareRev = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
     return CHIP_NO_ERROR;

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -39,7 +39,7 @@ private:
     CHIP_ERROR GetProductRevision(uint16_t & productRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreProductRevision(uint16_t productRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetFirmwareRevision(uint16_t & firmwareRev) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -38,14 +38,13 @@ namespace Attributes {
 
 namespace MainsVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) mainsVoltage,
-                                      sizeof(*mainsVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &mainsVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -53,14 +52,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltage)
 
 namespace MainsFrequency {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsFrequency)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) mainsFrequency,
-                                      sizeof(*mainsFrequency));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &mainsFrequency,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -68,14 +66,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsFrequency)
 
 namespace MainsAlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsAlarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) mainsAlarmMask,
-                                      sizeof(*mainsAlarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsAlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &mainsAlarmMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -83,14 +80,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsAlarmMask)
 
 namespace MainsVoltageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) mainsVoltageMinThreshold,
-                                      sizeof(*mainsVoltageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &mainsVoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -98,14 +94,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold)
 
 namespace MainsVoltageMaxThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) mainsVoltageMaxThreshold,
-                                      sizeof(*mainsVoltageMaxThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &mainsVoltageMaxThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -113,14 +108,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold)
 
 namespace MainsVoltageDwellTrip {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) mainsVoltageDwellTrip,
-                                      sizeof(*mainsVoltageDwellTrip));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &mainsVoltageDwellTrip,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -128,14 +122,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip)
 
 namespace BatteryVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryVoltage,
-                                      sizeof(*batteryVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -143,29 +136,50 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltage)
 
 namespace BatteryPercentageRemaining {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryPercentageRemaining,
-                                      sizeof(*batteryPercentageRemaining));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryPercentageRemaining,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryPercentageRemaining
 
+namespace BatteryManufacturer {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace BatteryManufacturer
+
 namespace BatterySize {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batterySize)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batterySize,
-                                      sizeof(*batterySize));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batterySize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batterySize,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -173,14 +187,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batterySize)
 
 namespace BatteryAhrRating {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * batteryAhrRating)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryAhrRating,
-                                      sizeof(*batteryAhrRating));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t batteryAhrRating)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryAhrRating,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -188,14 +201,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t batteryAhrRating)
 
 namespace BatteryQuantity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryQuantity,
-                                      sizeof(*batteryQuantity));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryQuantity,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -203,14 +215,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity)
 
 namespace BatteryRatedVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryRatedVoltage,
-                                      sizeof(*batteryRatedVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryRatedVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryRatedVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -218,14 +229,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryRatedVoltage)
 
 namespace BatteryAlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryAlarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryAlarmMask,
-                                      sizeof(*batteryAlarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryAlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryAlarmMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -233,14 +243,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryAlarmMask)
 
 namespace BatteryVoltageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryVoltageMinThreshold,
-                                      sizeof(*batteryVoltageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryVoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -248,14 +257,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold)
 
 namespace BatteryVoltageThreshold1 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryVoltageThreshold1,
-                                      sizeof(*batteryVoltageThreshold1));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryVoltageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -263,14 +271,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1)
 
 namespace BatteryVoltageThreshold2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryVoltageThreshold2,
-                                      sizeof(*batteryVoltageThreshold2));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryVoltageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -278,14 +285,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2)
 
 namespace BatteryVoltageThreshold3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryVoltageThreshold3,
-                                      sizeof(*batteryVoltageThreshold3));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryVoltageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -293,14 +299,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3)
 
 namespace BatteryPercentageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryPercentageMinThreshold,
-                                      sizeof(*batteryPercentageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryPercentageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -308,14 +313,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageMinThresho
 
 namespace BatteryPercentageThreshold1 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryPercentageThreshold1,
-                                      sizeof(*batteryPercentageThreshold1));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryPercentageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -323,14 +327,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1
 
 namespace BatteryPercentageThreshold2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryPercentageThreshold2,
-                                      sizeof(*batteryPercentageThreshold2));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryPercentageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -338,14 +341,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2
 
 namespace BatteryPercentageThreshold3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryPercentageThreshold3,
-                                      sizeof(*batteryPercentageThreshold3));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryPercentageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -353,14 +355,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3
 
 namespace BatteryAlarmState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryAlarmState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) batteryAlarmState,
-                                      sizeof(*batteryAlarmState));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryAlarmState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &batteryAlarmState,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
@@ -368,14 +369,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryAlarmState)
 
 namespace Battery2Voltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Voltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2Voltage,
-                                      sizeof(*battery2Voltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Voltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2Voltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -383,29 +383,50 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Voltage)
 
 namespace Battery2PercentageRemaining {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2PercentageRemaining,
-                                      sizeof(*battery2PercentageRemaining));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2PercentageRemaining,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Battery2PercentageRemaining
 
+namespace Battery2Manufacturer {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Battery2Manufacturer
+
 namespace Battery2Size {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Size)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2Size,
-                                      sizeof(*battery2Size));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Size)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2Size,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -413,14 +434,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Size)
 
 namespace Battery2AhrRating {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery2AhrRating)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2AhrRating,
-                                      sizeof(*battery2AhrRating));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery2AhrRating)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2AhrRating,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -428,14 +448,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery2AhrRating)
 
 namespace Battery2Quantity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Quantity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2Quantity,
-                                      sizeof(*battery2Quantity));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Quantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2Quantity,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -443,14 +462,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Quantity)
 
 namespace Battery2RatedVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2RatedVoltage,
-                                      sizeof(*battery2RatedVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2RatedVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2RatedVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -458,14 +476,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2RatedVoltage)
 
 namespace Battery2AlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2AlarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2AlarmMask,
-                                      sizeof(*battery2AlarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2AlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2AlarmMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -473,14 +490,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2AlarmMask)
 
 namespace Battery2VoltageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2VoltageMinThreshold,
-                                      sizeof(*battery2VoltageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2VoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -488,14 +504,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold
 
 namespace Battery2VoltageThreshold1 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2VoltageThreshold1,
-                                      sizeof(*battery2VoltageThreshold1));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2VoltageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -503,14 +518,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1)
 
 namespace Battery2VoltageThreshold2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2VoltageThreshold2,
-                                      sizeof(*battery2VoltageThreshold2));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2VoltageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -518,14 +532,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2)
 
 namespace Battery2VoltageThreshold3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2VoltageThreshold3,
-                                      sizeof(*battery2VoltageThreshold3));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2VoltageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -533,14 +546,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3)
 
 namespace Battery2PercentageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2PercentageMinThreshold,
-                                      sizeof(*battery2PercentageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2PercentageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -548,14 +560,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageMinThresh
 
 namespace Battery2PercentageThreshold1 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2PercentageThreshold1,
-                                      sizeof(*battery2PercentageThreshold1));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2PercentageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -563,14 +574,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold
 
 namespace Battery2PercentageThreshold2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2PercentageThreshold2,
-                                      sizeof(*battery2PercentageThreshold2));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2PercentageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -578,14 +588,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold
 
 namespace Battery2PercentageThreshold3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2PercentageThreshold3,
-                                      sizeof(*battery2PercentageThreshold3));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2PercentageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -593,14 +602,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold
 
 namespace Battery2AlarmState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery2AlarmState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery2AlarmState,
-                                      sizeof(*battery2AlarmState));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery2AlarmState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery2AlarmState,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
@@ -608,14 +616,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery2AlarmState)
 
 namespace Battery3Voltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Voltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3Voltage,
-                                      sizeof(*battery3Voltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Voltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3Voltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -623,29 +630,50 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Voltage)
 
 namespace Battery3PercentageRemaining {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3PercentageRemaining,
-                                      sizeof(*battery3PercentageRemaining));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3PercentageRemaining,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Battery3PercentageRemaining
 
+namespace Battery3Manufacturer {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Battery3Manufacturer
+
 namespace Battery3Size {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Size)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3Size,
-                                      sizeof(*battery3Size));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Size)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3Size,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -653,14 +681,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Size)
 
 namespace Battery3AhrRating {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery3AhrRating)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3AhrRating,
-                                      sizeof(*battery3AhrRating));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery3AhrRating)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3AhrRating,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -668,14 +695,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery3AhrRating)
 
 namespace Battery3Quantity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Quantity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3Quantity,
-                                      sizeof(*battery3Quantity));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Quantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3Quantity,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -683,14 +709,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Quantity)
 
 namespace Battery3RatedVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3RatedVoltage,
-                                      sizeof(*battery3RatedVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3RatedVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3RatedVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -698,14 +723,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3RatedVoltage)
 
 namespace Battery3AlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3AlarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3AlarmMask,
-                                      sizeof(*battery3AlarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3AlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3AlarmMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -713,14 +737,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3AlarmMask)
 
 namespace Battery3VoltageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3VoltageMinThreshold,
-                                      sizeof(*battery3VoltageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3VoltageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -728,14 +751,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold
 
 namespace Battery3VoltageThreshold1 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3VoltageThreshold1,
-                                      sizeof(*battery3VoltageThreshold1));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3VoltageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -743,14 +765,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1)
 
 namespace Battery3VoltageThreshold2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3VoltageThreshold2,
-                                      sizeof(*battery3VoltageThreshold2));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3VoltageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -758,14 +779,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2)
 
 namespace Battery3VoltageThreshold3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3VoltageThreshold3,
-                                      sizeof(*battery3VoltageThreshold3));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3VoltageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -773,14 +793,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3)
 
 namespace Battery3PercentageMinThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3PercentageMinThreshold,
-                                      sizeof(*battery3PercentageMinThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3PercentageMinThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -788,14 +807,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageMinThresh
 
 namespace Battery3PercentageThreshold1 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3PercentageThreshold1,
-                                      sizeof(*battery3PercentageThreshold1));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3PercentageThreshold1,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -803,14 +821,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold
 
 namespace Battery3PercentageThreshold2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3PercentageThreshold2,
-                                      sizeof(*battery3PercentageThreshold2));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3PercentageThreshold2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -818,14 +835,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold
 
 namespace Battery3PercentageThreshold3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3PercentageThreshold3,
-                                      sizeof(*battery3PercentageThreshold3));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3PercentageThreshold3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -833,14 +849,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold
 
 namespace Battery3AlarmState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery3AlarmState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) battery3AlarmState,
-                                      sizeof(*battery3AlarmState));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery3AlarmState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &battery3AlarmState,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
@@ -854,14 +869,14 @@ namespace Attributes {
 
 namespace CurrentTemperature {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentTemperature)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) currentTemperature,
-                                      sizeof(*currentTemperature));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &currentTemperature,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -869,14 +884,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentTemperature)
 
 namespace MinTempExperienced {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minTempExperienced)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) minTempExperienced,
-                                      sizeof(*minTempExperienced));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minTempExperienced)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &minTempExperienced,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -884,14 +899,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minTempExperienced)
 
 namespace MaxTempExperienced {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxTempExperienced)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) maxTempExperienced,
-                                      sizeof(*maxTempExperienced));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxTempExperienced)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &maxTempExperienced,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -899,14 +914,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxTempExperienced)
 
 namespace OverTempTotalDwell {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * overTempTotalDwell)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) overTempTotalDwell,
-                                      sizeof(*overTempTotalDwell));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t overTempTotalDwell)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &overTempTotalDwell,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -914,14 +929,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t overTempTotalDwell)
 
 namespace DeviceTempAlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) deviceTempAlarmMask,
-                                      sizeof(*deviceTempAlarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &deviceTempAlarmMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -929,14 +944,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask)
 
 namespace LowTempThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * lowTempThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) lowTempThreshold,
-                                      sizeof(*lowTempThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t lowTempThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &lowTempThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -944,14 +959,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t lowTempThreshold)
 
 namespace HighTempThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * highTempThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) highTempThreshold,
-                                      sizeof(*highTempThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t highTempThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &highTempThreshold,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DeviceTemperatureConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -965,26 +980,26 @@ namespace Attributes {
 
 namespace IdentifyTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * identifyTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) identifyTime, sizeof(*identifyTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t identifyTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) &identifyTime, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace IdentifyTime
 
 namespace IdentifyType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * identifyType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) identifyType, sizeof(*identifyType));
+    return emberAfReadServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t identifyType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) &identifyType, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Identify::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace IdentifyType
@@ -997,13 +1012,13 @@ namespace Attributes {
 
 namespace NameSupport {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Groups::Id, Id, (uint8_t *) nameSupport, sizeof(*nameSupport));
+    return emberAfReadServerAttribute(endpoint, Clusters::Groups::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Groups::Id, Id, (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Groups::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace NameSupport
@@ -1016,79 +1031,78 @@ namespace Attributes {
 
 namespace SceneCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sceneCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) sceneCount, sizeof(*sceneCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sceneCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &sceneCount, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SceneCount
 
 namespace CurrentScene {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentScene)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) currentScene, sizeof(*currentScene));
+    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentScene)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &currentScene, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentScene
 
 namespace CurrentGroup {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentGroup)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) currentGroup, sizeof(*currentGroup));
+    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentGroup)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &currentGroup, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentGroup
 
 namespace SceneValid {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * sceneValid)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) sceneValid, sizeof(*sceneValid));
+    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool sceneValid)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &sceneValid, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace SceneValid
 
 namespace NameSupport {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) nameSupport, sizeof(*nameSupport));
+    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace NameSupport
 
 namespace LastConfiguredBy {
 
-EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * lastConfiguredBy)
+EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) lastConfiguredBy, sizeof(*lastConfiguredBy));
+    return emberAfReadServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId lastConfiguredBy)
+EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &lastConfiguredBy,
-                                       ZCL_NODE_ID_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Scenes::Id, Id, (uint8_t *) &value, ZCL_NODE_ID_ATTRIBUTE_TYPE);
 }
 
 } // namespace LastConfiguredBy
@@ -1101,127 +1115,117 @@ namespace Attributes {
 
 namespace OnOff {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * onOff)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) onOff, sizeof(*onOff));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool onOff)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &onOff, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace OnOff
 
 namespace SampleMfgSpecificAttribute0x00000x1002 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00000x1002)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) sampleMfgSpecificAttribute0x00000x1002,
-                                      sizeof(*sampleMfgSpecificAttribute0x00000x1002));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &sampleMfgSpecificAttribute0x00000x1002,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SampleMfgSpecificAttribute0x00000x1002
 
 namespace SampleMfgSpecificAttribute0x00000x1049 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00000x1049)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) sampleMfgSpecificAttribute0x00000x1049,
-                                      sizeof(*sampleMfgSpecificAttribute0x00000x1049));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &sampleMfgSpecificAttribute0x00000x1049,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SampleMfgSpecificAttribute0x00000x1049
 
 namespace SampleMfgSpecificAttribute0x00010x1002 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00010x1002)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) sampleMfgSpecificAttribute0x00010x1002,
-                                      sizeof(*sampleMfgSpecificAttribute0x00010x1002));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &sampleMfgSpecificAttribute0x00010x1002,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SampleMfgSpecificAttribute0x00010x1002
 
 namespace SampleMfgSpecificAttribute0x00010x1040 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00010x1040)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) sampleMfgSpecificAttribute0x00010x1040,
-                                      sizeof(*sampleMfgSpecificAttribute0x00010x1040));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &sampleMfgSpecificAttribute0x00010x1040,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SampleMfgSpecificAttribute0x00010x1040
 
 namespace GlobalSceneControl {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * globalSceneControl)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) globalSceneControl,
-                                      sizeof(*globalSceneControl));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool globalSceneControl)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &globalSceneControl,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace GlobalSceneControl
 
 namespace OnTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) onTime, sizeof(*onTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &onTime, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OnTime
 
 namespace OffWaitTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offWaitTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) offWaitTime, sizeof(*offWaitTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offWaitTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &offWaitTime, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OffWaitTime
 
 namespace StartUpOnOff {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpOnOff)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) startUpOnOff, sizeof(*startUpOnOff));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpOnOff)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &startUpOnOff, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOff::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace StartUpOnOff
@@ -1234,14 +1238,13 @@ namespace Attributes {
 
 namespace SwitchType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) switchType,
-                                      sizeof(*switchType));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) &switchType,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -1249,14 +1252,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchType)
 
 namespace SwitchActions {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchActions)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) switchActions,
-                                      sizeof(*switchActions));
+    return emberAfReadServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchActions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) &switchActions,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OnOffSwitchConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -1270,198 +1272,182 @@ namespace Attributes {
 
 namespace CurrentLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) currentLevel, sizeof(*currentLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &currentLevel,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentLevel
 
 namespace RemainingTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) remainingTime, sizeof(*remainingTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &remainingTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RemainingTime
 
 namespace MinLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) minLevel, sizeof(*minLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &minLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinLevel
 
 namespace MaxLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) maxLevel, sizeof(*maxLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &maxLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxLevel
 
 namespace CurrentFrequency {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentFrequency)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) currentFrequency,
-                                      sizeof(*currentFrequency));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &currentFrequency,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentFrequency
 
 namespace MinFrequency {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minFrequency)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) minFrequency, sizeof(*minFrequency));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &minFrequency,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinFrequency
 
 namespace MaxFrequency {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxFrequency)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) maxFrequency, sizeof(*maxFrequency));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &maxFrequency,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxFrequency
 
 namespace Options {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * options)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) options, sizeof(*options));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t options)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &options, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Options
 
 namespace OnOffTransitionTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onOffTransitionTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) onOffTransitionTime,
-                                      sizeof(*onOffTransitionTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onOffTransitionTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &onOffTransitionTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OnOffTransitionTime
 
 namespace OnLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * onLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) onLevel, sizeof(*onLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t onLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &onLevel, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OnLevel
 
 namespace OnTransitionTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTransitionTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) onTransitionTime,
-                                      sizeof(*onTransitionTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTransitionTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &onTransitionTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OnTransitionTime
 
 namespace OffTransitionTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offTransitionTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) offTransitionTime,
-                                      sizeof(*offTransitionTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offTransitionTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &offTransitionTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OffTransitionTime
 
 namespace DefaultMoveRate {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * defaultMoveRate)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) defaultMoveRate,
-                                      sizeof(*defaultMoveRate));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t defaultMoveRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &defaultMoveRate,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DefaultMoveRate
 
 namespace StartUpCurrentLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) startUpCurrentLevel,
-                                      sizeof(*startUpCurrentLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpCurrentLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &startUpCurrentLevel,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::LevelControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace StartUpCurrentLevel
@@ -1474,13 +1460,13 @@ namespace Attributes {
 
 namespace AlarmCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Alarms::Id, Id, (uint8_t *) alarmCount, sizeof(*alarmCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::Alarms::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Alarms::Id, Id, (uint8_t *) &alarmCount, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Alarms::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AlarmCount
@@ -1493,130 +1479,130 @@ namespace Attributes {
 
 namespace Time {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * time)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) time, sizeof(*time));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t time)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &time, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
 
 } // namespace Time
 
 namespace TimeStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * timeStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) timeStatus, sizeof(*timeStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t timeStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &timeStatus, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace TimeStatus
 
 namespace TimeZone {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * timeZone)
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) timeZone, sizeof(*timeZone));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t timeZone)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &timeZone, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 
 } // namespace TimeZone
 
 namespace DstStart {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstStart)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) dstStart, sizeof(*dstStart));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstStart)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &dstStart, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DstStart
 
 namespace DstEnd {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstEnd)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) dstEnd, sizeof(*dstEnd));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstEnd)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &dstEnd, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DstEnd
 
 namespace DstShift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * dstShift)
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) dstShift, sizeof(*dstShift));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t dstShift)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &dstShift, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 
 } // namespace DstShift
 
 namespace StandardTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * standardTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) standardTime, sizeof(*standardTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t standardTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &standardTime, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace StandardTime
 
 namespace LocalTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * localTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) localTime, sizeof(*localTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t localTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &localTime, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace LocalTime
 
 namespace LastSetTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * lastSetTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) lastSetTime, sizeof(*lastSetTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lastSetTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &lastSetTime, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
 
 } // namespace LastSetTime
 
 namespace ValidUntilTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * validUntilTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) validUntilTime, sizeof(*validUntilTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t validUntilTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &validUntilTime, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Time::Id, Id, (uint8_t *) &value, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
 
 } // namespace ValidUntilTime
@@ -1627,16 +1613,84 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t validUntilTime)
 namespace BinaryInputBasic {
 namespace Attributes {
 
+namespace ActiveText {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ActiveText
+
+namespace Description {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Description
+
+namespace InactiveText {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace InactiveText
+
 namespace OutOfService {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * outOfService)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) outOfService,
-                                      sizeof(*outOfService));
+    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool outOfService)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &outOfService,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
@@ -1644,28 +1698,26 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool outOfService)
 
 namespace Polarity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * polarity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) polarity, sizeof(*polarity));
+    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t polarity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &polarity,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Polarity
 
 namespace PresentValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * presentValue)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) presentValue,
-                                      sizeof(*presentValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool presentValue)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &presentValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
@@ -1673,27 +1725,26 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool presentValue)
 
 namespace Reliability {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * reliability)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) reliability, sizeof(*reliability));
+    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t reliability)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &reliability,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Reliability
 
 namespace StatusFlags {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * statusFlags)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) statusFlags, sizeof(*statusFlags));
+    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t statusFlags)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &statusFlags,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -1701,15 +1752,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t statusFlags)
 
 namespace ApplicationType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * applicationType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) applicationType,
-                                      sizeof(*applicationType));
+    return emberAfReadServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t applicationType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &applicationType,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BinaryInputBasic::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ApplicationType
@@ -1722,73 +1771,65 @@ namespace Attributes {
 
 namespace TotalProfileNum {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * totalProfileNum)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) totalProfileNum,
-                                      sizeof(*totalProfileNum));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t totalProfileNum)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &totalProfileNum,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace TotalProfileNum
 
 namespace MultipleScheduling {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * multipleScheduling)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) multipleScheduling,
-                                      sizeof(*multipleScheduling));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool multipleScheduling)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &multipleScheduling,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace MultipleScheduling
 
 namespace EnergyFormatting {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * energyFormatting)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) energyFormatting,
-                                      sizeof(*energyFormatting));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t energyFormatting)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &energyFormatting,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnergyFormatting
 
 namespace EnergyRemote {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * energyRemote)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) energyRemote, sizeof(*energyRemote));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool energyRemote)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &energyRemote,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnergyRemote
 
 namespace ScheduleMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) scheduleMode, sizeof(*scheduleMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &scheduleMode,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerProfile::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ScheduleMode
@@ -1801,43 +1842,39 @@ namespace Attributes {
 
 namespace StartTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) startTime, sizeof(*startTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) &startTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace StartTime
 
 namespace FinishTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * finishTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) finishTime, sizeof(*finishTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t finishTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) &finishTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace FinishTime
 
 namespace RemainingTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) remainingTime,
-                                      sizeof(*remainingTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) &remainingTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RemainingTime
@@ -1856,105 +1893,91 @@ namespace Attributes {
 
 namespace CheckInInterval {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInInterval)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) checkInInterval,
-                                      sizeof(*checkInInterval));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInInterval)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &checkInInterval,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CheckInInterval
 
 namespace LongPollInterval {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollInterval)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) longPollInterval,
-                                      sizeof(*longPollInterval));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollInterval)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &longPollInterval,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace LongPollInterval
 
 namespace ShortPollInterval {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * shortPollInterval)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) shortPollInterval,
-                                      sizeof(*shortPollInterval));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t shortPollInterval)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &shortPollInterval,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ShortPollInterval
 
 namespace FastPollTimeout {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeout)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) fastPollTimeout,
-                                      sizeof(*fastPollTimeout));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeout)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &fastPollTimeout,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace FastPollTimeout
 
 namespace CheckInIntervalMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInIntervalMin)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) checkInIntervalMin,
-                                      sizeof(*checkInIntervalMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInIntervalMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &checkInIntervalMin,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CheckInIntervalMin
 
 namespace LongPollIntervalMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollIntervalMin)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) longPollIntervalMin,
-                                      sizeof(*longPollIntervalMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollIntervalMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &longPollIntervalMin,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace LongPollIntervalMin
 
 namespace FastPollTimeoutMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) fastPollTimeoutMax,
-                                      sizeof(*fastPollTimeoutMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &fastPollTimeoutMax,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PollControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace FastPollTimeoutMax
@@ -1967,95 +1990,344 @@ namespace Attributes {
 
 namespace InteractionModelVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * interactionModelVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) interactionModelVersion,
-                                      sizeof(*interactionModelVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t interactionModelVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &interactionModelVersion,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace InteractionModelVersion
 
+namespace VendorName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace VendorName
+
 namespace VendorID {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) vendorID, sizeof(*vendorID));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &vendorID, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace VendorID
 
+namespace ProductName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductName
+
 namespace ProductID {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productID)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) productID, sizeof(*productID));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productID)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &productID, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ProductID
 
+namespace UserLabel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace UserLabel
+
+namespace Location {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 2, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[2 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 2);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 2, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[2 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Location
+
 namespace HardwareVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) hardwareVersion, sizeof(*hardwareVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &hardwareVersion, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace HardwareVersion
 
+namespace HardwareVersionString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 64);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace HardwareVersionString
+
 namespace SoftwareVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) softwareVersion, sizeof(*softwareVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &softwareVersion, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SoftwareVersion
 
+namespace SoftwareVersionString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 64);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace SoftwareVersionString
+
+namespace ManufacturingDate {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ManufacturingDate
+
+namespace PartNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace PartNumber
+
+namespace ProductURL {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 256, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[256 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 256);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 256, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[256 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductURL
+
+namespace ProductLabel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 64);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductLabel
+
+namespace SerialNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace SerialNumber
+
 namespace LocalConfigDisabled {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * localConfigDisabled)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) localConfigDisabled,
-                                      sizeof(*localConfigDisabled));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool localConfigDisabled)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &localConfigDisabled,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace LocalConfigDisabled
 
 namespace Reachable {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) reachable, sizeof(*reachable));
+    return emberAfReadServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool reachable)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &reachable, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Basic::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace Reachable
@@ -2066,16 +2338,40 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool reachable)
 namespace OtaSoftwareUpdateRequestor {
 namespace Attributes {
 
+namespace DefaultOtaProvider {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace DefaultOtaProvider
+
 namespace UpdatePossible {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * updatePossible)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, (uint8_t *) updatePossible,
-                                      sizeof(*updatePossible));
+    return emberAfReadServerAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool updatePossible)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, (uint8_t *) &updatePossible,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OtaSoftwareUpdateRequestor::Id, Id, (uint8_t *) &value,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
@@ -2089,353 +2385,404 @@ namespace Attributes {
 
 namespace Status {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) status, sizeof(*status));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &status, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Status
 
 namespace Order {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * order)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) order, sizeof(*order));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t order)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &order, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Order
 
+namespace Description {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 60, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[60 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 60);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 60, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[60 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Description
+
 namespace WiredAssessedInputVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredAssessedInputVoltage,
-                                      sizeof(*wiredAssessedInputVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredAssessedInputVoltage,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredAssessedInputVoltage
 
 namespace WiredAssessedInputFrequency {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredAssessedInputFrequency,
-                                      sizeof(*wiredAssessedInputFrequency));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredAssessedInputFrequency,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredAssessedInputFrequency
 
 namespace WiredCurrentType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiredCurrentType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredCurrentType,
-                                      sizeof(*wiredCurrentType));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiredCurrentType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredCurrentType,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredCurrentType
 
 namespace WiredAssessedCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredAssessedCurrent,
-                                      sizeof(*wiredAssessedCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredAssessedCurrent,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredAssessedCurrent
 
 namespace WiredNominalVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredNominalVoltage,
-                                      sizeof(*wiredNominalVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredNominalVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredNominalVoltage,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredNominalVoltage
 
 namespace WiredMaximumCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredMaximumCurrent,
-                                      sizeof(*wiredMaximumCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredMaximumCurrent,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredMaximumCurrent
 
 namespace WiredPresent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * wiredPresent)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) wiredPresent, sizeof(*wiredPresent));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool wiredPresent)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &wiredPresent,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace WiredPresent
 
 namespace BatteryVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryVoltage, sizeof(*batteryVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryVoltage,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryVoltage
 
 namespace BatteryPercentRemaining {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryPercentRemaining,
-                                      sizeof(*batteryPercentRemaining));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryPercentRemaining,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryPercentRemaining
 
 namespace BatteryTimeRemaining {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryTimeRemaining,
-                                      sizeof(*batteryTimeRemaining));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeRemaining)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryTimeRemaining,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryTimeRemaining
 
 namespace BatteryChargeLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryChargeLevel,
-                                      sizeof(*batteryChargeLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryChargeLevel,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryChargeLevel
 
 namespace BatteryReplacementNeeded {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryReplacementNeeded)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryReplacementNeeded,
-                                      sizeof(*batteryReplacementNeeded));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool batteryReplacementNeeded)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryReplacementNeeded,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryReplacementNeeded
 
 namespace BatteryReplaceability {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryReplaceability)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryReplaceability,
-                                      sizeof(*batteryReplaceability));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryReplaceability)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryReplaceability,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryReplaceability
 
 namespace BatteryPresent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryPresent)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryPresent, sizeof(*batteryPresent));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool batteryPresent)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryPresent,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryPresent
 
+namespace BatteryReplacementDescription {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 60, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[60 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 60);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 60, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[60 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace BatteryReplacementDescription
+
 namespace BatteryCommonDesignation {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryCommonDesignation,
-                                      sizeof(*batteryCommonDesignation));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCommonDesignation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryCommonDesignation,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryCommonDesignation
 
+namespace BatteryANSIDesignation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 20, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[20 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 20);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 20, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[20 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace BatteryANSIDesignation
+
+namespace BatteryIECDesignation {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 20, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[20 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 20);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 20, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[20 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace BatteryIECDesignation
+
 namespace BatteryApprovedChemistry {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryApprovedChemistry,
-                                      sizeof(*batteryApprovedChemistry));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryApprovedChemistry,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryApprovedChemistry
 
 namespace BatteryCapacity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCapacity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryCapacity,
-                                      sizeof(*batteryCapacity));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCapacity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryCapacity,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryCapacity
 
 namespace BatteryQuantity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryQuantity,
-                                      sizeof(*batteryQuantity));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryQuantity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryQuantity
 
 namespace BatteryChargeState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryChargeState,
-                                      sizeof(*batteryChargeState));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryChargeState,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryChargeState
 
 namespace BatteryTimeToFullCharge {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryTimeToFullCharge,
-                                      sizeof(*batteryTimeToFullCharge));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryTimeToFullCharge,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryTimeToFullCharge
 
 namespace BatteryFunctionalWhileCharging {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryFunctionalWhileCharging,
-                                      sizeof(*batteryFunctionalWhileCharging));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryFunctionalWhileCharging,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryFunctionalWhileCharging
 
 namespace BatteryChargingCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) batteryChargingCurrent,
-                                      sizeof(*batteryChargingCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryChargingCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &batteryChargingCurrent,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::PowerSource::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BatteryChargingCurrent
@@ -2448,14 +2795,13 @@ namespace Attributes {
 
 namespace Breadcrumb {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * breadcrumb)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, (uint8_t *) breadcrumb,
-                                      sizeof(*breadcrumb));
+    return emberAfReadServerAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t breadcrumb)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, (uint8_t *) &breadcrumb,
+    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralCommissioning::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -2469,14 +2815,13 @@ namespace Attributes {
 
 namespace RebootCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rebootCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) rebootCount,
-                                      sizeof(*rebootCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rebootCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &rebootCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2484,13 +2829,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rebootCount)
 
 namespace UpTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * upTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) upTime, sizeof(*upTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t upTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &upTime,
+    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -2498,14 +2843,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t upTime)
 
 namespace TotalOperationalHours {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalOperationalHours)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) totalOperationalHours,
-                                      sizeof(*totalOperationalHours));
+    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalOperationalHours)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &totalOperationalHours,
+    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2513,14 +2857,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalOperationalHours)
 
 namespace BootReasons {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bootReasons)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) bootReasons,
-                                      sizeof(*bootReasons));
+    return emberAfReadServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bootReasons)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &bootReasons,
+    return emberAfWriteServerAttribute(endpoint, Clusters::GeneralDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -2534,14 +2877,13 @@ namespace Attributes {
 
 namespace CurrentHeapFree {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapFree)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) currentHeapFree,
-                                      sizeof(*currentHeapFree));
+    return emberAfReadServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapFree)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) &currentHeapFree,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -2549,14 +2891,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapFree)
 
 namespace CurrentHeapUsed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapUsed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) currentHeapUsed,
-                                      sizeof(*currentHeapUsed));
+    return emberAfReadServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapUsed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) &currentHeapUsed,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -2564,14 +2905,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapUsed)
 
 namespace CurrentHeapHighWatermark {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) currentHeapHighWatermark,
-                                      sizeof(*currentHeapHighWatermark));
+    return emberAfReadServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) &currentHeapHighWatermark,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SoftwareDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -2585,13 +2925,13 @@ namespace Attributes {
 
 namespace Channel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * channel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) channel, sizeof(*channel));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t channel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &channel,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -2599,28 +2939,52 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t channel)
 
 namespace RoutingRole {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * routingRole)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) routingRole,
-                                      sizeof(*routingRole));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t routingRole)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &routingRole,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace RoutingRole
 
+namespace NetworkName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace NetworkName
+
 namespace PanId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * panId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) panId, sizeof(*panId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t panId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &panId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2628,29 +2992,52 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t panId)
 
 namespace ExtendedPanId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * extendedPanId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) extendedPanId,
-                                      sizeof(*extendedPanId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t extendedPanId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &extendedPanId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ExtendedPanId
 
+namespace MeshLocalPrefix {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 17, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[17 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 17);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 17, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[17 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace MeshLocalPrefix
+
 namespace OverrunCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) overrunCount,
-                                      sizeof(*overrunCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &overrunCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -2658,14 +3045,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
 
 namespace PartitionId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * partitionId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) partitionId,
-                                      sizeof(*partitionId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t partitionId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &partitionId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2673,14 +3059,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t partitionId)
 
 namespace Weighting {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * weighting)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) weighting,
-                                      sizeof(*weighting));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t weighting)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &weighting,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -2688,14 +3073,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t weighting)
 
 namespace DataVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dataVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) dataVersion,
-                                      sizeof(*dataVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dataVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &dataVersion,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -2703,14 +3087,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dataVersion)
 
 namespace StableDataVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * stableDataVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) stableDataVersion,
-                                      sizeof(*stableDataVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t stableDataVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &stableDataVersion,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -2718,14 +3101,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t stableDataVersion)
 
 namespace LeaderRouterId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * leaderRouterId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) leaderRouterId,
-                                      sizeof(*leaderRouterId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t leaderRouterId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &leaderRouterId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -2733,14 +3115,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t leaderRouterId)
 
 namespace DetachedRoleCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * detachedRoleCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) detachedRoleCount,
-                                      sizeof(*detachedRoleCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t detachedRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &detachedRoleCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2748,14 +3129,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t detachedRoleCount)
 
 namespace ChildRoleCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * childRoleCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) childRoleCount,
-                                      sizeof(*childRoleCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t childRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &childRoleCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2763,14 +3143,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t childRoleCount)
 
 namespace RouterRoleCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * routerRoleCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) routerRoleCount,
-                                      sizeof(*routerRoleCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t routerRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &routerRoleCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2778,14 +3157,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t routerRoleCount)
 
 namespace LeaderRoleCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * leaderRoleCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) leaderRoleCount,
-                                      sizeof(*leaderRoleCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t leaderRoleCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &leaderRoleCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2793,14 +3171,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t leaderRoleCount)
 
 namespace AttachAttemptCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * attachAttemptCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) attachAttemptCount,
-                                      sizeof(*attachAttemptCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t attachAttemptCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &attachAttemptCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2808,14 +3185,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t attachAttemptCount)
 
 namespace PartitionIdChangeCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) partitionIdChangeCount,
-                                      sizeof(*partitionIdChangeCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t partitionIdChangeCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &partitionIdChangeCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2823,29 +3199,27 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t partitionIdChangeCount)
 
 namespace BetterPartitionAttachAttemptCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * betterPartitionAttachAttemptCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id,
-                                      (uint8_t *) betterPartitionAttachAttemptCount, sizeof(*betterPartitionAttachAttemptCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id,
-                                       (uint8_t *) &betterPartitionAttachAttemptCount, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BetterPartitionAttachAttemptCount
 
 namespace ParentChangeCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * parentChangeCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) parentChangeCount,
-                                      sizeof(*parentChangeCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t parentChangeCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &parentChangeCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -2853,14 +3227,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t parentChangeCount)
 
 namespace TxTotalCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txTotalCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txTotalCount,
-                                      sizeof(*txTotalCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txTotalCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txTotalCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2868,14 +3241,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txTotalCount)
 
 namespace TxUnicastCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txUnicastCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txUnicastCount,
-                                      sizeof(*txUnicastCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txUnicastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txUnicastCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2883,14 +3255,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txUnicastCount)
 
 namespace TxBroadcastCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBroadcastCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txBroadcastCount,
-                                      sizeof(*txBroadcastCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBroadcastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txBroadcastCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2898,14 +3269,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBroadcastCount)
 
 namespace TxAckRequestedCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckRequestedCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txAckRequestedCount,
-                                      sizeof(*txAckRequestedCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckRequestedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txAckRequestedCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2913,14 +3283,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckRequestedCount)
 
 namespace TxAckedCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckedCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txAckedCount,
-                                      sizeof(*txAckedCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txAckedCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2928,14 +3297,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckedCount)
 
 namespace TxNoAckRequestedCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txNoAckRequestedCount,
-                                      sizeof(*txNoAckRequestedCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txNoAckRequestedCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2943,14 +3311,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount)
 
 namespace TxDataCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txDataCount,
-                                      sizeof(*txDataCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txDataCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2958,14 +3325,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataCount)
 
 namespace TxDataPollCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataPollCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txDataPollCount,
-                                      sizeof(*txDataPollCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataPollCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txDataPollCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2973,14 +3339,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataPollCount)
 
 namespace TxBeaconCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txBeaconCount,
-                                      sizeof(*txBeaconCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txBeaconCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -2988,14 +3353,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconCount)
 
 namespace TxBeaconRequestCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txBeaconRequestCount,
-                                      sizeof(*txBeaconRequestCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconRequestCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txBeaconRequestCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3003,14 +3367,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconRequestCount)
 
 namespace TxOtherCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txOtherCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txOtherCount,
-                                      sizeof(*txOtherCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txOtherCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txOtherCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3018,14 +3381,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txOtherCount)
 
 namespace TxRetryCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txRetryCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txRetryCount,
-                                      sizeof(*txRetryCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txRetryCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txRetryCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3033,44 +3395,41 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txRetryCount)
 
 namespace TxDirectMaxRetryExpiryCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txDirectMaxRetryExpiryCount,
-                                      sizeof(*txDirectMaxRetryExpiryCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id,
-                                       (uint8_t *) &txDirectMaxRetryExpiryCount, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace TxDirectMaxRetryExpiryCount
 
 namespace TxIndirectMaxRetryExpiryCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id,
-                                      (uint8_t *) txIndirectMaxRetryExpiryCount, sizeof(*txIndirectMaxRetryExpiryCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id,
-                                       (uint8_t *) &txIndirectMaxRetryExpiryCount, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace TxIndirectMaxRetryExpiryCount
 
 namespace TxErrCcaCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrCcaCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txErrCcaCount,
-                                      sizeof(*txErrCcaCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrCcaCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txErrCcaCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3078,14 +3437,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrCcaCount)
 
 namespace TxErrAbortCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrAbortCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txErrAbortCount,
-                                      sizeof(*txErrAbortCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrAbortCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txErrAbortCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3093,14 +3451,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrAbortCount)
 
 namespace TxErrBusyChannelCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) txErrBusyChannelCount,
-                                      sizeof(*txErrBusyChannelCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &txErrBusyChannelCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3108,14 +3465,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount)
 
 namespace RxTotalCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxTotalCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxTotalCount,
-                                      sizeof(*rxTotalCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxTotalCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxTotalCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3123,14 +3479,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxTotalCount)
 
 namespace RxUnicastCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxUnicastCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxUnicastCount,
-                                      sizeof(*rxUnicastCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxUnicastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxUnicastCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3138,14 +3493,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxUnicastCount)
 
 namespace RxBroadcastCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBroadcastCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxBroadcastCount,
-                                      sizeof(*rxBroadcastCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBroadcastCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxBroadcastCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3153,14 +3507,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBroadcastCount)
 
 namespace RxDataCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxDataCount,
-                                      sizeof(*rxDataCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxDataCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3168,14 +3521,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataCount)
 
 namespace RxDataPollCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataPollCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxDataPollCount,
-                                      sizeof(*rxDataPollCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataPollCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxDataPollCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3183,14 +3535,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataPollCount)
 
 namespace RxBeaconCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxBeaconCount,
-                                      sizeof(*rxBeaconCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxBeaconCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3198,14 +3549,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconCount)
 
 namespace RxBeaconRequestCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxBeaconRequestCount,
-                                      sizeof(*rxBeaconRequestCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxBeaconRequestCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3213,14 +3563,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount)
 
 namespace RxOtherCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxOtherCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxOtherCount,
-                                      sizeof(*rxOtherCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxOtherCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxOtherCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3228,14 +3577,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxOtherCount)
 
 namespace RxAddressFilteredCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxAddressFilteredCount,
-                                      sizeof(*rxAddressFilteredCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxAddressFilteredCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3243,14 +3591,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount)
 
 namespace RxDestAddrFilteredCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxDestAddrFilteredCount,
-                                      sizeof(*rxDestAddrFilteredCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxDestAddrFilteredCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3258,14 +3605,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount)
 
 namespace RxDuplicatedCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxDuplicatedCount,
-                                      sizeof(*rxDuplicatedCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDuplicatedCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxDuplicatedCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3273,14 +3619,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDuplicatedCount)
 
 namespace RxErrNoFrameCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxErrNoFrameCount,
-                                      sizeof(*rxErrNoFrameCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxErrNoFrameCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3288,14 +3633,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount)
 
 namespace RxErrUnknownNeighborCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxErrUnknownNeighborCount,
-                                      sizeof(*rxErrUnknownNeighborCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxErrUnknownNeighborCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3303,14 +3647,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount)
 
 namespace RxErrInvalidSrcAddrCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxErrInvalidSrcAddrCount,
-                                      sizeof(*rxErrInvalidSrcAddrCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxErrInvalidSrcAddrCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3318,14 +3661,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount)
 
 namespace RxErrSecCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrSecCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxErrSecCount,
-                                      sizeof(*rxErrSecCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrSecCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxErrSecCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3333,14 +3675,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrSecCount)
 
 namespace RxErrFcsCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrFcsCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxErrFcsCount,
-                                      sizeof(*rxErrFcsCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrFcsCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxErrFcsCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3348,14 +3689,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrFcsCount)
 
 namespace RxErrOtherCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrOtherCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) rxErrOtherCount,
-                                      sizeof(*rxErrOtherCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrOtherCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &rxErrOtherCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3363,14 +3703,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrOtherCount)
 
 namespace ActiveTimestamp {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * activeTimestamp)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) activeTimestamp,
-                                      sizeof(*activeTimestamp));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t activeTimestamp)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &activeTimestamp,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3378,14 +3717,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t activeTimestamp)
 
 namespace PendingTimestamp {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * pendingTimestamp)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) pendingTimestamp,
-                                      sizeof(*pendingTimestamp));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t pendingTimestamp)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &pendingTimestamp,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3393,17 +3731,42 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t pendingTimestamp)
 
 namespace Delay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * delay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) delay, sizeof(*delay));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t delay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &delay,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Delay
+
+namespace ChannelMask {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 4, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[4 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 4);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 4, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[4 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThreadNetworkDiagnostics::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ChannelMask
 
 } // namespace Attributes
 } // namespace ThreadNetworkDiagnostics
@@ -3411,16 +3774,40 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t delay)
 namespace WiFiNetworkDiagnostics {
 namespace Attributes {
 
+namespace Bssid {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 6);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Bssid
+
 namespace SecurityType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * securityType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) securityType,
-                                      sizeof(*securityType));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t securityType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &securityType,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -3428,14 +3815,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t securityType)
 
 namespace WiFiVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiFiVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) wiFiVersion,
-                                      sizeof(*wiFiVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiFiVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &wiFiVersion,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -3443,14 +3829,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiFiVersion)
 
 namespace ChannelNumber {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * channelNumber)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) channelNumber,
-                                      sizeof(*channelNumber));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t channelNumber)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &channelNumber,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -3458,13 +3843,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t channelNumber)
 
 namespace Rssi {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * rssi)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) rssi, sizeof(*rssi));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t rssi)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &rssi,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
@@ -3472,14 +3857,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int8_t rssi)
 
 namespace BeaconLostCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconLostCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) beaconLostCount,
-                                      sizeof(*beaconLostCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconLostCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &beaconLostCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3487,14 +3871,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconLostCount)
 
 namespace BeaconRxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconRxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) beaconRxCount,
-                                      sizeof(*beaconRxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &beaconRxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3502,14 +3885,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconRxCount)
 
 namespace PacketMulticastRxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) packetMulticastRxCount,
-                                      sizeof(*packetMulticastRxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &packetMulticastRxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3517,14 +3899,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastRxCount)
 
 namespace PacketMulticastTxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) packetMulticastTxCount,
-                                      sizeof(*packetMulticastTxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastTxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &packetMulticastTxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3532,14 +3913,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastTxCount)
 
 namespace PacketUnicastRxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) packetUnicastRxCount,
-                                      sizeof(*packetUnicastRxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &packetUnicastRxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3547,14 +3927,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastRxCount)
 
 namespace PacketUnicastTxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) packetUnicastTxCount,
-                                      sizeof(*packetUnicastTxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastTxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &packetUnicastTxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -3562,14 +3941,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastTxCount)
 
 namespace CurrentMaxRate {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentMaxRate)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) currentMaxRate,
-                                      sizeof(*currentMaxRate));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentMaxRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &currentMaxRate,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3577,14 +3955,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentMaxRate)
 
 namespace OverrunCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) overrunCount,
-                                      sizeof(*overrunCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &overrunCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::WiFiNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3598,14 +3975,13 @@ namespace Attributes {
 
 namespace PHYRate {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * PHYRate)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) PHYRate,
-                                      sizeof(*PHYRate));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t PHYRate)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &PHYRate,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -3613,14 +3989,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t PHYRate)
 
 namespace FullDuplex {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * fullDuplex)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) fullDuplex,
-                                      sizeof(*fullDuplex));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool fullDuplex)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &fullDuplex,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
@@ -3628,14 +4003,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool fullDuplex)
 
 namespace PacketRxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetRxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) packetRxCount,
-                                      sizeof(*packetRxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetRxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &packetRxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3643,14 +4017,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetRxCount)
 
 namespace PacketTxCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetTxCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) packetTxCount,
-                                      sizeof(*packetTxCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetTxCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &packetTxCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3658,14 +4031,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetTxCount)
 
 namespace TxErrCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * txErrCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) txErrCount,
-                                      sizeof(*txErrCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t txErrCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &txErrCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3673,14 +4045,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t txErrCount)
 
 namespace CollisionCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * collisionCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) collisionCount,
-                                      sizeof(*collisionCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t collisionCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &collisionCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3688,14 +4059,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t collisionCount)
 
 namespace OverrunCount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) overrunCount,
-                                      sizeof(*overrunCount));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &overrunCount,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3703,14 +4073,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount)
 
 namespace CarrierDetect {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * carrierDetect)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) carrierDetect,
-                                      sizeof(*carrierDetect));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool carrierDetect)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &carrierDetect,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
@@ -3718,14 +4087,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool carrierDetect)
 
 namespace TimeSinceReset {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * timeSinceReset)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) timeSinceReset,
-                                      sizeof(*timeSinceReset));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t timeSinceReset)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &timeSinceReset,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthernetNetworkDiagnostics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
@@ -3737,59 +4105,287 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t timeSinceReset)
 namespace BridgedDeviceBasic {
 namespace Attributes {
 
+namespace VendorName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace VendorName
+
 namespace VendorID {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) vendorID, sizeof(*vendorID));
+    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &vendorID,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace VendorID
 
+namespace ProductName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductName
+
+namespace UserLabel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace UserLabel
+
 namespace HardwareVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) hardwareVersion,
-                                      sizeof(*hardwareVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &hardwareVersion,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace HardwareVersion
 
+namespace HardwareVersionString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 64);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace HardwareVersionString
+
 namespace SoftwareVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) softwareVersion,
-                                      sizeof(*softwareVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &softwareVersion,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SoftwareVersion
 
+namespace SoftwareVersionString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 64);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace SoftwareVersionString
+
+namespace ManufacturingDate {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ManufacturingDate
+
+namespace PartNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 254);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace PartNumber
+
+namespace ProductURL {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 254);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductURL
+
+namespace ProductLabel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 64);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 64, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[64 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductLabel
+
+namespace SerialNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace SerialNumber
+
 namespace Reachable {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) reachable, sizeof(*reachable));
+    return emberAfReadServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool reachable)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &reachable,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BridgedDeviceBasic::Id, Id, (uint8_t *) &value,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
@@ -3803,41 +4399,39 @@ namespace Attributes {
 
 namespace NumberOfPositions {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPositions)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) numberOfPositions,
-                                      sizeof(*numberOfPositions));
+    return emberAfReadServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPositions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) &numberOfPositions,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfPositions
 
 namespace CurrentPosition {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPosition)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) currentPosition, sizeof(*currentPosition));
+    return emberAfReadServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPosition)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) &currentPosition, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPosition
 
 namespace MultiPressMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * multiPressMax)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) multiPressMax, sizeof(*multiPressMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t multiPressMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) &multiPressMax, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Switch::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MultiPressMax
@@ -3850,14 +4444,13 @@ namespace Attributes {
 
 namespace SupportedFabrics {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * supportedFabrics)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) supportedFabrics,
-                                      sizeof(*supportedFabrics));
+    return emberAfReadServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t supportedFabrics)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) &supportedFabrics,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -3865,14 +4458,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t supportedFabrics)
 
 namespace CommissionedFabrics {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * commissionedFabrics)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) commissionedFabrics,
-                                      sizeof(*commissionedFabrics));
+    return emberAfReadServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t commissionedFabrics)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) &commissionedFabrics,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OperationalCredentials::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -3892,14 +4484,13 @@ namespace Attributes {
 
 namespace StateValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * stateValue)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BooleanState::Id, Id, (uint8_t *) stateValue, sizeof(*stateValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BooleanState::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool stateValue)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BooleanState::Id, Id, (uint8_t *) &stateValue,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BooleanState::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace StateValue
@@ -3912,14 +4503,13 @@ namespace Attributes {
 
 namespace PhysicalClosedLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) physicalClosedLimit,
-                                      sizeof(*physicalClosedLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &physicalClosedLimit,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -3927,14 +4517,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimit)
 
 namespace MotorStepSize {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * motorStepSize)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) motorStepSize,
-                                      sizeof(*motorStepSize));
+    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t motorStepSize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &motorStepSize,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -3942,13 +4531,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t motorStepSize)
 
 namespace Status {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) status, sizeof(*status));
+    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &status,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -3956,14 +4545,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status)
 
 namespace ClosedLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * closedLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) closedLimit,
-                                      sizeof(*closedLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t closedLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &closedLimit,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -3971,13 +4559,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t closedLimit)
 
 namespace Mode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) mode, sizeof(*mode));
+    return emberAfReadServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &mode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ShadeConfiguration::Id, Id, (uint8_t *) &value,
+                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Mode
@@ -3990,606 +4579,569 @@ namespace Attributes {
 
 namespace LockState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) lockState, sizeof(*lockState));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &lockState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace LockState
 
 namespace LockType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) lockType, sizeof(*lockType));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &lockType, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace LockType
 
 namespace ActuatorEnabled {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * actuatorEnabled)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) actuatorEnabled, sizeof(*actuatorEnabled));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool actuatorEnabled)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &actuatorEnabled,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace ActuatorEnabled
 
 namespace DoorState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * doorState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) doorState, sizeof(*doorState));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t doorState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &doorState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace DoorState
 
 namespace DoorOpenEvents {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorOpenEvents)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) doorOpenEvents, sizeof(*doorOpenEvents));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorOpenEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &doorOpenEvents,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DoorOpenEvents
 
 namespace DoorClosedEvents {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorClosedEvents)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) doorClosedEvents,
-                                      sizeof(*doorClosedEvents));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorClosedEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &doorClosedEvents,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DoorClosedEvents
 
 namespace OpenPeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * openPeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) openPeriod, sizeof(*openPeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t openPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &openPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace OpenPeriod
 
 namespace NumLockRecordsSupported {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numLockRecordsSupported,
-                                      sizeof(*numLockRecordsSupported));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numLockRecordsSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numLockRecordsSupported,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumLockRecordsSupported
 
 namespace NumTotalUsersSupported {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numTotalUsersSupported,
-                                      sizeof(*numTotalUsersSupported));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numTotalUsersSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numTotalUsersSupported,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumTotalUsersSupported
 
 namespace NumPinUsersSupported {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numPinUsersSupported)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numPinUsersSupported,
-                                      sizeof(*numPinUsersSupported));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numPinUsersSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numPinUsersSupported,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumPinUsersSupported
 
 namespace NumRfidUsersSupported {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numRfidUsersSupported,
-                                      sizeof(*numRfidUsersSupported));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numRfidUsersSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numRfidUsersSupported,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumRfidUsersSupported
 
 namespace NumWeekdaySchedulesSupportedPerUser {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numWeekdaySchedulesSupportedPerUser)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numWeekdaySchedulesSupportedPerUser,
-                                      sizeof(*numWeekdaySchedulesSupportedPerUser));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numWeekdaySchedulesSupportedPerUser,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumWeekdaySchedulesSupportedPerUser
 
 namespace NumYeardaySchedulesSupportedPerUser {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numYeardaySchedulesSupportedPerUser)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numYeardaySchedulesSupportedPerUser,
-                                      sizeof(*numYeardaySchedulesSupportedPerUser));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numYeardaySchedulesSupportedPerUser,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumYeardaySchedulesSupportedPerUser
 
 namespace NumHolidaySchedulesSupportedPerUser {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numHolidaySchedulesSupportedPerUser)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) numHolidaySchedulesSupportedPerUser,
-                                      sizeof(*numHolidaySchedulesSupportedPerUser));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &numHolidaySchedulesSupportedPerUser,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumHolidaySchedulesSupportedPerUser
 
 namespace MaxPinLength {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxPinLength)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) maxPinLength, sizeof(*maxPinLength));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxPinLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &maxPinLength, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxPinLength
 
 namespace MinPinLength {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minPinLength)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) minPinLength, sizeof(*minPinLength));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minPinLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &minPinLength, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinPinLength
 
 namespace MaxRfidCodeLength {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) maxRfidCodeLength,
-                                      sizeof(*maxRfidCodeLength));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxRfidCodeLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &maxRfidCodeLength,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxRfidCodeLength
 
 namespace MinRfidCodeLength {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minRfidCodeLength)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) minRfidCodeLength,
-                                      sizeof(*minRfidCodeLength));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minRfidCodeLength)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &minRfidCodeLength,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinRfidCodeLength
 
 namespace EnableLogging {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLogging)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) enableLogging, sizeof(*enableLogging));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableLogging)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &enableLogging,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnableLogging
 
+namespace Language {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 2, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[2 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 2);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 2, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[2 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Language
+
 namespace LedSettings {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ledSettings)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) ledSettings, sizeof(*ledSettings));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ledSettings)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &ledSettings, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace LedSettings
 
 namespace AutoRelockTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * autoRelockTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) autoRelockTime, sizeof(*autoRelockTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t autoRelockTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &autoRelockTime,
-                                       ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AutoRelockTime
 
 namespace SoundVolume {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * soundVolume)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) soundVolume, sizeof(*soundVolume));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t soundVolume)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &soundVolume, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SoundVolume
 
 namespace OperatingMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operatingMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) operatingMode, sizeof(*operatingMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operatingMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &operatingMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace OperatingMode
 
 namespace SupportedOperatingModes {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * supportedOperatingModes)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) supportedOperatingModes,
-                                      sizeof(*supportedOperatingModes));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t supportedOperatingModes)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &supportedOperatingModes,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace SupportedOperatingModes
 
 namespace DefaultConfigurationRegister {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) defaultConfigurationRegister,
-                                      sizeof(*defaultConfigurationRegister));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &defaultConfigurationRegister,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace DefaultConfigurationRegister
 
 namespace EnableLocalProgramming {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLocalProgramming)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) enableLocalProgramming,
-                                      sizeof(*enableLocalProgramming));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableLocalProgramming)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &enableLocalProgramming,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnableLocalProgramming
 
 namespace EnableOneTouchLocking {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableOneTouchLocking)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) enableOneTouchLocking,
-                                      sizeof(*enableOneTouchLocking));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableOneTouchLocking)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &enableOneTouchLocking,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnableOneTouchLocking
 
 namespace EnableInsideStatusLed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableInsideStatusLed)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) enableInsideStatusLed,
-                                      sizeof(*enableInsideStatusLed));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableInsideStatusLed)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &enableInsideStatusLed,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnableInsideStatusLed
 
 namespace EnablePrivacyModeButton {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enablePrivacyModeButton)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) enablePrivacyModeButton,
-                                      sizeof(*enablePrivacyModeButton));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool enablePrivacyModeButton)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &enablePrivacyModeButton,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnablePrivacyModeButton
 
 namespace WrongCodeEntryLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) wrongCodeEntryLimit,
-                                      sizeof(*wrongCodeEntryLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &wrongCodeEntryLimit,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WrongCodeEntryLimit
 
 namespace UserCodeTemporaryDisableTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) userCodeTemporaryDisableTime,
-                                      sizeof(*userCodeTemporaryDisableTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &userCodeTemporaryDisableTime,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace UserCodeTemporaryDisableTime
 
 namespace SendPinOverTheAir {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * sendPinOverTheAir)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) sendPinOverTheAir,
-                                      sizeof(*sendPinOverTheAir));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool sendPinOverTheAir)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &sendPinOverTheAir,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace SendPinOverTheAir
 
 namespace RequirePinForRfOperation {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * requirePinForRfOperation)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) requirePinForRfOperation,
-                                      sizeof(*requirePinForRfOperation));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool requirePinForRfOperation)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &requirePinForRfOperation,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace RequirePinForRfOperation
 
 namespace ZigbeeSecurityLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) zigbeeSecurityLevel,
-                                      sizeof(*zigbeeSecurityLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &zigbeeSecurityLevel,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ZigbeeSecurityLevel
 
 namespace AlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) alarmMask, sizeof(*alarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &alarmMask, ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace AlarmMask
 
 namespace KeypadOperationEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) keypadOperationEventMask,
-                                      sizeof(*keypadOperationEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &keypadOperationEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace KeypadOperationEventMask
 
 namespace RfOperationEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfOperationEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) rfOperationEventMask,
-                                      sizeof(*rfOperationEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &rfOperationEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace RfOperationEventMask
 
 namespace ManualOperationEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * manualOperationEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) manualOperationEventMask,
-                                      sizeof(*manualOperationEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t manualOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &manualOperationEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace ManualOperationEventMask
 
 namespace RfidOperationEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) rfidOperationEventMask,
-                                      sizeof(*rfidOperationEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidOperationEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &rfidOperationEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace RfidOperationEventMask
 
 namespace KeypadProgrammingEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) keypadProgrammingEventMask,
-                                      sizeof(*keypadProgrammingEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &keypadProgrammingEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace KeypadProgrammingEventMask
 
 namespace RfProgrammingEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) rfProgrammingEventMask,
-                                      sizeof(*rfProgrammingEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &rfProgrammingEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace RfProgrammingEventMask
 
 namespace RfidProgrammingEventMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) rfidProgrammingEventMask,
-                                      sizeof(*rfidProgrammingEventMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &rfidProgrammingEventMask,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DoorLock::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace RfidProgrammingEventMask
@@ -4602,368 +5154,371 @@ namespace Attributes {
 
 namespace Type {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * type)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) type, sizeof(*type));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t type)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &type, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Type
 
 namespace PhysicalClosedLimitLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) physicalClosedLimitLift,
-                                      sizeof(*physicalClosedLimitLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &physicalClosedLimitLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PhysicalClosedLimitLift
 
 namespace PhysicalClosedLimitTilt {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) physicalClosedLimitTilt,
-                                      sizeof(*physicalClosedLimitTilt));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &physicalClosedLimitTilt,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PhysicalClosedLimitTilt
 
 namespace CurrentPositionLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) currentPositionLift,
-                                      sizeof(*currentPositionLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &currentPositionLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPositionLift
 
 namespace CurrentPositionTilt {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTilt)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) currentPositionTilt,
-                                      sizeof(*currentPositionTilt));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &currentPositionTilt,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPositionTilt
 
 namespace NumberOfActuationsLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) numberOfActuationsLift,
-                                      sizeof(*numberOfActuationsLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &numberOfActuationsLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfActuationsLift
 
 namespace NumberOfActuationsTilt {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) numberOfActuationsTilt,
-                                      sizeof(*numberOfActuationsTilt));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &numberOfActuationsTilt,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfActuationsTilt
 
 namespace ConfigStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * configStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) configStatus, sizeof(*configStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t configStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &configStatus,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ConfigStatus
 
 namespace CurrentPositionLiftPercentage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) currentPositionLiftPercentage,
-                                      sizeof(*currentPositionLiftPercentage));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &currentPositionLiftPercentage,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPositionLiftPercentage
 
 namespace CurrentPositionTiltPercentage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) currentPositionTiltPercentage,
-                                      sizeof(*currentPositionTiltPercentage));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &currentPositionTiltPercentage,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPositionTiltPercentage
 
 namespace OperationalStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationalStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) operationalStatus,
-                                      sizeof(*operationalStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationalStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &operationalStatus,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace OperationalStatus
 
 namespace TargetPositionLiftPercent100ths {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) targetPositionLiftPercent100ths,
-                                      sizeof(*targetPositionLiftPercent100ths));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &targetPositionLiftPercent100ths,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace TargetPositionLiftPercent100ths
 
 namespace TargetPositionTiltPercent100ths {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) targetPositionTiltPercent100ths,
-                                      sizeof(*targetPositionTiltPercent100ths));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &targetPositionTiltPercent100ths,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace TargetPositionTiltPercent100ths
 
 namespace EndProductType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * endProductType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) endProductType,
-                                      sizeof(*endProductType));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t endProductType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &endProductType,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace EndProductType
 
 namespace CurrentPositionLiftPercent100ths {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) currentPositionLiftPercent100ths,
-                                      sizeof(*currentPositionLiftPercent100ths));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &currentPositionLiftPercent100ths,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPositionLiftPercent100ths
 
 namespace CurrentPositionTiltPercent100ths {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) currentPositionTiltPercent100ths,
-                                      sizeof(*currentPositionTiltPercent100ths));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &currentPositionTiltPercent100ths,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentPositionTiltPercent100ths
 
 namespace InstalledOpenLimitLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) installedOpenLimitLift,
-                                      sizeof(*installedOpenLimitLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &installedOpenLimitLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace InstalledOpenLimitLift
 
 namespace InstalledClosedLimitLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) installedClosedLimitLift,
-                                      sizeof(*installedClosedLimitLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &installedClosedLimitLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace InstalledClosedLimitLift
 
 namespace InstalledOpenLimitTilt {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) installedOpenLimitTilt,
-                                      sizeof(*installedOpenLimitTilt));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &installedOpenLimitTilt,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace InstalledOpenLimitTilt
 
 namespace InstalledClosedLimitTilt {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) installedClosedLimitTilt,
-                                      sizeof(*installedClosedLimitTilt));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &installedClosedLimitTilt,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace InstalledClosedLimitTilt
 
 namespace VelocityLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * velocityLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) velocityLift, sizeof(*velocityLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t velocityLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &velocityLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace VelocityLift
 
 namespace AccelerationTimeLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * accelerationTimeLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) accelerationTimeLift,
-                                      sizeof(*accelerationTimeLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t accelerationTimeLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &accelerationTimeLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AccelerationTimeLift
 
 namespace DecelerationTimeLift {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * decelerationTimeLift)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) decelerationTimeLift,
-                                      sizeof(*decelerationTimeLift));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t decelerationTimeLift)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &decelerationTimeLift,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DecelerationTimeLift
 
 namespace Mode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) mode, sizeof(*mode));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &mode, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Mode
 
+namespace IntermediateSetpointsLift {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 254);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace IntermediateSetpointsLift
+
+namespace IntermediateSetpointsTilt {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 254);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace IntermediateSetpointsTilt
+
 namespace SafetyStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * safetyStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) safetyStatus, sizeof(*safetyStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t safetyStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &safetyStatus,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::WindowCovering::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace SafetyStatus
@@ -4976,150 +5531,130 @@ namespace Attributes {
 
 namespace BarrierMovingState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierMovingState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierMovingState,
-                                      sizeof(*barrierMovingState));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierMovingState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierMovingState,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierMovingState
 
 namespace BarrierSafetyStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierSafetyStatus,
-                                      sizeof(*barrierSafetyStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierSafetyStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierSafetyStatus,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierSafetyStatus
 
 namespace BarrierCapabilities {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierCapabilities)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierCapabilities,
-                                      sizeof(*barrierCapabilities));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierCapabilities)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierCapabilities,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierCapabilities
 
 namespace BarrierOpenEvents {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenEvents)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierOpenEvents,
-                                      sizeof(*barrierOpenEvents));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierOpenEvents,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierOpenEvents
 
 namespace BarrierCloseEvents {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCloseEvents)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierCloseEvents,
-                                      sizeof(*barrierCloseEvents));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCloseEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierCloseEvents,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierCloseEvents
 
 namespace BarrierCommandOpenEvents {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierCommandOpenEvents,
-                                      sizeof(*barrierCommandOpenEvents));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierCommandOpenEvents,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierCommandOpenEvents
 
 namespace BarrierCommandCloseEvents {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierCommandCloseEvents,
-                                      sizeof(*barrierCommandCloseEvents));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierCommandCloseEvents,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierCommandCloseEvents
 
 namespace BarrierOpenPeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierOpenPeriod,
-                                      sizeof(*barrierOpenPeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierOpenPeriod,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierOpenPeriod
 
 namespace BarrierClosePeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierClosePeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierClosePeriod,
-                                      sizeof(*barrierClosePeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierClosePeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierClosePeriod,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierClosePeriod
 
 namespace BarrierPosition {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierPosition)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) barrierPosition,
-                                      sizeof(*barrierPosition));
+    return emberAfReadServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierPosition)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &barrierPosition,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BarrierControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BarrierPosition
@@ -5132,14 +5667,13 @@ namespace Attributes {
 
 namespace MaxPressure {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxPressure)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxPressure,
-                                      sizeof(*maxPressure));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxPressure,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5147,14 +5681,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxPressure)
 
 namespace MaxSpeed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxSpeed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxSpeed,
-                                      sizeof(*maxSpeed));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxSpeed,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5162,14 +5695,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxSpeed)
 
 namespace MaxFlow {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxFlow)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxFlow,
-                                      sizeof(*maxFlow));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFlow)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxFlow,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5177,14 +5709,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFlow)
 
 namespace MinConstPressure {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstPressure)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) minConstPressure,
-                                      sizeof(*minConstPressure));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &minConstPressure,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5192,14 +5723,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstPressure)
 
 namespace MaxConstPressure {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstPressure)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxConstPressure,
-                                      sizeof(*maxConstPressure));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxConstPressure,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5207,14 +5737,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstPressure)
 
 namespace MinCompPressure {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCompPressure)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) minCompPressure,
-                                      sizeof(*minCompPressure));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCompPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &minCompPressure,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5222,14 +5751,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCompPressure)
 
 namespace MaxCompPressure {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCompPressure)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxCompPressure,
-                                      sizeof(*maxCompPressure));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCompPressure)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxCompPressure,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5237,14 +5765,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCompPressure)
 
 namespace MinConstSpeed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstSpeed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) minConstSpeed,
-                                      sizeof(*minConstSpeed));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &minConstSpeed,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5252,14 +5779,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstSpeed)
 
 namespace MaxConstSpeed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstSpeed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxConstSpeed,
-                                      sizeof(*maxConstSpeed));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxConstSpeed,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5267,14 +5793,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstSpeed)
 
 namespace MinConstFlow {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstFlow)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) minConstFlow,
-                                      sizeof(*minConstFlow));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstFlow)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &minConstFlow,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5282,14 +5807,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstFlow)
 
 namespace MaxConstFlow {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstFlow)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxConstFlow,
-                                      sizeof(*maxConstFlow));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstFlow)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxConstFlow,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5297,14 +5821,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstFlow)
 
 namespace MinConstTemp {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstTemp)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) minConstTemp,
-                                      sizeof(*minConstTemp));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstTemp)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &minConstTemp,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5312,14 +5835,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstTemp)
 
 namespace MaxConstTemp {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstTemp)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) maxConstTemp,
-                                      sizeof(*maxConstTemp));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstTemp)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &maxConstTemp,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5327,14 +5849,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstTemp)
 
 namespace PumpStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pumpStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) pumpStatus,
-                                      sizeof(*pumpStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pumpStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &pumpStatus,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
@@ -5342,14 +5863,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pumpStatus)
 
 namespace EffectiveOperationMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveOperationMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) effectiveOperationMode,
-                                      sizeof(*effectiveOperationMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveOperationMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &effectiveOperationMode,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -5357,14 +5877,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveOperationMode)
 
 namespace EffectiveControlMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveControlMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) effectiveControlMode,
-                                      sizeof(*effectiveControlMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveControlMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &effectiveControlMode,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -5372,14 +5891,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveControlMode)
 
 namespace Capacity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * capacity)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) capacity,
-                                      sizeof(*capacity));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t capacity)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &capacity,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -5387,13 +5905,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t capacity)
 
 namespace Speed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * speed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) speed, sizeof(*speed));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t speed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &speed,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -5401,14 +5919,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t speed)
 
 namespace LifetimeEnergyConsumed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) lifetimeEnergyConsumed,
-                                      sizeof(*lifetimeEnergyConsumed));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &lifetimeEnergyConsumed,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -5416,14 +5933,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed)
 
 namespace OperationMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) operationMode,
-                                      sizeof(*operationMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &operationMode,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -5431,14 +5947,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationMode)
 
 namespace ControlMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) controlMode,
-                                      sizeof(*controlMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &controlMode,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -5446,14 +5961,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlMode)
 
 namespace AlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) alarmMask,
-                                      sizeof(*alarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &alarmMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PumpConfigurationAndControl::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
@@ -5467,628 +5981,559 @@ namespace Attributes {
 
 namespace LocalTemperature {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * localTemperature)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) localTemperature,
-                                      sizeof(*localTemperature));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t localTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &localTemperature,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace LocalTemperature
 
 namespace OutdoorTemperature {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * outdoorTemperature)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) outdoorTemperature,
-                                      sizeof(*outdoorTemperature));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t outdoorTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &outdoorTemperature,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace OutdoorTemperature
 
 namespace Occupancy {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) occupancy, sizeof(*occupancy));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &occupancy, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Occupancy
 
 namespace AbsMinHeatSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) absMinHeatSetpointLimit,
-                                      sizeof(*absMinHeatSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &absMinHeatSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace AbsMinHeatSetpointLimit
 
 namespace AbsMaxHeatSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) absMaxHeatSetpointLimit,
-                                      sizeof(*absMaxHeatSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &absMaxHeatSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace AbsMaxHeatSetpointLimit
 
 namespace AbsMinCoolSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) absMinCoolSetpointLimit,
-                                      sizeof(*absMinCoolSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &absMinCoolSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace AbsMinCoolSetpointLimit
 
 namespace AbsMaxCoolSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) absMaxCoolSetpointLimit,
-                                      sizeof(*absMaxCoolSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &absMaxCoolSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace AbsMaxCoolSetpointLimit
 
 namespace PiCoolingDemand {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piCoolingDemand)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) piCoolingDemand,
-                                      sizeof(*piCoolingDemand));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piCoolingDemand)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &piCoolingDemand,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PiCoolingDemand
 
 namespace PiHeatingDemand {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piHeatingDemand)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) piHeatingDemand,
-                                      sizeof(*piHeatingDemand));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piHeatingDemand)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &piHeatingDemand,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PiHeatingDemand
 
 namespace HvacSystemTypeConfiguration {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) hvacSystemTypeConfiguration,
-                                      sizeof(*hvacSystemTypeConfiguration));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &hvacSystemTypeConfiguration,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace HvacSystemTypeConfiguration
 
 namespace LocalTemperatureCalibration {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * localTemperatureCalibration)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) localTemperatureCalibration,
-                                      sizeof(*localTemperatureCalibration));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t localTemperatureCalibration)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &localTemperatureCalibration,
-                                       ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
 } // namespace LocalTemperatureCalibration
 
 namespace OccupiedCoolingSetpoint {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) occupiedCoolingSetpoint,
-                                      sizeof(*occupiedCoolingSetpoint));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &occupiedCoolingSetpoint,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace OccupiedCoolingSetpoint
 
 namespace OccupiedHeatingSetpoint {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) occupiedHeatingSetpoint,
-                                      sizeof(*occupiedHeatingSetpoint));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &occupiedHeatingSetpoint,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace OccupiedHeatingSetpoint
 
 namespace UnoccupiedCoolingSetpoint {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) unoccupiedCoolingSetpoint,
-                                      sizeof(*unoccupiedCoolingSetpoint));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &unoccupiedCoolingSetpoint,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace UnoccupiedCoolingSetpoint
 
 namespace UnoccupiedHeatingSetpoint {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) unoccupiedHeatingSetpoint,
-                                      sizeof(*unoccupiedHeatingSetpoint));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &unoccupiedHeatingSetpoint,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace UnoccupiedHeatingSetpoint
 
 namespace MinHeatSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) minHeatSetpointLimit,
-                                      sizeof(*minHeatSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &minHeatSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinHeatSetpointLimit
 
 namespace MaxHeatSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) maxHeatSetpointLimit,
-                                      sizeof(*maxHeatSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &maxHeatSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxHeatSetpointLimit
 
 namespace MinCoolSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) minCoolSetpointLimit,
-                                      sizeof(*minCoolSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &minCoolSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinCoolSetpointLimit
 
 namespace MaxCoolSetpointLimit {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) maxCoolSetpointLimit,
-                                      sizeof(*maxCoolSetpointLimit));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &maxCoolSetpointLimit,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxCoolSetpointLimit
 
 namespace MinSetpointDeadBand {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * minSetpointDeadBand)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) minSetpointDeadBand,
-                                      sizeof(*minSetpointDeadBand));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t minSetpointDeadBand)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &minSetpointDeadBand,
-                                       ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinSetpointDeadBand
 
 namespace RemoteSensing {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * remoteSensing)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) remoteSensing, sizeof(*remoteSensing));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t remoteSensing)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &remoteSensing,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace RemoteSensing
 
 namespace ControlSequenceOfOperation {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) controlSequenceOfOperation,
-                                      sizeof(*controlSequenceOfOperation));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &controlSequenceOfOperation,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ControlSequenceOfOperation
 
 namespace SystemMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * systemMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) systemMode, sizeof(*systemMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t systemMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &systemMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace SystemMode
 
 namespace AlarmMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * alarmMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) alarmMask, sizeof(*alarmMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t alarmMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &alarmMask, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace AlarmMask
 
 namespace ThermostatRunningMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatRunningMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) thermostatRunningMode,
-                                      sizeof(*thermostatRunningMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatRunningMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &thermostatRunningMode,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ThermostatRunningMode
 
 namespace StartOfWeek {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startOfWeek)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) startOfWeek, sizeof(*startOfWeek));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startOfWeek)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &startOfWeek, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace StartOfWeek
 
 namespace NumberOfWeeklyTransitions {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) numberOfWeeklyTransitions,
-                                      sizeof(*numberOfWeeklyTransitions));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &numberOfWeeklyTransitions,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfWeeklyTransitions
 
 namespace NumberOfDailyTransitions {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) numberOfDailyTransitions,
-                                      sizeof(*numberOfDailyTransitions));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &numberOfDailyTransitions,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfDailyTransitions
 
 namespace TemperatureSetpointHold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) temperatureSetpointHold,
-                                      sizeof(*temperatureSetpointHold));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureSetpointHold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &temperatureSetpointHold,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace TemperatureSetpointHold
 
 namespace TemperatureSetpointHoldDuration {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) temperatureSetpointHoldDuration,
-                                      sizeof(*temperatureSetpointHoldDuration));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &temperatureSetpointHoldDuration,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace TemperatureSetpointHoldDuration
 
 namespace ThermostatProgrammingOperationMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatProgrammingOperationMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) thermostatProgrammingOperationMode,
-                                      sizeof(*thermostatProgrammingOperationMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &thermostatProgrammingOperationMode,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ThermostatProgrammingOperationMode
 
 namespace HvacRelayState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hvacRelayState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) hvacRelayState, sizeof(*hvacRelayState));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hvacRelayState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &hvacRelayState,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace HvacRelayState
 
 namespace SetpointChangeSource {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * setpointChangeSource)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) setpointChangeSource,
-                                      sizeof(*setpointChangeSource));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t setpointChangeSource)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &setpointChangeSource,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace SetpointChangeSource
 
 namespace SetpointChangeAmount {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * setpointChangeAmount)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) setpointChangeAmount,
-                                      sizeof(*setpointChangeAmount));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t setpointChangeAmount)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &setpointChangeAmount,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace SetpointChangeAmount
 
 namespace SetpointChangeSourceTimestamp {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * setpointChangeSourceTimestamp)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) setpointChangeSourceTimestamp,
-                                      sizeof(*setpointChangeSourceTimestamp));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t setpointChangeSourceTimestamp)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &setpointChangeSourceTimestamp,
-                                       ZCL_EPOCH_S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
 
 } // namespace SetpointChangeSourceTimestamp
 
 namespace AcType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acType, sizeof(*acType));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acType, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcType
 
 namespace AcCapacity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCapacity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acCapacity, sizeof(*acCapacity));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCapacity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acCapacity, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcCapacity
 
 namespace AcRefrigerantType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acRefrigerantType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acRefrigerantType,
-                                      sizeof(*acRefrigerantType));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acRefrigerantType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acRefrigerantType,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcRefrigerantType
 
 namespace AcCompressor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCompressor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acCompressor, sizeof(*acCompressor));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCompressor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acCompressor, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcCompressor
 
 namespace AcErrorCode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * acErrorCode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acErrorCode, sizeof(*acErrorCode));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t acErrorCode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acErrorCode,
-                                       ZCL_BITMAP32_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcErrorCode
 
 namespace AcLouverPosition {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acLouverPosition)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acLouverPosition,
-                                      sizeof(*acLouverPosition));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acLouverPosition)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acLouverPosition,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcLouverPosition
 
 namespace AcCoilTemperature {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCoilTemperature)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acCoilTemperature,
-                                      sizeof(*acCoilTemperature));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCoilTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acCoilTemperature,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcCoilTemperature
 
 namespace AcCapacityFormat {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCapacityFormat)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) acCapacityFormat,
-                                      sizeof(*acCapacityFormat));
+    return emberAfReadServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCapacityFormat)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &acCapacityFormat,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::Thermostat::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace AcCapacityFormat
@@ -6101,28 +6546,26 @@ namespace Attributes {
 
 namespace FanMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) fanMode, sizeof(*fanMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) &fanMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace FanMode
 
 namespace FanModeSequence {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanModeSequence)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) fanModeSequence,
-                                      sizeof(*fanModeSequence));
+    return emberAfReadServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanModeSequence)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) &fanModeSequence,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::FanControl::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace FanModeSequence
@@ -6135,14 +6578,13 @@ namespace Attributes {
 
 namespace RelativeHumidity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) relativeHumidity,
-                                      sizeof(*relativeHumidity));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &relativeHumidity,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -6150,14 +6592,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidity)
 
 namespace DehumidificationCooling {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationCooling)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) dehumidificationCooling,
-                                      sizeof(*dehumidificationCooling));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationCooling)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &dehumidificationCooling,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -6165,14 +6606,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationCooling)
 
 namespace RhDehumidificationSetpoint {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) rhDehumidificationSetpoint,
-                                      sizeof(*rhDehumidificationSetpoint));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &rhDehumidificationSetpoint,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -6180,14 +6620,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint)
 
 namespace RelativeHumidityMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) relativeHumidityMode,
-                                      sizeof(*relativeHumidityMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &relativeHumidityMode,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -6195,14 +6634,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityMode)
 
 namespace DehumidificationLockout {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationLockout)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) dehumidificationLockout,
-                                      sizeof(*dehumidificationLockout));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationLockout)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &dehumidificationLockout,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -6210,14 +6648,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationLockout)
 
 namespace DehumidificationHysteresis {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) dehumidificationHysteresis,
-                                      sizeof(*dehumidificationHysteresis));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &dehumidificationHysteresis,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -6225,14 +6662,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis)
 
 namespace DehumidificationMaxCool {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) dehumidificationMaxCool,
-                                      sizeof(*dehumidificationMaxCool));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &dehumidificationMaxCool,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -6240,14 +6676,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool)
 
 namespace RelativeHumidityDisplay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) relativeHumidityDisplay,
-                                      sizeof(*relativeHumidityDisplay));
+    return emberAfReadServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &relativeHumidityDisplay,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DehumidificationControl::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -6261,29 +6696,29 @@ namespace Attributes {
 
 namespace TemperatureDisplayMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id,
-                                      (uint8_t *) temperatureDisplayMode, sizeof(*temperatureDisplayMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureDisplayMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id,
-                                       (uint8_t *) &temperatureDisplayMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) &value,
+                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace TemperatureDisplayMode
 
 namespace KeypadLockout {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * keypadLockout)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) keypadLockout,
-                                      sizeof(*keypadLockout));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t keypadLockout)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) &keypadLockout,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -6291,15 +6726,15 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t keypadLockout)
 
 namespace ScheduleProgrammingVisibility {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id,
-                                      (uint8_t *) scheduleProgrammingVisibility, sizeof(*scheduleProgrammingVisibility));
+    return emberAfReadServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id,
-                                       (uint8_t *) &scheduleProgrammingVisibility, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ThermostatUserInterfaceConfiguration::Id, Id, (uint8_t *) &value,
+                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ScheduleProgrammingVisibility
@@ -6312,723 +6747,686 @@ namespace Attributes {
 
 namespace CurrentHue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentHue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) currentHue, sizeof(*currentHue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &currentHue, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentHue
 
 namespace CurrentSaturation {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentSaturation)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) currentSaturation,
-                                      sizeof(*currentSaturation));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentSaturation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &currentSaturation,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentSaturation
 
 namespace RemainingTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) remainingTime, sizeof(*remainingTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &remainingTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RemainingTime
 
 namespace CurrentX {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentX)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) currentX, sizeof(*currentX));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &currentX, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentX
 
 namespace CurrentY {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentY)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) currentY, sizeof(*currentY));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &currentY, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentY
 
 namespace DriftCompensation {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * driftCompensation)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) driftCompensation,
-                                      sizeof(*driftCompensation));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t driftCompensation)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &driftCompensation,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace DriftCompensation
 
+namespace CompensationText {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 254);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 254, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[254 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace CompensationText
+
 namespace ColorTemperature {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTemperature)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorTemperature,
-                                      sizeof(*colorTemperature));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTemperature)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorTemperature,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorTemperature
 
 namespace ColorMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorMode, sizeof(*colorMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorMode, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorMode
 
 namespace ColorControlOptions {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorControlOptions)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorControlOptions,
-                                      sizeof(*colorControlOptions));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorControlOptions)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorControlOptions,
-                                       ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorControlOptions
 
 namespace NumberOfPrimaries {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPrimaries)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) numberOfPrimaries,
-                                      sizeof(*numberOfPrimaries));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPrimaries)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &numberOfPrimaries,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfPrimaries
 
 namespace Primary1X {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1X)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary1X, sizeof(*primary1X));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary1X, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary1X
 
 namespace Primary1Y {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1Y)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary1Y, sizeof(*primary1Y));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary1Y, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary1Y
 
 namespace Primary1Intensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary1Intensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary1Intensity,
-                                      sizeof(*primary1Intensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary1Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary1Intensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary1Intensity
 
 namespace Primary2X {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2X)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary2X, sizeof(*primary2X));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary2X, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary2X
 
 namespace Primary2Y {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2Y)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary2Y, sizeof(*primary2Y));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary2Y, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary2Y
 
 namespace Primary2Intensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary2Intensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary2Intensity,
-                                      sizeof(*primary2Intensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary2Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary2Intensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary2Intensity
 
 namespace Primary3X {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3X)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary3X, sizeof(*primary3X));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary3X, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary3X
 
 namespace Primary3Y {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3Y)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary3Y, sizeof(*primary3Y));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary3Y, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary3Y
 
 namespace Primary3Intensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary3Intensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary3Intensity,
-                                      sizeof(*primary3Intensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary3Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary3Intensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary3Intensity
 
 namespace Primary4X {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4X)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary4X, sizeof(*primary4X));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary4X, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary4X
 
 namespace Primary4Y {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4Y)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary4Y, sizeof(*primary4Y));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary4Y, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary4Y
 
 namespace Primary4Intensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary4Intensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary4Intensity,
-                                      sizeof(*primary4Intensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary4Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary4Intensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary4Intensity
 
 namespace Primary5X {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5X)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary5X, sizeof(*primary5X));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary5X, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary5X
 
 namespace Primary5Y {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5Y)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary5Y, sizeof(*primary5Y));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary5Y, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary5Y
 
 namespace Primary5Intensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary5Intensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary5Intensity,
-                                      sizeof(*primary5Intensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary5Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary5Intensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary5Intensity
 
 namespace Primary6X {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6X)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary6X, sizeof(*primary6X));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6X)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary6X, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary6X
 
 namespace Primary6Y {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6Y)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary6Y, sizeof(*primary6Y));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6Y)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary6Y, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary6Y
 
 namespace Primary6Intensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary6Intensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) primary6Intensity,
-                                      sizeof(*primary6Intensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary6Intensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &primary6Intensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Primary6Intensity
 
 namespace WhitePointX {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointX)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) whitePointX, sizeof(*whitePointX));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &whitePointX,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WhitePointX
 
 namespace WhitePointY {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointY)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) whitePointY, sizeof(*whitePointY));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &whitePointY,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace WhitePointY
 
 namespace ColorPointRX {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRX)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointRX, sizeof(*colorPointRX));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointRX,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointRX
 
 namespace ColorPointRY {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRY)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointRY, sizeof(*colorPointRY));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointRY,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointRY
 
 namespace ColorPointRIntensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointRIntensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointRIntensity,
-                                      sizeof(*colorPointRIntensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointRIntensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointRIntensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointRIntensity
 
 namespace ColorPointGX {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGX)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointGX, sizeof(*colorPointGX));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointGX,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointGX
 
 namespace ColorPointGY {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGY)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointGY, sizeof(*colorPointGY));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointGY,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointGY
 
 namespace ColorPointGIntensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointGIntensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointGIntensity,
-                                      sizeof(*colorPointGIntensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointGIntensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointGIntensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointGIntensity
 
 namespace ColorPointBX {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBX)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointBX, sizeof(*colorPointBX));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBX)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointBX,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointBX
 
 namespace ColorPointBY {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBY)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointBY, sizeof(*colorPointBY));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBY)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointBY,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointBY
 
 namespace ColorPointBIntensity {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointBIntensity)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorPointBIntensity,
-                                      sizeof(*colorPointBIntensity));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointBIntensity)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorPointBIntensity,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorPointBIntensity
 
 namespace EnhancedCurrentHue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) enhancedCurrentHue,
-                                      sizeof(*enhancedCurrentHue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enhancedCurrentHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &enhancedCurrentHue,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnhancedCurrentHue
 
 namespace EnhancedColorMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enhancedColorMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) enhancedColorMode,
-                                      sizeof(*enhancedColorMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enhancedColorMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &enhancedColorMode,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace EnhancedColorMode
 
 namespace ColorLoopActive {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopActive)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorLoopActive,
-                                      sizeof(*colorLoopActive));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopActive)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorLoopActive,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorLoopActive
 
 namespace ColorLoopDirection {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopDirection)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorLoopDirection,
-                                      sizeof(*colorLoopDirection));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopDirection)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorLoopDirection,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorLoopDirection
 
 namespace ColorLoopTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorLoopTime, sizeof(*colorLoopTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorLoopTime,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorLoopTime
 
 namespace ColorLoopStartEnhancedHue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorLoopStartEnhancedHue,
-                                      sizeof(*colorLoopStartEnhancedHue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorLoopStartEnhancedHue,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorLoopStartEnhancedHue
 
 namespace ColorLoopStoredEnhancedHue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorLoopStoredEnhancedHue,
-                                      sizeof(*colorLoopStoredEnhancedHue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorLoopStoredEnhancedHue,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorLoopStoredEnhancedHue
 
 namespace ColorCapabilities {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorCapabilities)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorCapabilities,
-                                      sizeof(*colorCapabilities));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorCapabilities)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorCapabilities,
-                                       ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorCapabilities
 
 namespace ColorTempPhysicalMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorTempPhysicalMin,
-                                      sizeof(*colorTempPhysicalMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorTempPhysicalMin,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorTempPhysicalMin
 
 namespace ColorTempPhysicalMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) colorTempPhysicalMax,
-                                      sizeof(*colorTempPhysicalMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &colorTempPhysicalMax,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ColorTempPhysicalMax
 
 namespace CoupleColorTempToLevelMinMireds {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) coupleColorTempToLevelMinMireds,
-                                      sizeof(*coupleColorTempToLevelMinMireds));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &coupleColorTempToLevelMinMireds,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CoupleColorTempToLevelMinMireds
 
 namespace StartUpColorTemperatureMireds {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) startUpColorTemperatureMireds,
-                                      sizeof(*startUpColorTemperatureMireds));
+    return emberAfReadServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &startUpColorTemperatureMireds,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ColorControl::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace StartUpColorTemperatureMireds
@@ -7041,14 +7439,13 @@ namespace Attributes {
 
 namespace PhysicalMinLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMinLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) physicalMinLevel,
-                                      sizeof(*physicalMinLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMinLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &physicalMinLevel,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7056,14 +7453,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMinLevel)
 
 namespace PhysicalMaxLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMaxLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) physicalMaxLevel,
-                                      sizeof(*physicalMaxLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMaxLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &physicalMaxLevel,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7071,14 +7467,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMaxLevel)
 
 namespace BallastStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) ballastStatus,
-                                      sizeof(*ballastStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &ballastStatus,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -7086,13 +7481,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastStatus)
 
 namespace MinLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) minLevel, sizeof(*minLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &minLevel,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7100,13 +7495,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel)
 
 namespace MaxLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) maxLevel, sizeof(*maxLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &maxLevel,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7114,14 +7509,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel)
 
 namespace PowerOnLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * powerOnLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) powerOnLevel,
-                                      sizeof(*powerOnLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t powerOnLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &powerOnLevel,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7129,14 +7523,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t powerOnLevel)
 
 namespace PowerOnFadeTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * powerOnFadeTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) powerOnFadeTime,
-                                      sizeof(*powerOnFadeTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t powerOnFadeTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &powerOnFadeTime,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7144,14 +7537,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t powerOnFadeTime)
 
 namespace IntrinsicBallastFactor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) intrinsicBallastFactor,
-                                      sizeof(*intrinsicBallastFactor));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &intrinsicBallastFactor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7159,14 +7551,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor)
 
 namespace BallastFactorAdjustment {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) ballastFactorAdjustment,
-                                      sizeof(*ballastFactorAdjustment));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &ballastFactorAdjustment,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -7174,29 +7565,75 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment)
 
 namespace LampQuality {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampQuality)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) lampQuality,
-                                      sizeof(*lampQuality));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampQuality)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &lampQuality,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace LampQuality
 
+namespace LampType {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace LampType
+
+namespace LampManufacturer {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace LampManufacturer
+
 namespace LampAlarmMode {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampAlarmMode)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) lampAlarmMode,
-                                      sizeof(*lampAlarmMode));
+    return emberAfReadServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampAlarmMode)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &lampAlarmMode,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BallastConfiguration::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -7210,14 +7647,13 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7225,14 +7661,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7240,14 +7675,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7255,14 +7689,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7270,14 +7703,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 
 namespace LightSensorType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lightSensorType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) lightSensorType,
-                                      sizeof(*lightSensorType));
+    return emberAfReadServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lightSensorType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &lightSensorType,
+    return emberAfWriteServerAttribute(endpoint, Clusters::IlluminanceMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
@@ -7291,14 +7723,13 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7306,14 +7737,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7321,14 +7751,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7336,14 +7765,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TemperatureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7357,14 +7785,13 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7372,14 +7799,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7387,14 +7813,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7402,13 +7827,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7416,14 +7841,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
 
 namespace ScaledValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * scaledValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) scaledValue,
-                                      sizeof(*scaledValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t scaledValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &scaledValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7431,14 +7855,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t scaledValue)
 
 namespace MinScaledValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minScaledValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) minScaledValue,
-                                      sizeof(*minScaledValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minScaledValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &minScaledValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7446,14 +7869,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t minScaledValue)
 
 namespace MaxScaledValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxScaledValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) maxScaledValue,
-                                      sizeof(*maxScaledValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxScaledValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &maxScaledValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -7461,14 +7883,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxScaledValue)
 
 namespace ScaledTolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * scaledTolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) scaledTolerance,
-                                      sizeof(*scaledTolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t scaledTolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &scaledTolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7476,13 +7897,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t scaledTolerance)
 
 namespace Scale {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * scale)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) scale, sizeof(*scale));
+    return emberAfReadServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t scale)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &scale,
+    return emberAfWriteServerAttribute(endpoint, Clusters::PressureMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
@@ -7496,59 +7917,52 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &measuredValue,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
-                                       ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &tolerance,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::FlowMeasurement::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Tolerance
@@ -7561,14 +7975,13 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7576,14 +7989,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7591,14 +8003,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7606,14 +8017,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::RelativeHumidityMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -7627,13 +8037,13 @@ namespace Attributes {
 
 namespace Occupancy {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) occupancy, sizeof(*occupancy));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &occupancy,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -7641,29 +8051,26 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy)
 
 namespace OccupancySensorType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) occupancySensorType,
-                                      sizeof(*occupancySensorType));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &occupancySensorType,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace OccupancySensorType
 
 namespace OccupancySensorTypeBitmap {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) occupancySensorTypeBitmap,
-                                      sizeof(*occupancySensorTypeBitmap));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &occupancySensorTypeBitmap,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -7671,139 +8078,117 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap)
 
 namespace PirOccupiedToUnoccupiedDelay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) pirOccupiedToUnoccupiedDelay,
-                                      sizeof(*pirOccupiedToUnoccupiedDelay));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &pirOccupiedToUnoccupiedDelay,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PirOccupiedToUnoccupiedDelay
 
 namespace PirUnoccupiedToOccupiedDelay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) pirUnoccupiedToOccupiedDelay,
-                                      sizeof(*pirUnoccupiedToOccupiedDelay));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &pirUnoccupiedToOccupiedDelay,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PirUnoccupiedToOccupiedDelay
 
 namespace PirUnoccupiedToOccupiedThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) pirUnoccupiedToOccupiedThreshold,
-                                      sizeof(*pirUnoccupiedToOccupiedThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &pirUnoccupiedToOccupiedThreshold,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PirUnoccupiedToOccupiedThreshold
 
 namespace UltrasonicOccupiedToUnoccupiedDelay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicOccupiedToUnoccupiedDelay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) ultrasonicOccupiedToUnoccupiedDelay,
-                                      sizeof(*ultrasonicOccupiedToUnoccupiedDelay));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                       (uint8_t *) &ultrasonicOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace UltrasonicOccupiedToUnoccupiedDelay
 
 namespace UltrasonicUnoccupiedToOccupiedDelay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicUnoccupiedToOccupiedDelay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) ultrasonicUnoccupiedToOccupiedDelay,
-                                      sizeof(*ultrasonicUnoccupiedToOccupiedDelay));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                       (uint8_t *) &ultrasonicUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace UltrasonicUnoccupiedToOccupiedDelay
 
 namespace UltrasonicUnoccupiedToOccupiedThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ultrasonicUnoccupiedToOccupiedThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                      (uint8_t *) ultrasonicUnoccupiedToOccupiedThreshold,
-                                      sizeof(*ultrasonicUnoccupiedToOccupiedThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ultrasonicUnoccupiedToOccupiedThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                       (uint8_t *) &ultrasonicUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace UltrasonicUnoccupiedToOccupiedThreshold
 
 namespace PhysicalContactOccupiedToUnoccupiedDelay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactOccupiedToUnoccupiedDelay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                      (uint8_t *) physicalContactOccupiedToUnoccupiedDelay,
-                                      sizeof(*physicalContactOccupiedToUnoccupiedDelay));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactOccupiedToUnoccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                       (uint8_t *) &physicalContactOccupiedToUnoccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PhysicalContactOccupiedToUnoccupiedDelay
 
 namespace PhysicalContactUnoccupiedToOccupiedDelay {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactUnoccupiedToOccupiedDelay)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                      (uint8_t *) physicalContactUnoccupiedToOccupiedDelay,
-                                      sizeof(*physicalContactUnoccupiedToOccupiedDelay));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactUnoccupiedToOccupiedDelay)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                       (uint8_t *) &physicalContactUnoccupiedToOccupiedDelay, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PhysicalContactUnoccupiedToOccupiedDelay
 
 namespace PhysicalContactUnoccupiedToOccupiedThreshold {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalContactUnoccupiedToOccupiedThreshold)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                      (uint8_t *) physicalContactUnoccupiedToOccupiedThreshold,
-                                      sizeof(*physicalContactUnoccupiedToOccupiedThreshold));
+    return emberAfReadServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalContactUnoccupiedToOccupiedThreshold)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id,
-                                       (uint8_t *) &physicalContactUnoccupiedToOccupiedThreshold, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::OccupancySensing::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PhysicalContactUnoccupiedToOccupiedThreshold
@@ -7816,59 +8201,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonMonoxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -7882,59 +8267,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::CarbonDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -7948,14 +8333,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -7963,14 +8348,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -7978,14 +8363,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -7993,14 +8378,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8014,59 +8399,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::EthyleneOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8080,14 +8465,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8095,14 +8480,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8110,14 +8495,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8125,14 +8510,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8146,59 +8531,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::HydrogenSulphideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8212,14 +8597,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8227,44 +8612,44 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitricOxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8278,59 +8663,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::NitrogenDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8344,14 +8729,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8359,14 +8744,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8374,14 +8759,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8389,14 +8774,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8410,14 +8795,13 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8425,14 +8809,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8440,14 +8823,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8455,14 +8837,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::OzoneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8476,59 +8857,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfurDioxideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8542,59 +8923,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::DissolvedOxygenConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8608,14 +8989,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8623,14 +9004,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8638,14 +9019,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8653,14 +9034,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8674,14 +9055,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8689,44 +9070,44 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloraminesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8740,14 +9121,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8755,14 +9136,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8770,14 +9151,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8785,14 +9166,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorineConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8806,60 +9187,60 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::FecalColiformAndEColiConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace Tolerance
@@ -8872,14 +9253,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8887,14 +9268,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8902,14 +9283,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8917,14 +9298,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::FluorideConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -8938,59 +9319,59 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::HaloaceticAcidsConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9004,60 +9385,60 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TotalTrihalomethanesConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace Tolerance
@@ -9070,60 +9451,60 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
     return emberAfWriteServerAttribute(endpoint, Clusters::TotalColiformBacteriaConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+                                       (uint8_t *) &value, ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace Tolerance
@@ -9136,14 +9517,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9151,14 +9532,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9166,14 +9547,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9181,14 +9562,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::TurbidityConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9202,14 +9583,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9217,14 +9598,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9232,14 +9613,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9247,14 +9628,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::CopperConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9268,14 +9649,13 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9283,14 +9663,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9298,14 +9677,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9313,14 +9691,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::LeadConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9334,14 +9711,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9349,14 +9726,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9364,14 +9741,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9379,14 +9756,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ManganeseConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9400,14 +9777,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9415,14 +9792,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9430,14 +9807,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9445,14 +9822,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SulfateConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9466,60 +9843,60 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromodichloromethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace Tolerance
@@ -9532,14 +9909,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9547,14 +9924,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9562,14 +9939,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9577,14 +9954,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::BromoformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9598,60 +9975,60 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) measuredValue, sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &measuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                      (uint8_t *) tolerance, sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &tolerance, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChlorodibromomethaneConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace Tolerance
@@ -9664,14 +10041,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9679,44 +10056,44 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &minMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id,
-                                       (uint8_t *) &maxMeasuredValue, ZCL_SINGLE_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ChloroformConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9730,14 +10107,14 @@ namespace Attributes {
 
 namespace MeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) measuredValue,
-                                      sizeof(*measuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &measuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9745,14 +10122,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue)
 
 namespace MinMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) minMeasuredValue,
-                                      sizeof(*minMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &minMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9760,14 +10137,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue)
 
 namespace MaxMeasuredValue {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) maxMeasuredValue,
-                                      sizeof(*maxMeasuredValue));
+    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &maxMeasuredValue,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9775,14 +10152,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue)
 
 namespace Tolerance {
 
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance)
+EmberAfStatus Get(chip::EndpointId endpoint, float * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) tolerance,
-                                      sizeof(*tolerance));
+    return emberAfReadServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) value,
+                                      sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance)
+EmberAfStatus Set(chip::EndpointId endpoint, float value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &tolerance,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SodiumConcentrationMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_SINGLE_ATTRIBUTE_TYPE);
 }
 
@@ -9796,95 +10173,91 @@ namespace Attributes {
 
 namespace ZoneState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) zoneState, sizeof(*zoneState));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &zoneState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ZoneState
 
 namespace ZoneType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) zoneType, sizeof(*zoneType));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &zoneType, ZCL_ENUM16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
 
 } // namespace ZoneType
 
 namespace ZoneStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) zoneStatus, sizeof(*zoneStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &zoneStatus, ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace ZoneStatus
 
 namespace IasCieAddress {
 
-EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * iasCieAddress)
+EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) iasCieAddress, sizeof(*iasCieAddress));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId iasCieAddress)
+EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &iasCieAddress, ZCL_NODE_ID_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_NODE_ID_ATTRIBUTE_TYPE);
 }
 
 } // namespace IasCieAddress
 
 namespace ZoneId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) zoneId, sizeof(*zoneId));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &zoneId, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ZoneId
 
 namespace NumberOfZoneSensitivityLevelsSupported {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfZoneSensitivityLevelsSupported)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) numberOfZoneSensitivityLevelsSupported,
-                                      sizeof(*numberOfZoneSensitivityLevelsSupported));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &numberOfZoneSensitivityLevelsSupported,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace NumberOfZoneSensitivityLevelsSupported
 
 namespace CurrentZoneSensitivityLevel {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) currentZoneSensitivityLevel,
-                                      sizeof(*currentZoneSensitivityLevel));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &currentZoneSensitivityLevel,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasZone::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentZoneSensitivityLevel
@@ -9897,13 +10270,13 @@ namespace Attributes {
 
 namespace MaxDuration {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxDuration)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::IasWd::Id, Id, (uint8_t *) maxDuration, sizeof(*maxDuration));
+    return emberAfReadServerAttribute(endpoint, Clusters::IasWd::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxDuration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::IasWd::Id, Id, (uint8_t *) &maxDuration, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::IasWd::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace MaxDuration
@@ -9914,11 +10287,80 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxDuration)
 namespace WakeOnLan {
 namespace Attributes {
 
+namespace WakeOnLanMacAddress {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::WakeOnLan::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace WakeOnLanMacAddress
+
 } // namespace Attributes
 } // namespace WakeOnLan
 
 namespace TvChannel {
 namespace Attributes {
+
+namespace TvChannelLineup {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::TvChannel::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::TvChannel::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace TvChannelLineup
+
+namespace CurrentTvChannel {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::TvChannel::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::TvChannel::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace CurrentTvChannel
 
 } // namespace Attributes
 } // namespace TvChannel
@@ -9928,15 +10370,13 @@ namespace Attributes {
 
 namespace CurrentNavigatorTarget {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TargetNavigator::Id, Id, (uint8_t *) currentNavigatorTarget,
-                                      sizeof(*currentNavigatorTarget));
+    return emberAfReadServerAttribute(endpoint, Clusters::TargetNavigator::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentNavigatorTarget)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TargetNavigator::Id, Id, (uint8_t *) &currentNavigatorTarget,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TargetNavigator::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentNavigatorTarget
@@ -9949,112 +10389,104 @@ namespace Attributes {
 
 namespace PlaybackState {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * playbackState)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) playbackState, sizeof(*playbackState));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t playbackState)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &playbackState,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace PlaybackState
 
 namespace StartTime {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * startTime)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) startTime, sizeof(*startTime));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t startTime)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &startTime,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace StartTime
 
 namespace Duration {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * duration)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) duration, sizeof(*duration));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t duration)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &duration, ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Duration
 
 namespace PositionUpdatedAt {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * positionUpdatedAt)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) positionUpdatedAt,
-                                      sizeof(*positionUpdatedAt));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t positionUpdatedAt)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &positionUpdatedAt,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PositionUpdatedAt
 
 namespace Position {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * position)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) position, sizeof(*position));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t position)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &position, ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Position
 
 namespace PlaybackSpeed {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * playbackSpeed)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) playbackSpeed, sizeof(*playbackSpeed));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t playbackSpeed)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &playbackSpeed,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace PlaybackSpeed
 
 namespace SeekRangeEnd {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeEnd)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) seekRangeEnd, sizeof(*seekRangeEnd));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeEnd)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &seekRangeEnd,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SeekRangeEnd
 
 namespace SeekRangeStart {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeStart)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) seekRangeStart,
-                                      sizeof(*seekRangeStart));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeStart)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &seekRangeStart,
-                                       ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaPlayback::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace SeekRangeStart
@@ -10067,15 +10499,13 @@ namespace Attributes {
 
 namespace CurrentMediaInput {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentMediaInput)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MediaInput::Id, Id, (uint8_t *) currentMediaInput,
-                                      sizeof(*currentMediaInput));
+    return emberAfReadServerAttribute(endpoint, Clusters::MediaInput::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentMediaInput)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MediaInput::Id, Id, (uint8_t *) &currentMediaInput,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::MediaInput::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentMediaInput
@@ -10094,15 +10524,13 @@ namespace Attributes {
 
 namespace CurrentAudioOutput {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentAudioOutput)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::AudioOutput::Id, Id, (uint8_t *) currentAudioOutput,
-                                      sizeof(*currentAudioOutput));
+    return emberAfReadServerAttribute(endpoint, Clusters::AudioOutput::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentAudioOutput)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::AudioOutput::Id, Id, (uint8_t *) &currentAudioOutput,
-                                       ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::AudioOutput::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CurrentAudioOutput
@@ -10115,14 +10543,13 @@ namespace Attributes {
 
 namespace CatalogVendorId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * catalogVendorId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) catalogVendorId,
-                                      sizeof(*catalogVendorId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t catalogVendorId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) &catalogVendorId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -10130,14 +10557,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t catalogVendorId)
 
 namespace ApplicationId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) applicationId,
-                                      sizeof(*applicationId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) &applicationId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationLauncher::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -10149,60 +10575,123 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationId)
 namespace ApplicationBasic {
 namespace Attributes {
 
+namespace VendorName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace VendorName
+
 namespace VendorId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) vendorId, sizeof(*vendorId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &vendorId,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace VendorId
 
+namespace ApplicationName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ApplicationName
+
 namespace ProductId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) productId, sizeof(*productId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &productId,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace ProductId
 
+namespace ApplicationId {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 32);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 32, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[32 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ApplicationId
+
 namespace CatalogVendorId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * catalogVendorId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) catalogVendorId,
-                                      sizeof(*catalogVendorId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t catalogVendorId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &catalogVendorId,
-                                       ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CatalogVendorId
 
 namespace ApplicationStatus {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationStatus)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) applicationStatus,
-                                      sizeof(*applicationStatus));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationStatus)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &applicationStatus,
-                                       ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplicationBasic::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace ApplicationStatus
@@ -10215,235 +10704,326 @@ namespace Attributes {
 
 namespace Boolean {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * boolean)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) boolean, sizeof(*boolean));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool boolean)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &boolean, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace Boolean
 
 namespace Bitmap8 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bitmap8)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) bitmap8, sizeof(*bitmap8));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bitmap8)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &bitmap8, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Bitmap8
 
 namespace Bitmap16 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * bitmap16)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) bitmap16, sizeof(*bitmap16));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t bitmap16)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &bitmap16, ZCL_BITMAP16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
 } // namespace Bitmap16
 
 namespace Bitmap32 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * bitmap32)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) bitmap32, sizeof(*bitmap32));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t bitmap32)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &bitmap32, ZCL_BITMAP32_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
 } // namespace Bitmap32
 
 namespace Bitmap64 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * bitmap64)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) bitmap64, sizeof(*bitmap64));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t bitmap64)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &bitmap64, ZCL_BITMAP64_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_BITMAP64_ATTRIBUTE_TYPE);
 }
 
 } // namespace Bitmap64
 
 namespace Int8u {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * int8u)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int8u, sizeof(*int8u));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t int8u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int8u, ZCL_INT8U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int8u
 
 namespace Int16u {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * int16u)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int16u, sizeof(*int16u));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t int16u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int16u, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int16u
 
 namespace Int32u {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * int32u)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int32u, sizeof(*int32u));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t int32u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int32u, ZCL_INT32U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int32u
 
 namespace Int64u {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * int64u)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int64u, sizeof(*int64u));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t int64u)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int64u, ZCL_INT64U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT64U_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int64u
 
 namespace Int8s {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * int8s)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int8s, sizeof(*int8s));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t int8s)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int8s, ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int8s
 
 namespace Int16s {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * int16s)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int16s, sizeof(*int16s));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t int16s)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int16s, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int16s
 
 namespace Int32s {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * int32s)
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int32s, sizeof(*int32s));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t int32s)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int32s, ZCL_INT32S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int32s
 
 namespace Int64s {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int64_t * int64s)
+EmberAfStatus Get(chip::EndpointId endpoint, int64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) int64s, sizeof(*int64s));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int64_t int64s)
+EmberAfStatus Set(chip::EndpointId endpoint, int64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &int64s, ZCL_INT64S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_INT64S_ATTRIBUTE_TYPE);
 }
 
 } // namespace Int64s
 
 namespace Enum8 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enum8)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) enum8, sizeof(*enum8));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enum8)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &enum8, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
 
 } // namespace Enum8
 
 namespace Enum16 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enum16)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) enum16, sizeof(*enum16));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enum16)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &enum16, ZCL_ENUM16_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
 
 } // namespace Enum16
 
+namespace OctetString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 10, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[10 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 10);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 10, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[10 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace OctetString
+
+namespace LongOctetString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 1000, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[1000 + 2];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[2], 1000);
+    value.reduce_size(emberAfLongStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 1000, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[1000 + 2];
+    emberAfCopyInt16u(zclString, 0, static_cast<uint16_t>(value.size()));
+    memcpy(&zclString[2], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, ZCL_LONG_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace LongOctetString
+
+namespace CharString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 10, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[10 + 1];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 10);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 10, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[10 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace CharString
+
+namespace LongCharString {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 1000, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[1000 + 2];
+    EmberAfStatus status = emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[2], 1000);
+    value.reduce_size(emberAfLongStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 1000, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[1000 + 2];
+    emberAfCopyInt16u(zclString, 0, static_cast<uint16_t>(value.size()));
+    memcpy(&zclString[2], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, zclString, ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace LongCharString
+
 namespace EpochUs {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * epochUs)
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) epochUs, sizeof(*epochUs));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t epochUs)
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &epochUs, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_EPOCH_US_ATTRIBUTE_TYPE);
 }
 
 } // namespace EpochUs
 
 namespace EpochS {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * epochS)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) epochS, sizeof(*epochS));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t epochS)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &epochS, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_EPOCH_S_ATTRIBUTE_TYPE);
 }
 
 } // namespace EpochS
 
 namespace Unsupported {
 
-EmberAfStatus Get(chip::EndpointId endpoint, bool * unsupported)
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) unsupported, sizeof(*unsupported));
+    return emberAfReadServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, bool unsupported)
+EmberAfStatus Set(chip::EndpointId endpoint, bool value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &unsupported,
-                                       ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::TestCluster::Id, Id, (uint8_t *) &value, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
 } // namespace Unsupported
@@ -10454,45 +11034,218 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool unsupported)
 namespace ApplianceIdentification {
 namespace Attributes {
 
+namespace CompanyName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace CompanyName
+
 namespace CompanyId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * companyId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) companyId,
-                                      sizeof(*companyId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t companyId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &companyId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace CompanyId
 
+namespace BrandName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace BrandName
+
 namespace BrandId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * brandId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) brandId, sizeof(*brandId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t brandId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &brandId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace BrandId
 
+namespace Model {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Model
+
+namespace PartNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace PartNumber
+
+namespace ProductRevision {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 6);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductRevision
+
+namespace SoftwareRevision {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 6);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace SoftwareRevision
+
+namespace ProductTypeName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 2, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[2 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 2);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 2, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[2 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, zclString,
+                                       ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductTypeName
+
 namespace ProductTypeId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productTypeId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) productTypeId,
-                                      sizeof(*productTypeId));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productTypeId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &productTypeId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10500,14 +11253,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productTypeId)
 
 namespace CecedSpecificationVersion {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) cecedSpecificationVersion,
-                                      sizeof(*cecedSpecificationVersion));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &cecedSpecificationVersion,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceIdentification::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -10519,16 +11271,39 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion)
 namespace MeterIdentification {
 namespace Attributes {
 
+namespace CompanyName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace CompanyName
+
 namespace MeterTypeId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * meterTypeId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) meterTypeId,
-                                      sizeof(*meterTypeId));
+    return emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t meterTypeId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) &meterTypeId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10536,18 +11311,185 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t meterTypeId)
 
 namespace DataQualityId {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dataQualityId)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) dataQualityId,
-                                      sizeof(*dataQualityId));
+    return emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dataQualityId)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) &dataQualityId,
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace DataQualityId
+
+namespace CustomerName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace CustomerName
+
+namespace Model {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Model
+
+namespace PartNumber {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace PartNumber
+
+namespace ProductRevision {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 6);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace ProductRevision
+
+namespace SoftwareRevision {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value)
+{
+    VerifyOrReturnError(value.size() == 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 6);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value)
+{
+    VerifyOrReturnError(value.size() <= 6, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[6 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_OCTET_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace SoftwareRevision
+
+namespace UtilityName {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace UtilityName
+
+namespace Pod {
+
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value)
+{
+    VerifyOrReturnError(value.size() == 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    EmberAfStatus status =
+        emberAfReadServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, sizeof(zclString));
+    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, status);
+    memcpy(value.data(), &zclString[1], 16);
+    value.reduce_size(emberAfStringLength(zclString));
+    return status;
+}
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value)
+{
+    VerifyOrReturnError(value.size() <= 16, EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+    uint8_t zclString[16 + 1];
+    emberAfCopyInt8u(zclString, 0, static_cast<uint8_t>(value.size()));
+    memcpy(&zclString[1], value.data(), value.size());
+    return emberAfWriteServerAttribute(endpoint, Clusters::MeterIdentification::Id, Id, zclString, ZCL_CHAR_STRING_ATTRIBUTE_TYPE);
+}
+
+} // namespace Pod
 
 } // namespace Attributes
 } // namespace MeterIdentification
@@ -10557,13 +11499,13 @@ namespace Attributes {
 
 namespace LogMaxSize {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * logMaxSize)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) logMaxSize, sizeof(*logMaxSize));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t logMaxSize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) &logMaxSize,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -10571,14 +11513,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t logMaxSize)
 
 namespace LogQueueMaxSize {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * logQueueMaxSize)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) logQueueMaxSize,
-                                      sizeof(*logQueueMaxSize));
+    return emberAfReadServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t logQueueMaxSize)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) &logQueueMaxSize,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ApplianceStatistics::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -10592,14 +11533,13 @@ namespace Attributes {
 
 namespace MeasurementType {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * measurementType)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measurementType,
-                                      sizeof(*measurementType));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t measurementType)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measurementType,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
 
@@ -10607,13 +11547,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t measurementType)
 
 namespace DcVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcVoltage, sizeof(*dcVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10621,14 +11561,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltage)
 
 namespace DcVoltageMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMin)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcVoltageMin,
-                                      sizeof(*dcVoltageMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcVoltageMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10636,14 +11575,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMin)
 
 namespace DcVoltageMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMax)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcVoltageMax,
-                                      sizeof(*dcVoltageMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcVoltageMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10651,13 +11589,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMax)
 
 namespace DcCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcCurrent, sizeof(*dcCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10665,14 +11603,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrent)
 
 namespace DcCurrentMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMin)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcCurrentMin,
-                                      sizeof(*dcCurrentMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcCurrentMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10680,14 +11617,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMin)
 
 namespace DcCurrentMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMax)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcCurrentMax,
-                                      sizeof(*dcCurrentMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcCurrentMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10695,13 +11631,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMax)
 
 namespace DcPower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPower)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcPower, sizeof(*dcPower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcPower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10709,14 +11645,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPower)
 
 namespace DcPowerMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMin)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcPowerMin,
-                                      sizeof(*dcPowerMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcPowerMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10724,14 +11659,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMin)
 
 namespace DcPowerMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMax)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcPowerMax,
-                                      sizeof(*dcPowerMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcPowerMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10739,14 +11673,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMax)
 
 namespace DcVoltageMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcVoltageMultiplier,
-                                      sizeof(*dcVoltageMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcVoltageMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10754,14 +11687,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier)
 
 namespace DcVoltageDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcVoltageDivisor,
-                                      sizeof(*dcVoltageDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcVoltageDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10769,14 +11701,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageDivisor)
 
 namespace DcCurrentMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcCurrentMultiplier,
-                                      sizeof(*dcCurrentMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10784,14 +11715,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier)
 
 namespace DcCurrentDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcCurrentDivisor,
-                                      sizeof(*dcCurrentDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcCurrentDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10799,14 +11729,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentDivisor)
 
 namespace DcPowerMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcPowerMultiplier,
-                                      sizeof(*dcPowerMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcPowerMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10814,14 +11743,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerMultiplier)
 
 namespace DcPowerDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) dcPowerDivisor,
-                                      sizeof(*dcPowerDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &dcPowerDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10829,14 +11757,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerDivisor)
 
 namespace AcFrequency {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequency)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acFrequency,
-                                      sizeof(*acFrequency));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequency)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acFrequency,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10844,14 +11771,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequency)
 
 namespace AcFrequencyMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMin)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acFrequencyMin,
-                                      sizeof(*acFrequencyMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acFrequencyMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10859,14 +11785,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMin)
 
 namespace AcFrequencyMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMax)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acFrequencyMax,
-                                      sizeof(*acFrequencyMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acFrequencyMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10874,14 +11799,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMax)
 
 namespace NeutralCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * neutralCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) neutralCurrent,
-                                      sizeof(*neutralCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t neutralCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &neutralCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -10889,14 +11813,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t neutralCurrent)
 
 namespace TotalActivePower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalActivePower)
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) totalActivePower,
-                                      sizeof(*totalActivePower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalActivePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &totalActivePower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 
@@ -10904,14 +11827,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalActivePower)
 
 namespace TotalReactivePower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalReactivePower)
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) totalReactivePower,
-                                      sizeof(*totalReactivePower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalReactivePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &totalReactivePower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32S_ATTRIBUTE_TYPE);
 }
 
@@ -10919,14 +11841,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalReactivePower)
 
 namespace TotalApparentPower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalApparentPower)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) totalApparentPower,
-                                      sizeof(*totalApparentPower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalApparentPower)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &totalApparentPower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -10934,14 +11855,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalApparentPower)
 
 namespace Measured1stHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measured1stHarmonicCurrent,
-                                      sizeof(*measured1stHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measured1stHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10949,14 +11869,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent)
 
 namespace Measured3rdHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measured3rdHarmonicCurrent,
-                                      sizeof(*measured3rdHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measured3rdHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10964,14 +11883,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent)
 
 namespace Measured5thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measured5thHarmonicCurrent,
-                                      sizeof(*measured5thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measured5thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10979,14 +11897,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent)
 
 namespace Measured7thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measured7thHarmonicCurrent,
-                                      sizeof(*measured7thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measured7thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -10994,14 +11911,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent)
 
 namespace Measured9thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measured9thHarmonicCurrent,
-                                      sizeof(*measured9thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measured9thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11009,14 +11925,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent)
 
 namespace Measured11thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) measured11thHarmonicCurrent,
-                                      sizeof(*measured11thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &measured11thHarmonicCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11024,104 +11939,97 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent
 
 namespace MeasuredPhase1stHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) measuredPhase1stHarmonicCurrent, sizeof(*measuredPhase1stHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &measuredPhase1stHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredPhase1stHarmonicCurrent
 
 namespace MeasuredPhase3rdHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) measuredPhase3rdHarmonicCurrent, sizeof(*measuredPhase3rdHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &measuredPhase3rdHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredPhase3rdHarmonicCurrent
 
 namespace MeasuredPhase5thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) measuredPhase5thHarmonicCurrent, sizeof(*measuredPhase5thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &measuredPhase5thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredPhase5thHarmonicCurrent
 
 namespace MeasuredPhase7thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) measuredPhase7thHarmonicCurrent, sizeof(*measuredPhase7thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &measuredPhase7thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredPhase7thHarmonicCurrent
 
 namespace MeasuredPhase9thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) measuredPhase9thHarmonicCurrent, sizeof(*measuredPhase9thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &measuredPhase9thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredPhase9thHarmonicCurrent
 
 namespace MeasuredPhase11thHarmonicCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) measuredPhase11thHarmonicCurrent, sizeof(*measuredPhase11thHarmonicCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &measuredPhase11thHarmonicCurrent, ZCL_INT16S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
 } // namespace MeasuredPhase11thHarmonicCurrent
 
 namespace AcFrequencyMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acFrequencyMultiplier,
-                                      sizeof(*acFrequencyMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acFrequencyMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11129,14 +12037,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier)
 
 namespace AcFrequencyDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acFrequencyDivisor,
-                                      sizeof(*acFrequencyDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acFrequencyDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11144,14 +12051,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyDivisor)
 
 namespace PowerMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) powerMultiplier,
-                                      sizeof(*powerMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &powerMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -11159,14 +12065,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerMultiplier)
 
 namespace PowerDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) powerDivisor,
-                                      sizeof(*powerDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &powerDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
 
@@ -11174,14 +12079,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerDivisor)
 
 namespace HarmonicCurrentMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) harmonicCurrentMultiplier,
-                                      sizeof(*harmonicCurrentMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &harmonicCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
@@ -11189,29 +12093,27 @@ EmberAfStatus Set(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier)
 
 namespace PhaseHarmonicCurrentMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) phaseHarmonicCurrentMultiplier,
-                                      sizeof(*phaseHarmonicCurrentMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &phaseHarmonicCurrentMultiplier, ZCL_INT8S_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
 } // namespace PhaseHarmonicCurrentMultiplier
 
 namespace InstantaneousVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) instantaneousVoltage,
-                                      sizeof(*instantaneousVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &instantaneousVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11219,14 +12121,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousVoltage)
 
 namespace InstantaneousLineCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) instantaneousLineCurrent,
-                                      sizeof(*instantaneousLineCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &instantaneousLineCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11234,14 +12135,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent)
 
 namespace InstantaneousActiveCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) instantaneousActiveCurrent,
-                                      sizeof(*instantaneousActiveCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &instantaneousActiveCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11249,14 +12149,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent)
 
 namespace InstantaneousReactiveCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) instantaneousReactiveCurrent,
-                                      sizeof(*instantaneousReactiveCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &instantaneousReactiveCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11264,14 +12163,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousReactiveCurren
 
 namespace InstantaneousPower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousPower)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) instantaneousPower,
-                                      sizeof(*instantaneousPower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousPower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &instantaneousPower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11279,14 +12177,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousPower)
 
 namespace RmsVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltage,
-                                      sizeof(*rmsVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11294,14 +12191,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltage)
 
 namespace RmsVoltageMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMin)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageMin,
-                                      sizeof(*rmsVoltageMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11309,14 +12205,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMin)
 
 namespace RmsVoltageMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMax)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageMax,
-                                      sizeof(*rmsVoltageMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11324,14 +12219,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMax)
 
 namespace RmsCurrent {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrent)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrent,
-                                      sizeof(*rmsCurrent));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrent)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrent,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11339,14 +12233,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrent)
 
 namespace RmsCurrentMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMin)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentMin,
-                                      sizeof(*rmsCurrentMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMin)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11354,14 +12247,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMin)
 
 namespace RmsCurrentMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMax)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentMax,
-                                      sizeof(*rmsCurrentMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMax)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11369,14 +12261,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMax)
 
 namespace ActivePower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePower)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePower,
-                                      sizeof(*activePower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11384,14 +12275,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePower)
 
 namespace ActivePowerMin {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMin)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerMin,
-                                      sizeof(*activePowerMin));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMin)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerMin,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11399,14 +12289,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMin)
 
 namespace ActivePowerMax {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMax)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerMax,
-                                      sizeof(*activePowerMax));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMax)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerMax,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11414,14 +12303,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMax)
 
 namespace ReactivePower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePower)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) reactivePower,
-                                      sizeof(*reactivePower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePower)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &reactivePower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11429,14 +12317,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePower)
 
 namespace ApparentPower {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPower)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) apparentPower,
-                                      sizeof(*apparentPower));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPower)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &apparentPower,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11444,14 +12331,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPower)
 
 namespace PowerFactor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactor)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) powerFactor,
-                                      sizeof(*powerFactor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactor)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &powerFactor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
@@ -11459,44 +12345,41 @@ EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactor)
 
 namespace AverageRmsVoltageMeasurementPeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsVoltageMeasurementPeriod, sizeof(*averageRmsVoltageMeasurementPeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsVoltageMeasurementPeriod, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsVoltageMeasurementPeriod
 
 namespace AverageRmsUnderVoltageCounter {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) averageRmsUnderVoltageCounter,
-                                      sizeof(*averageRmsUnderVoltageCounter));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsUnderVoltageCounter, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsUnderVoltageCounter
 
 namespace RmsExtremeOverVoltagePeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsExtremeOverVoltagePeriod,
-                                      sizeof(*rmsExtremeOverVoltagePeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsExtremeOverVoltagePeriod,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11504,14 +12387,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePerio
 
 namespace RmsExtremeUnderVoltagePeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsExtremeUnderVoltagePeriod,
-                                      sizeof(*rmsExtremeUnderVoltagePeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsExtremeUnderVoltagePeriod,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11519,14 +12401,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeri
 
 namespace RmsVoltageSagPeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSagPeriod,
-                                      sizeof(*rmsVoltageSagPeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSagPeriod,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11534,14 +12415,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod)
 
 namespace RmsVoltageSwellPeriod {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSwellPeriod,
-                                      sizeof(*rmsVoltageSwellPeriod));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSwellPeriod,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11549,14 +12429,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod)
 
 namespace AcVoltageMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acVoltageMultiplier,
-                                      sizeof(*acVoltageMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acVoltageMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11564,14 +12443,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageMultiplier)
 
 namespace AcVoltageDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acVoltageDivisor,
-                                      sizeof(*acVoltageDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acVoltageDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11579,14 +12457,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageDivisor)
 
 namespace AcCurrentMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acCurrentMultiplier,
-                                      sizeof(*acCurrentMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acCurrentMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11594,14 +12471,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentMultiplier)
 
 namespace AcCurrentDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acCurrentDivisor,
-                                      sizeof(*acCurrentDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acCurrentDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11609,14 +12485,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentDivisor)
 
 namespace AcPowerMultiplier {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerMultiplier)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acPowerMultiplier,
-                                      sizeof(*acPowerMultiplier));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerMultiplier)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acPowerMultiplier,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11624,14 +12499,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerMultiplier)
 
 namespace AcPowerDivisor {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerDivisor)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acPowerDivisor,
-                                      sizeof(*acPowerDivisor));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerDivisor)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acPowerDivisor,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11639,14 +12513,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerDivisor)
 
 namespace OverloadAlarmsMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) overloadAlarmsMask,
-                                      sizeof(*overloadAlarmsMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t overloadAlarmsMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &overloadAlarmsMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
 
@@ -11654,14 +12527,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t overloadAlarmsMask)
 
 namespace VoltageOverload {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * voltageOverload)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) voltageOverload,
-                                      sizeof(*voltageOverload));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t voltageOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &voltageOverload,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11669,14 +12541,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t voltageOverload)
 
 namespace CurrentOverload {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentOverload)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) currentOverload,
-                                      sizeof(*currentOverload));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &currentOverload,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11684,14 +12555,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentOverload)
 
 namespace AcOverloadAlarmsMask {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acOverloadAlarmsMask,
-                                      sizeof(*acOverloadAlarmsMask));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acOverloadAlarmsMask,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
 
@@ -11699,14 +12569,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask)
 
 namespace AcVoltageOverload {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acVoltageOverload)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acVoltageOverload,
-                                      sizeof(*acVoltageOverload));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acVoltageOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acVoltageOverload,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11714,14 +12583,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t acVoltageOverload)
 
 namespace AcCurrentOverload {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCurrentOverload)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acCurrentOverload,
-                                      sizeof(*acCurrentOverload));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCurrentOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acCurrentOverload,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11729,14 +12597,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCurrentOverload)
 
 namespace AcActivePowerOverload {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acActivePowerOverload)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acActivePowerOverload,
-                                      sizeof(*acActivePowerOverload));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acActivePowerOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acActivePowerOverload,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11744,14 +12611,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t acActivePowerOverload)
 
 namespace AcReactivePowerOverload {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acReactivePowerOverload)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) acReactivePowerOverload,
-                                      sizeof(*acReactivePowerOverload));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acReactivePowerOverload)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &acReactivePowerOverload,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11759,14 +12625,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t acReactivePowerOverload)
 
 namespace AverageRmsOverVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) averageRmsOverVoltage,
-                                      sizeof(*averageRmsOverVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsOverVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &averageRmsOverVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11774,14 +12639,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsOverVoltage)
 
 namespace AverageRmsUnderVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) averageRmsUnderVoltage,
-                                      sizeof(*averageRmsUnderVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &averageRmsUnderVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11789,14 +12653,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage)
 
 namespace RmsExtremeOverVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsExtremeOverVoltage,
-                                      sizeof(*rmsExtremeOverVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsExtremeOverVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11804,14 +12667,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage)
 
 namespace RmsExtremeUnderVoltage {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsExtremeUnderVoltage,
-                                      sizeof(*rmsExtremeUnderVoltage));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsExtremeUnderVoltage,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11819,14 +12681,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage)
 
 namespace RmsVoltageSag {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSag)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSag,
-                                      sizeof(*rmsVoltageSag));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSag)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSag,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11834,14 +12695,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSag)
 
 namespace RmsVoltageSwell {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSwell)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSwell,
-                                      sizeof(*rmsVoltageSwell));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSwell)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSwell,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11849,14 +12709,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSwell)
 
 namespace LineCurrentPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) lineCurrentPhaseB,
-                                      sizeof(*lineCurrentPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &lineCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11864,14 +12723,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB)
 
 namespace ActiveCurrentPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activeCurrentPhaseB,
-                                      sizeof(*activeCurrentPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activeCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11879,14 +12737,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseB)
 
 namespace ReactiveCurrentPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) reactiveCurrentPhaseB,
-                                      sizeof(*reactiveCurrentPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &reactiveCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11894,14 +12751,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB)
 
 namespace RmsVoltagePhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltagePhaseB,
-                                      sizeof(*rmsVoltagePhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltagePhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11909,14 +12765,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB)
 
 namespace RmsVoltageMinPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageMinPhaseB,
-                                      sizeof(*rmsVoltageMinPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageMinPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11924,14 +12779,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB)
 
 namespace RmsVoltageMaxPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageMaxPhaseB,
-                                      sizeof(*rmsVoltageMaxPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageMaxPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11939,14 +12793,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB)
 
 namespace RmsCurrentPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentPhaseB,
-                                      sizeof(*rmsCurrentPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11954,14 +12807,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB)
 
 namespace RmsCurrentMinPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentMinPhaseB,
-                                      sizeof(*rmsCurrentMinPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentMinPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11969,14 +12821,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB)
 
 namespace RmsCurrentMaxPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentMaxPhaseB,
-                                      sizeof(*rmsCurrentMaxPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentMaxPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -11984,14 +12835,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB)
 
 namespace ActivePowerPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerPhaseB,
-                                      sizeof(*activePowerPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -11999,14 +12849,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseB)
 
 namespace ActivePowerMinPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerMinPhaseB,
-                                      sizeof(*activePowerMinPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerMinPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12014,14 +12863,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseB)
 
 namespace ActivePowerMaxPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerMaxPhaseB,
-                                      sizeof(*activePowerMaxPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerMaxPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12029,14 +12877,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB)
 
 namespace ReactivePowerPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) reactivePowerPhaseB,
-                                      sizeof(*reactivePowerPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &reactivePowerPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12044,14 +12891,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseB)
 
 namespace ApparentPowerPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) apparentPowerPhaseB,
-                                      sizeof(*apparentPowerPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &apparentPowerPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12059,14 +12905,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB)
 
 namespace PowerFactorPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) powerFactorPhaseB,
-                                      sizeof(*powerFactorPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &powerFactorPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
@@ -12074,91 +12919,83 @@ EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseB)
 
 namespace AverageRmsVoltageMeasurementPeriodPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsVoltageMeasurementPeriodPhaseB,
-                                      sizeof(*averageRmsVoltageMeasurementPeriodPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsVoltageMeasurementPeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsVoltageMeasurementPeriodPhaseB
 
 namespace AverageRmsOverVoltageCounterPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsOverVoltageCounterPhaseB, sizeof(*averageRmsOverVoltageCounterPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsOverVoltageCounterPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsOverVoltageCounterPhaseB
 
 namespace AverageRmsUnderVoltageCounterPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsUnderVoltageCounterPhaseB,
-                                      sizeof(*averageRmsUnderVoltageCounterPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsUnderVoltageCounterPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsUnderVoltageCounterPhaseB
 
 namespace RmsExtremeOverVoltagePeriodPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) rmsExtremeOverVoltagePeriodPhaseB, sizeof(*rmsExtremeOverVoltagePeriodPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &rmsExtremeOverVoltagePeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RmsExtremeOverVoltagePeriodPhaseB
 
 namespace RmsExtremeUnderVoltagePeriodPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) rmsExtremeUnderVoltagePeriodPhaseB, sizeof(*rmsExtremeUnderVoltagePeriodPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &rmsExtremeUnderVoltagePeriodPhaseB, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RmsExtremeUnderVoltagePeriodPhaseB
 
 namespace RmsVoltageSagPeriodPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSagPeriodPhaseB,
-                                      sizeof(*rmsVoltageSagPeriodPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSagPeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12166,14 +13003,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB)
 
 namespace RmsVoltageSwellPeriodPhaseB {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSwellPeriodPhaseB,
-                                      sizeof(*rmsVoltageSwellPeriodPhaseB));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSwellPeriodPhaseB,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12181,14 +13017,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhase
 
 namespace LineCurrentPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) lineCurrentPhaseC,
-                                      sizeof(*lineCurrentPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &lineCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12196,14 +13031,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC)
 
 namespace ActiveCurrentPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activeCurrentPhaseC,
-                                      sizeof(*activeCurrentPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activeCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12211,14 +13045,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseC)
 
 namespace ReactiveCurrentPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) reactiveCurrentPhaseC,
-                                      sizeof(*reactiveCurrentPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &reactiveCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12226,14 +13059,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC)
 
 namespace RmsVoltagePhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltagePhaseC,
-                                      sizeof(*rmsVoltagePhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltagePhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12241,14 +13073,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC)
 
 namespace RmsVoltageMinPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageMinPhaseC,
-                                      sizeof(*rmsVoltageMinPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageMinPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12256,14 +13087,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC)
 
 namespace RmsVoltageMaxPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageMaxPhaseC,
-                                      sizeof(*rmsVoltageMaxPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageMaxPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12271,14 +13101,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC)
 
 namespace RmsCurrentPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentPhaseC,
-                                      sizeof(*rmsCurrentPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12286,14 +13115,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC)
 
 namespace RmsCurrentMinPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentMinPhaseC,
-                                      sizeof(*rmsCurrentMinPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentMinPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12301,14 +13129,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC)
 
 namespace RmsCurrentMaxPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsCurrentMaxPhaseC,
-                                      sizeof(*rmsCurrentMaxPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsCurrentMaxPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12316,14 +13143,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC)
 
 namespace ActivePowerPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerPhaseC,
-                                      sizeof(*activePowerPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12331,14 +13157,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseC)
 
 namespace ActivePowerMinPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerMinPhaseC,
-                                      sizeof(*activePowerMinPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerMinPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12346,14 +13171,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseC)
 
 namespace ActivePowerMaxPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) activePowerMaxPhaseC,
-                                      sizeof(*activePowerMaxPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &activePowerMaxPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12361,14 +13185,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC)
 
 namespace ReactivePowerPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) reactivePowerPhaseC,
-                                      sizeof(*reactivePowerPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &reactivePowerPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
@@ -12376,14 +13199,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseC)
 
 namespace ApparentPowerPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) apparentPowerPhaseC,
-                                      sizeof(*apparentPowerPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &apparentPowerPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12391,14 +13213,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC)
 
 namespace PowerFactorPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) powerFactorPhaseC,
-                                      sizeof(*powerFactorPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &powerFactorPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8S_ATTRIBUTE_TYPE);
 }
 
@@ -12406,91 +13227,83 @@ EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseC)
 
 namespace AverageRmsVoltageMeasurementPeriodPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsVoltageMeasurementPeriodPhaseC,
-                                      sizeof(*averageRmsVoltageMeasurementPeriodPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsVoltageMeasurementPeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsVoltageMeasurementPeriodPhaseC
 
 namespace AverageRmsOverVoltageCounterPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsOverVoltageCounterPhaseC, sizeof(*averageRmsOverVoltageCounterPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsOverVoltageCounterPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsOverVoltageCounterPhaseC
 
 namespace AverageRmsUnderVoltageCounterPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) averageRmsUnderVoltageCounterPhaseC,
-                                      sizeof(*averageRmsUnderVoltageCounterPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &averageRmsUnderVoltageCounterPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace AverageRmsUnderVoltageCounterPhaseC
 
 namespace RmsExtremeOverVoltagePeriodPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) rmsExtremeOverVoltagePeriodPhaseC, sizeof(*rmsExtremeOverVoltagePeriodPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &rmsExtremeOverVoltagePeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RmsExtremeOverVoltagePeriodPhaseC
 
 namespace RmsExtremeUnderVoltagePeriodPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                      (uint8_t *) rmsExtremeUnderVoltagePeriodPhaseC, sizeof(*rmsExtremeUnderVoltagePeriodPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id,
-                                       (uint8_t *) &rmsExtremeUnderVoltagePeriodPhaseC, ZCL_INT16U_ATTRIBUTE_TYPE);
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
+                                       ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
 } // namespace RmsExtremeUnderVoltagePeriodPhaseC
 
 namespace RmsVoltageSagPeriodPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSagPeriodPhaseC,
-                                      sizeof(*rmsVoltageSagPeriodPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSagPeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12498,14 +13311,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC)
 
 namespace RmsVoltageSwellPeriodPhaseC {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) rmsVoltageSwellPeriodPhaseC,
-                                      sizeof(*rmsVoltageSwellPeriodPhaseC));
+    return emberAfReadServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &rmsVoltageSwellPeriodPhaseC,
+    return emberAfWriteServerAttribute(endpoint, Clusters::ElectricalMeasurement::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12525,14 +13337,13 @@ namespace Attributes {
 
 namespace EmberSampleAttribute {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) emberSampleAttribute,
-                                      sizeof(*emberSampleAttribute));
+    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) &emberSampleAttribute,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -12540,14 +13351,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute)
 
 namespace EmberSampleAttribute2 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2)
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) emberSampleAttribute2,
-                                      sizeof(*emberSampleAttribute2));
+    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute2)
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) &emberSampleAttribute2,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster::Id, Id, (uint8_t *) &value,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
 
@@ -12561,14 +13371,13 @@ namespace Attributes {
 
 namespace EmberSampleAttribute3 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) emberSampleAttribute3,
-                                      sizeof(*emberSampleAttribute3));
+    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute3)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) &emberSampleAttribute3,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
@@ -12576,14 +13385,13 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute3)
 
 namespace EmberSampleAttribute4 {
 
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4)
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value)
 {
-    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) emberSampleAttribute4,
-                                      sizeof(*emberSampleAttribute4));
+    return emberAfReadServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute4)
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value)
 {
-    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) &emberSampleAttribute4,
+    return emberAfWriteServerAttribute(endpoint, Clusters::SampleMfgSpecificCluster2::Id, Id, (uint8_t *) &value,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -35,273 +35,288 @@ namespace PowerConfiguration {
 namespace Attributes {
 
 namespace MainsVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltage); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MainsVoltage
 
 namespace MainsFrequency {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsFrequency); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsFrequency);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MainsFrequency
 
 namespace MainsAlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mainsAlarmMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mainsAlarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MainsAlarmMask
 
 namespace MainsVoltageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMinThreshold); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MainsVoltageMinThreshold
 
 namespace MainsVoltageMaxThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageMaxThreshold); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageMaxThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MainsVoltageMaxThreshold
 
 namespace MainsVoltageDwellTrip {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * mainsVoltageDwellTrip); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t mainsVoltageDwellTrip);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MainsVoltageDwellTrip
 
 namespace BatteryVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryVoltage
 
 namespace BatteryPercentageRemaining {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageRemaining); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageRemaining);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryPercentageRemaining
 
+namespace BatteryManufacturer {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace BatteryManufacturer
+
 namespace BatterySize {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batterySize); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batterySize);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatterySize
 
 namespace BatteryAhrRating {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * batteryAhrRating); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t batteryAhrRating);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BatteryAhrRating
 
 namespace BatteryQuantity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryQuantity
 
 namespace BatteryRatedVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryRatedVoltage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryRatedVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryRatedVoltage
 
 namespace BatteryAlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryAlarmMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryAlarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryAlarmMask
 
 namespace BatteryVoltageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageMinThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryVoltageMinThreshold
 
 namespace BatteryVoltageThreshold1 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold1); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold1);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryVoltageThreshold1
 
 namespace BatteryVoltageThreshold2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryVoltageThreshold2
 
 namespace BatteryVoltageThreshold3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryVoltageThreshold3); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryVoltageThreshold3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryVoltageThreshold3
 
 namespace BatteryPercentageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageMinThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryPercentageMinThreshold
 
 namespace BatteryPercentageThreshold1 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold1); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold1);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryPercentageThreshold1
 
 namespace BatteryPercentageThreshold2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryPercentageThreshold2
 
 namespace BatteryPercentageThreshold3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentageThreshold3); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentageThreshold3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryPercentageThreshold3
 
 namespace BatteryAlarmState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryAlarmState); // bitmap32
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryAlarmState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryAlarmState
 
 namespace Battery2Voltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Voltage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Voltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2Voltage
 
 namespace Battery2PercentageRemaining {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageRemaining); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageRemaining);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2PercentageRemaining
 
+namespace Battery2Manufacturer {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Battery2Manufacturer
+
 namespace Battery2Size {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Size); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Size);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2Size
 
 namespace Battery2AhrRating {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery2AhrRating); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery2AhrRating);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Battery2AhrRating
 
 namespace Battery2Quantity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2Quantity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2Quantity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2Quantity
 
 namespace Battery2RatedVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2RatedVoltage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2RatedVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2RatedVoltage
 
 namespace Battery2AlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2AlarmMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2AlarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2AlarmMask
 
 namespace Battery2VoltageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageMinThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2VoltageMinThreshold
 
 namespace Battery2VoltageThreshold1 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold1); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold1);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2VoltageThreshold1
 
 namespace Battery2VoltageThreshold2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2VoltageThreshold2
 
 namespace Battery2VoltageThreshold3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2VoltageThreshold3); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2VoltageThreshold3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2VoltageThreshold3
 
 namespace Battery2PercentageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageMinThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2PercentageMinThreshold
 
 namespace Battery2PercentageThreshold1 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold1); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold1);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2PercentageThreshold1
 
 namespace Battery2PercentageThreshold2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2PercentageThreshold2
 
 namespace Battery2PercentageThreshold3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery2PercentageThreshold3); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery2PercentageThreshold3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery2PercentageThreshold3
 
 namespace Battery2AlarmState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery2AlarmState); // bitmap32
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery2AlarmState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace Battery2AlarmState
 
 namespace Battery3Voltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Voltage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Voltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3Voltage
 
 namespace Battery3PercentageRemaining {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageRemaining); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageRemaining);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3PercentageRemaining
 
+namespace Battery3Manufacturer {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Battery3Manufacturer
+
 namespace Battery3Size {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Size); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Size);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3Size
 
 namespace Battery3AhrRating {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * battery3AhrRating); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t battery3AhrRating);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Battery3AhrRating
 
 namespace Battery3Quantity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3Quantity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3Quantity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3Quantity
 
 namespace Battery3RatedVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3RatedVoltage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3RatedVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3RatedVoltage
 
 namespace Battery3AlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3AlarmMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3AlarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3AlarmMask
 
 namespace Battery3VoltageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageMinThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3VoltageMinThreshold
 
 namespace Battery3VoltageThreshold1 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold1); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold1);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3VoltageThreshold1
 
 namespace Battery3VoltageThreshold2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3VoltageThreshold2
 
 namespace Battery3VoltageThreshold3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3VoltageThreshold3); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3VoltageThreshold3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3VoltageThreshold3
 
 namespace Battery3PercentageMinThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageMinThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageMinThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3PercentageMinThreshold
 
 namespace Battery3PercentageThreshold1 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold1); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold1);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3PercentageThreshold1
 
 namespace Battery3PercentageThreshold2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3PercentageThreshold2
 
 namespace Battery3PercentageThreshold3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * battery3PercentageThreshold3); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t battery3PercentageThreshold3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Battery3PercentageThreshold3
 
 namespace Battery3AlarmState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * battery3AlarmState); // bitmap32
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t battery3AlarmState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace Battery3AlarmState
 
 } // namespace Attributes
@@ -311,38 +326,38 @@ namespace DeviceTemperatureConfiguration {
 namespace Attributes {
 
 namespace CurrentTemperature {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentTemperature); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentTemperature);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace CurrentTemperature
 
 namespace MinTempExperienced {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minTempExperienced); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minTempExperienced);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinTempExperienced
 
 namespace MaxTempExperienced {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxTempExperienced); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxTempExperienced);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxTempExperienced
 
 namespace OverTempTotalDwell {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * overTempTotalDwell); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t overTempTotalDwell);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OverTempTotalDwell
 
 namespace DeviceTempAlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * deviceTempAlarmMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t deviceTempAlarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DeviceTempAlarmMask
 
 namespace LowTempThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * lowTempThreshold); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t lowTempThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace LowTempThreshold
 
 namespace HighTempThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * highTempThreshold); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t highTempThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace HighTempThreshold
 
 } // namespace Attributes
@@ -352,13 +367,13 @@ namespace Identify {
 namespace Attributes {
 
 namespace IdentifyTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * identifyTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t identifyTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace IdentifyTime
 
 namespace IdentifyType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * identifyType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t identifyType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace IdentifyType
 
 } // namespace Attributes
@@ -368,8 +383,8 @@ namespace Groups {
 namespace Attributes {
 
 namespace NameSupport {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NameSupport
 
 } // namespace Attributes
@@ -379,33 +394,33 @@ namespace Scenes {
 namespace Attributes {
 
 namespace SceneCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sceneCount); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sceneCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SceneCount
 
 namespace CurrentScene {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentScene); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentScene);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentScene
 
 namespace CurrentGroup {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentGroup); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentGroup);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentGroup
 
 namespace SceneValid {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * sceneValid); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool sceneValid);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace SceneValid
 
 namespace NameSupport {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t nameSupport);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NameSupport
 
 namespace LastConfiguredBy {
-EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * lastConfiguredBy); // node_id
-EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId lastConfiguredBy);
+EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * value); // node_id
+EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId value);
 } // namespace LastConfiguredBy
 
 } // namespace Attributes
@@ -415,48 +430,48 @@ namespace OnOff {
 namespace Attributes {
 
 namespace OnOff {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * onOff); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool onOff);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace OnOff
 
 namespace SampleMfgSpecificAttribute0x00000x1002 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00000x1002); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace SampleMfgSpecificAttribute0x00000x1002
 
 namespace SampleMfgSpecificAttribute0x00000x1049 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00000x1049); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00000x1049);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SampleMfgSpecificAttribute0x00000x1049
 
 namespace SampleMfgSpecificAttribute0x00010x1002 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * sampleMfgSpecificAttribute0x00010x1002); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t sampleMfgSpecificAttribute0x00010x1002);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SampleMfgSpecificAttribute0x00010x1002
 
 namespace SampleMfgSpecificAttribute0x00010x1040 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * sampleMfgSpecificAttribute0x00010x1040); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace SampleMfgSpecificAttribute0x00010x1040
 
 namespace GlobalSceneControl {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * globalSceneControl); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool globalSceneControl);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace GlobalSceneControl
 
 namespace OnTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OnTime
 
 namespace OffWaitTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offWaitTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offWaitTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OffWaitTime
 
 namespace StartUpOnOff {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpOnOff); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpOnOff);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace StartUpOnOff
 
 } // namespace Attributes
@@ -466,13 +481,13 @@ namespace OnOffSwitchConfiguration {
 namespace Attributes {
 
 namespace SwitchType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SwitchType
 
 namespace SwitchActions {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * switchActions); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t switchActions);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SwitchActions
 
 } // namespace Attributes
@@ -482,73 +497,73 @@ namespace LevelControl {
 namespace Attributes {
 
 namespace CurrentLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentLevel
 
 namespace RemainingTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RemainingTime
 
 namespace MinLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MinLevel
 
 namespace MaxLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MaxLevel
 
 namespace CurrentFrequency {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentFrequency); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentFrequency);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentFrequency
 
 namespace MinFrequency {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minFrequency); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minFrequency);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MinFrequency
 
 namespace MaxFrequency {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxFrequency); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFrequency);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxFrequency
 
 namespace Options {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * options); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t options);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Options
 
 namespace OnOffTransitionTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onOffTransitionTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onOffTransitionTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OnOffTransitionTime
 
 namespace OnLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * onLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t onLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OnLevel
 
 namespace OnTransitionTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * onTransitionTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t onTransitionTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OnTransitionTime
 
 namespace OffTransitionTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * offTransitionTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t offTransitionTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OffTransitionTime
 
 namespace DefaultMoveRate {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * defaultMoveRate); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t defaultMoveRate);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DefaultMoveRate
 
 namespace StartUpCurrentLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startUpCurrentLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startUpCurrentLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace StartUpCurrentLevel
 
 } // namespace Attributes
@@ -558,8 +573,8 @@ namespace Alarms {
 namespace Attributes {
 
 namespace AlarmCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AlarmCount
 
 } // namespace Attributes
@@ -569,53 +584,53 @@ namespace Time {
 namespace Attributes {
 
 namespace Time {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * time); // epoch_s
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t time);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // epoch_s
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace Time
 
 namespace TimeStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * timeStatus); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t timeStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace TimeStatus
 
 namespace TimeZone {
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * timeZone); // int32s
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t timeZone);
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value);
 } // namespace TimeZone
 
 namespace DstStart {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstStart); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstStart);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace DstStart
 
 namespace DstEnd {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * dstEnd); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t dstEnd);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace DstEnd
 
 namespace DstShift {
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * dstShift); // int32s
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t dstShift);
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value);
 } // namespace DstShift
 
 namespace StandardTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * standardTime); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t standardTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace StandardTime
 
 namespace LocalTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * localTime); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t localTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace LocalTime
 
 namespace LastSetTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * lastSetTime); // epoch_s
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lastSetTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // epoch_s
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace LastSetTime
 
 namespace ValidUntilTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * validUntilTime); // epoch_s
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t validUntilTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // epoch_s
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace ValidUntilTime
 
 } // namespace Attributes
@@ -624,34 +639,49 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t validUntilTime);
 namespace BinaryInputBasic {
 namespace Attributes {
 
+namespace ActiveText {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ActiveText
+
+namespace Description {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Description
+
+namespace InactiveText {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace InactiveText
+
 namespace OutOfService {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * outOfService); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool outOfService);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace OutOfService
 
 namespace Polarity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * polarity); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t polarity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Polarity
 
 namespace PresentValue {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * presentValue); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool presentValue);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace PresentValue
 
 namespace Reliability {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * reliability); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t reliability);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Reliability
 
 namespace StatusFlags {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * statusFlags); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t statusFlags);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace StatusFlags
 
 namespace ApplicationType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * applicationType); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t applicationType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace ApplicationType
 
 } // namespace Attributes
@@ -661,28 +691,28 @@ namespace PowerProfile {
 namespace Attributes {
 
 namespace TotalProfileNum {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * totalProfileNum); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t totalProfileNum);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace TotalProfileNum
 
 namespace MultipleScheduling {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * multipleScheduling); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool multipleScheduling);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace MultipleScheduling
 
 namespace EnergyFormatting {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * energyFormatting); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t energyFormatting);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EnergyFormatting
 
 namespace EnergyRemote {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * energyRemote); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool energyRemote);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace EnergyRemote
 
 namespace ScheduleMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleMode); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ScheduleMode
 
 } // namespace Attributes
@@ -692,18 +722,18 @@ namespace ApplianceControl {
 namespace Attributes {
 
 namespace StartTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace StartTime
 
 namespace FinishTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * finishTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t finishTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace FinishTime
 
 namespace RemainingTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RemainingTime
 
 } // namespace Attributes
@@ -719,38 +749,38 @@ namespace PollControl {
 namespace Attributes {
 
 namespace CheckInInterval {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInInterval); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInInterval);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace CheckInInterval
 
 namespace LongPollInterval {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollInterval); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollInterval);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace LongPollInterval
 
 namespace ShortPollInterval {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * shortPollInterval); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t shortPollInterval);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ShortPollInterval
 
 namespace FastPollTimeout {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeout); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeout);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace FastPollTimeout
 
 namespace CheckInIntervalMin {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * checkInIntervalMin); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t checkInIntervalMin);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace CheckInIntervalMin
 
 namespace LongPollIntervalMin {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * longPollIntervalMin); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t longPollIntervalMin);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace LongPollIntervalMin
 
 namespace FastPollTimeoutMax {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * fastPollTimeoutMax); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t fastPollTimeoutMax);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace FastPollTimeoutMax
 
 } // namespace Attributes
@@ -760,38 +790,93 @@ namespace Basic {
 namespace Attributes {
 
 namespace InteractionModelVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * interactionModelVersion); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t interactionModelVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace InteractionModelVersion
 
+namespace VendorName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace VendorName
+
 namespace VendorID {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace VendorID
 
+namespace ProductName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ProductName
+
 namespace ProductID {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productID); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productID);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ProductID
 
+namespace UserLabel {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace UserLabel
+
+namespace Location {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Location
+
 namespace HardwareVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace HardwareVersion
 
+namespace HardwareVersionString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace HardwareVersionString
+
 namespace SoftwareVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace SoftwareVersion
 
+namespace SoftwareVersionString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace SoftwareVersionString
+
+namespace ManufacturingDate {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ManufacturingDate
+
+namespace PartNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace PartNumber
+
+namespace ProductURL {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ProductURL
+
+namespace ProductLabel {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ProductLabel
+
+namespace SerialNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace SerialNumber
+
 namespace LocalConfigDisabled {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * localConfigDisabled); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool localConfigDisabled);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace LocalConfigDisabled
 
 namespace Reachable {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool reachable);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace Reachable
 
 } // namespace Attributes
@@ -800,9 +885,14 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool reachable);
 namespace OtaSoftwareUpdateRequestor {
 namespace Attributes {
 
+namespace DefaultOtaProvider {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace DefaultOtaProvider
+
 namespace UpdatePossible {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * updatePossible); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool updatePossible);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace UpdatePossible
 
 } // namespace Attributes
@@ -812,123 +902,143 @@ namespace PowerSource {
 namespace Attributes {
 
 namespace Status {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Status
 
 namespace Order {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * order); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t order);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Order
 
+namespace Description {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Description
+
 namespace WiredAssessedInputVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedInputVoltage); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedInputVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace WiredAssessedInputVoltage
 
 namespace WiredAssessedInputFrequency {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * wiredAssessedInputFrequency); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t wiredAssessedInputFrequency);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace WiredAssessedInputFrequency
 
 namespace WiredCurrentType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiredCurrentType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiredCurrentType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace WiredCurrentType
 
 namespace WiredAssessedCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredAssessedCurrent); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredAssessedCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace WiredAssessedCurrent
 
 namespace WiredNominalVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredNominalVoltage); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredNominalVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace WiredNominalVoltage
 
 namespace WiredMaximumCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * wiredMaximumCurrent); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t wiredMaximumCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace WiredMaximumCurrent
 
 namespace WiredPresent {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * wiredPresent); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool wiredPresent);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace WiredPresent
 
 namespace BatteryVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryVoltage); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryVoltage
 
 namespace BatteryPercentRemaining {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryPercentRemaining); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryPercentRemaining);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryPercentRemaining
 
 namespace BatteryTimeRemaining {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeRemaining); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeRemaining);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryTimeRemaining
 
 namespace BatteryChargeLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeLevel); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryChargeLevel
 
 namespace BatteryReplacementNeeded {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryReplacementNeeded); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool batteryReplacementNeeded);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace BatteryReplacementNeeded
 
 namespace BatteryReplaceability {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryReplaceability); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryReplaceability);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryReplaceability
 
 namespace BatteryPresent {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryPresent); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool batteryPresent);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace BatteryPresent
 
+namespace BatteryReplacementDescription {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace BatteryReplacementDescription
+
 namespace BatteryCommonDesignation {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCommonDesignation); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCommonDesignation);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryCommonDesignation
 
+namespace BatteryANSIDesignation {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace BatteryANSIDesignation
+
+namespace BatteryIECDesignation {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace BatteryIECDesignation
+
 namespace BatteryApprovedChemistry {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryApprovedChemistry); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryApprovedChemistry);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryApprovedChemistry
 
 namespace BatteryCapacity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryCapacity); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryCapacity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryCapacity
 
 namespace BatteryQuantity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryQuantity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryQuantity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryQuantity
 
 namespace BatteryChargeState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * batteryChargeState); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t batteryChargeState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BatteryChargeState
 
 namespace BatteryTimeToFullCharge {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryTimeToFullCharge); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryTimeToFullCharge);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryTimeToFullCharge
 
 namespace BatteryFunctionalWhileCharging {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * batteryFunctionalWhileCharging); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool batteryFunctionalWhileCharging);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace BatteryFunctionalWhileCharging
 
 namespace BatteryChargingCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * batteryChargingCurrent); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t batteryChargingCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BatteryChargingCurrent
 
 } // namespace Attributes
@@ -938,8 +1048,8 @@ namespace GeneralCommissioning {
 namespace Attributes {
 
 namespace Breadcrumb {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * breadcrumb); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t breadcrumb);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace Breadcrumb
 
 } // namespace Attributes
@@ -949,23 +1059,23 @@ namespace GeneralDiagnostics {
 namespace Attributes {
 
 namespace RebootCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rebootCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rebootCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RebootCount
 
 namespace UpTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * upTime); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t upTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace UpTime
 
 namespace TotalOperationalHours {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalOperationalHours); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalOperationalHours);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TotalOperationalHours
 
 namespace BootReasons {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bootReasons); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bootReasons);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BootReasons
 
 } // namespace Attributes
@@ -975,18 +1085,18 @@ namespace SoftwareDiagnostics {
 namespace Attributes {
 
 namespace CurrentHeapFree {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapFree); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapFree);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace CurrentHeapFree
 
 namespace CurrentHeapUsed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapUsed); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapUsed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace CurrentHeapUsed
 
 namespace CurrentHeapHighWatermark {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentHeapHighWatermark); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentHeapHighWatermark);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace CurrentHeapHighWatermark
 
 } // namespace Attributes
@@ -996,279 +1106,294 @@ namespace ThreadNetworkDiagnostics {
 namespace Attributes {
 
 namespace Channel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * channel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t channel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Channel
 
 namespace RoutingRole {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * routingRole); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t routingRole);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace RoutingRole
 
+namespace NetworkName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace NetworkName
+
 namespace PanId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * panId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t panId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PanId
 
 namespace ExtendedPanId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * extendedPanId); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t extendedPanId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace ExtendedPanId
 
+namespace MeshLocalPrefix {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace MeshLocalPrefix
+
 namespace OverrunCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace OverrunCount
 
 namespace PartitionId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * partitionId); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t partitionId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PartitionId
 
 namespace Weighting {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * weighting); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t weighting);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Weighting
 
 namespace DataVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dataVersion); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dataVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DataVersion
 
 namespace StableDataVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * stableDataVersion); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t stableDataVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace StableDataVersion
 
 namespace LeaderRouterId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * leaderRouterId); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t leaderRouterId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LeaderRouterId
 
 namespace DetachedRoleCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * detachedRoleCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t detachedRoleCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DetachedRoleCount
 
 namespace ChildRoleCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * childRoleCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t childRoleCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ChildRoleCount
 
 namespace RouterRoleCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * routerRoleCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t routerRoleCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RouterRoleCount
 
 namespace LeaderRoleCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * leaderRoleCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t leaderRoleCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace LeaderRoleCount
 
 namespace AttachAttemptCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * attachAttemptCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t attachAttemptCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AttachAttemptCount
 
 namespace PartitionIdChangeCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * partitionIdChangeCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t partitionIdChangeCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PartitionIdChangeCount
 
 namespace BetterPartitionAttachAttemptCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * betterPartitionAttachAttemptCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t betterPartitionAttachAttemptCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BetterPartitionAttachAttemptCount
 
 namespace ParentChangeCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * parentChangeCount); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t parentChangeCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ParentChangeCount
 
 namespace TxTotalCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txTotalCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txTotalCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxTotalCount
 
 namespace TxUnicastCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txUnicastCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txUnicastCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxUnicastCount
 
 namespace TxBroadcastCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBroadcastCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBroadcastCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxBroadcastCount
 
 namespace TxAckRequestedCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckRequestedCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckRequestedCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxAckRequestedCount
 
 namespace TxAckedCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txAckedCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txAckedCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxAckedCount
 
 namespace TxNoAckRequestedCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txNoAckRequestedCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txNoAckRequestedCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxNoAckRequestedCount
 
 namespace TxDataCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxDataCount
 
 namespace TxDataPollCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDataPollCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDataPollCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxDataPollCount
 
 namespace TxBeaconCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxBeaconCount
 
 namespace TxBeaconRequestCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txBeaconRequestCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txBeaconRequestCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxBeaconRequestCount
 
 namespace TxOtherCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txOtherCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txOtherCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxOtherCount
 
 namespace TxRetryCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txRetryCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txRetryCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxRetryCount
 
 namespace TxDirectMaxRetryExpiryCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txDirectMaxRetryExpiryCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txDirectMaxRetryExpiryCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxDirectMaxRetryExpiryCount
 
 namespace TxIndirectMaxRetryExpiryCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txIndirectMaxRetryExpiryCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txIndirectMaxRetryExpiryCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxIndirectMaxRetryExpiryCount
 
 namespace TxErrCcaCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrCcaCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrCcaCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxErrCcaCount
 
 namespace TxErrAbortCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrAbortCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrAbortCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxErrAbortCount
 
 namespace TxErrBusyChannelCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * txErrBusyChannelCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t txErrBusyChannelCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TxErrBusyChannelCount
 
 namespace RxTotalCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxTotalCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxTotalCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxTotalCount
 
 namespace RxUnicastCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxUnicastCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxUnicastCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxUnicastCount
 
 namespace RxBroadcastCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBroadcastCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBroadcastCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxBroadcastCount
 
 namespace RxDataCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxDataCount
 
 namespace RxDataPollCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDataPollCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDataPollCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxDataPollCount
 
 namespace RxBeaconCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxBeaconCount
 
 namespace RxBeaconRequestCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxBeaconRequestCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxBeaconRequestCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxBeaconRequestCount
 
 namespace RxOtherCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxOtherCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxOtherCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxOtherCount
 
 namespace RxAddressFilteredCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxAddressFilteredCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxAddressFilteredCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxAddressFilteredCount
 
 namespace RxDestAddrFilteredCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDestAddrFilteredCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDestAddrFilteredCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxDestAddrFilteredCount
 
 namespace RxDuplicatedCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxDuplicatedCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxDuplicatedCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxDuplicatedCount
 
 namespace RxErrNoFrameCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrNoFrameCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrNoFrameCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxErrNoFrameCount
 
 namespace RxErrUnknownNeighborCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrUnknownNeighborCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrUnknownNeighborCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxErrUnknownNeighborCount
 
 namespace RxErrInvalidSrcAddrCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrInvalidSrcAddrCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrInvalidSrcAddrCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxErrInvalidSrcAddrCount
 
 namespace RxErrSecCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrSecCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrSecCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxErrSecCount
 
 namespace RxErrFcsCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrFcsCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrFcsCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxErrFcsCount
 
 namespace RxErrOtherCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * rxErrOtherCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t rxErrOtherCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace RxErrOtherCount
 
 namespace ActiveTimestamp {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * activeTimestamp); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t activeTimestamp);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace ActiveTimestamp
 
 namespace PendingTimestamp {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * pendingTimestamp); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t pendingTimestamp);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace PendingTimestamp
 
 namespace Delay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * delay); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t delay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace Delay
+
+namespace ChannelMask {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace ChannelMask
 
 } // namespace Attributes
 } // namespace ThreadNetworkDiagnostics
@@ -1276,64 +1401,69 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint32_t delay);
 namespace WiFiNetworkDiagnostics {
 namespace Attributes {
 
+namespace Bssid {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace Bssid
+
 namespace SecurityType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * securityType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t securityType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SecurityType
 
 namespace WiFiVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wiFiVersion); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wiFiVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace WiFiVersion
 
 namespace ChannelNumber {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * channelNumber); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t channelNumber);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ChannelNumber
 
 namespace Rssi {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * rssi); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t rssi);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace Rssi
 
 namespace BeaconLostCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconLostCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconLostCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BeaconLostCount
 
 namespace BeaconRxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * beaconRxCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t beaconRxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace BeaconRxCount
 
 namespace PacketMulticastRxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastRxCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastRxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PacketMulticastRxCount
 
 namespace PacketMulticastTxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetMulticastTxCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetMulticastTxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PacketMulticastTxCount
 
 namespace PacketUnicastRxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastRxCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastRxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PacketUnicastRxCount
 
 namespace PacketUnicastTxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * packetUnicastTxCount); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t packetUnicastTxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PacketUnicastTxCount
 
 namespace CurrentMaxRate {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * currentMaxRate); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t currentMaxRate);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace CurrentMaxRate
 
 namespace OverrunCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace OverrunCount
 
 } // namespace Attributes
@@ -1343,48 +1473,48 @@ namespace EthernetNetworkDiagnostics {
 namespace Attributes {
 
 namespace PHYRate {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * PHYRate); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t PHYRate);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PHYRate
 
 namespace FullDuplex {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * fullDuplex); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool fullDuplex);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace FullDuplex
 
 namespace PacketRxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetRxCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetRxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace PacketRxCount
 
 namespace PacketTxCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * packetTxCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t packetTxCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace PacketTxCount
 
 namespace TxErrCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * txErrCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t txErrCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace TxErrCount
 
 namespace CollisionCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * collisionCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t collisionCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace CollisionCount
 
 namespace OverrunCount {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t overrunCount);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace OverrunCount
 
 namespace CarrierDetect {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * carrierDetect); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool carrierDetect);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace CarrierDetect
 
 namespace TimeSinceReset {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * timeSinceReset); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t timeSinceReset);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace TimeSinceReset
 
 } // namespace Attributes
@@ -1393,24 +1523,74 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint64_t timeSinceReset);
 namespace BridgedDeviceBasic {
 namespace Attributes {
 
+namespace VendorName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace VendorName
+
 namespace VendorID {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorID); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorID);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace VendorID
 
+namespace ProductName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ProductName
+
+namespace UserLabel {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace UserLabel
+
 namespace HardwareVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hardwareVersion); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hardwareVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace HardwareVersion
 
+namespace HardwareVersionString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace HardwareVersionString
+
 namespace SoftwareVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t softwareVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace SoftwareVersion
 
+namespace SoftwareVersionString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace SoftwareVersionString
+
+namespace ManufacturingDate {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ManufacturingDate
+
+namespace PartNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace PartNumber
+
+namespace ProductURL {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ProductURL
+
+namespace ProductLabel {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ProductLabel
+
+namespace SerialNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace SerialNumber
+
 namespace Reachable {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * reachable); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool reachable);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace Reachable
 
 } // namespace Attributes
@@ -1420,18 +1600,18 @@ namespace Switch {
 namespace Attributes {
 
 namespace NumberOfPositions {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPositions); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPositions);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumberOfPositions
 
 namespace CurrentPosition {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPosition); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPosition);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentPosition
 
 namespace MultiPressMax {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * multiPressMax); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t multiPressMax);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MultiPressMax
 
 } // namespace Attributes
@@ -1441,13 +1621,13 @@ namespace OperationalCredentials {
 namespace Attributes {
 
 namespace SupportedFabrics {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * supportedFabrics); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t supportedFabrics);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SupportedFabrics
 
 namespace CommissionedFabrics {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * commissionedFabrics); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t commissionedFabrics);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CommissionedFabrics
 
 } // namespace Attributes
@@ -1463,8 +1643,8 @@ namespace BooleanState {
 namespace Attributes {
 
 namespace StateValue {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * stateValue); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool stateValue);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace StateValue
 
 } // namespace Attributes
@@ -1474,28 +1654,28 @@ namespace ShadeConfiguration {
 namespace Attributes {
 
 namespace PhysicalClosedLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimit); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PhysicalClosedLimit
 
 namespace MotorStepSize {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * motorStepSize); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t motorStepSize);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MotorStepSize
 
 namespace Status {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * status); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t status);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Status
 
 namespace ClosedLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * closedLimit); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t closedLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ClosedLimit
 
 namespace Mode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Mode
 
 } // namespace Attributes
@@ -1505,213 +1685,218 @@ namespace DoorLock {
 namespace Attributes {
 
 namespace LockState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockState); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LockState
 
 namespace LockType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lockType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lockType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LockType
 
 namespace ActuatorEnabled {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * actuatorEnabled); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool actuatorEnabled);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace ActuatorEnabled
 
 namespace DoorState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * doorState); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t doorState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DoorState
 
 namespace DoorOpenEvents {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorOpenEvents); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorOpenEvents);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace DoorOpenEvents
 
 namespace DoorClosedEvents {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * doorClosedEvents); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t doorClosedEvents);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace DoorClosedEvents
 
 namespace OpenPeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * openPeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t openPeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace OpenPeriod
 
 namespace NumLockRecordsSupported {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numLockRecordsSupported); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numLockRecordsSupported);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NumLockRecordsSupported
 
 namespace NumTotalUsersSupported {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numTotalUsersSupported); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numTotalUsersSupported);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NumTotalUsersSupported
 
 namespace NumPinUsersSupported {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numPinUsersSupported); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numPinUsersSupported);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NumPinUsersSupported
 
 namespace NumRfidUsersSupported {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numRfidUsersSupported); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numRfidUsersSupported);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NumRfidUsersSupported
 
 namespace NumWeekdaySchedulesSupportedPerUser {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numWeekdaySchedulesSupportedPerUser); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numWeekdaySchedulesSupportedPerUser);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumWeekdaySchedulesSupportedPerUser
 
 namespace NumYeardaySchedulesSupportedPerUser {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numYeardaySchedulesSupportedPerUser); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numYeardaySchedulesSupportedPerUser);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumYeardaySchedulesSupportedPerUser
 
 namespace NumHolidaySchedulesSupportedPerUser {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numHolidaySchedulesSupportedPerUser); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numHolidaySchedulesSupportedPerUser);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumHolidaySchedulesSupportedPerUser
 
 namespace MaxPinLength {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxPinLength); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxPinLength);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MaxPinLength
 
 namespace MinPinLength {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minPinLength); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minPinLength);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MinPinLength
 
 namespace MaxRfidCodeLength {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxRfidCodeLength); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxRfidCodeLength);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MaxRfidCodeLength
 
 namespace MinRfidCodeLength {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minRfidCodeLength); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minRfidCodeLength);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MinRfidCodeLength
 
 namespace EnableLogging {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLogging); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableLogging);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace EnableLogging
 
+namespace Language {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Language
+
 namespace LedSettings {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ledSettings); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ledSettings);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LedSettings
 
 namespace AutoRelockTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * autoRelockTime); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t autoRelockTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace AutoRelockTime
 
 namespace SoundVolume {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * soundVolume); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t soundVolume);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SoundVolume
 
 namespace OperatingMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operatingMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operatingMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OperatingMode
 
 namespace SupportedOperatingModes {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * supportedOperatingModes); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t supportedOperatingModes);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace SupportedOperatingModes
 
 namespace DefaultConfigurationRegister {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DefaultConfigurationRegister
 
 namespace EnableLocalProgramming {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableLocalProgramming); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableLocalProgramming);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace EnableLocalProgramming
 
 namespace EnableOneTouchLocking {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableOneTouchLocking); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableOneTouchLocking);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace EnableOneTouchLocking
 
 namespace EnableInsideStatusLed {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enableInsideStatusLed); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool enableInsideStatusLed);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace EnableInsideStatusLed
 
 namespace EnablePrivacyModeButton {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * enablePrivacyModeButton); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool enablePrivacyModeButton);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace EnablePrivacyModeButton
 
 namespace WrongCodeEntryLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace WrongCodeEntryLimit
 
 namespace UserCodeTemporaryDisableTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace UserCodeTemporaryDisableTime
 
 namespace SendPinOverTheAir {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * sendPinOverTheAir); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool sendPinOverTheAir);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace SendPinOverTheAir
 
 namespace RequirePinForRfOperation {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * requirePinForRfOperation); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool requirePinForRfOperation);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace RequirePinForRfOperation
 
 namespace ZigbeeSecurityLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ZigbeeSecurityLevel
 
 namespace AlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AlarmMask
 
 namespace KeypadOperationEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadOperationEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadOperationEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace KeypadOperationEventMask
 
 namespace RfOperationEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfOperationEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfOperationEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RfOperationEventMask
 
 namespace ManualOperationEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * manualOperationEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t manualOperationEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ManualOperationEventMask
 
 namespace RfidOperationEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidOperationEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidOperationEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RfidOperationEventMask
 
 namespace KeypadProgrammingEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * keypadProgrammingEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t keypadProgrammingEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace KeypadProgrammingEventMask
 
 namespace RfProgrammingEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfProgrammingEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfProgrammingEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RfProgrammingEventMask
 
 namespace RfidProgrammingEventMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rfidProgrammingEventMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rfidProgrammingEventMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RfidProgrammingEventMask
 
 } // namespace Attributes
@@ -1721,128 +1906,138 @@ namespace WindowCovering {
 namespace Attributes {
 
 namespace Type {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * type); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t type);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Type
 
 namespace PhysicalClosedLimitLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PhysicalClosedLimitLift
 
 namespace PhysicalClosedLimitTilt {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalClosedLimitTilt); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalClosedLimitTilt);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PhysicalClosedLimitTilt
 
 namespace CurrentPositionLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentPositionLift
 
 namespace CurrentPositionTilt {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTilt); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTilt);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentPositionTilt
 
 namespace NumberOfActuationsLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NumberOfActuationsLift
 
 namespace NumberOfActuationsTilt {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * numberOfActuationsTilt); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t numberOfActuationsTilt);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NumberOfActuationsTilt
 
 namespace ConfigStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * configStatus); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t configStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ConfigStatus
 
 namespace CurrentPositionLiftPercentage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionLiftPercentage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionLiftPercentage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentPositionLiftPercentage
 
 namespace CurrentPositionTiltPercentage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentPositionTiltPercentage); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentPositionTiltPercentage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentPositionTiltPercentage
 
 namespace OperationalStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationalStatus); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationalStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OperationalStatus
 
 namespace TargetPositionLiftPercent100ths {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionLiftPercent100ths); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionLiftPercent100ths);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace TargetPositionLiftPercent100ths
 
 namespace TargetPositionTiltPercent100ths {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * targetPositionTiltPercent100ths); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t targetPositionTiltPercent100ths);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace TargetPositionTiltPercent100ths
 
 namespace EndProductType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * endProductType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t endProductType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EndProductType
 
 namespace CurrentPositionLiftPercent100ths {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionLiftPercent100ths); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionLiftPercent100ths);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentPositionLiftPercent100ths
 
 namespace CurrentPositionTiltPercent100ths {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentPositionTiltPercent100ths); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentPositionTiltPercent100ths);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentPositionTiltPercent100ths
 
 namespace InstalledOpenLimitLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace InstalledOpenLimitLift
 
 namespace InstalledClosedLimitLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace InstalledClosedLimitLift
 
 namespace InstalledOpenLimitTilt {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedOpenLimitTilt); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedOpenLimitTilt);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace InstalledOpenLimitTilt
 
 namespace InstalledClosedLimitTilt {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * installedClosedLimitTilt); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t installedClosedLimitTilt);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace InstalledClosedLimitTilt
 
 namespace VelocityLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * velocityLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t velocityLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace VelocityLift
 
 namespace AccelerationTimeLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * accelerationTimeLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t accelerationTimeLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AccelerationTimeLift
 
 namespace DecelerationTimeLift {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * decelerationTimeLift); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t decelerationTimeLift);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DecelerationTimeLift
 
 namespace Mode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * mode); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t mode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Mode
 
+namespace IntermediateSetpointsLift {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace IntermediateSetpointsLift
+
+namespace IntermediateSetpointsTilt {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace IntermediateSetpointsTilt
+
 namespace SafetyStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * safetyStatus); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t safetyStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace SafetyStatus
 
 } // namespace Attributes
@@ -1852,53 +2047,53 @@ namespace BarrierControl {
 namespace Attributes {
 
 namespace BarrierMovingState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierMovingState); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierMovingState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BarrierMovingState
 
 namespace BarrierSafetyStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierSafetyStatus); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierSafetyStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierSafetyStatus
 
 namespace BarrierCapabilities {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierCapabilities); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierCapabilities);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BarrierCapabilities
 
 namespace BarrierOpenEvents {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenEvents); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenEvents);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierOpenEvents
 
 namespace BarrierCloseEvents {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCloseEvents); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCloseEvents);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierCloseEvents
 
 namespace BarrierCommandOpenEvents {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandOpenEvents); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandOpenEvents);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierCommandOpenEvents
 
 namespace BarrierCommandCloseEvents {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierCommandCloseEvents); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierCommandCloseEvents);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierCommandCloseEvents
 
 namespace BarrierOpenPeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierOpenPeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierOpenPeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierOpenPeriod
 
 namespace BarrierClosePeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * barrierClosePeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t barrierClosePeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BarrierClosePeriod
 
 namespace BarrierPosition {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * barrierPosition); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t barrierPosition);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BarrierPosition
 
 } // namespace Attributes
@@ -1908,113 +2103,113 @@ namespace PumpConfigurationAndControl {
 namespace Attributes {
 
 namespace MaxPressure {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxPressure); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxPressure);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxPressure
 
 namespace MaxSpeed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxSpeed); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxSpeed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxSpeed
 
 namespace MaxFlow {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxFlow); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxFlow);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxFlow
 
 namespace MinConstPressure {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstPressure); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstPressure);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinConstPressure
 
 namespace MaxConstPressure {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstPressure); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstPressure);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxConstPressure
 
 namespace MinCompPressure {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCompPressure); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCompPressure);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinCompPressure
 
 namespace MaxCompPressure {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCompPressure); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCompPressure);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxCompPressure
 
 namespace MinConstSpeed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstSpeed); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstSpeed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MinConstSpeed
 
 namespace MaxConstSpeed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstSpeed); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstSpeed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxConstSpeed
 
 namespace MinConstFlow {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minConstFlow); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minConstFlow);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MinConstFlow
 
 namespace MaxConstFlow {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxConstFlow); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxConstFlow);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxConstFlow
 
 namespace MinConstTemp {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minConstTemp); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minConstTemp);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinConstTemp
 
 namespace MaxConstTemp {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxConstTemp); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxConstTemp);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxConstTemp
 
 namespace PumpStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pumpStatus); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pumpStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PumpStatus
 
 namespace EffectiveOperationMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveOperationMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveOperationMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EffectiveOperationMode
 
 namespace EffectiveControlMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * effectiveControlMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t effectiveControlMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EffectiveControlMode
 
 namespace Capacity {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * capacity); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t capacity);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Capacity
 
 namespace Speed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * speed); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t speed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Speed
 
 namespace LifetimeEnergyConsumed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * lifetimeEnergyConsumed); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t lifetimeEnergyConsumed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace LifetimeEnergyConsumed
 
 namespace OperationMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * operationMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t operationMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OperationMode
 
 namespace ControlMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ControlMode
 
 namespace AlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t alarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AlarmMask
 
 } // namespace Attributes
@@ -2024,218 +2219,218 @@ namespace Thermostat {
 namespace Attributes {
 
 namespace LocalTemperature {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * localTemperature); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t localTemperature);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace LocalTemperature
 
 namespace OutdoorTemperature {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * outdoorTemperature); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t outdoorTemperature);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace OutdoorTemperature
 
 namespace Occupancy {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Occupancy
 
 namespace AbsMinHeatSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinHeatSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinHeatSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AbsMinHeatSetpointLimit
 
 namespace AbsMaxHeatSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxHeatSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxHeatSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AbsMaxHeatSetpointLimit
 
 namespace AbsMinCoolSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMinCoolSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMinCoolSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AbsMinCoolSetpointLimit
 
 namespace AbsMaxCoolSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * absMaxCoolSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t absMaxCoolSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AbsMaxCoolSetpointLimit
 
 namespace PiCoolingDemand {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piCoolingDemand); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piCoolingDemand);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PiCoolingDemand
 
 namespace PiHeatingDemand {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * piHeatingDemand); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t piHeatingDemand);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PiHeatingDemand
 
 namespace HvacSystemTypeConfiguration {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * hvacSystemTypeConfiguration); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t hvacSystemTypeConfiguration);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace HvacSystemTypeConfiguration
 
 namespace LocalTemperatureCalibration {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * localTemperatureCalibration); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t localTemperatureCalibration);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace LocalTemperatureCalibration
 
 namespace OccupiedCoolingSetpoint {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedCoolingSetpoint); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedCoolingSetpoint);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace OccupiedCoolingSetpoint
 
 namespace OccupiedHeatingSetpoint {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * occupiedHeatingSetpoint); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t occupiedHeatingSetpoint);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace OccupiedHeatingSetpoint
 
 namespace UnoccupiedCoolingSetpoint {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedCoolingSetpoint); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedCoolingSetpoint);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace UnoccupiedCoolingSetpoint
 
 namespace UnoccupiedHeatingSetpoint {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * unoccupiedHeatingSetpoint); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t unoccupiedHeatingSetpoint);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace UnoccupiedHeatingSetpoint
 
 namespace MinHeatSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minHeatSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minHeatSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinHeatSetpointLimit
 
 namespace MaxHeatSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxHeatSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxHeatSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxHeatSetpointLimit
 
 namespace MinCoolSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minCoolSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minCoolSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinCoolSetpointLimit
 
 namespace MaxCoolSetpointLimit {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxCoolSetpointLimit); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxCoolSetpointLimit);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxCoolSetpointLimit
 
 namespace MinSetpointDeadBand {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * minSetpointDeadBand); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t minSetpointDeadBand);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace MinSetpointDeadBand
 
 namespace RemoteSensing {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * remoteSensing); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t remoteSensing);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace RemoteSensing
 
 namespace ControlSequenceOfOperation {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * controlSequenceOfOperation); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t controlSequenceOfOperation);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ControlSequenceOfOperation
 
 namespace SystemMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * systemMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t systemMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SystemMode
 
 namespace AlarmMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * alarmMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t alarmMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace AlarmMask
 
 namespace ThermostatRunningMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatRunningMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatRunningMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ThermostatRunningMode
 
 namespace StartOfWeek {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * startOfWeek); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t startOfWeek);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace StartOfWeek
 
 namespace NumberOfWeeklyTransitions {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfWeeklyTransitions); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfWeeklyTransitions);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumberOfWeeklyTransitions
 
 namespace NumberOfDailyTransitions {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfDailyTransitions); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfDailyTransitions);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumberOfDailyTransitions
 
 namespace TemperatureSetpointHold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureSetpointHold); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureSetpointHold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace TemperatureSetpointHold
 
 namespace TemperatureSetpointHoldDuration {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * temperatureSetpointHoldDuration); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t temperatureSetpointHoldDuration);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace TemperatureSetpointHoldDuration
 
 namespace ThermostatProgrammingOperationMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * thermostatProgrammingOperationMode); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t thermostatProgrammingOperationMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ThermostatProgrammingOperationMode
 
 namespace HvacRelayState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * hvacRelayState); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t hvacRelayState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace HvacRelayState
 
 namespace SetpointChangeSource {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * setpointChangeSource); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t setpointChangeSource);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace SetpointChangeSource
 
 namespace SetpointChangeAmount {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * setpointChangeAmount); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t setpointChangeAmount);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace SetpointChangeAmount
 
 namespace SetpointChangeSourceTimestamp {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * setpointChangeSourceTimestamp); // epoch_s
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t setpointChangeSourceTimestamp);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // epoch_s
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace SetpointChangeSourceTimestamp
 
 namespace AcType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace AcType
 
 namespace AcCapacity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCapacity); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCapacity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcCapacity
 
 namespace AcRefrigerantType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acRefrigerantType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acRefrigerantType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace AcRefrigerantType
 
 namespace AcCompressor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCompressor); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCompressor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace AcCompressor
 
 namespace AcErrorCode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * acErrorCode); // bitmap32
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t acErrorCode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace AcErrorCode
 
 namespace AcLouverPosition {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acLouverPosition); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acLouverPosition);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace AcLouverPosition
 
 namespace AcCoilTemperature {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCoilTemperature); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCoilTemperature);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AcCoilTemperature
 
 namespace AcCapacityFormat {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * acCapacityFormat); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t acCapacityFormat);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace AcCapacityFormat
 
 } // namespace Attributes
@@ -2245,13 +2440,13 @@ namespace FanControl {
 namespace Attributes {
 
 namespace FanMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace FanMode
 
 namespace FanModeSequence {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * fanModeSequence); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t fanModeSequence);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace FanModeSequence
 
 } // namespace Attributes
@@ -2261,43 +2456,43 @@ namespace DehumidificationControl {
 namespace Attributes {
 
 namespace RelativeHumidity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace RelativeHumidity
 
 namespace DehumidificationCooling {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationCooling); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationCooling);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DehumidificationCooling
 
 namespace RhDehumidificationSetpoint {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * rhDehumidificationSetpoint); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t rhDehumidificationSetpoint);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace RhDehumidificationSetpoint
 
 namespace RelativeHumidityMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace RelativeHumidityMode
 
 namespace DehumidificationLockout {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationLockout); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationLockout);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DehumidificationLockout
 
 namespace DehumidificationHysteresis {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationHysteresis); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationHysteresis);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DehumidificationHysteresis
 
 namespace DehumidificationMaxCool {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * dehumidificationMaxCool); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t dehumidificationMaxCool);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DehumidificationMaxCool
 
 namespace RelativeHumidityDisplay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * relativeHumidityDisplay); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t relativeHumidityDisplay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace RelativeHumidityDisplay
 
 } // namespace Attributes
@@ -2307,18 +2502,18 @@ namespace ThermostatUserInterfaceConfiguration {
 namespace Attributes {
 
 namespace TemperatureDisplayMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * temperatureDisplayMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t temperatureDisplayMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace TemperatureDisplayMode
 
 namespace KeypadLockout {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * keypadLockout); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t keypadLockout);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace KeypadLockout
 
 namespace ScheduleProgrammingVisibility {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * scheduleProgrammingVisibility); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t scheduleProgrammingVisibility);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ScheduleProgrammingVisibility
 
 } // namespace Attributes
@@ -2328,258 +2523,263 @@ namespace ColorControl {
 namespace Attributes {
 
 namespace CurrentHue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentHue); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentHue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentHue
 
 namespace CurrentSaturation {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentSaturation); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentSaturation);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentSaturation
 
 namespace RemainingTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * remainingTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t remainingTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RemainingTime
 
 namespace CurrentX {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentX); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentX);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentX
 
 namespace CurrentY {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * currentY); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t currentY);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CurrentY
 
 namespace DriftCompensation {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * driftCompensation); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t driftCompensation);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace DriftCompensation
 
+namespace CompensationText {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace CompensationText
+
 namespace ColorTemperature {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTemperature); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTemperature);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorTemperature
 
 namespace ColorMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorMode
 
 namespace ColorControlOptions {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorControlOptions); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorControlOptions);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorControlOptions
 
 namespace NumberOfPrimaries {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfPrimaries); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfPrimaries);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumberOfPrimaries
 
 namespace Primary1X {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1X); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1X);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary1X
 
 namespace Primary1Y {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary1Y); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary1Y);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary1Y
 
 namespace Primary1Intensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary1Intensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary1Intensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Primary1Intensity
 
 namespace Primary2X {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2X); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2X);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary2X
 
 namespace Primary2Y {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary2Y); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary2Y);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary2Y
 
 namespace Primary2Intensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary2Intensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary2Intensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Primary2Intensity
 
 namespace Primary3X {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3X); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3X);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary3X
 
 namespace Primary3Y {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary3Y); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary3Y);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary3Y
 
 namespace Primary3Intensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary3Intensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary3Intensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Primary3Intensity
 
 namespace Primary4X {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4X); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4X);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary4X
 
 namespace Primary4Y {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary4Y); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary4Y);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary4Y
 
 namespace Primary4Intensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary4Intensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary4Intensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Primary4Intensity
 
 namespace Primary5X {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5X); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5X);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary5X
 
 namespace Primary5Y {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary5Y); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary5Y);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary5Y
 
 namespace Primary5Intensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary5Intensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary5Intensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Primary5Intensity
 
 namespace Primary6X {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6X); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6X);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary6X
 
 namespace Primary6Y {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * primary6Y); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t primary6Y);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Primary6Y
 
 namespace Primary6Intensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * primary6Intensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t primary6Intensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Primary6Intensity
 
 namespace WhitePointX {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointX); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointX);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace WhitePointX
 
 namespace WhitePointY {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * whitePointY); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t whitePointY);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace WhitePointY
 
 namespace ColorPointRX {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRX); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRX);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorPointRX
 
 namespace ColorPointRY {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointRY); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointRY);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorPointRY
 
 namespace ColorPointRIntensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointRIntensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointRIntensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorPointRIntensity
 
 namespace ColorPointGX {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGX); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGX);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorPointGX
 
 namespace ColorPointGY {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointGY); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointGY);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorPointGY
 
 namespace ColorPointGIntensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointGIntensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointGIntensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorPointGIntensity
 
 namespace ColorPointBX {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBX); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBX);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorPointBX
 
 namespace ColorPointBY {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorPointBY); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorPointBY);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorPointBY
 
 namespace ColorPointBIntensity {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorPointBIntensity); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorPointBIntensity);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorPointBIntensity
 
 namespace EnhancedCurrentHue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enhancedCurrentHue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enhancedCurrentHue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace EnhancedCurrentHue
 
 namespace EnhancedColorMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enhancedColorMode); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enhancedColorMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EnhancedColorMode
 
 namespace ColorLoopActive {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopActive); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopActive);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorLoopActive
 
 namespace ColorLoopDirection {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * colorLoopDirection); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t colorLoopDirection);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ColorLoopDirection
 
 namespace ColorLoopTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorLoopTime
 
 namespace ColorLoopStartEnhancedHue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStartEnhancedHue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStartEnhancedHue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorLoopStartEnhancedHue
 
 namespace ColorLoopStoredEnhancedHue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorLoopStoredEnhancedHue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorLoopStoredEnhancedHue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorLoopStoredEnhancedHue
 
 namespace ColorCapabilities {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorCapabilities); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorCapabilities);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorCapabilities
 
 namespace ColorTempPhysicalMin {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMin); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMin);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorTempPhysicalMin
 
 namespace ColorTempPhysicalMax {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * colorTempPhysicalMax); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t colorTempPhysicalMax);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ColorTempPhysicalMax
 
 namespace CoupleColorTempToLevelMinMireds {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * coupleColorTempToLevelMinMireds); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t coupleColorTempToLevelMinMireds);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CoupleColorTempToLevelMinMireds
 
 namespace StartUpColorTemperatureMireds {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * startUpColorTemperatureMireds); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t startUpColorTemperatureMireds);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace StartUpColorTemperatureMireds
 
 } // namespace Attributes
@@ -2589,58 +2789,68 @@ namespace BallastConfiguration {
 namespace Attributes {
 
 namespace PhysicalMinLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMinLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMinLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PhysicalMinLevel
 
 namespace PhysicalMaxLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalMaxLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalMaxLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PhysicalMaxLevel
 
 namespace BallastStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastStatus); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BallastStatus
 
 namespace MinLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * minLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t minLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MinLevel
 
 namespace MaxLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * maxLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t maxLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace MaxLevel
 
 namespace PowerOnLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * powerOnLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t powerOnLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PowerOnLevel
 
 namespace PowerOnFadeTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * powerOnFadeTime); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t powerOnFadeTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PowerOnFadeTime
 
 namespace IntrinsicBallastFactor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * intrinsicBallastFactor); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t intrinsicBallastFactor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace IntrinsicBallastFactor
 
 namespace BallastFactorAdjustment {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ballastFactorAdjustment); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ballastFactorAdjustment);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace BallastFactorAdjustment
 
 namespace LampQuality {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampQuality); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampQuality);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LampQuality
 
+namespace LampType {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace LampType
+
+namespace LampManufacturer {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace LampManufacturer
+
 namespace LampAlarmMode {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lampAlarmMode); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lampAlarmMode);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LampAlarmMode
 
 } // namespace Attributes
@@ -2650,28 +2860,28 @@ namespace IlluminanceMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Tolerance
 
 namespace LightSensorType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * lightSensorType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t lightSensorType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LightSensorType
 
 } // namespace Attributes
@@ -2681,23 +2891,23 @@ namespace TemperatureMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2707,48 +2917,48 @@ namespace PressureMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Tolerance
 
 namespace ScaledValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * scaledValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t scaledValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ScaledValue
 
 namespace MinScaledValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minScaledValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minScaledValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinScaledValue
 
 namespace MaxScaledValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxScaledValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxScaledValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxScaledValue
 
 namespace ScaledTolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * scaledTolerance); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t scaledTolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ScaledTolerance
 
 namespace Scale {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * scale); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t scale);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace Scale
 
 } // namespace Attributes
@@ -2758,23 +2968,23 @@ namespace FlowMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * minMeasuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * maxMeasuredValue); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2784,23 +2994,23 @@ namespace RelativeHumidityMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * measuredValue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * minMeasuredValue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxMeasuredValue); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * tolerance); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2810,63 +3020,63 @@ namespace OccupancySensing {
 namespace Attributes {
 
 namespace Occupancy {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancy); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancy);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Occupancy
 
 namespace OccupancySensorType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorType); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OccupancySensorType
 
 namespace OccupancySensorTypeBitmap {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * occupancySensorTypeBitmap); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t occupancySensorTypeBitmap);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OccupancySensorTypeBitmap
 
 namespace PirOccupiedToUnoccupiedDelay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirOccupiedToUnoccupiedDelay); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirOccupiedToUnoccupiedDelay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PirOccupiedToUnoccupiedDelay
 
 namespace PirUnoccupiedToOccupiedDelay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * pirUnoccupiedToOccupiedDelay); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t pirUnoccupiedToOccupiedDelay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PirUnoccupiedToOccupiedDelay
 
 namespace PirUnoccupiedToOccupiedThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * pirUnoccupiedToOccupiedThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t pirUnoccupiedToOccupiedThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PirUnoccupiedToOccupiedThreshold
 
 namespace UltrasonicOccupiedToUnoccupiedDelay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicOccupiedToUnoccupiedDelay); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicOccupiedToUnoccupiedDelay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace UltrasonicOccupiedToUnoccupiedDelay
 
 namespace UltrasonicUnoccupiedToOccupiedDelay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * ultrasonicUnoccupiedToOccupiedDelay); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t ultrasonicUnoccupiedToOccupiedDelay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace UltrasonicUnoccupiedToOccupiedDelay
 
 namespace UltrasonicUnoccupiedToOccupiedThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * ultrasonicUnoccupiedToOccupiedThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t ultrasonicUnoccupiedToOccupiedThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace UltrasonicUnoccupiedToOccupiedThreshold
 
 namespace PhysicalContactOccupiedToUnoccupiedDelay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactOccupiedToUnoccupiedDelay); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactOccupiedToUnoccupiedDelay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PhysicalContactOccupiedToUnoccupiedDelay
 
 namespace PhysicalContactUnoccupiedToOccupiedDelay {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * physicalContactUnoccupiedToOccupiedDelay); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t physicalContactUnoccupiedToOccupiedDelay);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace PhysicalContactUnoccupiedToOccupiedDelay
 
 namespace PhysicalContactUnoccupiedToOccupiedThreshold {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * physicalContactUnoccupiedToOccupiedThreshold); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t physicalContactUnoccupiedToOccupiedThreshold);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PhysicalContactUnoccupiedToOccupiedThreshold
 
 } // namespace Attributes
@@ -2876,23 +3086,23 @@ namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2902,23 +3112,23 @@ namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2928,23 +3138,23 @@ namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2954,23 +3164,23 @@ namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -2980,23 +3190,23 @@ namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3006,23 +3216,23 @@ namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3032,23 +3242,23 @@ namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3058,23 +3268,23 @@ namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3084,23 +3294,23 @@ namespace OxygenConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3110,23 +3320,23 @@ namespace OzoneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3136,23 +3346,23 @@ namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3162,23 +3372,23 @@ namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3188,23 +3398,23 @@ namespace BromateConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3214,23 +3424,23 @@ namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3240,23 +3450,23 @@ namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3266,23 +3476,23 @@ namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3292,23 +3502,23 @@ namespace FluorideConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3318,23 +3528,23 @@ namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3344,23 +3554,23 @@ namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3370,23 +3580,23 @@ namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3396,23 +3606,23 @@ namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3422,23 +3632,23 @@ namespace CopperConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3448,23 +3658,23 @@ namespace LeadConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3474,23 +3684,23 @@ namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3500,23 +3710,23 @@ namespace SulfateConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3526,23 +3736,23 @@ namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3552,23 +3762,23 @@ namespace BromoformConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3578,23 +3788,23 @@ namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3604,23 +3814,23 @@ namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3630,23 +3840,23 @@ namespace SodiumConcentrationMeasurement {
 namespace Attributes {
 
 namespace MeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * measuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float measuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MeasuredValue
 
 namespace MinMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * minMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float minMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MinMeasuredValue
 
 namespace MaxMeasuredValue {
-EmberAfStatus Get(chip::EndpointId endpoint, float * maxMeasuredValue); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float maxMeasuredValue);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace MaxMeasuredValue
 
 namespace Tolerance {
-EmberAfStatus Get(chip::EndpointId endpoint, float * tolerance); // single
-EmberAfStatus Set(chip::EndpointId endpoint, float tolerance);
+EmberAfStatus Get(chip::EndpointId endpoint, float * value); // single
+EmberAfStatus Set(chip::EndpointId endpoint, float value);
 } // namespace Tolerance
 
 } // namespace Attributes
@@ -3656,38 +3866,38 @@ namespace IasZone {
 namespace Attributes {
 
 namespace ZoneState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneState); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ZoneState
 
 namespace ZoneType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneType); // enum16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // enum16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ZoneType
 
 namespace ZoneStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * zoneStatus); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t zoneStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ZoneStatus
 
 namespace IasCieAddress {
-EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * iasCieAddress); // node_id
-EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId iasCieAddress);
+EmberAfStatus Get(chip::EndpointId endpoint, chip::NodeId * value); // node_id
+EmberAfStatus Set(chip::EndpointId endpoint, chip::NodeId value);
 } // namespace IasCieAddress
 
 namespace ZoneId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * zoneId); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t zoneId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ZoneId
 
 namespace NumberOfZoneSensitivityLevelsSupported {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * numberOfZoneSensitivityLevelsSupported); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t numberOfZoneSensitivityLevelsSupported);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace NumberOfZoneSensitivityLevelsSupported
 
 namespace CurrentZoneSensitivityLevel {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentZoneSensitivityLevel); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentZoneSensitivityLevel);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentZoneSensitivityLevel
 
 } // namespace Attributes
@@ -3697,8 +3907,8 @@ namespace IasWd {
 namespace Attributes {
 
 namespace MaxDuration {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * maxDuration); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxDuration);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MaxDuration
 
 } // namespace Attributes
@@ -3707,11 +3917,26 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint16_t maxDuration);
 namespace WakeOnLan {
 namespace Attributes {
 
+namespace WakeOnLanMacAddress {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace WakeOnLanMacAddress
+
 } // namespace Attributes
 } // namespace WakeOnLan
 
 namespace TvChannel {
 namespace Attributes {
+
+namespace TvChannelLineup {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace TvChannelLineup
+
+namespace CurrentTvChannel {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace CurrentTvChannel
 
 } // namespace Attributes
 } // namespace TvChannel
@@ -3720,8 +3945,8 @@ namespace TargetNavigator {
 namespace Attributes {
 
 namespace CurrentNavigatorTarget {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentNavigatorTarget); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentNavigatorTarget);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentNavigatorTarget
 
 } // namespace Attributes
@@ -3731,43 +3956,43 @@ namespace MediaPlayback {
 namespace Attributes {
 
 namespace PlaybackState {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * playbackState); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t playbackState);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace PlaybackState
 
 namespace StartTime {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * startTime); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t startTime);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace StartTime
 
 namespace Duration {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * duration); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t duration);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace Duration
 
 namespace PositionUpdatedAt {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * positionUpdatedAt); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t positionUpdatedAt);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace PositionUpdatedAt
 
 namespace Position {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * position); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t position);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace Position
 
 namespace PlaybackSpeed {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * playbackSpeed); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t playbackSpeed);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace PlaybackSpeed
 
 namespace SeekRangeEnd {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeEnd); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeEnd);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace SeekRangeEnd
 
 namespace SeekRangeStart {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * seekRangeStart); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t seekRangeStart);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace SeekRangeStart
 
 } // namespace Attributes
@@ -3777,8 +4002,8 @@ namespace MediaInput {
 namespace Attributes {
 
 namespace CurrentMediaInput {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentMediaInput); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentMediaInput);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentMediaInput
 
 } // namespace Attributes
@@ -3794,8 +4019,8 @@ namespace AudioOutput {
 namespace Attributes {
 
 namespace CurrentAudioOutput {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * currentAudioOutput); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t currentAudioOutput);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CurrentAudioOutput
 
 } // namespace Attributes
@@ -3805,13 +4030,13 @@ namespace ApplicationLauncher {
 namespace Attributes {
 
 namespace CatalogVendorId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * catalogVendorId); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t catalogVendorId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CatalogVendorId
 
 namespace ApplicationId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationId); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ApplicationId
 
 } // namespace Attributes
@@ -3820,24 +4045,39 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationId);
 namespace ApplicationBasic {
 namespace Attributes {
 
+namespace VendorName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace VendorName
+
 namespace VendorId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * vendorId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t vendorId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace VendorId
 
+namespace ApplicationName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ApplicationName
+
 namespace ProductId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ProductId
 
+namespace ApplicationId {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace ApplicationId
+
 namespace CatalogVendorId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * catalogVendorId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t catalogVendorId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CatalogVendorId
 
 namespace ApplicationStatus {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * applicationStatus); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t applicationStatus);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace ApplicationStatus
 
 } // namespace Attributes
@@ -3847,93 +4087,113 @@ namespace TestCluster {
 namespace Attributes {
 
 namespace Boolean {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * boolean); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool boolean);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace Boolean
 
 namespace Bitmap8 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * bitmap8); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t bitmap8);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Bitmap8
 
 namespace Bitmap16 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * bitmap16); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t bitmap16);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Bitmap16
 
 namespace Bitmap32 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * bitmap32); // bitmap32
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t bitmap32);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace Bitmap32
 
 namespace Bitmap64 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * bitmap64); // bitmap64
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t bitmap64);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // bitmap64
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace Bitmap64
 
 namespace Int8u {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * int8u); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t int8u);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Int8u
 
 namespace Int16u {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * int16u); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t int16u);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Int16u
 
 namespace Int32u {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * int32u); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t int32u);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace Int32u
 
 namespace Int64u {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * int64u); // int64u
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t int64u);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // int64u
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace Int64u
 
 namespace Int8s {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * int8s); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t int8s);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace Int8s
 
 namespace Int16s {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * int16s); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t int16s);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Int16s
 
 namespace Int32s {
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * int32s); // int32s
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t int32s);
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value);
 } // namespace Int32s
 
 namespace Int64s {
-EmberAfStatus Get(chip::EndpointId endpoint, int64_t * int64s); // int64s
-EmberAfStatus Set(chip::EndpointId endpoint, int64_t int64s);
+EmberAfStatus Get(chip::EndpointId endpoint, int64_t * value); // int64s
+EmberAfStatus Set(chip::EndpointId endpoint, int64_t value);
 } // namespace Int64s
 
 namespace Enum8 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * enum8); // enum8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t enum8);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // enum8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace Enum8
 
 namespace Enum16 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * enum16); // enum16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t enum16);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // enum16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace Enum16
 
+namespace OctetString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace OctetString
+
+namespace LongOctetString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // long_octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace LongOctetString
+
+namespace CharString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace CharString
+
+namespace LongCharString {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // long_char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace LongCharString
+
 namespace EpochUs {
-EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * epochUs); // epoch_us
-EmberAfStatus Set(chip::EndpointId endpoint, uint64_t epochUs);
+EmberAfStatus Get(chip::EndpointId endpoint, uint64_t * value); // epoch_us
+EmberAfStatus Set(chip::EndpointId endpoint, uint64_t value);
 } // namespace EpochUs
 
 namespace EpochS {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * epochS); // epoch_s
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t epochS);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // epoch_s
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace EpochS
 
 namespace Unsupported {
-EmberAfStatus Get(chip::EndpointId endpoint, bool * unsupported); // boolean
-EmberAfStatus Set(chip::EndpointId endpoint, bool unsupported);
+EmberAfStatus Get(chip::EndpointId endpoint, bool * value); // boolean
+EmberAfStatus Set(chip::EndpointId endpoint, bool value);
 } // namespace Unsupported
 
 } // namespace Attributes
@@ -3942,24 +4202,59 @@ EmberAfStatus Set(chip::EndpointId endpoint, bool unsupported);
 namespace ApplianceIdentification {
 namespace Attributes {
 
+namespace CompanyName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace CompanyName
+
 namespace CompanyId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * companyId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t companyId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace CompanyId
 
+namespace BrandName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace BrandName
+
 namespace BrandId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * brandId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t brandId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace BrandId
 
+namespace Model {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace Model
+
+namespace PartNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace PartNumber
+
+namespace ProductRevision {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace ProductRevision
+
+namespace SoftwareRevision {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace SoftwareRevision
+
+namespace ProductTypeName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace ProductTypeName
+
 namespace ProductTypeId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * productTypeId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t productTypeId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ProductTypeId
 
 namespace CecedSpecificationVersion {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * cecedSpecificationVersion); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace CecedSpecificationVersion
 
 } // namespace Attributes
@@ -3968,15 +4263,55 @@ EmberAfStatus Set(chip::EndpointId endpoint, uint8_t cecedSpecificationVersion);
 namespace MeterIdentification {
 namespace Attributes {
 
+namespace CompanyName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace CompanyName
+
 namespace MeterTypeId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * meterTypeId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t meterTypeId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace MeterTypeId
 
 namespace DataQualityId {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dataQualityId); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dataQualityId);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DataQualityId
+
+namespace CustomerName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace CustomerName
+
+namespace Model {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace Model
+
+namespace PartNumber {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace PartNumber
+
+namespace ProductRevision {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace ProductRevision
+
+namespace SoftwareRevision {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableByteSpan value); // octet_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::ByteSpan value);
+} // namespace SoftwareRevision
+
+namespace UtilityName {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace UtilityName
+
+namespace Pod {
+EmberAfStatus Get(chip::EndpointId endpoint, chip::MutableCharSpan value); // char_string
+EmberAfStatus Set(chip::EndpointId endpoint, chip::CharSpan value);
+} // namespace Pod
 
 } // namespace Attributes
 } // namespace MeterIdentification
@@ -3985,13 +4320,13 @@ namespace ApplianceStatistics {
 namespace Attributes {
 
 namespace LogMaxSize {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * logMaxSize); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t logMaxSize);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace LogMaxSize
 
 namespace LogQueueMaxSize {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * logQueueMaxSize); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t logQueueMaxSize);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace LogQueueMaxSize
 
 } // namespace Attributes
@@ -4001,643 +4336,643 @@ namespace ElectricalMeasurement {
 namespace Attributes {
 
 namespace MeasurementType {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * measurementType); // bitmap32
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t measurementType);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace MeasurementType
 
 namespace DcVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltage); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcVoltage
 
 namespace DcVoltageMin {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMin); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMin);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcVoltageMin
 
 namespace DcVoltageMax {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcVoltageMax); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcVoltageMax);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcVoltageMax
 
 namespace DcCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcCurrent
 
 namespace DcCurrentMin {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMin); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMin);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcCurrentMin
 
 namespace DcCurrentMax {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcCurrentMax); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcCurrentMax);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcCurrentMax
 
 namespace DcPower {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPower); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPower);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcPower
 
 namespace DcPowerMin {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMin); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMin);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcPowerMin
 
 namespace DcPowerMax {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * dcPowerMax); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t dcPowerMax);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace DcPowerMax
 
 namespace DcVoltageMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DcVoltageMultiplier
 
 namespace DcVoltageDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcVoltageDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcVoltageDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DcVoltageDivisor
 
 namespace DcCurrentMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DcCurrentMultiplier
 
 namespace DcCurrentDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcCurrentDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcCurrentDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DcCurrentDivisor
 
 namespace DcPowerMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DcPowerMultiplier
 
 namespace DcPowerDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * dcPowerDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t dcPowerDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace DcPowerDivisor
 
 namespace AcFrequency {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequency); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequency);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcFrequency
 
 namespace AcFrequencyMin {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMin); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMin);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcFrequencyMin
 
 namespace AcFrequencyMax {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMax); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMax);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcFrequencyMax
 
 namespace NeutralCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * neutralCurrent); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t neutralCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace NeutralCurrent
 
 namespace TotalActivePower {
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalActivePower); // int32s
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalActivePower);
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value);
 } // namespace TotalActivePower
 
 namespace TotalReactivePower {
-EmberAfStatus Get(chip::EndpointId endpoint, int32_t * totalReactivePower); // int32s
-EmberAfStatus Set(chip::EndpointId endpoint, int32_t totalReactivePower);
+EmberAfStatus Get(chip::EndpointId endpoint, int32_t * value); // int32s
+EmberAfStatus Set(chip::EndpointId endpoint, int32_t value);
 } // namespace TotalReactivePower
 
 namespace TotalApparentPower {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * totalApparentPower); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t totalApparentPower);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace TotalApparentPower
 
 namespace Measured1stHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured1stHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured1stHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Measured1stHarmonicCurrent
 
 namespace Measured3rdHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured3rdHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured3rdHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Measured3rdHarmonicCurrent
 
 namespace Measured5thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured5thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured5thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Measured5thHarmonicCurrent
 
 namespace Measured7thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured7thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured7thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Measured7thHarmonicCurrent
 
 namespace Measured9thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured9thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured9thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Measured9thHarmonicCurrent
 
 namespace Measured11thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measured11thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measured11thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace Measured11thHarmonicCurrent
 
 namespace MeasuredPhase1stHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase1stHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase1stHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredPhase1stHarmonicCurrent
 
 namespace MeasuredPhase3rdHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase3rdHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase3rdHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredPhase3rdHarmonicCurrent
 
 namespace MeasuredPhase5thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase5thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase5thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredPhase5thHarmonicCurrent
 
 namespace MeasuredPhase7thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase7thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase7thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredPhase7thHarmonicCurrent
 
 namespace MeasuredPhase9thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase9thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase9thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredPhase9thHarmonicCurrent
 
 namespace MeasuredPhase11thHarmonicCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * measuredPhase11thHarmonicCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t measuredPhase11thHarmonicCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace MeasuredPhase11thHarmonicCurrent
 
 namespace AcFrequencyMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcFrequencyMultiplier
 
 namespace AcFrequencyDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acFrequencyDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acFrequencyDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcFrequencyDivisor
 
 namespace PowerMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerMultiplier); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PowerMultiplier
 
 namespace PowerDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * powerDivisor); // int32u
-EmberAfStatus Set(chip::EndpointId endpoint, uint32_t powerDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint32_t * value); // int32u
+EmberAfStatus Set(chip::EndpointId endpoint, uint32_t value);
 } // namespace PowerDivisor
 
 namespace HarmonicCurrentMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * harmonicCurrentMultiplier); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t harmonicCurrentMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace HarmonicCurrentMultiplier
 
 namespace PhaseHarmonicCurrentMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * phaseHarmonicCurrentMultiplier); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t phaseHarmonicCurrentMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace PhaseHarmonicCurrentMultiplier
 
 namespace InstantaneousVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousVoltage); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace InstantaneousVoltage
 
 namespace InstantaneousLineCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * instantaneousLineCurrent); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t instantaneousLineCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace InstantaneousLineCurrent
 
 namespace InstantaneousActiveCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousActiveCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousActiveCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace InstantaneousActiveCurrent
 
 namespace InstantaneousReactiveCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousReactiveCurrent); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousReactiveCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace InstantaneousReactiveCurrent
 
 namespace InstantaneousPower {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * instantaneousPower); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t instantaneousPower);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace InstantaneousPower
 
 namespace RmsVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltage); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltage
 
 namespace RmsVoltageMin {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMin); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMin);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageMin
 
 namespace RmsVoltageMax {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMax); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMax);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageMax
 
 namespace RmsCurrent {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrent); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrent);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrent
 
 namespace RmsCurrentMin {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMin); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMin);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentMin
 
 namespace RmsCurrentMax {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMax); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMax);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentMax
 
 namespace ActivePower {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePower); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePower);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePower
 
 namespace ActivePowerMin {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMin); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMin);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerMin
 
 namespace ActivePowerMax {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMax); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMax);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerMax
 
 namespace ReactivePower {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePower); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePower);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ReactivePower
 
 namespace ApparentPower {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPower); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPower);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ApparentPower
 
 namespace PowerFactor {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactor); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactor);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace PowerFactor
 
 namespace AverageRmsVoltageMeasurementPeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsVoltageMeasurementPeriod
 
 namespace AverageRmsUnderVoltageCounter {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounter); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounter);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsUnderVoltageCounter
 
 namespace RmsExtremeOverVoltagePeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsExtremeOverVoltagePeriod
 
 namespace RmsExtremeUnderVoltagePeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsExtremeUnderVoltagePeriod
 
 namespace RmsVoltageSagPeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageSagPeriod
 
 namespace RmsVoltageSwellPeriod {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriod); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriod);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageSwellPeriod
 
 namespace AcVoltageMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcVoltageMultiplier
 
 namespace AcVoltageDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acVoltageDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acVoltageDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcVoltageDivisor
 
 namespace AcCurrentMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcCurrentMultiplier
 
 namespace AcCurrentDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acCurrentDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acCurrentDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcCurrentDivisor
 
 namespace AcPowerMultiplier {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerMultiplier); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerMultiplier);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcPowerMultiplier
 
 namespace AcPowerDivisor {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acPowerDivisor); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acPowerDivisor);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcPowerDivisor
 
 namespace OverloadAlarmsMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * overloadAlarmsMask); // bitmap8
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t overloadAlarmsMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // bitmap8
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace OverloadAlarmsMask
 
 namespace VoltageOverload {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * voltageOverload); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t voltageOverload);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace VoltageOverload
 
 namespace CurrentOverload {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * currentOverload); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t currentOverload);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace CurrentOverload
 
 namespace AcOverloadAlarmsMask {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * acOverloadAlarmsMask); // bitmap16
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t acOverloadAlarmsMask);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // bitmap16
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AcOverloadAlarmsMask
 
 namespace AcVoltageOverload {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acVoltageOverload); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acVoltageOverload);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AcVoltageOverload
 
 namespace AcCurrentOverload {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acCurrentOverload); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acCurrentOverload);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AcCurrentOverload
 
 namespace AcActivePowerOverload {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acActivePowerOverload); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acActivePowerOverload);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AcActivePowerOverload
 
 namespace AcReactivePowerOverload {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * acReactivePowerOverload); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t acReactivePowerOverload);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AcReactivePowerOverload
 
 namespace AverageRmsOverVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsOverVoltage); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsOverVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AverageRmsOverVoltage
 
 namespace AverageRmsUnderVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * averageRmsUnderVoltage); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t averageRmsUnderVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace AverageRmsUnderVoltage
 
 namespace RmsExtremeOverVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeOverVoltage); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeOverVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace RmsExtremeOverVoltage
 
 namespace RmsExtremeUnderVoltage {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsExtremeUnderVoltage); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsExtremeUnderVoltage);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace RmsExtremeUnderVoltage
 
 namespace RmsVoltageSag {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSag); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSag);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace RmsVoltageSag
 
 namespace RmsVoltageSwell {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * rmsVoltageSwell); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t rmsVoltageSwell);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace RmsVoltageSwell
 
 namespace LineCurrentPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace LineCurrentPhaseB
 
 namespace ActiveCurrentPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseB); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActiveCurrentPhaseB
 
 namespace ReactiveCurrentPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseB); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ReactiveCurrentPhaseB
 
 namespace RmsVoltagePhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltagePhaseB
 
 namespace RmsVoltageMinPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageMinPhaseB
 
 namespace RmsVoltageMaxPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageMaxPhaseB
 
 namespace RmsCurrentPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentPhaseB
 
 namespace RmsCurrentMinPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentMinPhaseB
 
 namespace RmsCurrentMaxPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentMaxPhaseB
 
 namespace ActivePowerPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseB); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerPhaseB
 
 namespace ActivePowerMinPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseB); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerMinPhaseB
 
 namespace ActivePowerMaxPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseB); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerMaxPhaseB
 
 namespace ReactivePowerPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseB); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ReactivePowerPhaseB
 
 namespace ApparentPowerPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ApparentPowerPhaseB
 
 namespace PowerFactorPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseB); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace PowerFactorPhaseB
 
 namespace AverageRmsVoltageMeasurementPeriodPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsVoltageMeasurementPeriodPhaseB
 
 namespace AverageRmsOverVoltageCounterPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsOverVoltageCounterPhaseB
 
 namespace AverageRmsUnderVoltageCounterPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsUnderVoltageCounterPhaseB
 
 namespace RmsExtremeOverVoltagePeriodPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsExtremeOverVoltagePeriodPhaseB
 
 namespace RmsExtremeUnderVoltagePeriodPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsExtremeUnderVoltagePeriodPhaseB
 
 namespace RmsVoltageSagPeriodPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageSagPeriodPhaseB
 
 namespace RmsVoltageSwellPeriodPhaseB {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseB); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseB);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageSwellPeriodPhaseB
 
 namespace LineCurrentPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * lineCurrentPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t lineCurrentPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace LineCurrentPhaseC
 
 namespace ActiveCurrentPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activeCurrentPhaseC); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activeCurrentPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActiveCurrentPhaseC
 
 namespace ReactiveCurrentPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactiveCurrentPhaseC); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactiveCurrentPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ReactiveCurrentPhaseC
 
 namespace RmsVoltagePhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltagePhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltagePhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltagePhaseC
 
 namespace RmsVoltageMinPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMinPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMinPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageMinPhaseC
 
 namespace RmsVoltageMaxPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageMaxPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageMaxPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageMaxPhaseC
 
 namespace RmsCurrentPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentPhaseC
 
 namespace RmsCurrentMinPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMinPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMinPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentMinPhaseC
 
 namespace RmsCurrentMaxPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsCurrentMaxPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsCurrentMaxPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsCurrentMaxPhaseC
 
 namespace ActivePowerPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerPhaseC); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerPhaseC
 
 namespace ActivePowerMinPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMinPhaseC); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMinPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerMinPhaseC
 
 namespace ActivePowerMaxPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * activePowerMaxPhaseC); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t activePowerMaxPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ActivePowerMaxPhaseC
 
 namespace ReactivePowerPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int16_t * reactivePowerPhaseC); // int16s
-EmberAfStatus Set(chip::EndpointId endpoint, int16_t reactivePowerPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int16_t * value); // int16s
+EmberAfStatus Set(chip::EndpointId endpoint, int16_t value);
 } // namespace ReactivePowerPhaseC
 
 namespace ApparentPowerPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * apparentPowerPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t apparentPowerPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace ApparentPowerPhaseC
 
 namespace PowerFactorPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, int8_t * powerFactorPhaseC); // int8s
-EmberAfStatus Set(chip::EndpointId endpoint, int8_t powerFactorPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, int8_t * value); // int8s
+EmberAfStatus Set(chip::EndpointId endpoint, int8_t value);
 } // namespace PowerFactorPhaseC
 
 namespace AverageRmsVoltageMeasurementPeriodPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsVoltageMeasurementPeriodPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsVoltageMeasurementPeriodPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsVoltageMeasurementPeriodPhaseC
 
 namespace AverageRmsOverVoltageCounterPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsOverVoltageCounterPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsOverVoltageCounterPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsOverVoltageCounterPhaseC
 
 namespace AverageRmsUnderVoltageCounterPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * averageRmsUnderVoltageCounterPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t averageRmsUnderVoltageCounterPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace AverageRmsUnderVoltageCounterPhaseC
 
 namespace RmsExtremeOverVoltagePeriodPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeOverVoltagePeriodPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeOverVoltagePeriodPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsExtremeOverVoltagePeriodPhaseC
 
 namespace RmsExtremeUnderVoltagePeriodPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsExtremeUnderVoltagePeriodPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsExtremeUnderVoltagePeriodPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsExtremeUnderVoltagePeriodPhaseC
 
 namespace RmsVoltageSagPeriodPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSagPeriodPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSagPeriodPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageSagPeriodPhaseC
 
 namespace RmsVoltageSwellPeriodPhaseC {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * rmsVoltageSwellPeriodPhaseC); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t rmsVoltageSwellPeriodPhaseC);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace RmsVoltageSwellPeriodPhaseC
 
 } // namespace Attributes
@@ -4653,13 +4988,13 @@ namespace SampleMfgSpecificCluster {
 namespace Attributes {
 
 namespace EmberSampleAttribute {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EmberSampleAttribute
 
 namespace EmberSampleAttribute2 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * emberSampleAttribute2); // int8u
-EmberAfStatus Set(chip::EndpointId endpoint, uint8_t emberSampleAttribute2);
+EmberAfStatus Get(chip::EndpointId endpoint, uint8_t * value); // int8u
+EmberAfStatus Set(chip::EndpointId endpoint, uint8_t value);
 } // namespace EmberSampleAttribute2
 
 } // namespace Attributes
@@ -4669,13 +5004,13 @@ namespace SampleMfgSpecificCluster2 {
 namespace Attributes {
 
 namespace EmberSampleAttribute3 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute3); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute3);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace EmberSampleAttribute3
 
 namespace EmberSampleAttribute4 {
-EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * emberSampleAttribute4); // int16u
-EmberAfStatus Set(chip::EndpointId endpoint, uint16_t emberSampleAttribute4);
+EmberAfStatus Get(chip::EndpointId endpoint, uint16_t * value); // int16u
+EmberAfStatus Set(chip::EndpointId endpoint, uint16_t value);
 } // namespace EmberSampleAttribute4
 
 } // namespace Attributes


### PR DESCRIPTION
#### Problem

`src/app/clusters/basic/basic.cpp` does not use the provided attributes accessors and does not log anything if there is an error setting basic attributes from the configuration manager.

#### Change overview
 * Use attributes accessors
 * Add accessors for strings
 * Log errors

#### Testing
I was tested locally by updating the code to try to have a vendor name that is longer than the possible attribute size.