### PR TITLE
Code cleanup: CHIPCertToX509.

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -575,7 +575,7 @@ CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, uint64_t val)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, ByteSpan val)
+CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, CharSpan val)
 {
     uint8_t rdnCount = RDNCount();
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -196,7 +196,7 @@ enum
  */
 struct ChipRDN
 {
-    ByteSpan mString;         /**< Attribute value when encoded as a string. */
+    CharSpan mString;         /**< Attribute value when encoded as a string. */
     uint64_t mChipVal;        /**< CHIP specific DN attribute value. */
     chip::ASN1::OID mAttrOID; /**< DN attribute CHIP OID. */
 
@@ -231,12 +231,12 @@ public:
      * @brief Add string attribute to the DN.
      *
      * @param oid     String OID for DN attribute.
-     * @param val     A ByteSpan object containing a pointer and length of the DN string attribute
+     * @param val     A CharSpan object containing a pointer and length of the DN string attribute
      *                buffer. The value in the buffer should remain valid while the object is in use.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR AddAttribute(chip::ASN1::OID oid, ByteSpan val);
+    CHIP_ERROR AddAttribute(chip::ASN1::OID oid, CharSpan val);
 
     /**
      * @brief Determine type of a CHIP certificate.

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -467,6 +467,26 @@ public:
     CHIP_ERROR Get(ByteSpan & v);
 
     /**
+     * Get the value of the current element as a FixedByteSpan
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV bytes array, or
+     *                                      the reader is not positioned on an element.
+     *
+     */
+    template <size_t N>
+    CHIP_ERROR Get(FixedByteSpan<N> & v)
+    {
+        const uint8_t * val;
+        ReturnErrorOnFailure(GetDataPtr(val));
+        VerifyOrReturnError(GetLength() == N, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+        v = FixedByteSpan<N>(val);
+        return CHIP_NO_ERROR;
+    }
+
+    /**
      * Get the value of the current element as a CharSpan
      *
      * @param[out]  v                       Receives the value associated with current TLV element.

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -97,8 +97,8 @@ bool ToolChipDN::SetCertSubjectDN(X509 * cert) const
         else
         {
             if (!X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), attrNID, MBSTRING_UTF8,
-                                            const_cast<uint8_t *>(rdn[i].mString.data()), static_cast<int>(rdn[i].mString.size()),
-                                            -1, 0))
+                                            reinterpret_cast<uint8_t *>(const_cast<char *>(rdn[i].mString.data())),
+                                            static_cast<int>(rdn[i].mString.size()), -1, 0))
             {
                 ReportOpenSSLErrorAndExit("X509_NAME_add_entry_by_NID", res = false);
             }

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -311,8 +311,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'c':
-        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName,
-                                      chip::ByteSpan(reinterpret_cast<const uint8_t *>(arg), strlen(arg)));
+        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, chip::CharSpan(arg, strlen(arg)));
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add Common Name attribute to the subject DN: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
Code cleanup and simplifications

#### Change overview
 -- removed element type check from reader.Next() where it is later checked by reader.Get()
 -- removed size checks/adjustments around integer reader.Get().
    These checks are now performed by the Get() method itself.
 -- Added new Get(FixedByteSpan<N> & v) method to the TLVReader class.
 -- handle UTF8 DN attribute as CharSpan instead on ByteSpan.
 -- Switched to use VerifyOrReturnError() and ReturnErrorOnFailure() macros.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
