### PR TITLE
Remove cluster-id.h and use accessors into various clusters

### DIFF
--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -21,15 +21,14 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 #include <string>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AccountLogin;
 
 bool accountLoginClusterIsUserLoggedIn(std::string requestTempAccountIdentifier, std::string requestSetupPin);
@@ -38,8 +37,8 @@ std::string accountLoginClusterGetSetupPin(std::string requestTempAccountIdentif
 void sendResponse(app::CommandHandler * command, const char * responseSetupPin)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_ACCOUNT_LOGIN_CLUSTER_ID,
-                                         ZCL_GET_SETUP_PIN_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, AccountLogin::Id,
+                                         Commands::GetSetupPINResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -23,9 +23,7 @@
  ******************************************************************************/
 
 #include <app-common/zap-generated/af-structs.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app-common/zap-generated/enums.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
@@ -33,6 +31,7 @@
 #include <app/util/af.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ApplicationLauncher;
 
 ApplicationLauncherResponse applicationLauncherClusterLaunchApp(::ApplicationLauncherApp application, std::string data);
@@ -49,8 +48,8 @@ bool emberAfApplicationLauncherClusterLaunchAppCallback(app::CommandHandler * co
 void sendResponse(app::CommandHandler * command, ApplicationLauncherResponse response)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_APPLICATION_LAUNCHER_CLUSTER_ID,
-                                         ZCL_LAUNCH_APP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ApplicationLauncher::Id,
+                                         Commands::LaunchAppResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -37,10 +37,7 @@
 #include <app/util/af.h>
 
 #include <app-common/zap-generated/af-structs.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
@@ -94,7 +91,7 @@ bool ColorControlServer::shouldExecuteIfOff(EndpointId endpoint, uint8_t optionM
     //        (FALSE).
     //      - The value of the ExecuteIfOff bit is 0."
 
-    if (!emberAfContainsServer(endpoint, ZCL_ON_OFF_CLUSTER_ID))
+    if (!emberAfContainsServer(endpoint, OnOff::Id))
     {
         return true;
     }
@@ -257,7 +254,7 @@ uint16_t ColorControlServer::computeTransitionTimeFromStateAndRate(ColorControlS
  */
 EmberEventControl * ColorControlServer::getEventControl(EndpointId endpoint)
 {
-    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID);
+    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ColorControl::Id);
     return &eventControls[index];
 }
 
@@ -357,7 +354,7 @@ bool ColorControlServer::computeNewColor16uValue(ColorControlServer::Color16uTra
  */
 ColorControlServer::ColorHueTransitionState * ColorControlServer::getColorHueTransitionState(EndpointId endpoint)
 {
-    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID);
+    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ColorControl::Id);
     return &colorHueTransitionStates[index];
 }
 
@@ -369,7 +366,7 @@ ColorControlServer::ColorHueTransitionState * ColorControlServer::getColorHueTra
  */
 ColorControlServer::Color16uTransitionState * ColorControlServer::getSaturationTransitionState(EndpointId endpoint)
 {
-    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID);
+    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ColorControl::Id);
     return &colorSatTransitionStates[index];
 }
 
@@ -1520,7 +1517,7 @@ void ColorControlServer::updateHueSatCommand(EndpointId endpoint)
  */
 ColorControlServer::Color16uTransitionState * ColorControlServer::getXTransitionState(EndpointId endpoint)
 {
-    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID);
+    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ColorControl::Id);
     return &colorXtransitionStates[index];
 }
 
@@ -1532,7 +1529,7 @@ ColorControlServer::Color16uTransitionState * ColorControlServer::getXTransition
  */
 ColorControlServer::Color16uTransitionState * ColorControlServer::getYTransitionState(EndpointId endpoint)
 {
-    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID);
+    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ColorControl::Id);
     return &colorYtransitionStates[index];
 }
 
@@ -1815,7 +1812,7 @@ void ColorControlServer::updateXYCommand(EndpointId endpoint)
  */
 ColorControlServer::Color16uTransitionState * ColorControlServer::getTempTransitionState(EndpointId endpoint)
 {
-    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID);
+    uint16_t index = emberAfFindClusterServerEndpointIndex(endpoint, ColorControl::Id);
     return &colorTempTransitionStates[index];
 }
 
