### PR TITLE
Use System::Clock::Timeout for ExchangeContext::Timeout

### DIFF
--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -28,7 +28,7 @@
 constexpr size_t kMaxTcpActiveConnectionCount = 4;
 constexpr size_t kMaxTcpPendingPackets        = 4;
 #endif
-constexpr size_t kResponseTimeOut = 1000;
+constexpr chip::System::Clock::Timeout kResponseTimeOut = chip::System::Clock::Seconds16(1);
 
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
 extern chip::Messaging::ExchangeManager gExchangeManager;

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -37,7 +37,7 @@ CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager *
 {}
 
 CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> secureSession,
-                                             uint32_t timeout)
+                                             System::Clock::Timeout timeout)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle commandPacket;

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -154,7 +154,7 @@ public:
     // Default timeout value will be used otherwise.
     //
     CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> secureSession,
-                                  uint32_t timeout = kImMessageTimeoutMsec);
+                                  System::Clock::Timeout timeout = kImMessageTimeout);
 
 private:
     // ExchangeDelegate interface implementation.  Private so people won't

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -36,7 +36,7 @@
 namespace chip {
 namespace app {
 
-static constexpr uint32_t kImMessageTimeoutMsec = 12000;
+static constexpr System::Clock::Timeout kImMessageTimeout = System::Clock::Seconds16(12);
 
 class ReadClient;
 class WriteClient;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -650,7 +650,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
 
     mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHandle, this);
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+    mpExchangeCtx->SetResponseTimeout(kImMessageTimeout);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::SubscribeRequest, std::move(msgBuf),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -202,7 +202,7 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload)
     {
         VerifyOrReturnLogError(mpExchangeCtx == nullptr, CHIP_ERROR_INCORRECT_STATE);
         mpExchangeCtx = mpExchangeMgr->NewContext(mSessionHandle.Value(), this);
-        mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+        mpExchangeCtx->SetResponseTimeout(kImMessageTimeout);
     }
     VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
     MoveToState(HandlerState::AwaitingReportResponse);

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -35,7 +35,7 @@ struct ReadPrepareParams
     AttributePathParams * mpAttributePathParamsList = nullptr;
     size_t mAttributePathParamsListSize             = 0;
     EventNumber mEventNumber                        = 0;
-    uint32_t mTimeout                               = kImMessageTimeoutMsec;
+    System::Clock::Timeout mTimeout                 = kImMessageTimeout;
     uint16_t mMinIntervalFloorSeconds               = 0;
     uint16_t mMaxIntervalCeilingSeconds             = 0;
     bool mKeepSubscriptions                         = true;

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -243,7 +243,7 @@ void WriteClient::ClearState()
 }
 
 CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> apSecureSession,
-                                         uint32_t timeout)
+                                         System::Clock::Timeout timeout)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle packet;
@@ -381,7 +381,7 @@ exit:
 }
 
 CHIP_ERROR WriteClientHandle::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> apSecureSession,
-                                               uint32_t timeout)
+                                               System::Clock::Timeout timeout)
 {
     CHIP_ERROR err = mpWriteClient->SendWriteRequest(aNodeId, aFabricIndex, apSecureSession, timeout);
 

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -96,7 +96,7 @@ private:
      *  consumer is responsible for calling Shutdown on the WriteClient.
      */
     CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> apSecureSession,
-                                uint32_t timeout);
+                                System::Clock::Timeout timeout);
 
     /**
      *  Initialize the client object. Within the lifetime
@@ -178,7 +178,7 @@ public:
      * should not use this object after calling this function.
      */
     CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, Optional<SessionHandle> apSecureSession,
