### PR TITLE
[Warnings] Update the documentation of some files in src/app to avoid…

### DIFF
--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -64,9 +64,9 @@ public:
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param[in] apCommandSender: The command sender object that initiated the command transaction.
-         * @param[in] aPath: The command path field in invoke command response.
-         * @param[in] aData: The command data, will be nullptr if the server returns a StatusIB.
+         * @param[in] apCommandSender The command sender object that initiated the command transaction.
+         * @param[in] aPath           The command path field in invoke command response.
+         * @param[in] aData           The command data, will be nullptr if the server returns a StatusIB.
          */
         virtual void OnResponse(CommandSender * apCommandSender, const ConcreteCommandPath & aPath, TLV::TLVReader * aData) {}
 
@@ -84,10 +84,10 @@ public:
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy and free the object.
          *
-         * @param[in] apCommandSender: The command sender object that initiated the command transaction.
-         * @param[in] aInteractionModelStatus: Contains an IM status code. This SHALL never be IM::Success, and will contain a valid
-         * server-side emitted error if aProtocolError == CHIP_ERROR_IM_STATUS_CODE_RECEIVED.
-         * @param[in] aError: A system error code that conveys the overall error code.
+         * @param[in] apCommandSender         The command sender object that initiated the command transaction.
+         * @param[in] aInteractionModelStatus Contains an IM status code. This SHALL never be IM::Success, and will contain a valid
+         *                                    server-side emitted error if aProtocolError == CHIP_ERROR_IM_STATUS_CODE_RECEIVED.
+         * @param[in] aError                  A system error code that conveys the overall error code.
          */
         virtual void OnError(const CommandSender * apCommandSender, Protocols::InteractionModel::Status aInteractionModelStatus,
                              CHIP_ERROR aError)
@@ -104,7 +104,7 @@ public:
          *
          * This function must be implemented to destroy the CommandSender object.
          *
-         * @param[in] apCommandSender: The command sender object of the terminated invoke command transaction.
+         * @param[in] apCommandSender   The command sender object of the terminated invoke command transaction.
          */
         virtual void OnDone(CommandSender * apCommandSender) = 0;
     };
@@ -122,8 +122,8 @@ public:
      * object that can be encoded using the DataModel::Encode machinery and
      * exposes the right command id will work.
      *
-     * @param [in] aRequestCommandPath the path of the command being requested.
-     * @param [in] aData the data for the request.
+     * @param [in] aCommandPath  The path of the command being requested.
+     * @param [in] aData         The data for the request.
      */
     template <typename CommandDataT>
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData)

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -158,7 +158,6 @@ public:
      * Notification that a read interaction was completed on the client successfully.
      * @param[in]  apReadClient  A current read client which can identify the read client to the consumer, particularly
      * during multiple read interactions
-     * @param[in]  aError  notify final error regarding the current read interaction
      * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
      */
     virtual CHIP_ERROR ReadDone(ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -138,7 +138,7 @@ public:
      *  Allocate a ReadClient that can be used to do a read interaction.  If the call succeeds, the consumer
      *  is responsible for calling Shutdown() on the ReadClient once it's done using it.
      *
-     *  @param[inout] 	apReadClient	    A double pointer to a ReadClient that is updated to point to a valid ReadClient
+     *  @param[in,out] 	apReadClient	      A double pointer to a ReadClient that is updated to point to a valid ReadClient
      *                                      on successful completion of this function. On failure, it will be updated to point to
      *                                      nullptr.
      *  @param[in]      aInteractionType    Type of interaction (read or subscription) that the requested ReadClient should execute.


### PR DESCRIPTION
… a warning when compiling with Xcode

#### Problem

When compiling with Xcode, There are warnings such as:
```
warning: parameter 'apCommandSender:' not found in the function declaration [-Wdocumentation]
 * @param[in] apCommandSender: The command sender object of the terminated invoke command transaction.
```

#### Change overview
 * Update the documentation
