### PR TITLE
Tool: Allow to flash EFR32 via IP interface instead of default USB

### DIFF
--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -22,7 +22,7 @@ interface or standalone execution:
 usage: efr32_firmware_utils.py [-h] [--verbose] [--erase] [--application FILE]
                                [--verify_application] [--reset] [--skip_reset]
                                [--commander FILE] [--device DEVICE]
-                               [--serialno SERIAL]
+                               [--serialno SERIAL] [--ip ADDRESS]
 
 Flash EFR32 device
 
@@ -36,6 +36,8 @@ configuration:
                         Device family or platform to target
   --serialno SERIAL, -s SERIAL
                         Serial number of device to flash
+  --ip ADDRESS, -a ADDRESS
+                        Ip Address of the targeted flasher
 
 operations:
   --erase               Erase device
@@ -90,6 +92,14 @@ EFR32_OPTIONS = {
                 'metavar': 'SERIAL'
             },
         },
+        'ip': {
+            'help': 'Ip Address of the probe connected to the target',
+            'default': None,
+            'alias': ['-a'],
+            'argparse': {
+                'metavar': 'ADDRESS'
+            },
+        },
     },
 }
 
@@ -102,7 +112,7 @@ class Flasher(firmware_utils.Flasher):
         self.define_options(EFR32_OPTIONS)
 
     # Common command line arguments for commander device subcommands.
-    DEVICE_ARGUMENTS = [{'optional': 'serialno'}, {'optional': 'device'}]
+    DEVICE_ARGUMENTS = [{'optional': 'serialno'}, {'optional': 'ip'}, {'optional': 'device'}]
 
     def erase(self):
         """Perform `commander device masserase`."""

--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -112,7 +112,8 @@ class Flasher(firmware_utils.Flasher):
         self.define_options(EFR32_OPTIONS)
 
     # Common command line arguments for commander device subcommands.
-    DEVICE_ARGUMENTS = [{'optional': 'serialno'}, {'optional': 'ip'}, {'optional': 'device'}]
+    DEVICE_ARGUMENTS = [{'optional': 'serialno'}, {
+        'optional': 'ip'}, {'optional': 'device'}]
 
     def erase(self):
         """Perform `commander device masserase`."""


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* This is simply adding a flashing tool option compatible with the "commander" cli tool called by a python script
* Convenient tool shared with the SDK

#### Change overview
Trivial and Simple wrapping tool modification 

#### Testing
How was this tested? (at least one bullet point required)
* No codebase modification: used for simplicity with IP devices
