### PR TITLE
[msg] Correct nonce to match spec.

### DIFF
--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -37,7 +37,7 @@ namespace chip {
 
 namespace {
 
-constexpr size_t kAESCCMIVLen = 12;
+constexpr size_t kAESCCMIVLen = 13;
 constexpr size_t kMaxAADLen   = 128;
 
 /* Session Establish Key Info */
@@ -137,8 +137,9 @@ CHIP_ERROR CryptoContext::GetIV(const PacketHeader & header, uint8_t * iv, size_
 
     Encoding::LittleEndian::BufferWriter bbuf(iv, len);
 
-    bbuf.Put64(header.GetSourceNodeId().ValueOr(0));
+    bbuf.Put8(header.GetSecurityFlags());
     bbuf.Put32(header.GetMessageCounter());
+    bbuf.Put64(header.GetSourceNodeId().ValueOr(0));
 
     return bbuf.Fit() ? CHIP_NO_ERROR : CHIP_ERROR_NO_MEMORY;
 }

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -158,6 +158,14 @@ public:
     uint16_t GetSessionId() const { return mSessionId; }
     Header::SessionType GetSessionType() const { return mSessionType; }
 
+    uint8_t GetMessageFlags() const { return mMsgFlags.Raw(); }
+
+    uint8_t GetSecurityFlags() const { return mSecFlags.Raw(); }
+
+    void SetMessageFlags(uint8_t flags) { mMsgFlags.SetRaw(flags); }
+
+    void SetSecurityFlags(uint8_t flags) { mSecFlags.SetRaw(flags); }
+
     bool IsGroupSession() const { return mSessionType == Header::SessionType::kGroupSession; }
     bool IsUnicastSession() const { return mSessionType == Header::SessionType::kUnicastSession; }
 


### PR DESCRIPTION
#### Problem
NONCE calculation in `GetIV()` does not match specification.

#### Change overview
Correct the NONCE calculation.

#### Testing
Uses the unit tests to prove encrypt / decrypt work full-circle.  There are no strict known-good test vectors at this time.