### PR TITLE
Use safe System::Clock types in src/protocols/bdx

### DIFF
--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -54,9 +54,9 @@ constexpr uint16_t kOptionQueryImageBehavior   = 'q';
 constexpr uint16_t kOptionDelayedActionTimeSec = 'd';
 
 // Arbitrary BDX Transfer Params
-constexpr uint32_t kMaxBdxBlockSize = 1024;
-constexpr uint32_t kBdxTimeoutMs    = 5 * 60 * 1000; // OTA Spec mandates >= 5 minutes
-constexpr uint32_t kBdxPollFreqMs   = 500;
+constexpr uint32_t kMaxBdxBlockSize                 = 1024;
+constexpr chip::System::Clock::Timeout kBdxTimeout  = chip::System::Clock::Seconds16(5 * 60); // OTA Spec mandates >= 5 minutes
+constexpr chip::System::Clock::Timeout kBdxPollFreq = chip::System::Clock::Milliseconds32(500);
 
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
 OTAProviderExample::queryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
@@ -188,7 +188,7 @@ int main(int argc, char * argv[])
     BitFlags<TransferControlFlags> bdxFlags;
     bdxFlags.Set(TransferControlFlags::kReceiverDrive);
     err = bdxServer.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender, bdxFlags,
-                                       kMaxBdxBlockSize, kBdxTimeoutMs, kBdxPollFreqMs);
+                                       kMaxBdxBlockSize, kBdxTimeout, kBdxPollFreq);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(BDX, "failed to init BDX server: %s", chip::ErrorStr(err));

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -97,7 +97,8 @@ void OnQueryImageResponse(void * context, uint8_t status, uint32_t delayedAction
     bdxDownloader.SetInitialExchange(exchangeCtx);
 
     // This will kick of a timer which will regularly check for updates to the bdx::TransferSession state machine.
-    bdxDownloader.InitiateTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kReceiver, initOptions, 20000);
+    bdxDownloader.InitiateTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kReceiver, initOptions,
+                                   chip::System::Clock::Seconds16(20));
 }
 
 void OnQueryFailure(void * context, uint8_t status)

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -144,14 +144,14 @@ public:
      *   TransferSession object.
      *
      *   Note that if the type outputted is kMsgToSend, the caller is expected to send the message immediately, and the session
-     *   timeout timer will begin at curTimeMs.
+     *   timeout timer will begin at curTime.
      *
      *   See OutputEventType for all possible output event types.
      *
      * @param event     Reference to an OutputEvent struct that will be filled out with any pending output data
-     * @param curTimeMs Current time indicated by the number of milliseconds since some epoch defined by the platform
+     * @param curTime   Current time
      */
-    void PollOutput(OutputEvent & event, uint64_t curTimeMs);
+    void PollOutput(OutputEvent & event, System::Clock::Timestamp curTime);
 
     /**
      * @brief
@@ -162,13 +162,13 @@ public:
      * @param role      Inidcates whether this object will be sending or receiving data
      * @param initData  Data for initializing this object and for populating a TransferInit message
      *                  The role parameter will determine whether to populate a ReceiveInit or SendInit
-     * @param timeoutMs The amount of time to wait for a response before considering the transfer failed (milliseconds)
-     * @param curTimeMs The current time since epoch in milliseconds. Needed to set a start time for the transfer timeout.
+     * @param timeout   The amount of time to wait for a response before considering the transfer failed
+     * @param curTime   The current time since epoch. Needed to set a start time for the transfer timeout.
      *
      * @return CHIP_ERROR Result of initialization and preparation of a TransferInit message. May also indicate if the
      *                    TransferSession object is unable to handle this request.
      */
-    CHIP_ERROR StartTransfer(TransferRole role, const TransferInitData & initData, uint32_t timeoutMs);
+    CHIP_ERROR StartTransfer(TransferRole role, const TransferInitData & initData, System::Clock::Timeout timeout);
 
     /**
      * @brief
@@ -179,13 +179,13 @@ public:
      * @param role            Inidcates whether this object will be sending or receiving data
      * @param xferControlOpts Indicates all supported control modes. Used to respond to a TransferInit message
      * @param maxBlockSize    The max Block size that this object supports.
-     * @param timeoutMs       The amount of time to wait for a response before considering the transfer failed (milliseconds)
+     * @param timeout         The amount of time to wait for a response before considering the transfer failed
      *
      * @return CHIP_ERROR Result of initialization. May also indicate if the TransferSession object is unable to handle this
      *                    request.
      */
     CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<TransferControlFlags> xferControlOpts, uint16_t maxBlockSize,
