### PR TITLE
Enable Docker-slim tool

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -32,7 +32,7 @@ jobs:
             fail-fast: false
             matrix:
                 # TODO: Enables "-crosscompile" and "-vscode" images
-                img: ["", "-android", "-cirque", "-efr32", "-esp32", "-esp32-qemu", "-infineon", "-k32w", "-mbed-os", "-nrf-platform", "-telink", "-tizen"]
+                img: ["", "-ameba", "-android", "-cirque", "-efr32", "-esp32", "-esp32-qemu", "-infineon", "-k32w", "-mbed-os", "-nrf-platform", "-telink", "-tizen"]
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -81,6 +81,11 @@ docker build "${BUILD_ARGS[@]}" --build-arg VERSION="$VERSION" -t "$ORG/$IMAGE:$
         docker-squash "$ORG"/"$IMAGE":"$VERSION" -t "$ORG"/"$IMAGE":latest
 }
 
+[[ ${*/--slim//} != "${*}" ]] && {
+    command -v docker-slim >/dev/null &&
+        docker-slim build "$ORG"/"$IMAGE":"$VERSION" --http-probe=false --continue-after 1 --tag "$ORG"/"$IMAGE":latest
+}
+
 [[ ${*/--push//} != "${*}" ]] && {
     docker push "$ORG"/"$IMAGE":"$VERSION"
     [[ ${*/--latest//} != "${*}" ]] && {


### PR DESCRIPTION
#### Problem
[Docker-slim tool](https://dockersl.im/) allows to reduce the size of the Docker images and improve the time required to download the image during the CI execution.

#### Change overview
This flag enables the execution of the docker-slim tool in case this is installed. This change also includes ameba as part of the building images in the CI.

#### Testing
The following table displays the sizes of the images generated with the tool

| Name                                    | Original | Slim   |
|-----------------------------------------|----------|--------|
| connectedhomeip/chip-build              | 2.63GB   | 3.71MB |
| connectedhomeip/chip-build-ameba        | 4.15GB   | 3.71MB |
| connectedhomeip/chip-build-android      | 7.21GB   | 3.71MB |
| connectedhomeip/chip-build-cirque       | 3.19GB   | 3.71MB |
| connectedhomeip/chip-build-crosscompile | 5.2GB    | 3.71MB |
| connectedhomeip/chip-build-efr32        | 3.17GB   | 3.71MB |
| connectedhomeip/chip-build-esp32        | 5.49GB   | 3.71MB |
| connectedhomeip/chip-build-esp32-qemu   | 7.3GB    | 3.71MB |
| connectedhomeip/chip-build-infineon     | 4.73GB   | 3.71MB |
| connectedhomeip/chip-build-k32w         | 3.04GB   | 3.71MB |
| connectedhomeip/chip-build-mbed-os      | 2.64GB   | 3.71MB |
| connectedhomeip/chip-build-nrf-platform | 4.14GB   | 5.46MB |
| connectedhomeip/chip-build-telink       | 6.73GB   | 3.71MB |
| connectedhomeip/chip-build-tizen        | 3.48GB   | 3.71MB |
| connectedhomeip/chip-build-vscode       | 22.5GB   | 3.71MB |
