### PR TITLE
Increase some job timeouts that we keep hitting.

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     android:
         name: Build Android
-        timeout-minutes: 60
+        timeout-minutes: 75
 
         env:
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -26,7 +26,7 @@ jobs:
     # TODO ESP32 https://github.com/project-chip/connectedhomeip/issues/1510
     esp32:
         name: ESP32
-        timeout-minutes: 70
+        timeout-minutes: 85
 
         env:
             BUILD_TYPE: esp32


### PR DESCRIPTION
#### Problem
We keep hitting the Android and ESP32 job timeouts.

#### Change overview
Increase the timeouts a bit.

#### Testing
Will see if more CI passes now.