### PR TITLE
Fix dangling ExchangeContext pointer

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -83,6 +83,9 @@ CHIP_ERROR CommandHandler::SendCommandResponse()
     ReturnErrorOnFailure(
         mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandResponse, std::move(commandPacket)));
 
+    // The exchange will be automatically freed after SendMessage
+    mpExchangeCtx = nullptr;
+
     MoveToState(CommandState::CommandSent);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
The exchange is freed automatically after send a message, but the IM command is still holding a pointer to it.

#### Change overview
Set the dangling pointer to nullptr

#### Testing
Verified by unit-tests