@@ -2231,7 +2228,7 @@ void ColorControlServer::levelControlColorTempChangeCommand(EndpointId endpoint)
     // Control cluster is equal to 0, there SHALL be no link between color
     // temperature and current level.
 
-    if (!emberAfContainsServer(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID))
+    if (!emberAfContainsServer(endpoint, ColorControl::Id))
     {
         return;
     }

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -46,12 +46,8 @@
 // *******************************************************************
 #include "groups-server.h"
 
-#include <app-common/zap-generated/att-storage.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
@@ -62,6 +58,7 @@
 #endif // EMBER_AF_PLUGIN_SCENES
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Groups;
 
 static bool isGroupPresent(EndpointId endpoint, GroupId groupId);
@@ -76,8 +73,7 @@ void emberAfGroupsClusterServerInitCallback(EndpointId endpoint)
     // Group names are not supported by this plugin.
     EmberAfStatus status;
     uint8_t nameSupport = (uint8_t) emberAfPluginGroupsServerGroupNamesSupportedCallback(endpoint);
-    status = emberAfWriteAttribute(endpoint, ZCL_GROUPS_CLUSTER_ID, ZCL_GROUP_NAME_SUPPORT_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                   (uint8_t *) &nameSupport, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    status              = Attributes::NameSupport::Set(endpoint, nameSupport);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfGroupsClusterPrintln("ERR: writing name support %x", status);
@@ -174,8 +170,8 @@ bool emberAfGroupsClusterAddGroupCallback(app::CommandHandler * commandObj, cons
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                             ZCL_ADD_GROUP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, Groups::Id, Commands::AddGroupResponse::Id,
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -218,8 +214,8 @@ bool emberAfGroupsClusterViewGroupCallback(app::CommandHandler * commandObj, con
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                             ZCL_VIEW_GROUP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, Groups::Id,
+                                             Commands::ViewGroupResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -316,8 +312,8 @@ bool emberAfGroupsClusterGetGroupMembershipCallback(app::CommandHandler * comman
         // used for other purposes besides groups, we can't be sure what the
         // capacity will be in the future.
         {
-            app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                                 ZCL_GET_GROUP_MEMBERSHIP_RESPONSE_COMMAND_ID,
+            app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, Groups::Id,
+                                                 Commands::GetGroupMembershipResponse::Id,
                                                  (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
@@ -369,8 +365,8 @@ bool emberAfGroupsClusterRemoveGroupCallback(app::CommandHandler * commandObj, c
     // removed the scenes associated with that group SHOULD be removed."
     emberAfScenesClusterRemoveScenesInGroupCallback(emberAfCurrentEndpoint(), groupId);
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                             ZCL_REMOVE_GROUP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, Groups::Id,
+                                             Commands::RemoveGroupResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -21,17 +21,15 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 #include <string>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaInput;
 
 bool mediaInputClusterSelectInput(uint8_t input);
@@ -41,8 +39,7 @@ bool mediaInputClusterRenameInput(uint8_t input, std::string name);
 
 static void storeCurrentInput(EndpointId endpoint, uint8_t currentInput)
 {
-    EmberAfStatus status = emberAfWriteServerAttribute(
-        endpoint, ZCL_MEDIA_INPUT_CLUSTER_ID, ZCL_MEDIA_INPUT_CURRENT_INPUT_ATTRIBUTE_ID, &currentInput, ZCL_INT8U_ATTRIBUTE_TYPE);
+    EmberAfStatus status = Attributes::CurrentMediaInput::Set(endpoint, currentInput);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Failed to store media playback attribute.");

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -22,18 +22,15 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
-#include <app-common/zap-generated/enums.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/media-playback-server/media-playback-server.h>
 #include <app/util/af.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::MediaPlayback;
 
 EmberAfMediaPlaybackStatus mediaPlaybackClusterSendMediaPlaybackRequest(MediaPlaybackRequest mediaPlaybackRequest,
@@ -41,8 +38,7 @@ EmberAfMediaPlaybackStatus mediaPlaybackClusterSendMediaPlaybackRequest(MediaPla
 
 static void writePlaybackState(EndpointId endpoint, uint8_t playbackState)
 {
-    EmberAfStatus status = emberAfWriteServerAttribute(
-        endpoint, ZCL_MEDIA_PLAYBACK_CLUSTER_ID, ZCL_MEDIA_PLAYBACK_STATE_ATTRIBUTE_ID, &playbackState, ZCL_INT8U_ATTRIBUTE_TYPE);
+    EmberAfStatus status = Attributes::PlaybackState::Set(endpoint, playbackState);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Failed to store media playback attribute.");
@@ -52,8 +48,7 @@ static void writePlaybackState(EndpointId endpoint, uint8_t playbackState)
 static uint8_t readPlaybackStatus(EndpointId endpoint)
 {
     uint8_t playbackState;
-    EmberAfStatus status = emberAfReadServerAttribute(endpoint, ZCL_MEDIA_PLAYBACK_CLUSTER_ID,
-                                                      ZCL_MEDIA_PLAYBACK_STATE_ATTRIBUTE_ID, &playbackState, sizeof(uint8_t));
+    EmberAfStatus status = Attributes::PlaybackState::Get(endpoint, &playbackState);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         ChipLogError(Zcl, "Failed to read media playback attribute.");
@@ -80,7 +75,7 @@ static void sendResponse(app::CommandHandler * command, const char * responseNam
                          EmberAfMediaPlaybackStatus mediaPlaybackStatus)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_MEDIA_PLAYBACK_CLUSTER_ID, commandId,
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, MediaPlayback::Id, commandId,
                                          (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
 
@@ -102,7 +97,7 @@ bool emberAfMediaPlaybackClusterMediaPlayCallback(app::CommandHandler * command,
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PLAY, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_PLAYING);
-    sendResponse(command, "MediaPlayResponse", ZCL_MEDIA_PLAY_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaPlayResponse", Commands::MediaPlayResponse::Id, status);
     return true;
 }
 
@@ -111,7 +106,7 @@ bool emberAfMediaPlaybackClusterMediaPauseCallback(app::CommandHandler * command
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PAUSE, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_PAUSED);
-    sendResponse(command, "MediaPauseResponse", ZCL_MEDIA_PAUSE_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaPauseResponse", Commands::MediaPauseResponse::Id, status);
     return true;
 }
 
@@ -120,7 +115,7 @@ bool emberAfMediaPlaybackClusterMediaStopCallback(app::CommandHandler * command,
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_STOP, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_NOT_PLAYING);
-    sendResponse(command, "MediaStopResponse", ZCL_MEDIA_STOP_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaStopResponse", Commands::MediaStopResponse::Id, status);
     return true;
 }
 
@@ -129,7 +124,7 @@ bool emberAfMediaPlaybackClusterMediaFastForwardCallback(app::CommandHandler * c
                                                          const Commands::MediaFastForward::DecodableType & commandData)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_FAST_FORWARD, 0);
-    sendResponse(command, "MediaFastForward", ZCL_MEDIA_FAST_FORWARD_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaFastForward", Commands::MediaFastForwardResponse::Id, status);
     return true;
 }
 
@@ -137,7 +132,7 @@ bool emberAfMediaPlaybackClusterMediaPreviousCallback(app::CommandHandler * comm
                                                       const Commands::MediaPrevious::DecodableType & commandData)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PREVIOUS, 0);
-    sendResponse(command, "MediaPrevious", ZCL_MEDIA_PREVIOUS_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaPrevious", Commands::MediaPreviousResponse::Id, status);
     return true;
 }
 
@@ -145,7 +140,7 @@ bool emberAfMediaPlaybackClusterMediaRewindCallback(app::CommandHandler * comman
                                                     const Commands::MediaRewind::DecodableType & commandData)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_REWIND, 0);
-    sendResponse(command, "MediaRewind", ZCL_MEDIA_REWIND_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaRewind", Commands::MediaRewindResponse::Id, status);
     return true;
 }
 
@@ -157,7 +152,7 @@ bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(app::CommandHandler * 
 
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SKIP_BACKWARD, deltaPositionMilliseconds);
-    sendResponse(command, "MediaSkipBackward", ZCL_MEDIA_SKIP_BACKWARD_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaSkipBackward", Commands::MediaSkipBackwardResponse::Id, status);
     return true;
 }
 
@@ -169,7 +164,7 @@ bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(app::CommandHandler * c
 
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SKIP_FORWARD, deltaPositionMilliseconds);
-    sendResponse(command, "MediaSkipForward", ZCL_MEDIA_SKIP_FORWARD_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaSkipForward", Commands::MediaSkipForwardResponse::Id, status);
     return true;
 }
 
@@ -180,7 +175,7 @@ bool emberAfMediaPlaybackClusterMediaSeekCallback(app::CommandHandler * command,
 
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SEEK, positionMilliseconds);
-    sendResponse(command, "MediaSeek", ZCL_MEDIA_SEEK_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaSeek", Commands::MediaSeekResponse::Id, status);
     return true;
 }
 
@@ -188,13 +183,13 @@ bool emberAfMediaPlaybackClusterMediaNextCallback(app::CommandHandler * command,
                                                   const Commands::MediaNext::DecodableType & commandData)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_NEXT, 0);
-    sendResponse(command, "MediaNext", ZCL_MEDIA_NEXT_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaNext", Commands::MediaNextResponse::Id, status);
     return true;
 }
 bool emberAfMediaPlaybackClusterMediaStartOverCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                        const Commands::MediaStartOver::DecodableType & commandData)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_START_OVER, 0);
-    sendResponse(command, "MediaStartOver", ZCL_MEDIA_START_OVER_RESPONSE_COMMAND_ID, status);
+    sendResponse(command, "MediaStartOver", Commands::MediaStartOverResponse::Id, status);
     return true;
 }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -40,12 +40,8 @@
  ******************************************************************************/
 #include "on-off-server.h"
 
-#include <app-common/zap-generated/att-storage.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/util/af.h>
 
 #include <app/CommandHandler.h>
@@ -65,6 +61,7 @@
 #endif
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OnOff;
 
 #ifdef ZCL_USING_ON_OFF_CLUSTER_START_UP_ON_OFF_ATTRIBUTE
@@ -79,9 +76,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
     emberAfOnOffClusterPrintln("On/Off set value: %x %x", endpoint, command);
 
     // read current on/off value
-    status = emberAfReadAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                  (uint8_t *) &currentValue, sizeof(currentValue),
-                                  NULL); // data type
+    status = Attributes::OnOff::Get(endpoint, &currentValue);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfOnOffClusterPrintln("ERR: reading on/off %x", status);
@@ -89,7 +84,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
     }
 
     // if the value is already what we want to set it to then do nothing
-    if ((!currentValue && command == ZCL_OFF_COMMAND_ID) || (currentValue && command == ZCL_ON_COMMAND_ID))
+    if ((!currentValue && command == Commands::Off::Id) || (currentValue && command == Commands::On::Id))
     {
         emberAfOnOffClusterPrintln("On/off already set to new value");
         return EMBER_ZCL_STATUS_SUCCESS;
@@ -108,8 +103,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
     if (newValue)
     {
         // write the new on/off value
-        status = emberAfWriteAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                       (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+        status = Attributes::OnOff::Set(endpoint, newValue);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
@@ -119,7 +113,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
-        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, ZCL_LEVEL_CONTROL_CLUSTER_ID))
+        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, LevelControl::Id))
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
@@ -130,15 +124,14 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
-        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, ZCL_LEVEL_CONTROL_CLUSTER_ID))
+        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, LevelControl::Id))
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
 #endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
 
         // write the new on/off value
