### PR TITLE
[zap] Correct PCC cluster attribute names

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -10590,7 +10590,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "max pressure",
+              "name": "MaxPressure",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -10605,7 +10605,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max speed",
+              "name": "MaxSpeed",
               "code": 1,
               "mfgCode": null,
               "side": "server",
@@ -10620,7 +10620,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max flow",
+              "name": "MaxFlow",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -10635,7 +10635,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const pressure",
+              "name": "MinConstPressure",
               "code": 3,
               "mfgCode": null,
               "side": "server",
@@ -10650,7 +10650,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const pressure",
+              "name": "MaxConstPressure",
               "code": 4,
               "mfgCode": null,
               "side": "server",
@@ -10665,7 +10665,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min comp pressure",
+              "name": "MinCompPressure",
               "code": 5,
               "mfgCode": null,
               "side": "server",
@@ -10680,7 +10680,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max comp pressure",
+              "name": "MaxCompPressure",
               "code": 6,
               "mfgCode": null,
               "side": "server",
@@ -10695,7 +10695,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const speed",
+              "name": "MinConstSpeed",
               "code": 7,
               "mfgCode": null,
               "side": "server",
@@ -10710,7 +10710,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const speed",
+              "name": "MaxConstSpeed",
               "code": 8,
               "mfgCode": null,
               "side": "server",
@@ -10725,7 +10725,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const flow",
+              "name": "MinConstFlow",
               "code": 9,
               "mfgCode": null,
               "side": "server",
@@ -10740,7 +10740,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const flow",
+              "name": "MaxConstFlow",
               "code": 10,
               "mfgCode": null,
               "side": "server",
@@ -10755,7 +10755,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const temp",
+              "name": "MinConstTemp",
               "code": 11,
               "mfgCode": null,
               "side": "server",
@@ -10770,7 +10770,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const temp",
+              "name": "MaxConstTemp",
               "code": 12,
               "mfgCode": null,
               "side": "server",