-                                uint32_t timeout = kImMessageTimeoutMsec);
+                                System::Clock::Timeout timeout = kImMessageTimeout);
 
     /**
      *  Encode an attribute value that can be directly encoded using TLVWriter::Put

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
         SetResponseExpected(true);
 
         // Arm the response timer if a timeout has been specified.
-        if (mResponseTimeout > 0)
+        if (mResponseTimeout > System::Clock::Zero)
         {
             CHIP_ERROR err = StartResponseTimer();
             if (err != CHIP_NO_ERROR)
@@ -338,7 +338,7 @@ CHIP_ERROR ExchangeContext::StartResponseTimer()
         return CHIP_ERROR_INTERNAL;
     }
 
-    return lSystemLayer->StartTimer(chip::System::Clock::Milliseconds32(mResponseTimeout), HandleResponseTimeout, this);
+    return lSystemLayer->StartTimer(mResponseTimeout, HandleResponseTimeout, this);
 }
 
 void ExchangeContext::CancelResponseTimer()

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -61,7 +61,7 @@ class DLL_EXPORT ExchangeContext : public ReliableMessageContext, public Referen
     friend class ExchangeContextDeletor;
 
 public:
-    typedef uint32_t Timeout; // Type used to express the timeout in this ExchangeContext, in milliseconds
+    typedef System::Clock::Timeout Timeout; // Type used to express the timeout in this ExchangeContext
 
     ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SessionHandle session, bool Initiator, ExchangeDelegate * delegate);
 
@@ -165,7 +165,7 @@ public:
     void SetResponseTimeout(Timeout timeout);
 
 private:
-    Timeout mResponseTimeout       = 0; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.
+    Timeout mResponseTimeout{ 0 }; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.
     ExchangeDelegate * mDelegate   = nullptr;
     ExchangeManager * mExchangeMgr = nullptr;
 

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -30,7 +30,7 @@ namespace Protocols {
 namespace Echo {
 
 // The Echo message timeout value in milliseconds.
-constexpr uint32_t kEchoMessageTimeoutMsec = 800;
+constexpr System::Clock::Timeout kEchoMessageTimeout = System::Clock::Milliseconds32(800);
 
 CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SessionHandle session)
 {
@@ -77,7 +77,7 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload, Me
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    mExchangeCtx->SetResponseTimeout(kEchoMessageTimeoutMsec);
+    mExchangeCtx->SetResponseTimeout(kEchoMessageTimeout);
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
     err = mExchangeCtx->SendMessage(MsgType::EchoRequest, std::move(payload),

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -87,7 +87,7 @@ using HKDF_sha_crypto = HKDF_sha;
 // Wait at most 10 seconds for the response from the peer.
 // This timeout value assumes the underlying transport is reliable.
 // The session establishment fails if the response is not received within timeout window.
-static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = 10000;
+static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = System::Clock::Seconds16(10);
 
 CASESession::CASESession()
 {

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -37,6 +37,8 @@
 namespace chip {
 namespace secure_channel {
 
+constexpr System::Clock::Timeout MessageCounterManager::kSyncTimeout;
+
 CHIP_ERROR MessageCounterManager::Init(Messaging::ExchangeManager * exchangeMgr)
 {
     VerifyOrReturnError(exchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -197,8 +199,8 @@ CHIP_ERROR MessageCounterManager::SendMsgCounterSyncReq(SessionHandle session, T
 
     sendFlags.Set(Messaging::SendMessageFlags::kNoAutoRequestAck).Set(Messaging::SendMessageFlags::kExpectResponse);
 
-    // Arm a timer to enforce that a MsgCounterSyncRsp is received before kSyncTimeoutMs.
-    exchangeContext->SetResponseTimeout(kSyncTimeoutMs);
+    // Arm a timer to enforce that a MsgCounterSyncRsp is received before kSyncTimeout.
+    exchangeContext->SetResponseTimeout(kSyncTimeout);
 
     // Send the message counter synchronization request in a Secure Channel Protocol::MsgCounterSyncReq message.
     SuccessOrExit(

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -34,10 +34,10 @@ class ExchangeManager;
 class MessageCounterManager : public Messaging::ExchangeDelegate, public Transport::MessageCounterManagerInterface
 {
 public:
-    static constexpr uint16_t kChallengeSize   = Transport::PeerMessageCounter::kChallengeSize;
-    static constexpr uint16_t kCounterSize     = 4;
-    static constexpr uint16_t kSyncRespMsgSize = kChallengeSize + kCounterSize;
-    static constexpr uint32_t kSyncTimeoutMs   = 500;
+    static constexpr uint16_t kChallengeSize             = Transport::PeerMessageCounter::kChallengeSize;
+    static constexpr uint16_t kCounterSize               = 4;
+    static constexpr uint16_t kSyncRespMsgSize           = kChallengeSize + kCounterSize;
+    static constexpr System::Clock::Timeout kSyncTimeout = System::Clock::Milliseconds32(500);
 
     MessageCounterManager() : mExchangeMgr(nullptr) {}
     ~MessageCounterManager() override {}

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -62,7 +62,7 @@ const char * kSpake2pKeyExchangeSalt = "SPAKE2P Key Salt";
 // Wait at most 30 seconds for the response from the peer.
 // This timeout value assumes the underlying transport is reliable.
 // The session establishment fails if the response is not received with in timeout window.
-static constexpr ExchangeContext::Timeout kSpake2p_Response_Timeout = 30000;
+static constexpr ExchangeContext::Timeout kSpake2p_Response_Timeout = System::Clock::Seconds16(30);
 
 #ifdef ENABLE_HSM_PBKDF2
 using PBKDF2_sha256_crypto = PBKDF2_sha256HSM;


### PR DESCRIPTION
#### Problem

Code uses plain integers to represent time values and relies on
users to get the unit scale correct.

Part of #10062 _Some operations on System::Clock types are not safe_

#### Change overview

Change `ExchangeContext::Timeout` and affected code.

#### Testing

CI; no change to functionality intended.