-        status = emberAfWriteAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                       (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+        status = Attributes::OnOff::Set(endpoint, newValue);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
@@ -157,7 +150,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
     // the scene has been changed (the value of on/off has changed) so
     // the current scene as descibed in the attribute table is invalid,
     // so mark it as invalid (just writes the valid/invalid attribute)
-    if (emberAfContainsServer(endpoint, ZCL_SCENES_CLUSTER_ID))
+    if (emberAfContainsServer(endpoint, Scenes::Id))
     {
         emberAfScenesClusterMakeInvalidCallback(endpoint);
     }
@@ -171,7 +164,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
 bool emberAfOnOffClusterOffCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                     const Commands::Off::DecodableType & commandData)
 {
-    EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_OFF_COMMAND_ID, false);
+    EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), Commands::Off::Id, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -185,7 +178,7 @@ bool emberAfOnOffClusterOffCallback(app::CommandHandler * commandObj, const app:
 bool emberAfOnOffClusterOnCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                    const Commands::On::DecodableType & commandData)
 {
-    EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_ON_COMMAND_ID, false);
+    EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), Commands::On::Id, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -199,7 +192,7 @@ bool emberAfOnOffClusterOnCallback(app::CommandHandler * commandObj, const app::
 bool emberAfOnOffClusterToggleCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                        const Commands::Toggle::DecodableType & commandData)
 {
-    EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_TOGGLE_COMMAND_ID, false);
+    EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), Commands::Toggle::Id, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -235,14 +228,12 @@ void emberAfOnOffClusterServerInitCallback(EndpointId endpoint)
 
         // Initialize startUpOnOff to No action value 0xFE
         uint8_t startUpOnOff = 0xFE;
