### PR TITLE
Detect OpenCommissioningWindow errors in controller apps

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -155,10 +155,21 @@ CHIP_ERROR PairingCommand::Unpair(NodeId remoteId)
     return err;
 }
 
+void PairingCommand::OnOpenCommissioningWindowResponse(void * context, NodeId remoteId, CHIP_ERROR err, chip::SetupPayload payload)
+{
+    PairingCommand * command = reinterpret_cast<PairingCommand *>(context);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(chipTool, "Failed in opening commissioning window on the device: %" PRIu64 ", error %" CHIP_ERROR_FORMAT,
+                     remoteId, err.Format());
+    }
+    command->SetCommandExitStatus(err);
+}
+
 CHIP_ERROR PairingCommand::OpenCommissioningWindow()
 {
-    CHIP_ERROR err = mController.OpenCommissioningWindow(mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption);
-    SetCommandExitStatus(err);
+    CHIP_ERROR err = mController.OpenCommissioningWindowWithCallback(
+        mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback);
     return err;
 }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -160,17 +160,17 @@ void PairingCommand::OnOpenCommissioningWindowResponse(void * context, NodeId re
     PairingCommand * command = reinterpret_cast<PairingCommand *>(context);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(chipTool, "Failed in opening commissioning window on the device: %" PRIu64 ", error %" CHIP_ERROR_FORMAT,
-                     remoteId, err.Format());
+        ChipLogError(chipTool,
+                     "Failed in opening commissioning window on the device: 0x" ChipLogFormatX64 ", error %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(remoteId), err.Format());
     }
     command->SetCommandExitStatus(err);
 }
 
 CHIP_ERROR PairingCommand::OpenCommissioningWindow()
 {
-    CHIP_ERROR err = mController.OpenCommissioningWindowWithCallback(
-        mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback);
-    return err;
+    return mController.OpenCommissioningWindowWithCallback(mNodeId, mTimeout, mIteration, mDiscriminator,
+                                                           mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback);
 }
 
 void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -59,7 +59,9 @@ public:
         CHIPCommand(commandName),
         mPairingMode(mode), mNetworkType(networkType),
         mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() },
-        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
 
@@ -214,7 +216,9 @@ private:
 
     static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);
     static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
+    static void OnOpenCommissioningWindowResponse(void * context, NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload);
 
     chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+    chip::Callback::Callback<chip::Controller::OnOpenCommissioningWindow> mOnOpenCommissioningWindowCallback;
 };

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -37,7 +37,6 @@
 #include <lwip/tcpip.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandSender.h>
 #include <app/ReadPrepareParams.h>
 #include <app/util/DataModelHandler.h>

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -37,6 +37,7 @@
 #include <lwip/tcpip.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandSender.h>
 #include <app/ReadPrepareParams.h>
 #include <app/util/DataModelHandler.h>
@@ -308,11 +309,29 @@ void Device::OnResponseTimeout(Messaging::ExchangeContext * ec) {}
 void Device::OnOpenPairingWindowSuccessResponse(void * context)
 {
     ChipLogProgress(Controller, "Successfully opened pairing window on the device");
+    Device * device = reinterpret_cast<Device *>(context);
+    if (device->mCommissioningWindowCallback != nullptr)
+    {
+        device->mCommissioningWindowCallback->mCall(device->mCommissioningWindowCallback->mContext, device->GetDeviceId(),
+                                                    CHIP_NO_ERROR, device->mSetupPayload);
+    }
 }
 
 void Device::OnOpenPairingWindowFailureResponse(void * context, uint8_t status)
 {
     ChipLogError(Controller, "Failed to open pairing window on the device. Status %d", status);
+    Device * device = reinterpret_cast<Device *>(context);
+    if (device->mCommissioningWindowCallback != nullptr)
+    {
+        CHIP_ERROR error = CHIP_ERROR_INVALID_PASE_PARAMETER;
+        // TODO - Use cluster enum chip::app::Clusters::AdministratorCommissioning::StatusCode::kBusy
+        if (status == 1)
+        {
+            error = CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS;
+        }
+        device->mCommissioningWindowCallback->mCall(device->mCommissioningWindowCallback->mContext, device->GetDeviceId(), error,
+                                                    SetupPayload());
+    }
 }
 
 CHIP_ERROR Device::ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt,
@@ -325,7 +344,8 @@ CHIP_ERROR Device::ComputePASEVerifier(uint32_t iterations, uint32_t setupPincod
 }
 
 CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, CommissioningWindowOption option,
