### PR TITLE
Mark Objects.py as a generated file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,5 @@
 # And some specific generated files
 src/controller/python/chip/clusters/CHIPClusters.cpp linguist-generated
 src/controller/python/chip/clusters/CHIPClusters.py linguist-generated
+src/controller/python/chip/clusters/Objects.py linguist-generated
 src/darwin/Framework/CHIPTests/CHIPClustersTests.m linguist-generated


### PR DESCRIPTION
This way it won't clutter up reviews by default.

#### Problem
Objects.py shows up in reviews expanded.

#### Change overview
Mark it as a generated file.

#### Testing
Can't check until doing a review after this lands.