-        EmberAfStatus status = emberAfReadAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_START_UP_ON_OFF_ATTRIBUTE_ID,
-                                                    CLUSTER_MASK_SERVER, (uint8_t *) &startUpOnOff, sizeof(startUpOnOff), NULL);
+        EmberAfStatus status = Attributes::StartUpOnOff::Get(endpoint, &startUpOnOff);
         if (status == EMBER_ZCL_STATUS_SUCCESS)
         {
             // Initialise updated value to 0
             bool updatedOnOff = 0;
-            status            = emberAfReadAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                          (uint8_t *) &updatedOnOff, sizeof(updatedOnOff), NULL);
+            status            = Attributes::OnOff::Get(endpoint, &udpateOnOff);
             if (status == EMBER_ZCL_STATUS_SUCCESS)
             {
                 switch (startUpOnOff)
@@ -263,8 +254,7 @@ void emberAfOnOffClusterServerInitCallback(EndpointId endpoint)
                     // no action.
                     break;
                 }
-                status = emberAfWriteAttribute(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                                               (uint8_t *) &updatedOnOff, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
+                status = Attributes::OnOff::Set(endpoint, updatedOnOff);
             }
         }
     }
@@ -277,15 +267,15 @@ static bool areStartUpOnOffServerAttributesTokenized(EndpointId endpoint)
 {
     EmberAfAttributeMetadata * metadata;
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+    metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::OnOff::Id, CLUSTER_MASK_SERVER,
                                               EMBER_AF_NULL_MANUFACTURER_CODE);
     if (!emberAfAttributeIsTokenized(metadata))
     {
         return false;
     }
 