-                                           const ByteSpan & salt, SetupPayload & setupPayload)
+                                           const ByteSpan & salt, Callback::Callback<OnOpenCommissioningWindow> * callback,
+                                           SetupPayload & setupPayload)
 {
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 
@@ -335,6 +355,7 @@ CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration,
     Callback::Cancelable * successCallback = mOpenPairingSuccessCallback.Cancel();
     Callback::Cancelable * failureCallback = mOpenPairingFailureCallback.Cancel();
 
+    mCommissioningWindowCallback = callback;
     if (option != CommissioningWindowOption::kOriginalSetupCode)
     {
         bool randomSetupPIN = (option == CommissioningWindowOption::kTokenWithRandomPIN);
@@ -361,6 +382,8 @@ CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration,
     setupPayload.version               = 0;
     setupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
 
+    mSetupPayload = setupPayload;
+
     return CHIP_NO_ERROR;
 }
 
@@ -368,7 +391,7 @@ CHIP_ERROR Device::OpenPairingWindow(uint16_t timeout, CommissioningWindowOption
 {
     ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
 
-    return OpenCommissioningWindow(timeout, kPBKDFMinimumIterations, option, salt, setupPayload);
+    return OpenCommissioningWindow(timeout, kPBKDFMinimumIterations, option, salt, nullptr, setupPayload);
 }
 
 void Device::UpdateSession(bool connected)

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -103,6 +103,7 @@ class Device;
 
 typedef void (*OnDeviceConnected)(void * context, Device * device);
 typedef void (*OnDeviceConnectionFailure)(void * context, NodeId deviceId, CHIP_ERROR error);
+typedef void (*OnOpenCommissioningWindow)(void * context, NodeId deviceId, CHIP_ERROR status, SetupPayload payload);
 
 class DLL_EXPORT Device : public Messaging::ExchangeDelegate, public SessionEstablishmentDelegate
 {
@@ -289,12 +290,14 @@ public:
      *                            the PIN code provied in the setupPayload).
      * @param[in] salt            The PAKE Salt associated with the PAKE Passcode ID and ephemeral PAKE passcode
      *                            verifier to be used for this commissioning.
+     * @param[in] callback        The function to be called on success or failure of opening of commissioning window.
      * @param[out] setupPayload   The setup payload corresponding to the generated onboarding token.
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, CommissioningWindowOption option,
-                                       const ByteSpan & salt, SetupPayload & setupPayload);
+                                       const ByteSpan & salt, Callback::Callback<OnOpenCommissioningWindow> * callback,
+                                       SetupPayload & setupPayload);
 
     /**
      * @brief
@@ -578,6 +581,9 @@ private:
 
     Callback::CallbackDeque mConnectionSuccess;
     Callback::CallbackDeque mConnectionFailure;
+
+    Callback::Callback<OnOpenCommissioningWindow> * mCommissioningWindowCallback = nullptr;
+    SetupPayload mSetupPayload;
 
     Callback::Callback<DefaultSuccessCallback> mOpenPairingSuccessCallback;
     Callback::Callback<DefaultFailureCallback> mOpenPairingFailureCallback;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -875,8 +875,9 @@ CHIP_ERROR DeviceCommissioner::OperationalDiscoveryComplete(NodeId remoteDeviceI
     return GetConnectedDevice(remoteDeviceId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }
 
-CHIP_ERROR DeviceCommissioner::OpenCommissioningWindow(NodeId deviceId, uint16_t timeout, uint16_t iteration,
-                                                       uint16_t discriminator, uint8_t option)
+CHIP_ERROR DeviceCommissioner::OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration,
+                                                                   uint16_t discriminator, uint8_t option,
+                                                                   Callback::Callback<OnOpenCommissioningWindow> * callback)
 {
     ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, deviceId);
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
@@ -908,7 +909,7 @@ CHIP_ERROR DeviceCommissioner::OpenCommissioningWindow(NodeId deviceId, uint16_t
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ReturnErrorOnFailure(device->OpenCommissioningWindow(timeout, iteration, commissioningWindowOption, salt, payload));
+    ReturnErrorOnFailure(device->OpenCommissioningWindow(timeout, iteration, commissioningWindowOption, salt, callback, payload));
 
     if (commissioningWindowOption != Device::CommissioningWindowOption::kOriginalSetupCode)
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -460,7 +460,30 @@ public:
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR OpenCommissioningWindow(NodeId deviceId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
-                                       uint8_t option);
+                                       uint8_t option)
+    {
+        return OpenCommissioningWindowWithCallback(deviceId, timeout, iteration, discriminator, option, nullptr);
+    }
+
+    /**
+     * @brief
+     *   Trigger a paired device to re-enter the commissioning mode. The device will exit the commissioning mode
+     *   after a successful commissioning, or after the given `timeout` time.
+     *
+     * @param[in] deviceId        The device Id.
+     * @param[in] timeout         The commissioning mode should terminate after this much time.
+     * @param[in] iteration       The PAKE iteration count associated with the PAKE Passcode ID and ephemeral
+     *                            PAKE passcode verifier to be used for this commissioning.
+     * @param[in] discriminator   The long discriminator for the DNS-SD advertisement.
+     * @param[in] option          The commissioning window can be opened using the original setup code, or an
+     *                            onboarding token can be generated using a random setup PIN code (or with
+     *                            the PIN code provied in the setupPayload).
+     * @param[in] callback        The function to be called on success or failure of opening of commissioning window.
+     *
+     * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
+     */
+    CHIP_ERROR OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
+                                                   uint8_t option, Callback::Callback<OnOpenCommissioningWindow> * callback);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2207,6 +2207,15 @@ using CHIP_ERROR = ::chip::ChipError;
  */
 #define CHIP_ERROR_IM_STATUS_CODE_RECEIVED                     CHIP_CORE_ERROR(0xca)
 
+/*
+ * @def CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS
+ *
+ * @brief
+ *   Indicates that the commissioning window on the device is already open, and another
+ *   commissioning is in progress
+ */
+#define CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS           CHIP_CORE_ERROR(0xcb)
+
 /**
  *  @}
  */


### PR DESCRIPTION
#### Problem
* Fixes #10676 
* Fixes #10679 

#### Change overview
The controller API did not have provisions to propagate `OpenCommissioningWindow` command response status to the controller application. The application was just relying on command send status to determine if the command was successful or not.

This PR adds a callback to the API. The registered callback will convey the command status, and the generated setup payload to the application.

#### Testing
The failure was reported in TE6 testing while using chip-tool app. Tested this change by running chip-tool with all-cluster-app.
1. Commission the application
2. Try opening the commissioning window with 901 seconds timeout. Ensure that chip-tool reports a failure.
3. Open the commissioning window with 900 seconds timeout. Ensure it succeeds
4. Try opening the commissioning window while it is already open. Ensure that chip-tool reports a failure.
