### PR TITLE
Don't close session or update key id on spurious resolve

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -939,9 +939,11 @@ CHIP_ERROR DeviceCommissioner::OperationalDiscoveryComplete(NodeId remoteDeviceI
 
     Device * device = nullptr;
     ReturnErrorOnFailure(GetDevice(remoteDeviceId, &device));
-    device->OperationalCertProvisioned();
-    PersistDevice(device);
-    PersistNextKeyId();
+    if (!device->IsSecureConnected() && !device->IsSessionSetupInProgress()) {
+      device->OperationalCertProvisioned();
+      PersistDevice(device);
+      PersistNextKeyId();
+    }
 
     return GetConnectedDevice(remoteDeviceId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }


### PR DESCRIPTION
#### Problem
If we receive a second address update completion while we're establishing a case session already, the call to device->OperationalCertProvisioned() closes the session while it is being established and causes an error. 
Fixes #10772 (though I make no assurances that there are no other race conditions in the code).

#### Change overview
Adds a check around device->OperationalCertProvisioned() such that we don't call this function if we have a secure connection already set up or in the process of being set up.

#### Testing
Because of https://github.com/project-chip/connectedhomeip/pull/10771, I had a local cirque instance where the case establishment from the subscription thread was reliably conflicting with the UpdateNode call later in the test. This race doesn't appear to happen in the presubmits (gotta love race bugs). Adding this check fixed the race condition on my local cirque tests.