-    metadata = emberAfLocateAttributeMetadata(endpoint, ZCL_ON_OFF_CLUSTER_ID, ZCL_START_UP_ON_OFF_ATTRIBUTE_ID,
-                                              CLUSTER_MASK_SERVER, EMBER_AF_NULL_MANUFACTURER_CODE);
+    metadata = emberAfLocateAttributeMetadata(endpoint, OnOff::Id, Attributes::StartUpOnOff::Id, CLUSTER_MASK_SERVER,
+                                              EMBER_AF_NULL_MANUFACTURER_CODE);
     if (!emberAfAttributeIsTokenized(metadata))
     {
         return false;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -21,12 +21,8 @@
  ***************************************************************************/
 
 #include <app-common/zap-generated/af-structs.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app-common/zap-generated/enums.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/AttributeAccessInterface.h>
@@ -53,6 +49,7 @@ using namespace chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::Transport;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OperationalCredentials;
 
 namespace {
@@ -136,10 +133,10 @@ EmberAfStatus writeFabricAttribute(uint8_t * buffer, int32_t index = -1)
 {
     EmberAfAttributeSearchRecord record;
     record.endpoint         = 0;
-    record.clusterId        = ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID;
+    record.clusterId        = OperationalCredentials::Id;
     record.clusterMask      = CLUSTER_MASK_SERVER;
     record.manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE;
-    record.attributeId      = ZCL_FABRICS_ATTRIBUTE_ID;
+    record.attributeId      = Attributes::FabricsList::Id;
 
     // When reading or writing a List attribute the 'index' value could have 3 types of values:
     //  -1: Read/Write the whole list content, including the number of elements in the list
@@ -407,8 +404,8 @@ FabricInfo gFabricBeingCommissioned;
 
 CHIP_ERROR SendNOCResponse(app::Command * commandObj, EmberAfNodeOperationalCertStatus status, uint8_t index, CharSpan debug_text)
 {
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID,
-                                         ZCL_NOC_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, OperationalCredentials::Id,
+                                         Commands::NOCResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
 
     VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -16,14 +16,8 @@
  *    limitations under the License.
  */
 
-#include <app-common/zap-generated/att-storage.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/callback.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
-#include <app-common/zap-generated/enums.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
@@ -34,6 +28,7 @@
 #include "ota-provider.h"
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider;
 using chip::app::Clusters::OTAProviderDelegate;
 
@@ -47,7 +42,7 @@ OTAProviderDelegate * gDelegateTable[EMBER_AF_OTA_PROVIDER_CLUSTER_SERVER_ENDPOI
 
 OTAProviderDelegate * GetDelegate(EndpointId endpoint)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_OTA_PROVIDER_CLUSTER_ID);
+    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, OtaSoftwareUpdateProvider::Id);
     return (ep == 0xFFFF ? NULL : gDelegateTable[ep]);
 }
 
@@ -222,7 +217,7 @@ namespace OTAProvider {
 
 void SetDelegate(EndpointId endpoint, OTAProviderDelegate * delegate)
 {
-    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_OTA_PROVIDER_CLUSTER_ID);
+    uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, OtaSoftwareUpdateProvider::Id);
     if (ep != 0xFFFF)
     {
         gDelegateTable[ep] = delegate;

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -22,11 +22,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app-common/zap-generated/af-structs.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
-#include <app-common/zap-generated/enums.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/target-navigator-server/target-navigator-server.h>

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -20,18 +20,12 @@
  * @brief Implementation for the Test Server Cluster
  ***************************************************************************/
 
-#include <app-common/zap-generated/af-structs.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Commands.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/CHIPTLV.h>
@@ -94,7 +88,7 @@ EmberAfStatus writeAttribute(EndpointId endpoint, AttributeId attributeId, uint8
 {
     EmberAfAttributeSearchRecord record;
     record.endpoint         = endpoint;
-    record.clusterId        = ZCL_TEST_CLUSTER_ID;
+    record.clusterId        = TestCluster::Id;
     record.clusterMask      = CLUSTER_MASK_SERVER;
     record.manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE;
     record.attributeId      = attributeId;
@@ -440,7 +434,7 @@ void MatterTestClusterPluginServerInitCallback(void)
     for (uint8_t index = 0; index < emberAfEndpointCount(); index++)
     {
         EndpointId endpoint = emberAfEndpointFromIndex(index);
-        if (!emberAfContainsCluster(endpoint, ZCL_TEST_CLUSTER_ID))
+        if (!emberAfContainsCluster(endpoint, TestCluster::Id))
         {
             continue;
         }

--- a/src/app/clusters/tv-channel-server/tv-channel-server.cpp
+++ b/src/app/clusters/tv-channel-server/tv-channel-server.cpp
@@ -39,14 +39,13 @@
  ******************************************************************************/
 
 #include <app-common/zap-generated/af-structs.h>
-#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::TvChannel;
 
 ::TvChannelInfo tvChannelClusterChangeChannel(std::string match);
@@ -56,8 +55,8 @@ bool tvChannelClusterSkipChannel(uint16_t count);
 void sendResponse(app::CommandHandler * command, ::TvChannelInfo channelInfo)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
-    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TV_CHANNEL_CLUSTER_ID,
-                                         ZCL_CHANGE_CHANNEL_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, TvChannel::Id,
+                                         Commands::ChangeChannelResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
#### Problem

Second part of #10658 where more clusters are updated to not use `cluster-id.h`. 

#### Change overview
* Use `ids/Clusters.h`  instead of `cluster-id.h` into some clusters
* use `ids/Commands.h` instead of `command-id.h` into some clusters
* use `ids/Attributes.h` instead of `attribute-id.h` into some clusters
* Use attributes accessors instead of `emberAfReadServerAttribute` and `emberAfWriteServerAttribute`