### PR TITLE
[OperationalCredentials]: Support read TrustedRootCertificates attribute

### DIFF
--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -5138,6 +5138,21 @@
               "reportableChange": 0
             },
             {
+              "name": "TrustedRootCertificates",
+              "code": 4,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 0,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -7323,6 +7323,79 @@ private:
     jobject javaCallbackRef;
 };
 
+class CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback
+    : public Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>
+{
+public:
+    CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback(jobject javaCallback) :
+        Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>(CallbackFn, this)
+    {
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        if (env == nullptr)
+        {
+            ChipLogError(Zcl, "Could not create global reference for Java callback");
+            return;
+        }
+
+        javaCallbackRef = env->NewGlobalRef(javaCallback);
+        if (javaCallbackRef == nullptr)
+        {
+            ChipLogError(Zcl, "Could not create global reference for Java callback");
+        }
+    }
+
+    static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
+    {
+        chip::DeviceLayer::StackUnlock unlock;
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
+        jobject javaCallbackRef;
+
+        VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNI env"));
+
+        std::unique_ptr<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback> cppCallback(
+            reinterpret_cast<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback *>(context));
+
+        // It's valid for javaCallbackRef to be nullptr if the Java code passed in a null callback.
+        javaCallbackRef = cppCallback.get()->javaCallbackRef;
+        VerifyOrReturn(javaCallbackRef != nullptr,
+                       ChipLogProgress(Zcl, "Early return from attribute callback since Java callback is null"));
+
+        jclass arrayListClass;
+        err = JniReferences::GetInstance().GetClassRef(env, "java/util/ArrayList", arrayListClass);
+        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error using Java ArrayList"));
+        JniClass arrayListJniClass(arrayListClass);
+        jmethodID arrayListCtor      = env->GetMethodID(arrayListClass, "<init>", "()V");
+        jmethodID arrayListAddMethod = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
+        VerifyOrReturn(arrayListCtor != nullptr && arrayListAddMethod != nullptr,
+                       ChipLogError(Zcl, "Error finding Java ArrayList methods"));
+        jobject arrayListObj = env->NewObject(arrayListClass, arrayListCtor);
+        VerifyOrReturn(arrayListObj != nullptr, ChipLogError(Zcl, "Error creating Java ArrayList"));
+
+        jmethodID javaMethod;
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/util/List;)V", &javaMethod);
+        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess() method"));
+
+        auto iter = list.begin();
+        while (iter.Next())
+        {
+            auto & entry                       = iter.GetValue();
+            jbyteArray trustedRootCertificates = env->NewByteArray(entry.size());
+            env->SetByteArrayRegion(trustedRootCertificates, 0, entry.size(), reinterpret_cast<const jbyte *>(entry.data()));
+            env->CallBooleanMethod(arrayListObj, arrayListAddMethod, trustedRootCertificates);
+        }
+        VerifyOrReturn(iter.GetStatus() == CHIP_NO_ERROR,
+                       ChipLogError(Zcl, "Error decoding TrustedRootCertificatesAttribute value: %" CHIP_ERROR_FORMAT,
+                                    iter.GetStatus().Format()));
+
+        env->ExceptionClear();
+        env->CallVoidMethod(javaCallbackRef, javaMethod, arrayListObj);
+    }
+
+private:
+    jobject javaCallbackRef;
+};
+
 class CHIPPowerSourceActiveBatteryFaultsAttributeCallback
     : public Callback::Callback<PowerSourceActiveBatteryFaultsListAttributeCallback>
 {
@@ -22166,6 +22239,34 @@ JNI_METHOD(void, OperationalCredentialsCluster, readCommissionedFabricsAttribute
                    ReturnIllegalStateException(env, callback, "Could not get native cluster", CHIP_ERROR_INCORRECT_STATE));
 
     err = cppCluster->ReadAttributeCommissionedFabrics(onSuccess->Cancel(), onFailure->Cancel());
+    VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error reading attribute", err));
+
+    onSuccess.release();
+    onFailure.release();
+}
+
+JNI_METHOD(void, OperationalCredentialsCluster, readTrustedRootCertificatesAttribute)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+{
+    chip::DeviceLayer::StackLock lock;
+    std::unique_ptr<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback,
+                    void (*)(CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback *)>
+        onSuccess(Platform::New<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback>(callback),
+                  Platform::Delete<CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback>);
+    VerifyOrReturn(onSuccess.get() != nullptr,
+                   ReturnIllegalStateException(env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY));
+
+    std::unique_ptr<CHIPDefaultFailureCallback, void (*)(CHIPDefaultFailureCallback *)> onFailure(
+        Platform::New<CHIPDefaultFailureCallback>(callback), Platform::Delete<CHIPDefaultFailureCallback>);
+    VerifyOrReturn(onFailure.get() != nullptr,
+                   ReturnIllegalStateException(env, callback, "Error creating native failure callback", CHIP_ERROR_NO_MEMORY));
+
+    CHIP_ERROR err                             = CHIP_NO_ERROR;
+    OperationalCredentialsCluster * cppCluster = reinterpret_cast<OperationalCredentialsCluster *>(clusterPtr);
+    VerifyOrReturn(cppCluster != nullptr,
+                   ReturnIllegalStateException(env, callback, "Could not get native cluster", CHIP_ERROR_INCORRECT_STATE));
+
+    err = cppCluster->ReadAttributeTrustedRootCertificates(onSuccess->Cancel(), onFailure->Cancel());
     VerifyOrReturn(err == CHIP_NO_ERROR, ReturnIllegalStateException(env, callback, "Error reading attribute", err));
 
     onSuccess.release();

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -4710,6 +4710,12 @@ public class ChipClusters {
       void onError(Exception ex);
     }
 
+    public interface TrustedRootCertificatesAttributeCallback {
+      void onSuccess(List<byte[]> valueList);
+
+      void onError(Exception ex);
+    }
+
     public void readFabricsListAttribute(FabricsListAttributeCallback callback) {
       readFabricsListAttribute(chipClusterPtr, callback);
     }
@@ -4720,6 +4726,11 @@ public class ChipClusters {
 
     public void readCommissionedFabricsAttribute(IntegerAttributeCallback callback) {
       readCommissionedFabricsAttribute(chipClusterPtr, callback);
+    }
+
+    public void readTrustedRootCertificatesAttribute(
+        TrustedRootCertificatesAttributeCallback callback) {
+      readTrustedRootCertificatesAttribute(chipClusterPtr, callback);
     }
 
     public void readClusterRevisionAttribute(IntegerAttributeCallback callback) {
@@ -4734,6 +4745,9 @@ public class ChipClusters {
 
     private native void readCommissionedFabricsAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback);
+
+    private native void readTrustedRootCertificatesAttribute(
+        long chipClusterPtr, TrustedRootCertificatesAttributeCallback callback);
 
     private native void readClusterRevisionAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback);

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -832,6 +832,52 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(
 }
 chip::Callback::Callback<OperationalCredentialsFabricsListListAttributeCallback>
     gOperationalCredentialsFabricsListListAttributeCallback{ OnOperationalCredentialsFabricsListListAttributeResponse, nullptr };
+static void OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse(
+    void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
+{
+    size_t count   = 0;
+    CHIP_ERROR err = list.ComputeSize(&count);
+    if (err != CHIP_NO_ERROR)
+    {
+        if (gFailureResponseDelegate != nullptr)
+        {
+            gFailureResponseDelegate(EMBER_ZCL_STATUS_INVALID_VALUE);
+        }
+        return;
+    }
+
+    ChipLogProgress(Zcl, "  attributeValue:%s", count > 0 ? "" : " []");
+
+    if (count > 0)
+        ChipLogProgress(Zcl, "  [");
+
+    auto iter = list.begin();
+    while (iter.Next())
+    {
+#if CHIP_PROGRESS_LOGGING
+        auto & entry = iter.GetValue();
+#endif // CHIP_PROGRESS_LOGGING
+        ChipLogProgress(Zcl, "    %s,", ByteSpanToString(entry).c_str());
+    }
+    if (iter.GetStatus() != CHIP_NO_ERROR)
+    {
+        if (gFailureResponseDelegate != nullptr)
+        {
+            gFailureResponseDelegate(EMBER_ZCL_STATUS_INVALID_VALUE);
+        }
+        return;
+    }
+
+    if (count > 0)
+        ChipLogProgress(Zcl, "  ]");
+
+    if (gSuccessResponseDelegate != nullptr)
+        gSuccessResponseDelegate();
+}
+chip::Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>
+    gOperationalCredentialsTrustedRootCertificatesListAttributeCallback{
+        OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse, nullptr
+    };
 static void OnPowerSourceActiveBatteryFaultsListAttributeResponse(void * context,
                                                                   const chip::app::DataModel::DecodableList<uint8_t> & list)
 {
@@ -5627,6 +5673,18 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OperationalCredentials_Commi
     chip::Controller::OperationalCredentialsCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster.ReadAttributeCommissionedFabrics(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
+}
+
+chip::ChipError::StorageType chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates(
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
+{
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
+    chip::Controller::OperationalCredentialsCluster cluster;
+    cluster.Associate(device, ZCLendpointId);
+    return cluster
+        .ReadAttributeTrustedRootCertificates(gOperationalCredentialsTrustedRootCertificatesListAttributeCallback.Cancel(),
+                                              gDefaultFailureCallback.Cancel())
+        .AsInteger();
 }
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision(chip::Controller::Device * device,

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -2561,6 +2561,11 @@ class ChipClusters:
                 "attributeId": 0x00000003,
                 "type": "int",
             },
+            0x00000004: {
+                "attributeName": "TrustedRootCertificates",
+                "attributeId": 0x00000004,
+                "type": "bytes",
+            },
             0x0000FFFD: {
                 "attributeName": "ClusterRevision",
                 "attributeId": 0x0000FFFD,
@@ -5946,6 +5951,9 @@ class ChipClusters:
     def ClusterOperationalCredentials_ReadAttributeCommissionedFabrics(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics(device, ZCLendpoint, ZCLgroupid)
 
+    def ClusterOperationalCredentials_ReadAttributeTrustedRootCertificates(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+        return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOperationalCredentials_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
 
@@ -8400,6 +8408,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics.restype = ctypes.c_uint32
+        # Cluster OperationalCredentials ReadAttribute TrustedRootCertificates
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -378,6 +378,23 @@ void CHIPOperationalCredentialsFabricsListListAttributeCallbackBridge::OnSuccess
     DispatchSuccess(context, @ { @"value" : array });
 };
 
+void CHIPOperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
+{
+    id array = [[NSMutableArray alloc] init];
+    auto iter = list.begin();
+    while (iter.Next()) {
+        auto & entry = iter.GetValue();
+        [array addObject:[NSData dataWithBytes:entry.data() length:entry.size()]];
+    }
+    if (iter.GetStatus() != CHIP_NO_ERROR) {
+        OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
+        return;
+    }
+
+    DispatchSuccess(context, @ { @"value" : array });
+};
+
 void CHIPPowerSourceActiveBatteryFaultsListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<uint8_t> & list)
 {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -332,6 +332,18 @@ public:
                                 chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & list);
 };
 
+class CHIPOperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge
+    : public CHIPCallbackBridge<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>
+{
+public:
+    CHIPOperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+                                                                                 CHIPActionBlock action, bool keepAlive = false) :
+        CHIPCallbackBridge<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>(queue, handler, action, OnSuccessFn,
+                                                                                               keepAlive){};
+
+    static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
+};
+
 class CHIPPowerSourceActiveBatteryFaultsListAttributeCallbackBridge
     : public CHIPCallbackBridge<PowerSourceActiveBatteryFaultsListAttributeCallback>
 {

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -1235,6 +1235,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)readAttributeCommissionedFabricsWithResponseHandler:(ResponseHandler)responseHandler;
 
+- (void)readAttributeTrustedRootCertificatesWithResponseHandler:(ResponseHandler)responseHandler;
+
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -3641,6 +3641,14 @@ using chip::Callback::Cancelable;
     });
 }
 
+- (void)readAttributeTrustedRootCertificatesWithResponseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPOperationalCredentialsTrustedRootCertificatesListAttributeCallbackBridge(
+        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+            return self.cppCluster.ReadAttributeTrustedRootCertificates(success, failure);
+        });
+}
+
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler
 {
     new CHIPInt16uAttributeCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -16802,6 +16802,25 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+- (void)testSendClusterOperationalCredentialsReadAttributeTrustedRootCertificatesWithResponseHandler
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"OperationalCredentialsReadAttributeTrustedRootCertificatesWithResponseHandler"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOperationalCredentials * cluster = [[CHIPOperationalCredentials alloc] initWithDevice:device endpoint:0 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeTrustedRootCertificatesWithResponseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"OperationalCredentials TrustedRootCertificates Error: %@", err);
+        XCTAssertEqual(err.code, 0);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
 - (void)testSendClusterOperationalCredentialsReadAttributeClusterRevisionWithResponseHandler
 {
     XCTestExpectation * expectation =

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -123,7 +123,7 @@ public:
     // TODO - Refactor storing and loading of fabric info from persistent storage.
     //        The op cert array doesn't need to be in RAM except when it's being
     //        transmitted to peer node during CASE session setup.
-    CHIP_ERROR GetRootCert(ByteSpan & cert)
+    CHIP_ERROR GetRootCert(ByteSpan & cert) const
     {
         ReturnErrorCodeIf(mRootCert.empty(), CHIP_ERROR_INCORRECT_STATE);
         cert = mRootCert;

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -502,6 +502,31 @@ void OperationalCredentialsClusterFabricsListListAttributeFilter(TLV::TLVReader 
 #pragma GCC diagnostic pop
 #endif // __clang__
 
+void OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter(TLV::TLVReader * tlvData,
+                                                                             Callback::Cancelable * onSuccessCallback,
+                                                                             Callback::Cancelable * onFailureCallback)
+{
+    chip::app::DataModel::DecodableList<chip::ByteSpan> list;
+    CHIP_ERROR err = Decode(*tlvData, list);
+    if (err != CHIP_NO_ERROR)
+    {
+        if (onFailureCallback != nullptr)
+        {
+            Callback::Callback<DefaultFailureCallback> * cb =
+                Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
+            cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);
+        }
+        return;
+    }
+
+    Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback> * cb =
+        Callback::Callback<OperationalCredentialsTrustedRootCertificatesListAttributeCallback>::FromCancelable(onSuccessCallback);
+    cb->mCall(cb->mContext, list);
+}
+#if !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif // __clang__
+
 void PowerSourceClusterActiveBatteryFaultsListAttributeFilter(TLV::TLVReader * tlvData, Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback)
 {

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
@@ -229,6 +229,11 @@ typedef void (*OperationalCredentialsFabricsListListAttributeCallback)(
     void * context,
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & data);
+void OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter(chip::TLV::TLVReader * data,
+                                                                             chip::Callback::Cancelable * onSuccessCallback,
+                                                                             chip::Callback::Cancelable * onFailureCallback);
+typedef void (*OperationalCredentialsTrustedRootCertificatesListAttributeCallback)(
+    void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & data);
 void PowerSourceClusterActiveBatteryFaultsListAttributeFilter(chip::TLV::TLVReader * data,
                                                               chip::Callback::Cancelable * onSuccessCallback,
                                                               chip::Callback::Cancelable * onFailureCallback);

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -9773,6 +9773,18 @@ CHIP_ERROR OperationalCredentialsCluster::ReadAttributeCommissionedFabrics(Callb
                                              BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
+CHIP_ERROR OperationalCredentialsCluster::ReadAttributeTrustedRootCertificates(Callback::Cancelable * onSuccessCallback,
+                                                                               Callback::Cancelable * onFailureCallback)
+{
+    app::AttributePathParams attributePath;
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000004;
+    attributePath.mFlags.Set(app::AttributePathParams::Flags::kFieldIdValid);
+    return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
+                                             OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter);
+}
+
 CHIP_ERROR OperationalCredentialsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback)
 {

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -1050,6 +1050,8 @@ public:
     CHIP_ERROR ReadAttributeFabricsList(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeSupportedFabrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeCommissionedFabrics(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
+    CHIP_ERROR ReadAttributeTrustedRootCertificates(Callback::Cancelable * onSuccessCallback,
+                                                    Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
 private:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We have updated the chip clients to use DecodableList for list-typed attribute reads. https://github.com/project-chip/connectedhomeip/pull/10681. Now we can enable attribute TrustedRootCertificates with type of list in OperationalCredentials cluster.


#### Change overview
Support read TrustedRootCertificates attribute

#### Testing
How was this tested? (at least one bullet point required)
```
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/out/debug/standalone$ ./chip-tool operationalcredentials read trusted-root-certificates 12344321 0
[1635215987.564441][1664539:1664539] CHIP:CTL: Generating NOC
[1635215987.564538][1664539:1664539] CHIP:CTL: Generating ICAC
[1635215987.566488][1664539:1664539] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT START ====
[1635215987.566495][1664539:1664539] CHIP:DL: AUDIT: * Validate buf1 and buf2 are <<<different every run/boot!>>>
[1635215987.566498][1664539:1664539] CHIP:DL: AUDIT: * Validate r1 and r2 are <<<different every run/boot!>>>
[1635215987.566517][1664539:1664539] CHIP:DL: AUDIT: * buf1: 64D6F3677ACD54964516EA3369918942
[1635215987.566520][1664539:1664539] CHIP:DL: AUDIT: * buf2: EC9402944E171B4E01D0ED308329D6EC
[1635215987.566546][1664539:1664539] CHIP:DL: AUDIT: * r1: 0xC2AA46B7 r2: 0x1CEC4967
[1635215987.566550][1664539:1664539] CHIP:DL: AUDIT: ===== RANDOM NUMBER GENERATOR AUDIT END ====
[1635215987.566680][1664539:1664539] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-nudGzQ)
[1635215987.566879][1664539:1664539] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1635215987.566899][1664539:1664539] CHIP:DL: NVS set: chip-counters/reboot-count = 3 (0x3)
[1635215987.567194][1664539:1664539] CHIP:DL: Got Ethernet interface: enp1s0
[1635215987.567346][1664539:1664539] CHIP:DL: Found the primary Ethernet interface:enp1s0
[1635215987.567500][1664539:1664539] CHIP:DL: Got WiFi interface: wlp3s0
[1635215987.569751][1664539:1664539] CHIP:DL: Found the primary WiFi interface:wlp3s0
[1635215987.569814][1664539:1664539] CHIP:IN: UDP::Init bind&listen port=5541
[1635215987.569879][1664539:1664539] CHIP:IN: UDP::Init bound to port=5541
[1635215987.569899][1664539:1664539] CHIP:IN: UDP::Init bind&listen port=5541
[1635215987.569945][1664539:1664539] CHIP:IN: UDP::Init bound to port=5541
[1635215987.569963][1664539:1664539] CHIP:IN: TransportMgr initialized
[1635215987.570039][1664539:1664539] CHIP:DIS: Init fabric pairing table with server storage
[1635215987.570366][1664539:1664539] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-RIREeO)
[1635215987.570719][1664539:1664539] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1635215987.570769][1664539:1664539] CHIP:DL: NVS set: chip-counters/GlobalMCTR = 3000 (0xBB8)
[1635215987.570842][1664539:1664539] CHIP:CTL: System State Initialized...
[1635215987.571975][1664539:1664539] CHIP:DL: MDNS failed to join multicast group on enp1s0 for address type IPv4: ../../../examples/chip-tool/third_party/connectedhomeip/src/inet/IPEndPointBasis.cpp:388: Inet Error 0x00000110: Address not found
[1635215987.575306][1664539:1664539] CHIP:ZCL: Using ZAP configuration...
[1635215987.575499][1664539:1664539] CHIP:DIS: Verifying the received credentials
[1635215987.575976][1664539:1664539] CHIP:DIS: Added new fabric at index: 1, Initialized: 1
[1635215987.575981][1664539:1664539] CHIP:DIS: Assigned compressed fabric ID: 0x391C1C5511506A1D, node ID: 0x000000000001B669
[1635215987.575985][1664539:1664539] CHIP:CTL: Joined the fabric at index 1. Compressed fabric ID is: 0x391C1C5511506A1D
[1635215987.576121][1664539:1664544] CHIP:DL: CHIP task running
[1635215987.576174][1664539:1664544] CHIP:TOO: Sending command to node 0xbc5c01
[1635215987.576375][1664539:1664544] CHIP:IN: Prepared plaintext message 0x55909b75be20 to 0x0000000000000000 of type 0x30 and protocolId (0, 0) on exchange 39986i with MessageCounter:1726685955.
[1635215987.576385][1664539:1664544] CHIP:IN: Sending plaintext msg 0x55909b75be20 with MessageCounter:1726685955 to 0x0000000000000000 at monotonic time: 1166009162 msec
[1635215987.576464][1664539:1664544] CHIP:SC: Sent Sigma1 msg
[1635215987.577080][1664539:1664544] CHIP:EM: Received message of type 0x31 with protocolId (0, 0) and MessageCounter:3825397202 on exchange 39986i
[1635215987.577093][1664539:1664544] CHIP:EM: Rxd Ack; Removing MessageCounter:1726685955 from Retrans Table on exchange 39986i
[1635215987.577097][1664539:1664544] CHIP:EM: Removed CHIP MessageCounter:1726685955 from RetransTable on exchange 39986i
[1635215987.577103][1664539:1664544] CHIP:SC: Received Sigma2 msg
[1635215987.577109][1664539:1664544] CHIP:SC: Peer assigned session session ID 3
[1635215987.577735][1664539:1664544] CHIP:SC: Sending Sigma3
[1635215987.577798][1664539:1664544] CHIP:EM: Piggybacking Ack for MessageCounter:3825397202 on exchange: 39986i
[1635215987.577805][1664539:1664544] CHIP:IN: Prepared plaintext message 0x55909b75be20 to 0x0000000000000000 of type 0x32 and protocolId (0, 0) on exchange 39986i with MessageCounter:1726685956.
[1635215987.577812][1664539:1664544] CHIP:IN: Sending plaintext msg 0x55909b75be20 with MessageCounter:1726685956 to 0x0000000000000000 at monotonic time: 1166009163 msec
[1635215987.577831][1664539:1664544] CHIP:SC: Sent Sigma3 msg
[1635215987.578553][1664539:1664544] CHIP:EM: Received message of type 0x40 with protocolId (0, 0) and MessageCounter:3825397203 on exchange 39986i
[1635215987.578566][1664539:1664544] CHIP:EM: Rxd Ack; Removing MessageCounter:1726685956 from Retrans Table on exchange 39986i
[1635215987.578572][1664539:1664544] CHIP:EM: Removed CHIP MessageCounter:1726685956 from RetransTable on exchange 39986i
[1635215987.578599][1664539:1664544] CHIP:SC: Success status report received. Session was established
[1635215987.578605][1664539:1664544] CHIP:IN: New secure session created for device 0x0000000000BC5C01, key 3!!
[1635215987.578623][1664539:1664544] CHIP:TOO: Sending cluster (0x003E) command (0x00) on endpoint 0
[1635215987.578650][1664539:1664544] CHIP:DMG: SendReadRequest: Client[0] [ INIT]
[1635215987.578686][1664539:1664544] CHIP:IN: Prepared encrypted message 0x55909b75be20 to 0x0000000000BC5C01 of type 0x2 and protocolId (0, 1) on exchange 39987i with MessageCounter:0.
[1635215987.578693][1664539:1664544] CHIP:IN: Sending encrypted msg 0x55909b75be20 with MessageCounter:0 to 0x0000000000BC5C01 at monotonic time: 1166009164 msec
[1635215987.578711][1664539:1664544] CHIP:DMG: Client[0] moving to [AwaitingInitialReport]
[1635215987.578718][1664539:1664544] CHIP:EM: Sending Standalone Ack for MessageCounter:3825397203 on exchange 39986i
[1635215987.578738][1664539:1664544] CHIP:IN: Prepared plaintext message 0x7f5d4a054fe0 to 0x0000000000000000 of type 0x10 and protocolId (0, 0) on exchange 39986i with MessageCounter:1726685957.
[1635215987.578764][1664539:1664544] CHIP:IN: Sending plaintext msg 0x7f5d4a054fe0 with MessageCounter:1726685957 to 0x0000000000000000 at monotonic time: 1166009164 msec
[1635215987.578780][1664539:1664544] CHIP:EM: Flushed pending ack for MessageCounter:3825397203 on exchange 39986i
[1635215987.579129][1664539:1664544] CHIP:EM: Received message of type 0x5 with protocolId (0, 1) and MessageCounter:1 on exchange 39987i
[1635215987.579141][1664539:1664544] CHIP:EM: Rxd Ack; Removing MessageCounter:0 from Retrans Table on exchange 39987i
[1635215987.579146][1664539:1664544] CHIP:EM: Removed CHIP MessageCounter:0 from RetransTable on exchange 39987i
[1635215987.579155][1664539:1664544] CHIP:DMG: ReportData =
[1635215987.579160][1664539:1664544] CHIP:DMG: {
[1635215987.579163][1664539:1664544] CHIP:DMG: 	AttributeDataList =
[1635215987.579167][1664539:1664544] CHIP:DMG: 	[
[1635215987.579171][1664539:1664544] CHIP:DMG: 		AttributeDataElement =
[1635215987.579175][1664539:1664544] CHIP:DMG: 		{
[1635215987.579178][1664539:1664544] CHIP:DMG: 			AttributePath =
[1635215987.579182][1664539:1664544] CHIP:DMG: 			{
[1635215987.579187][1664539:1664544] CHIP:DMG: 				NodeId = 0xbc5c01,
[1635215987.579193][1664539:1664544] CHIP:DMG: 				EndpointId = 0x0,
[1635215987.579198][1664539:1664544] CHIP:DMG: 				ClusterId = 0x3e,
[1635215987.579202][1664539:1664544] CHIP:DMG: 				FieldTag = 0x0000_0004,
[1635215987.579206][1664539:1664544] CHIP:DMG: 			}
[1635215987.579211][1664539:1664544] CHIP:DMG: 				
[1635215987.579215][1664539:1664544] CHIP:DMG: 			Data = [
[1635215987.579220][1664539:1664544] CHIP:DMG: 				[
[1635215987.579228][1664539:1664544] CHIP:DMG: 					0x15, 0x30, 0x1, 0x1, 0x0, 0x24, 0x2, 0x1, 0x37, 0x3, 0x24, 0x14, 0x0, 0x24, 0x15, 0x0, 0x18, 0x26, 0x4, 0x80, 0x22, 0x81, 0x27, 0x26, 0x5, 0x80, 0x25, 0x4d, 0x3a, 0x37, 0x6, 0x24, 0x14, 0x0, 0x24, 0x15, 0x0, 0x18, 0x24, 0x7, 0x1, 0x24, 0x8, 0x1, 0x3
[1635215987.579233][1664539:1664544] CHIP:DMG: 				]
[1635215987.579238][1664539:1664544] CHIP:DMG: 			],
[1635215987.579242][1664539:1664544] CHIP:DMG: 			DataElementVersion = 0x0,
[1635215987.579246][1664539:1664544] CHIP:DMG: 		},
[1635215987.579251][1664539:1664544] CHIP:DMG: 		
[1635215987.579255][1664539:1664544] CHIP:DMG: 	],
[1635215987.579260][1664539:1664544] CHIP:DMG: 	
[1635215987.579263][1664539:1664544] CHIP:DMG: }
[1635215987.579280][1664539:1664544] CHIP:ZCL: ReadAttributesResponse:
[1635215987.579284][1664539:1664544] CHIP:ZCL:   ClusterId: 0x0000_003E
[1635215987.579287][1664539:1664544] CHIP:ZCL:   attributeId: 0x0000_0004
[1635215987.579291][1664539:1664544] CHIP:ZCL:   status: Success                (0x0000)
[1635215987.579294][1664539:1664544] CHIP:ZCL:   attribute TLV Type: 0x16
[1635215987.579299][1664539:1664544] CHIP:TOO: OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse: 1 entries
```

