### PR TITLE
Bump up timeout on Linux Test job.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,7 +84,7 @@ jobs:
                   # actually succeeded, because that just wastes space.
                   rsync -a out/debug/standalone/ objdir-clone || true
             - name: Run Tests
-              timeout-minutes: 10
+              timeout-minutes: 20
               run: |
                   scripts/tests/test_suites.sh
             - name: Run TV Tests


### PR DESCRIPTION
The timeout is at 10 mins, a typical execution is 9-9.5 mins, so if
something is just a bit slow the job ends up timing out.

#### Problem
Random timeouts in CI because job is bumping against the timeout limit.

#### Change overview
Bump the limit.

