### PR TITLE
Fix IPv6-only builds where platform LwIP has IPv4

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -76,7 +76,7 @@ IPAddress::IPAddress(const ip6_addr_t & ipv6Addr)
     memcpy(Addr, &ipv6Addr, sizeof(ipv6Addr));
 }
 
-#if INET_CONFIG_ENABLE_IPV4
+#if INET_CONFIG_ENABLE_IPV4 || LWIP_IPV4
 
 IPAddress::IPAddress(const ip4_addr_t & ipv4Addr)
 {
@@ -105,6 +105,10 @@ IPAddress::IPAddress(const ip_addr_t & addr)
         break;
     }
 }
+
+#endif // INET_CONFIG_ENABLE_IPV4 || LWIP_IPV4
+
+#if INET_CONFIG_ENABLE_IPV4
 
 ip4_addr_t IPAddress::ToIPv4() const
 {

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -147,7 +147,7 @@ public:
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     explicit IPAddress(const ip6_addr_t & ipv6Addr);
-#if INET_CONFIG_ENABLE_IPV4
+#if INET_CONFIG_ENABLE_IPV4 || LWIP_IPV4
     explicit IPAddress(const ip4_addr_t & ipv4Addr);
     explicit IPAddress(const ip_addr_t & addr);
 #endif // INET_CONFIG_ENABLE_IPV4


### PR DESCRIPTION
#### Problem

When LwIP is configured for IPv6 only, its type `ip_addr_t` is identical
to `ip6_addr_t`; otherwise they are different. PR #10791 made the
incorrect assumption that we would never build CHIP without IPv4 when
the platform LwIP is configured with IPv4, and left out the constructor
overload necessary for that case.

#### Change overview

Enable the `ip_addr_t` constructor if `LWIP_IPV4` is true.

#### Testing

Built
```
scripts/build/build_examples.py \
    --target esp32-m5stack-all-clusters-ipv6only build
```