@@ -10785,7 +10785,7 @@
               "reportableChange": 0
             },
             {
-              "name": "pump status",
+              "name": "PumpStatus",
               "code": 16,
               "mfgCode": null,
               "side": "server",
@@ -10800,7 +10800,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective operation mode",
+              "name": "EffectiveOperationMode",
               "code": 17,
               "mfgCode": null,
               "side": "server",
@@ -10815,7 +10815,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective control mode",
+              "name": "EffectiveControlMode",
               "code": 18,
               "mfgCode": null,
               "side": "server",
@@ -10830,7 +10830,7 @@
               "reportableChange": 0
             },
             {
-              "name": "capacity",
+              "name": "Capacity",
               "code": 19,
               "mfgCode": null,
               "side": "server",
@@ -10845,7 +10845,7 @@
               "reportableChange": 0
             },
             {
-              "name": "speed",
+              "name": "Speed",
               "code": 20,
               "mfgCode": null,
               "side": "server",
@@ -10860,7 +10860,7 @@
               "reportableChange": 0
             },
             {
-              "name": "lifetime running hours",
+              "name": "LifetimeRunningHours",
               "code": 21,
               "mfgCode": null,
               "side": "server",
@@ -10875,7 +10875,7 @@
               "reportableChange": 0
             },
             {
-              "name": "power",
+              "name": "Power",
               "code": 22,
               "mfgCode": null,
               "side": "server",
@@ -10890,7 +10890,7 @@
               "reportableChange": 0
             },
             {
-              "name": "lifetime energy consumed",
+              "name": "LifetimeEnergyConsumed",
               "code": 23,
               "mfgCode": null,
               "side": "server",
@@ -10905,7 +10905,7 @@
               "reportableChange": 0
             },
             {
-              "name": "operation mode",
+              "name": "OperationMode",
               "code": 32,
               "mfgCode": null,
               "side": "server",
@@ -10920,7 +10920,7 @@
               "reportableChange": 0
             },
             {
-              "name": "control mode",
+              "name": "ControlMode",
               "code": 33,
               "mfgCode": null,
               "side": "server",
@@ -10935,7 +10935,7 @@
               "reportableChange": 0
             },
             {
-              "name": "alarm mask",
+              "name": "AlarmMask",
               "code": 34,
               "mfgCode": null,
               "side": "server",

--- a/examples/pump-app/pump-common/pump-app.zap
+++ b/examples/pump-app/pump-common/pump-app.zap
@@ -3452,7 +3452,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "max pressure",
+              "name": "MaxPressure",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -3467,7 +3467,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max speed",
+              "name": "MaxSpeed",
               "code": 1,
               "mfgCode": null,
               "side": "server",
@@ -3482,7 +3482,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max flow",
+              "name": "MaxFlow",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -3497,7 +3497,7 @@
               "reportableChange": 0
             },
             {
-              "name": "pump status",
+              "name": "PumpStatus",
               "code": 16,
               "mfgCode": null,
               "side": "server",
@@ -3512,7 +3512,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective operation mode",
+              "name": "EffectiveOperationMode",
               "code": 17,
               "mfgCode": null,
               "side": "server",
@@ -3527,7 +3527,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective control mode",
+              "name": "EffectiveControlMode",
               "code": 18,
               "mfgCode": null,
               "side": "server",
@@ -3542,7 +3542,7 @@
               "reportableChange": 0
             },
             {
-              "name": "capacity",
+              "name": "Capacity",
               "code": 19,
               "mfgCode": null,
               "side": "server",
@@ -3557,7 +3557,7 @@
               "reportableChange": 0
             },
             {
-              "name": "operation mode",
+              "name": "OperationMode",
               "code": 32,
               "mfgCode": null,
               "side": "server",

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.zap
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.zap
@@ -3452,7 +3452,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "max pressure",
+              "name": "MaxPressure",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -3467,7 +3467,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max speed",
+              "name": "MaxSpeed",
               "code": 1,
               "mfgCode": null,
               "side": "server",
@@ -3482,7 +3482,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max flow",
+              "name": "MaxFlow",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -3497,7 +3497,7 @@
               "reportableChange": 0
             },
             {
-              "name": "pump status",
+              "name": "PumpStatus",
               "code": 16,
               "mfgCode": null,
               "side": "server",
@@ -3512,7 +3512,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective operation mode",
+              "name": "EffectiveOperationMode",
               "code": 17,
               "mfgCode": null,
               "side": "server",
@@ -3527,7 +3527,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective control mode",
+              "name": "EffectiveControlMode",
               "code": 18,
               "mfgCode": null,
               "side": "server",
@@ -3542,7 +3542,7 @@
               "reportableChange": 0
             },
             {
-              "name": "capacity",
+              "name": "Capacity",
               "code": 19,
               "mfgCode": null,
               "side": "server",
@@ -3557,7 +3557,7 @@
               "reportableChange": 0
             },
             {
-              "name": "operation mode",
+              "name": "OperationMode",
               "code": 32,
               "mfgCode": null,
               "side": "server",
@@ -4948,7 +4948,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "max pressure",
+              "name": "MaxPressure",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -4963,7 +4963,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max speed",
+              "name": "MaxSpeed",
               "code": 1,
               "mfgCode": null,
               "side": "server",
@@ -4978,7 +4978,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max flow",
+              "name": "MaxFlow",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -4993,7 +4993,7 @@
               "reportableChange": 0
             },
             {
-              "name": "pump status",
+              "name": "PumpStatus",
               "code": 16,
               "mfgCode": null,
               "side": "server",
@@ -5008,7 +5008,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective operation mode",
+              "name": "EffectiveOperationMode",
               "code": 17,
               "mfgCode": null,
               "side": "server",
@@ -5023,7 +5023,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective control mode",
+              "name": "EffectiveControlMode",
               "code": 18,
               "mfgCode": null,
               "side": "server",
@@ -5038,7 +5038,7 @@
               "reportableChange": 0
             },
             {
-              "name": "capacity",
+              "name": "Capacity",
               "code": 19,
               "mfgCode": null,
               "side": "server",
@@ -5053,7 +5053,7 @@
               "reportableChange": 0
             },
             {
-              "name": "operation mode",
+              "name": "OperationMode",
               "code": 32,
               "mfgCode": null,
               "side": "server",

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
@@ -22,13 +22,13 @@ tests:
     - label: "read the mandatory attribute: MaxPressure"
       disabled: true
       command: "readAttribute"
-      attribute: "max pressure"
+      attribute: "MaxPressure"
       response:
           value: null
 
     - label: "read the mandatory attribute: MaxPressure"
       command: "readAttribute"
-      attribute: "max pressure"
+      attribute: "MaxPressure"
       response:
           constraints:
               type: int16
@@ -36,14 +36,14 @@ tests:
     - label: "read the mandatory attribute: MaxSpeed"
       disabled: true
       command: "readAttribute"
-      attribute: "max speed"
+      attribute: "MaxSpeed"
       response:
           value: null
 
     - label: "read the mandatory attribute: MaxSpeed"
       disabled: true
       command: "readAttribute"
-      attribute: "max speed"
+      attribute: "MaxSpeed"
       response:
           constraints:
               type: uint16
@@ -51,14 +51,14 @@ tests:
     - label: "read the mandatory attribute: MaxFlow"
       disabled: true
       command: "readAttribute"
-      attribute: "max flow"
+      attribute: "MaxFlow"
       response:
           value: null
 
     - label: "read the mandatory attribute: MaxFlow"
       disabled: true
       command: "readAttribute"
-      attribute: "max flow"
+      attribute: "MaxFlow"
       response:
           constraints:
               type: uint16
@@ -66,13 +66,13 @@ tests:
     - label: "read the mandatory attribute: EffectiveOperationMode"
       disabled: true
       command: "readAttribute"
-      attribute: "effective operation mode"
+      attribute: "EffectiveOperationMode"
       response:
           value: desc
 
     - label: "read the mandatory attribute: EffectiveOperationMode"
       command: "readAttribute"
-      attribute: "effective operation mode"
+      attribute: "EffectiveOperationMode"
       response:
           constraints:
               type: enum8
@@ -80,13 +80,13 @@ tests:
     - label: "read the mandatory attribute: EffectiveControlMode"
       disabled: true
       command: "readAttribute"
-      attribute: "effective control mode"
+      attribute: "EffectiveControlMode"
       response:
           value: desc
 
     - label: "read the mandatory attribute: EffectiveControlMode"
       command: "readAttribute"
-      attribute: "effective control mode"
+      attribute: "EffectiveControlMode"
       response:
           constraints:
               type: enum8
@@ -94,13 +94,13 @@ tests:
     - label: "read the mandatory attribute: Capacity"
       disabled: true
       command: "readAttribute"
-      attribute: "capacity"
+      attribute: "Capacity"
       response:
           value: null
 
     - label: "read the mandatory attribute: Capacity"
       command: "readAttribute"
-      attribute: "capacity"
+      attribute: "Capacity"
       response:
           constraints:
               type: int16
@@ -108,7 +108,7 @@ tests:
     - label: "write to the mandatory attribute: MaxPressure"
       disabled: true
       command: "writeAttribute"
-      attribute: "max pressure"
+      attribute: "MaxPressure"
       arguments:
           value: null
       response:
@@ -117,7 +117,7 @@ tests:
     - label: "write to the mandatory attribute: MaxSpeed"
       disabled: true
       command: "writeAttribute"
-      attribute: "max speed"
+      attribute: "MaxSpeed"
       arguments:
           value: null
       response:
@@ -126,7 +126,7 @@ tests:
     - label: "write to the mandatory attribute: MaxFlow"
       disabled: true
       command: "writeAttribute"
-      attribute: "max flow"
+      attribute: "MaxFlow"
       arguments:
           value: null
       response:
@@ -135,7 +135,7 @@ tests:
     - label: "write to the mandatory attribute: EffectiveOperationMode"
       disabled: true
       command: "writeAttribute"
-      attribute: "effective operation mode"
+      attribute: "EffectiveOperationMode"
       arguments:
           value: desc
       response:
@@ -144,7 +144,7 @@ tests:
     - label: "write to the mandatory attribute: EffectiveControlMode"
       disabled: true
       command: "writeAttribute"
-      attribute: "effective control mode"
+      attribute: "EffectiveControlMode"
       arguments:
           value: desc
       response:
@@ -153,7 +153,7 @@ tests:
     - label: "write to the mandatory attribute: Capacity"
       disabled: true
       command: "writeAttribute"
-      attribute: "capacity"
+      attribute: "Capacity"
       arguments:
           value: null
       response:
@@ -162,13 +162,13 @@ tests:
     - label: "read the mandatory attribute: MaxPressure"
       disabled: true
       command: "readAttribute"
-      attribute: "max pressure"
+      attribute: "MaxPressure"
       response:
           value: null
 
     - label: "read the mandatory attribute: MaxPressure"
       command: "readAttribute"
-      attribute: "max pressure"
+      attribute: "MaxPressure"
       response:
           constraints:
               type: int16
@@ -176,14 +176,14 @@ tests:
     - label: "read the mandatory attribute: MaxSpeed"
       disabled: true
       command: "readAttribute"
-      attribute: "max speed"
+      attribute: "MaxSpeed"
       response:
           value: null
 
     - label: "read the mandatory attribute: MaxSpeed"
       disabled: true
       command: "readAttribute"
-      attribute: "max speed"
+      attribute: "MaxSpeed"
       response:
           constraints:
               type: uint16
@@ -191,14 +191,14 @@ tests:
     - label: "read the mandatory attribute: MaxFlow"
       disabled: true
       command: "readAttribute"
-      attribute: "max flow"
+      attribute: "MaxFlow"
       response:
           value: null
 
     - label: "read the mandatory attribute: MaxFlow"
       disabled: true
       command: "readAttribute"
-      attribute: "max flow"
+      attribute: "MaxFlow"
       response:
           constraints:
               type: uint16
@@ -206,13 +206,13 @@ tests:
     - label: "read the mandatory attribute: EffectiveOperationMode"
       disabled: true
       command: "readAttribute"
-      attribute: "effective operation mode"
+      attribute: "EffectiveOperationMode"
       response:
           value: desc
 
     - label: "read the mandatory attribute: EffectiveOperationMode"
       command: "readAttribute"
-      attribute: "effective operation mode"
+      attribute: "EffectiveOperationMode"
       response:
           constraints:
               type: enum8
@@ -220,13 +220,13 @@ tests:
     - label: "read the mandatory attribute: EffectiveControlMode"
       disabled: true
       command: "readAttribute"
-      attribute: "effective control mode"
+      attribute: "EffectiveControlMode"
       response:
           value: desc
 
     - label: "read the mandatory attribute: EffectiveControlMode"
       command: "readAttribute"
-      attribute: "effective control mode"
+      attribute: "EffectiveControlMode"
       response:
           constraints:
               type: enum8
@@ -234,13 +234,13 @@ tests:
     - label: "read the mandatory attribute: Capacity"
       disabled: true
       command: "readAttribute"
-      attribute: "capacity"
+      attribute: "Capacity"
       response:
           value: null
 
     - label: "read the mandatory attribute: Capacity"
       command: "readAttribute"
-      attribute: "capacity"
+      attribute: "Capacity"
       response:
           constraints:
               type: int16
@@ -400,14 +400,14 @@ tests:
     - label: "read the optional attribute: PumpStatus"
       disabled: true
       command: "readAttribute"
-      attribute: "pump status"
+      attribute: "PumpStatus"
       response:
           value: 0
 
     - label: "read the optional attribute: PumpStatus"
       disabled: true
       command: "readAttribute"
-      attribute: "pump status"
+      attribute: "PumpStatus"
       response:
           constraints:
               type: map16
@@ -415,14 +415,14 @@ tests:
     - label: "read the optional attribute: Speed"
       disabled: true
       command: "readAttribute"
-      attribute: "speed"
+      attribute: "Speed"
       response:
           value: null
 
     - label: "read the optional attribute: Speed"
       disabled: true
       command: "readAttribute"
-      attribute: "speed"
+      attribute: "Speed"
       response:
           constraints:
               type: uint16
@@ -430,14 +430,14 @@ tests:
     - label: "read the optional attribute: LifetimeRunningHours"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime running hours"
+      attribute: "LifetimeRunningHours"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeRunningHours"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime running hours"
+      attribute: "LifetimeRunningHours"
       response:
           constraints:
               type: uint24
@@ -445,14 +445,14 @@ tests:
     - label: "read the optional attribute: Power"
       disabled: true
       command: "readAttribute"
-      attribute: "power"
+      attribute: "Power"
       response:
           value: null
 
     - label: "read the optional attribute: Power"
       disabled: true
       command: "readAttribute"
-      attribute: "power"
+      attribute: "Power"
       response:
           constraints:
               type: uint24
@@ -460,14 +460,14 @@ tests:
     - label: "read the optional attribute: LifetimeEnergyConsumed"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime energy consumed"
+      attribute: "LifetimeEnergyConsumed"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeEnergyConsumed"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime energy consumed"
+      attribute: "LifetimeEnergyConsumed"
       response:
           constraints:
               type: uint32
@@ -565,7 +565,7 @@ tests:
     - label: "write to the optional attribute: PumpStatus"
       disabled: true
       command: "writeAttribute"
-      attribute: "pump status"
+      attribute: "PumpStatus"
       arguments:
           value: 0
       response:
@@ -574,7 +574,7 @@ tests:
     - label: "write to the optional attribute: Speed"
       disabled: true
       command: "writeAttribute"
-      attribute: "speed"
+      attribute: "Speed"
       arguments:
           value: null
       response:
@@ -583,7 +583,7 @@ tests:
     - label: "write to the optional attribute: LifetimeRunningHours"
       disabled: true
       command: "writeAttribute"
-      attribute: "lifetime running hours"
+      attribute: "LifetimeRunningHours"
       arguments:
           value: 0
       response:
@@ -592,7 +592,7 @@ tests:
     - label: "write to the optional attribute: Power"
       disabled: true
       command: "writeAttribute"
-      attribute: "power"
+      attribute: "Power"
       arguments:
           value: null
       response:
@@ -601,7 +601,7 @@ tests:
     - label: "write to the optional attribute: LifetimeEnergyConsumed"
       disabled: true
       command: "writeAttribute"
-      attribute: "lifetime energy consumed"
+      attribute: "LifetimeEnergyConsumed"
       arguments:
           value: 0
       response:
@@ -762,14 +762,14 @@ tests:
     - label: "read the optional attribute: PumpStatus"
       disabled: true
       command: "readAttribute"
-      attribute: "pump status"
+      attribute: "PumpStatus"
       response:
           value: 0
 
     - label: "read the optional attribute: PumpStatus"
       disabled: true
       command: "readAttribute"
-      attribute: "pump status"
+      attribute: "PumpStatus"
       response:
           constraints:
               type: map16
@@ -777,14 +777,14 @@ tests:
     - label: "read the optional attribute: Speed"
       disabled: true
       command: "readAttribute"
-      attribute: "speed"
+      attribute: "Speed"
       response:
           value: null
 
     - label: "read the optional attribute: Speed"
       disabled: true
       command: "readAttribute"
-      attribute: "speed"
+      attribute: "Speed"
       response:
           constraints:
               type: uint16
@@ -792,14 +792,14 @@ tests:
     - label: "read the optional attribute: LifetimeRunningHours"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime running hours"
+      attribute: "LifetimeRunningHours"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeRunningHours"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime running hours"
+      attribute: "LifetimeRunningHours"
       response:
           constraints:
               type: uint24
@@ -807,14 +807,14 @@ tests:
     - label: "read the optional attribute: Power"
       disabled: true
       command: "readAttribute"
-      attribute: "power"
+      attribute: "Power"
       response:
           value: null
 
     - label: "read the optional attribute: Power"
       disabled: true
       command: "readAttribute"
-      attribute: "power"
+      attribute: "Power"
       response:
           constraints:
               type: uint24
@@ -822,14 +822,14 @@ tests:
     - label: "read the optional attribute: LifetimeEnergyConsumed"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime energy consumed"
+      attribute: "LifetimeEnergyConsumed"
       response:
           value: 0
 
     - label: "read the optional attribute: LifetimeEnergyConsumed"
       disabled: true
       command: "readAttribute"
-      attribute: "lifetime energy consumed"
+      attribute: "LifetimeEnergyConsumed"
       response:
           constraints:
               type: uint32

--- a/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
@@ -24,30 +24,30 @@ limitations under the License.
     <define>PUMP_CONFIG_CONTROL_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" tickFrequency="half" init="false">true</server>
-    <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="false">max pressure</attribute>
-    <attribute side="server" code="0x0001" define="MAX_SPEED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">max speed</attribute>
-    <attribute side="server" code="0x0002" define="MAX_FLOW" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">max flow</attribute>
-    <attribute side="server" code="0x0003" define="MIN_CONST_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">min const pressure</attribute>
-    <attribute side="server" code="0x0004" define="MAX_CONST_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">max const pressure</attribute>
-    <attribute side="server" code="0x0005" define="MIN_COMP_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">min comp pressure</attribute>
-    <attribute side="server" code="0x0006" define="MAX_COMP_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">max comp pressure</attribute>
-    <attribute side="server" code="0x0007" define="MIN_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">min const speed</attribute>
-    <attribute side="server" code="0x0008" define="MAX_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">max const speed</attribute>
-    <attribute side="server" code="0x0009" define="MIN_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">min const flow</attribute>
-    <attribute side="server" code="0x000A" define="MAX_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">max const flow</attribute>
-    <attribute side="server" code="0x000B" define="MIN_CONST_TEMP" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">min const temp</attribute>
-    <attribute side="server" code="0x000C" define="MAX_CONST_TEMP" type="INT16S" min="0x0000" max="0x7FFF" writable="false" optional="true">max const temp</attribute>
-    <attribute side="server" code="0x0010" define="PUMP_STATUS" type="BITMAP16" writable="false" reportable="true" optional="true">pump status</attribute>
-    <attribute side="server" code="0x0011" define="EFFECTIVE_OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">effective operation mode</attribute>
-    <attribute side="server" code="0x0012" define="EFFECTIVE_CONTROL_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">effective control mode</attribute>
-    <attribute side="server" code="0x0013" define="CAPACITY" type="INT16S" min="0x0000" max="0x7FFF" writable="false" reportable="true" optional="false">capacity</attribute>
-    <attribute side="server" code="0x0014" define="SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">speed</attribute>
-    <attribute side="server" code="0x0015" define="LIFETIME_RUNNING_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0x000000" optional="true">lifetime running hours</attribute>
-    <attribute side="server" code="0x0016" define="PUMP_POWER" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" optional="true">power</attribute>
-    <attribute side="server" code="0x0017" define="LIFETIME_ENERGY_CONSUMED" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0x00000000" optional="true">lifetime energy consumed</attribute>
-    <attribute side="server" code="0x0020" define="OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="false">operation mode</attribute>
-    <attribute side="server" code="0x0021" define="CONTROL_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="true">control mode</attribute>
-    <attribute side="server" code="0x0022" define="PUMP_ALARM_MASK" type="BITMAP16" writable="false" optional="true">alarm mask</attribute>
+    <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="false">MaxPressure</attribute>
+    <attribute side="server" code="0x0001" define="MAX_SPEED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">MaxSpeed</attribute>
+    <attribute side="server" code="0x0002" define="MAX_FLOW" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">MaxFlow</attribute>
+    <attribute side="server" code="0x0003" define="MIN_CONST_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">MinConstPressure</attribute>
+    <attribute side="server" code="0x0004" define="MAX_CONST_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">MaxConstPressure</attribute>
+    <attribute side="server" code="0x0005" define="MIN_COMP_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">MinCompPressure</attribute>
+    <attribute side="server" code="0x0006" define="MAX_COMP_PRESSURE" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">MaxCompPressure</attribute>
+    <attribute side="server" code="0x0007" define="MIN_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">MinConstSpeed</attribute>
+    <attribute side="server" code="0x0008" define="MAX_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">MaxConstSpeed</attribute>
+    <attribute side="server" code="0x0009" define="MIN_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">MinConstFlow</attribute>
+    <attribute side="server" code="0x000A" define="MAX_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">MaxConstFlow</attribute>
+    <attribute side="server" code="0x000B" define="MIN_CONST_TEMP" type="INT16S" min="0x0000" max="0xFFFF" writable="false" optional="true">MinConstTemp</attribute>
+    <attribute side="server" code="0x000C" define="MAX_CONST_TEMP" type="INT16S" min="0x0000" max="0x7FFF" writable="false" optional="true">MaxConstTemp</attribute>
+    <attribute side="server" code="0x0010" define="PUMP_STATUS" type="BITMAP16" writable="false" default="0x0000" reportable="true" optional="true">PumpStatus</attribute>
+    <attribute side="server" code="0x0011" define="EFFECTIVE_OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">EffectiveOperationMode</attribute>
+    <attribute side="server" code="0x0012" define="EFFECTIVE_CONTROL_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">EffectiveControlMode</attribute>
+    <attribute side="server" code="0x0013" define="CAPACITY" type="INT16S" min="0x0000" max="0x7FFF" writable="false" reportable="true" optional="false">Capacity</attribute>
+    <attribute side="server" code="0x0014" define="SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">Speed</attribute>
+    <attribute side="server" code="0x0015" define="LIFETIME_RUNNING_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0x000000" optional="true">LifetimeRunningHours</attribute>
+    <attribute side="server" code="0x0016" define="PUMP_POWER" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" optional="true">Power</attribute>
+    <attribute side="server" code="0x0017" define="LIFETIME_ENERGY_CONSUMED" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0x00000000" optional="true">LifetimeEnergyConsumed</attribute>
+    <attribute side="server" code="0x0020" define="OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="false">OperationMode</attribute>
+    <attribute side="server" code="0x0021" define="CONTROL_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="true">ControlMode</attribute>
+    <attribute side="server" code="0x0022" define="PUMP_ALARM_MASK" type="BITMAP16" writable="false" optional="true">AlarmMask</attribute>
 
     <event side="server" code="0x00" priority="info" name="SupplyVoltageLow">
       <description>SupplyVoltageLow</description>

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -6705,7 +6705,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "max pressure",
+              "name": "MaxPressure",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -6720,7 +6720,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max speed",
+              "name": "MaxSpeed",
               "code": 1,
               "mfgCode": null,
               "side": "server",
@@ -6735,7 +6735,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max flow",
+              "name": "MaxFlow",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -6750,7 +6750,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const pressure",
+              "name": "MinConstPressure",
               "code": 3,
               "mfgCode": null,
               "side": "server",
@@ -6765,7 +6765,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const pressure",
+              "name": "MaxConstPressure",
               "code": 4,
               "mfgCode": null,
               "side": "server",
@@ -6780,7 +6780,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min comp pressure",
+              "name": "MinCompPressure",
               "code": 5,
               "mfgCode": null,
               "side": "server",
@@ -6795,7 +6795,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max comp pressure",
+              "name": "MaxCompPressure",
               "code": 6,
               "mfgCode": null,
               "side": "server",
@@ -6810,7 +6810,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const speed",
+              "name": "MinConstSpeed",
               "code": 7,
               "mfgCode": null,
               "side": "server",
@@ -6825,7 +6825,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const speed",
+              "name": "MaxConstSpeed",
               "code": 8,
               "mfgCode": null,
               "side": "server",
@@ -6840,7 +6840,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const flow",
+              "name": "MinConstFlow",
               "code": 9,
               "mfgCode": null,
               "side": "server",
@@ -6855,7 +6855,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const flow",
+              "name": "MaxConstFlow",
               "code": 10,
               "mfgCode": null,
               "side": "server",
@@ -6870,7 +6870,7 @@
               "reportableChange": 0
             },
             {
-              "name": "min const temp",
+              "name": "MinConstTemp",
               "code": 11,
               "mfgCode": null,
               "side": "server",
@@ -6885,7 +6885,7 @@
               "reportableChange": 0
             },
             {
-              "name": "max const temp",
+              "name": "MaxConstTemp",
               "code": 12,
               "mfgCode": null,
               "side": "server",
@@ -6900,7 +6900,7 @@
               "reportableChange": 0
             },
             {
-              "name": "pump status",
+              "name": "PumpStatus",
               "code": 16,
               "mfgCode": null,
               "side": "server",
@@ -6915,7 +6915,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective operation mode",
+              "name": "EffectiveOperationMode",
               "code": 17,
               "mfgCode": null,
               "side": "server",
@@ -6930,7 +6930,7 @@
               "reportableChange": 0
             },
             {
-              "name": "effective control mode",
+              "name": "EffectiveControlMode",
               "code": 18,
               "mfgCode": null,
               "side": "server",
@@ -6945,7 +6945,7 @@
               "reportableChange": 0
             },
             {
-              "name": "capacity",
+              "name": "Capacity",
               "code": 19,
               "mfgCode": null,
               "side": "server",
@@ -6960,7 +6960,7 @@
               "reportableChange": 0
             },
             {
-              "name": "speed",
+              "name": "Speed",
               "code": 20,
               "mfgCode": null,
               "side": "server",
@@ -6975,7 +6975,7 @@
               "reportableChange": 0
             },
             {
-              "name": "lifetime running hours",
+              "name": "LifetimeRunningHours",
               "code": 21,
               "mfgCode": null,
               "side": "server",
@@ -6990,7 +6990,7 @@
               "reportableChange": 0
             },
             {
-              "name": "power",
+              "name": "Power",
               "code": 22,
               "mfgCode": null,
               "side": "server",
@@ -7005,7 +7005,7 @@
               "reportableChange": 0
             },
             {
-              "name": "lifetime energy consumed",
+              "name": "LifetimeEnergyConsumed",
               "code": 23,
               "mfgCode": null,
               "side": "server",
@@ -7020,7 +7020,7 @@
               "reportableChange": 0
             },
             {
-              "name": "operation mode",
+              "name": "OperationMode",
               "code": 32,
               "mfgCode": null,
               "side": "server",
@@ -7035,7 +7035,7 @@
               "reportableChange": 0
             },
             {
-              "name": "control mode",
+              "name": "ControlMode",
               "code": 33,
               "mfgCode": null,
               "side": "server",
@@ -7050,7 +7050,7 @@
               "reportableChange": 0
             },
             {
-              "name": "alarm mask",
+              "name": "AlarmMask",
               "code": 34,
               "mfgCode": null,
               "side": "server",

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -577,7 +577,7 @@
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Pump Configuration and Control (server), big-endian */                                        \
                                                                                                                                    \
-            /* 4482 - lifetime energy consumed, */                                                                                 \
+            /* 4482 - LifetimeEnergyConsumed, */                                                                                   \
             0x00, 0x00, 0x00, 0x00,                                                                                                \
                                                                                                                                    \
             /* 4486 - FeatureMap, */                                                                                               \
@@ -1531,7 +1531,7 @@
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Pump Configuration and Control (server), little-endian */                                     \
                                                                                                                                    \
-            /* 4482 - lifetime energy consumed, */                                                                                 \
+            /* 4482 - LifetimeEnergyConsumed, */                                                                                   \
             0x00, 0x00, 0x00, 0x00,                                                                                                \
                                                                                                                                    \
             /* 4486 - FeatureMap, */                                                                                               \
@@ -2300,28 +2300,28 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                                  \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Pump Configuration and Control (server) */                                                    \
-            { 0x0000, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max pressure */             \
-            { 0x0001, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max speed */                \
-            { 0x0002, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max flow */                 \
-            { 0x0003, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* min const pressure */       \
-            { 0x0004, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max const pressure */       \
-            { 0x0005, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* min comp pressure */        \
-            { 0x0006, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max comp pressure */        \
-            { 0x0007, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* min const speed */          \
-            { 0x0008, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max const speed */          \
-            { 0x0009, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* min const flow */           \
-            { 0x000A, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max const flow */           \
-            { 0x000B, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* min const temp */           \
-            { 0x000C, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* max const temp */           \
-            { 0x0010, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() },                              /* pump status */              \
-            { 0x0011, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },                                 /* effective operation mode */ \
-            { 0x0012, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },                                 /* effective control mode */   \
-            { 0x0013, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* capacity */                 \
-            { 0x0014, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* speed */                    \
-            { 0x0017, ZAP_TYPE(INT32U), 4, 0, ZAP_LONG_DEFAULTS_INDEX(4482) },                      /* lifetime energy consumed */ \
-            { 0x0020, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* operation mode */           \
-            { 0x0021, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* control mode */             \
-            { 0x0022, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() },                              /* alarm mask */               \
+            { 0x0000, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxPressure */              \
+            { 0x0001, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxSpeed */                 \
+            { 0x0002, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxFlow */                  \
+            { 0x0003, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MinConstPressure */         \
+            { 0x0004, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxConstPressure */         \
+            { 0x0005, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MinCompPressure */          \
+            { 0x0006, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxCompPressure */          \
+            { 0x0007, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MinConstSpeed */            \
+            { 0x0008, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxConstSpeed */            \
+            { 0x0009, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MinConstFlow */             \
+            { 0x000A, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxConstFlow */             \
+            { 0x000B, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MinConstTemp */             \
+            { 0x000C, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* MaxConstTemp */             \
+            { 0x0010, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() },                              /* PumpStatus */               \
+            { 0x0011, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },                                 /* EffectiveOperationMode */   \
+            { 0x0012, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },                                 /* EffectiveControlMode */     \
+            { 0x0013, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* Capacity */                 \
+            { 0x0014, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                                /* Speed */                    \
+            { 0x0017, ZAP_TYPE(INT32U), 4, 0, ZAP_LONG_DEFAULTS_INDEX(4482) },                      /* LifetimeEnergyConsumed */   \
+            { 0x0020, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* OperationMode */            \
+            { 0x0021, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* ControlMode */              \
+            { 0x0022, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() },                              /* AlarmMask */                \
             { 0xFFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_LONG_DEFAULTS_INDEX(4486) },                    /* FeatureMap */               \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },                         /* ClusterRevision */          \
                                                                                                                                    \

--- a/zzz_generated/pump-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/pump-app/zap-generated/endpoint_config.h
@@ -383,13 +383,13 @@
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Pump Configuration and Control (server), big-endian */                                        \
                                                                                                                                    \
-            /* 2351 - lifetime running hours, */                                                                                   \
+            /* 2351 - LifetimeRunningHours, */                                                                                     \
             0x00, 0x00, 0x00,                                                                                                      \
                                                                                                                                    \
-            /* 2354 - power, */                                                                                                    \
+            /* 2354 - Power, */                                                                                                    \
             0x00, 0x00, 0x00,                                                                                                      \
                                                                                                                                    \
-            /* 2357 - lifetime energy consumed, */                                                                                 \
+            /* 2357 - LifetimeEnergyConsumed, */                                                                                   \
             0x00, 0x00, 0x00, 0x00,                                                                                                \
                                                                                                                                    \
             /* 2361 - FeatureMap, */                                                                                               \
@@ -756,13 +756,13 @@
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Pump Configuration and Control (server), little-endian */                                     \
                                                                                                                                    \
-            /* 2351 - lifetime running hours, */                                                                                   \
+            /* 2351 - LifetimeRunningHours, */                                                                                     \
             0x00, 0x00, 0x00,                                                                                                      \
                                                                                                                                    \
-            /* 2354 - power, */                                                                                                    \
+            /* 2354 - Power, */                                                                                                    \
             0x00, 0x00, 0x00,                                                                                                      \
                                                                                                                                    \
-            /* 2357 - lifetime energy consumed, */                                                                                 \
+            /* 2357 - LifetimeEnergyConsumed, */                                                                                   \
             0x00, 0x00, 0x00, 0x00,                                                                                                \
                                                                                                                                    \
             /* 2361 - FeatureMap, */                                                                                               \
@@ -963,31 +963,31 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(3) },   /* ClusterRevision */                                     \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Pump Configuration and Control (server) */                                                    \
-            { 0x0000, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max pressure */                                          \
-            { 0x0001, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max speed */                                             \
-            { 0x0002, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max flow */                                              \
-            { 0x0003, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* min const pressure */                                    \
-            { 0x0004, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max const pressure */                                    \
-            { 0x0005, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* min comp pressure */                                     \
-            { 0x0006, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max comp pressure */                                     \
-            { 0x0007, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* min const speed */                                       \
-            { 0x0008, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max const speed */                                       \
-            { 0x0009, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* min const flow */                                        \
-            { 0x000A, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max const flow */                                        \
-            { 0x000B, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* min const temp */                                        \
-            { 0x000C, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* max const temp */                                        \
-            { 0x0010, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() }, /* pump status */                                           \
-            { 0x0011, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },    /* effective operation mode */                              \
-            { 0x0012, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },    /* effective control mode */                                \
-            { 0x0013, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* capacity */                                              \
-            { 0x0014, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* speed */                                                 \
+            { 0x0000, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxPressure */                                           \
+            { 0x0001, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxSpeed */                                              \
+            { 0x0002, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxFlow */                                               \
+            { 0x0003, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MinConstPressure */                                      \
+            { 0x0004, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxConstPressure */                                      \
+            { 0x0005, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MinCompPressure */                                       \
+            { 0x0006, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxCompPressure */                                       \
+            { 0x0007, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MinConstSpeed */                                         \
+            { 0x0008, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxConstSpeed */                                         \
+            { 0x0009, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MinConstFlow */                                          \
+            { 0x000A, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxConstFlow */                                          \
+            { 0x000B, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MinConstTemp */                                          \
+            { 0x000C, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* MaxConstTemp */                                          \
+            { 0x0010, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() }, /* PumpStatus */                                            \
+            { 0x0011, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },    /* EffectiveOperationMode */                                \
+            { 0x0012, ZAP_TYPE(ENUM8), 1, 0, ZAP_EMPTY_DEFAULT() },    /* EffectiveControlMode */                                  \
+            { 0x0013, ZAP_TYPE(INT16S), 2, 0, ZAP_EMPTY_DEFAULT() },   /* Capacity */                                              \
+            { 0x0014, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },   /* Speed */                                                 \
             { 0x0015, ZAP_TYPE(INT24U), 3, ZAP_ATTRIBUTE_MASK(WRITABLE),                                                           \
-              ZAP_LONG_DEFAULTS_INDEX(2351) }, /* lifetime running hours */                                                        \
-            { 0x0016, ZAP_TYPE(INT24U), 3, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_LONG_DEFAULTS_INDEX(2354) }, /* power */              \
-            { 0x0017, ZAP_TYPE(INT32U), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2357) },                      /* lifetime energy consumed */ \
-            { 0x0020, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* operation mode */           \
-            { 0x0021, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* control mode */             \
-            { 0x0022, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() },                              /* alarm mask */               \
+              ZAP_LONG_DEFAULTS_INDEX(2351) }, /* LifetimeRunningHours */                                                          \
+            { 0x0016, ZAP_TYPE(INT24U), 3, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_LONG_DEFAULTS_INDEX(2354) }, /* Power */              \
+            { 0x0017, ZAP_TYPE(INT32U), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2357) },                      /* LifetimeEnergyConsumed */   \
+            { 0x0020, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* OperationMode */            \
+            { 0x0021, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x00) }, /* ControlMode */              \
+            { 0x0022, ZAP_TYPE(BITMAP16), 2, 0, ZAP_EMPTY_DEFAULT() },                              /* AlarmMask */                \
             { 0xFFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_LONG_DEFAULTS_INDEX(2361) },                    /* FeatureMap */               \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },                         /* ClusterRevision */          \
                                                                                                                                    \


### PR DESCRIPTION
#### Problem
* The PCC cluster attribute names was not defined correctly in the .xml file. They need to be in CamelCase

#### Change overview
* Changed the attribute names in the `pump-configuration-and-control.xml` cluster definition file to be in CamelCase
* Modified the `Test_TC_PCC_2_1.yaml` file to use these new attribute names
* Reloaded the `controller-clusters.zap` and the `pump-app.zap` and the `pump-controller-app.zap` and the `all-clusters-app.zap` files to force usage of the new attribute names
* Re-generated using these updated .zap files

#### Testing
* Build the `chip-tool` and verified that the PCC cluster attributes was correct
* Build the `chip-device-ctrl` and verified that the PCC cluster attributes was correct
* Build the `all-clusters-app` successfully
* Build the `pump-app` and the `pump-controller-app` successfully