### PR TITLE
Use accessors into the level control cluster, the occupancy sensor cl…

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
@@ -38,10 +38,8 @@
  ******************************************************************************/
 
 #include "door-lock-server.h"
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/command-id.h>
 #include <app/util/af.h>
 
 #include <app/CommandHandler.h>
@@ -108,15 +106,15 @@ void emAfPluginDoorLockServerInitSchedule(void)
     defined(ZCL_USING_DOOR_LOCK_CLUSTER_NUM_HOLIDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE)
     const EmAfPluginDoorLockServerAttributeData data[] = {
 #ifdef ZCL_USING_DOOR_LOCK_CLUSTER_NUM_WEEKDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE
-        { ZCL_NUM_WEEKDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE_ID, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_WEEKDAY_SCHEDULE_TABLE_SIZE },
+        { Attributes::NumWeekdaySchedulesSupportedPerUser::Id, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_WEEKDAY_SCHEDULE_TABLE_SIZE },
 #endif
 
 #ifdef ZCL_USING_DOOR_LOCK_CLUSTER_NUM_YEARDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE
-        { ZCL_NUM_YEARDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE_ID, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_YEARDAY_SCHEDULE_TABLE_SIZE },
+        { Attributes::NumYeardaySchedulesSupportedPerUser::Id, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_YEARDAY_SCHEDULE_TABLE_SIZE },
 #endif
 
 #ifdef ZCL_USING_DOOR_LOCK_CLUSTER_NUM_HOLIDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE
-        { ZCL_NUM_HOLIDAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE_ID, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_HOLIDAY_SCHEDULE_TABLE_SIZE },
+        { Attributes::NumHolidaySchedulesSupportedPerUser::Id, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_HOLIDAY_SCHEDULE_TABLE_SIZE },
 #endif
     };
     emAfPluginDoorLockServerWriteAttributes(data, ArraySize(data), "schedule table");
@@ -160,9 +158,8 @@ bool emberAfDoorLockClusterSetWeekdayScheduleCallback(app::CommandHandler * comm
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_SET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::SetWeekdayScheduleResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -171,14 +168,13 @@ bool emberAfDoorLockClusterSetWeekdayScheduleCallback(app::CommandHandler * comm
     }
 
     // get bitmask so we can check if we should send event notification
-    emberAfReadServerAttribute(DOOR_LOCK_SERVER_ENDPOINT, ZCL_DOOR_LOCK_CLUSTER_ID, ZCL_RF_PROGRAMMING_EVENT_MASK_ATTRIBUTE_ID,
-                               (uint8_t *) &rfProgrammingEventMask, sizeof(rfProgrammingEventMask));
+    Attributes::RfProgrammingEventMask::Get(DOOR_LOCK_SERVER_ENDPOINT, &rfProgrammingEventMask);
 
     if (rfProgrammingEventMask & EMBER_BIT(0))
     {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_PROGRAMMING_EVENT_NOTIFICATION_COMMAND_ID, "uuvsuuws", 0x01, 0x00, userId, &userPin, 0x00,
-                                  0x00, 0x00, &userPin);
+        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ::Id,
+                                  Commands::ProgrammingEventNotification::Id, "uuvsuuws", 0x01, 0x00, userId, &userPin, 0x00, 0x00,
+                                  0x00, &userPin);
         SEND_COMMAND_UNICAST_TO_BINDINGS();
     }
 exit:
@@ -209,9 +205,8 @@ bool emberAfDoorLockClusterGetWeekdayScheduleCallback(app::CommandHandler * comm
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_GET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::GetWeekdayScheduleResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -251,8 +246,8 @@ bool emberAfDoorLockClusterClearWeekdayScheduleCallback(app::CommandHandler * co
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::ClearWeekdayScheduleResponse::Id,
                                              (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
@@ -293,9 +288,8 @@ bool emberAfDoorLockClusterSetYeardayScheduleCallback(app::CommandHandler * comm
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_SET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::SetYeardayScheduleResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -339,9 +333,8 @@ bool emberAfDoorLockClusterGetYeardayScheduleCallback(app::CommandHandler * comm
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_GET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::GetYeardayScheduleResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -381,8 +374,8 @@ bool emberAfDoorLockClusterClearYeardayScheduleCallback(app::CommandHandler * co
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::ClearYeardayScheduleResponse::Id,
                                              (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
@@ -425,9 +418,8 @@ bool emberAfDoorLockClusterSetHolidayScheduleCallback(app::CommandHandler * comm
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_SET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::SetHolidayScheduleResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -469,9 +461,8 @@ bool emberAfDoorLockClusterGetHolidayScheduleCallback(app::CommandHandler * comm
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_GET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (app::CommandPathFlags::kEndpointIdValid) };
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::GetHolidayScheduleResponse::Id, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -509,8 +500,8 @@ bool emberAfDoorLockClusterClearHolidayScheduleCallback(app::CommandHandler * co
     }
 
     {
-        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
+        app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ::Id,
+                                             Commands::ClearHolidayScheduleResponse::Id,
                                              (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));

--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -42,34 +42,21 @@
 
 #include <app/util/af.h>
 
-#include <app-common/zap-generated/att-storage.h>
-#include <app-common/zap-generated/attribute-id.h>
-#include <app-common/zap-generated/attribute-type.h>
-#include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/command-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/enums.h>
-#include <app/util/af-event.h>
-#include <app/util/attribute-storage.h>
 
 #include "occupancy-hal.h"
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
-#include <app/reporting/reporting.h>
-#endif
-
 using namespace chip;
+using namespace chip::app::Clusters::OccupancySensing;
 
 //******************************************************************************
 // Plugin init function
 //******************************************************************************
 void emberAfOccupancySensingClusterServerInitCallback(EndpointId endpoint)
 {
-    HalOccupancySensorType deviceType;
-
-    deviceType = halOccupancyGetSensorType(endpoint);
-
-    emberAfWriteAttribute(endpoint, ZCL_OCCUPANCY_SENSING_CLUSTER_ID, ZCL_OCCUPANCY_SENSOR_TYPE_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                          (uint8_t *) &deviceType, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    auto deviceType = halOccupancyGetSensorType(endpoint);
+    Attributes::OccupancySensorType::Set(endpoint, deviceType);
 
     uint8_t deviceTypeBitmap = 0;
     switch (deviceType)
@@ -93,8 +80,7 @@ void emberAfOccupancySensingClusterServerInitCallback(EndpointId endpoint)
     default:
         break;
     }
-    emberAfWriteAttribute(endpoint, ZCL_OCCUPANCY_SENSING_CLUSTER_ID, ZCL_OCCUPANCY_SENSOR_TYPE_BITMAP_ATTRIBUTE_ID,
-                          CLUSTER_MASK_SERVER, &deviceTypeBitmap, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    Attributes::OccupancySensorTypeBitmap::Set(endpoint, deviceTypeBitmap);
 
     emberAfPluginOccupancyClusterServerPostInitCallback(endpoint);
 }
@@ -113,8 +99,7 @@ void halOccupancyStateChangedCallback(EndpointId endpoint, HalOccupancyState occ
         emberAfOccupancySensingClusterPrintln("Occupancy no longer detected");
     }
 
-    emberAfWriteAttribute(endpoint, ZCL_OCCUPANCY_SENSING_CLUSTER_ID, ZCL_OCCUPANCY_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
-                          (uint8_t *) &occupancyState, ZCL_BITMAP8_ATTRIBUTE_TYPE);
+    Attributes::Occupancy::Set(endpoint, occupancyState);
 }
 
 void emberAfPluginOccupancyClusterServerPostInitCallback(EndpointId endpoint) {}


### PR DESCRIPTION
…uster and some parts of door lock

#### Problem

Third part of #10658 where more clusters are updated to not use `cluster-id.h`. 

#### Change overview
* Use `ids/Clusters.h`  instead of `cluster-id.h` into some clusters
* use `ids/Commands.h` instead of `command-id.h` into some clusters
* use `ids/Attributes.h` instead of `attribute-id.h` into some clusters
* Use attributes accessors instead of `emberAfReadServerAttribute` and `emberAfWriteServerAttribute`