### PR TITLE
Adding EFR32 Matter building guide

### DIFF
--- a/docs/guides/silabs_efr32_building.md
+++ b/docs/guides/silabs_efr32_building.md
@@ -1,0 +1,20 @@
+# Building Silicon Labs EFR32 examples
+
+Developers can start prototyping with Matter today. Silicon Labs offers a number
+of examples using Matter, such as
+[smart locks](https://github.com/project-chip/connectedhomeip/tree/master/examples/lock-app/efr32),
+[smart lights](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/efr32),
+and
+[window coverings](https://github.com/project-chip/connectedhomeip/tree/master/examples/window-app/efr32).
+Matter simplifies the developer experience by maximizing the interoperability of
+IoT devices across different vendors, so developers can focus on innovating.
+
+The full list of examples can be found
+[here](https://github.com/project-chip/connectedhomeip/tree/master/examples).
+The GitHub repository also includes tools for testing your Matter project.
+
+## Getting Started with Matter on EFR32
+
+Developers can find more resources on
+[Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US)
+.


### PR DESCRIPTION
#### Problem
Adding Getting started documentation for Silabs EFR32 device.

#### Change overview
Added a link to Silabs Matter page for setup board and configuration steps. 