-                               uint32_t timeoutMs);
+                               System::Clock::Timeout timeout);
 
     /**
      * @brief
@@ -263,12 +263,13 @@ public:
      * @param payloadHeader A PayloadHeader containing the Protocol type and Message Type
      * @param msg           A PacketBufferHandle pointing to the message buffer to process. May be BDX or StatusReport protocol.
      *                      Buffer is expected to start at data (not header).
-     * @param curTimeMs     Current time indicated by the number of milliseconds since some epoch defined by the platform
+     * @param curTime       Current time
      *
      * @return CHIP_ERROR Indicates any problems in decoding the message, or if the message is not of the BDX or StatusReport
      *                    protocols.
      */
-    CHIP_ERROR HandleMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle msg, uint64_t curTimeMs);
+    CHIP_ERROR HandleMessageReceived(const PayloadHeader & payloadHeader, System::PacketBufferHandle msg,
+                                     System::Clock::Timestamp curTime);
 
     TransferControlFlags GetControlMode() const { return mControlMode; }
     uint64_t GetStartOffset() const { return mStartOffset; }
@@ -349,8 +350,8 @@ private:
     uint32_t mLastQueryNum = 0;
     uint32_t mNextQueryNum = 0;
 
-    uint32_t mTimeoutMs          = 0;
-    uint64_t mTimeoutStartTimeMs = 0;
+    System::Clock::Timeout mTimeout{ 0 };
+    System::Clock::Timestamp mTimeoutStartTime{ 0 };
     bool mShouldInitTimeoutStart = true;
     bool mAwaitingResponse       = false;
 };

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -44,7 +44,7 @@ namespace bdx {
 class TransferFacilitator : public Messaging::ExchangeDelegate
 {
 public:
-    TransferFacilitator() : mExchangeCtx(nullptr), mSystemLayer(nullptr), mPollFreqMs(kDefaultPollFreqMs) {}
+    TransferFacilitator() : mExchangeCtx(nullptr), mSystemLayer(nullptr), mPollFreq(kDefaultPollFreq) {}
     ~TransferFacilitator() = default;
 
 private:
@@ -82,9 +82,9 @@ protected:
     TransferSession mTransfer;
     Messaging::ExchangeContext * mExchangeCtx;
     System::Layer * mSystemLayer;
-    uint32_t mPollFreqMs;
-    static constexpr uint32_t kDefaultPollFreqMs    = 500;
-    static constexpr uint32_t kImmediatePollDelayMs = 1;
+    System::Clock::Timeout mPollFreq;
+    static constexpr System::Clock::Timeout kDefaultPollFreq    = System::Clock::Milliseconds32(500);
+    static constexpr System::Clock::Timeout kImmediatePollDelay = System::Clock::Milliseconds32(1);
 };
 
 /**
@@ -103,12 +103,12 @@ public:
      * @param[in] role            The role of the Responder: Sender or Receiver of BDX data
      * @param[in] xferControlOpts Supported transfer modes (see TransferControlFlags)
      * @param[in] maxBlockSize    The supported maximum size of BDX Block data
-     * @param[in] timeoutMs       The chosen timeout delay for the BDX transfer in milliseconds
-     * @param[in] pollFreqMs      The period for the TransferSession poll timer in milliseconds
+     * @param[in] timeout         The chosen timeout delay for the BDX transfer
+     * @param[in] pollFreq        The period for the TransferSession poll timer
      */
     CHIP_ERROR PrepareForTransfer(System::Layer * layer, TransferRole role, BitFlags<TransferControlFlags> xferControlOpts,
-                                  uint16_t maxBlockSize, uint32_t timeoutMs,
-                                  uint32_t pollFreqMs = TransferFacilitator::kDefaultPollFreqMs);
+                                  uint16_t maxBlockSize, System::Clock::Timeout timeout,
+                                  System::Clock::Timeout pollFreq = TransferFacilitator::kDefaultPollFreq);
 };
 
 /**
@@ -131,7 +131,8 @@ public:
      * @param[in] pollFreqMs The period for the TransferSession poll timer in milliseconds
      */
     CHIP_ERROR InitiateTransfer(System::Layer * layer, TransferRole role, const TransferSession::TransferInitData & initData,
-                                uint32_t timeoutMs, uint32_t pollFreqMs = TransferFacilitator::kDefaultPollFreqMs);
+                                System::Clock::Timeout timeout,
+                                System::Clock::Timeout pollFreq = TransferFacilitator::kDefaultPollFreq);
 };
 
 } // namespace bdx


### PR DESCRIPTION
#### Problem

Code uses plain integers to represent time values and relies on
users to get the unit scale correct.

Part of #10062 _Some operations on System::Clock types are not safe_

#### Change overview

Change code under `src/protocols/bdx` to use the safer `Clock` types.

#### Testing

CI; no change to functionality intended.
