### PR TITLE
EstimateTLVStructOverhead should not need manual field counting.

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -325,8 +325,12 @@ CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session, CryptoConte
 
 CHIP_ERROR CASESession::SendSigma1()
 {
-    size_t data_len = EstimateTLVStructOverhead(kSigmaParamRandomNumberSize, sizeof(uint16_t), kSHA256_Hash_Length,
-                                                kP256_PublicKey_Length, /* kMRPOptionalParamsLength, */
+    size_t data_len = EstimateTLVStructOverhead(kSigmaParamRandomNumberSize, // initiatorRandom
+                                                sizeof(uint16_t),            // initiatorSessionId,
+                                                kSHA256_Hash_Length,         // destinationId
+                                                kP256_PublicKey_Length,      // InitiatorEphPubKey,
+                                                /* EstimateTLVStructOverhead(sizeof(uint16_t),
+                                                   sizeof(uint16)_t), // initiatorMRPParams */
                                                 kCASEResumptionIDSize, CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES);
 
     System::PacketBufferTLVWriter tlvWriter;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -237,11 +237,6 @@ private:
     CHIP_ERROR ValidateSigmaResumeMIC(const ByteSpan & resumeMIC, const ByteSpan & initiatorRandom, const ByteSpan & resumptionID,
                                       const ByteSpan & skInfo, const ByteSpan & nonce);
 
-    static constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields)
-    {
-        return dataLen + (sizeof(uint64_t) * nFields);
-    }
-
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -353,7 +353,7 @@ CHIP_ERROR PASESession::SendPBKDFParamRequest()
     ReturnErrorOnFailure(DRBG_get_bytes(mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
 
     const size_t max_msg_len =
-        EstimateTLVStructOverhead(kPBKDFParamRandomNumberSize + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint8_t), 4);
+        EstimateTLVStructOverhead(kPBKDFParamRandomNumberSize, sizeof(uint16_t), sizeof(uint16_t), sizeof(uint8_t));
     System::PacketBufferHandle req = System::PacketBufferHandle::New(max_msg_len);
     VerifyOrReturnError(!req.IsNull(), CHIP_ERROR_NO_MEMORY);
 
@@ -443,8 +443,8 @@ CHIP_ERROR PASESession::SendPBKDFParamResponse(ByteSpan initiatorRandom, bool in
 {
     ReturnErrorOnFailure(DRBG_get_bytes(mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
 
-    const size_t max_msg_len = EstimateTLVStructOverhead(
-        kPBKDFParamRandomNumberSize + kPBKDFParamRandomNumberSize + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint8_t), 5);
+    const size_t max_msg_len = EstimateTLVStructOverhead(kPBKDFParamRandomNumberSize, kPBKDFParamRandomNumberSize, sizeof(uint16_t),
+                                                         sizeof(uint16_t), sizeof(uint8_t));
     System::PacketBufferHandle resp = System::PacketBufferHandle::New(max_msg_len);
     VerifyOrReturnError(!resp.IsNull(), CHIP_ERROR_NO_MEMORY);
 
@@ -566,7 +566,7 @@ exit:
 
 CHIP_ERROR PASESession::SendMsg1()
 {
-    const size_t max_msg_len       = EstimateTLVStructOverhead(kMAX_Point_Length, 1);
+    const size_t max_msg_len       = EstimateTLVStructOverhead(kMAX_Point_Length);
     System::PacketBufferHandle msg = System::PacketBufferHandle::New(max_msg_len);
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
 
@@ -633,7 +633,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
     msg1 = nullptr;
 
     {
-        const size_t max_msg_len    = EstimateTLVStructOverhead(Y_len + verifier_len, 2);
+        const size_t max_msg_len    = EstimateTLVStructOverhead(Y_len, verifier_len);
         constexpr uint8_t kPake2_pB = 1;
         constexpr uint8_t kPake2_cB = 2;
 
@@ -710,7 +710,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(System::PacketBufferHandle && ms
     msg2 = nullptr;
 
     {
-        const size_t max_msg_len    = EstimateTLVStructOverhead(verifier_len, 1);
+        const size_t max_msg_len    = EstimateTLVStructOverhead(verifier_len);
         constexpr uint8_t kPake3_cB = 1;
 
         System::PacketBufferHandle msg3 = System::PacketBufferHandle::New(max_msg_len);

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -269,9 +269,6 @@ private:
     void OnSuccessStatusReport() override;
     CHIP_ERROR OnFailureStatusReport(Protocols::SecureChannel::GeneralStatusCode generalCode, uint16_t protocolCode) override;
 
-    // TODO - Move EstimateTLVStructOverhead to CHIPTLV header file
-    constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields) { return dataLen + (sizeof(uint64_t) * nFields); }
-
     void CloseExchange();
 
     SessionEstablishmentDelegate * mDelegate = nullptr;

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -88,6 +88,21 @@ public:
     virtual const char * GetR2ISessionInfo() const = 0;
 
 protected:
+    // TODO - Move EstimateTLVStructOverhead to CHIPTLV header file
+    static constexpr size_t EstimateTLVStructOverhead()
+    {
+        // The struct itself has a control byte and an end-of-struct marker.
+        return 2;
+    }
+
+    template <typename... FieldSizes>
+    static constexpr size_t EstimateTLVStructOverhead(size_t firstFieldSize, FieldSizes... otherFields)
+    {
+        // Conservatively estimate 8 bytes of overhead per field.  We should be
+        // able to do better...
+        return firstFieldSize + 8 + EstimateTLVStructOverhead(otherFields...);
+    }
+
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
     void SetLocalSessionId(uint16_t id) { mLocalSessionId = id; }

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -98,9 +98,10 @@ protected:
     template <typename... FieldSizes>
     static constexpr size_t EstimateTLVStructOverhead(size_t firstFieldSize, FieldSizes... otherFields)
     {
-        // Conservatively estimate 8 bytes of overhead per field.  We should be
-        // able to do better...
-        return firstFieldSize + 8 + EstimateTLVStructOverhead(otherFields...);
+        // stimate 4 bytes of overhead per field.  This can happen for a large
+        // octet string field: 1 byte control, 1 byte context tag, 2 bytes
+        // length.
+        return firstFieldSize + 4 + EstimateTLVStructOverhead(otherFields...);
     }
 
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -98,7 +98,7 @@ protected:
     template <typename... FieldSizes>
     static constexpr size_t EstimateTLVStructOverhead(size_t firstFieldSize, FieldSizes... otherFields)
     {
-        // stimate 4 bytes of overhead per field.  This can happen for a large
+        // Estimate 4 bytes of overhead per field.  This can happen for a large
         // octet string field: 1 byte control, 1 byte context tag, 2 bytes
         // length.
         return firstFieldSize + 4 + EstimateTLVStructOverhead(otherFields...);


### PR DESCRIPTION
We can just pass in the field sizes and have the compiler count the
fields for us.

#### Problem
Need to count up fields manually to use `EstimateTLVStructOverhead`.

#### Change overview
Make the compiler do the counting.

#### Testing
Existing unit tests pass.

Note: I tried reducing the per-field overhead to 4 bytes, which seemed like it should be fine, but then things fail.  So something somewhere is doing something wrong (e.g. not telling us about all its fields).