### PR TITLE
Use safer System::Clock types in chip-tool

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -46,7 +46,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 10; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endPointId) = 0;
 

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -57,7 +57,7 @@ protected:
     virtual CHIP_ERROR RunCommand() = 0;
 
     // Get the wait duration, in seconds, before the command times out.
-    virtual uint16_t GetWaitDurationInSeconds() const = 0;
+    virtual chip::System::Clock::Timeout GetWaitDuration() const = 0;
 
     // Shut down the command, in case any work needs to be done after the event
     // loop has been stopped.
@@ -72,7 +72,7 @@ private:
     CHIP_ERROR mCommandExitStatus = CHIP_ERROR_INTERNAL;
     chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 
-    CHIP_ERROR StartWaiting(uint16_t seconds);
+    CHIP_ERROR StartWaiting(chip::System::Clock::Timeout seconds);
     void StopWaiting();
 
 #if CONFIG_USE_SEPARATE_EVENTLOOP

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -36,7 +36,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 30; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
 
     virtual CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) = 0;
 

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -30,5 +30,5 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 30; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
 };

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -41,5 +41,5 @@ void DiscoverCommissionersCommand::Shutdown()
     }
 
     ChipLogProgress(chipTool, "Total of %d commissioner(s) discovered in %" PRIu16 " sec", commissionerCount,
-                    GetWaitDurationInSeconds());
+                    std::chrono::duration_cast<System::Clock::Seconds16>(GetWaitDuration()).count());
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
@@ -28,7 +28,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 3; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(3); }
     void Shutdown() override;
 
 private:

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -149,7 +149,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 120; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(120); }
     void Shutdown() override;
 
     /////////// DevicePairingDelegate Interface /////////

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -40,7 +40,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return UINT16_MAX; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(UINT16_MAX); }
 
     virtual void AddReportCallbacks(NodeId remoteId, uint8_t endPointId) = 0;
 

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -47,9 +47,9 @@ void TestCommand::OnWaitForMsFn(chip::System::Layer * systemLayer, void * contex
     command->NextTest();
 }
 
-CHIP_ERROR TestCommand::WaitForMs(uint32_t ms)
+CHIP_ERROR TestCommand::Wait(chip::System::Clock::Timeout duration)
 {
-    return chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(ms), OnWaitForMsFn, this);
+    return chip::DeviceLayer::SystemLayer().StartTimer(duration, OnWaitForMsFn, this);
 }
 
 CHIP_ERROR TestCommand::Log(const char * message)

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -38,12 +38,13 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 30; }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
 
     virtual void NextTest() = 0;
 
     /////////// GlobalCommands Interface /////////
-    CHIP_ERROR WaitForMs(uint32_t ms);
+    CHIP_ERROR Wait(chip::System::Clock::Timeout ms);
+    CHIP_ERROR WaitForMs(uint16_t ms) { return Wait(chip::System::Clock::Milliseconds32(ms)); }
     CHIP_ERROR Log(const char * message);
 
 protected:


### PR DESCRIPTION
#### Problem

Code uses plain integers to represent time values and relies on
users to get the unit scale correct.

Part of #10062 _Some operations on System::Clock types are not safe_

#### Change overview

Convert `examples/chip-tool` to use the safer `Clock` types.

#### Testing

CI; no change to functionality intended.
