### PR TITLE
[IM] Move ReadClient callbacks to separate callback class

### DIFF
--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -51,62 +51,6 @@ class InteractionModelDelegate
 {
 public:
     /**
-     * Notification that the interaction model has received a list of events in response to a Read request and that list
-     * of events needs to be processed.
-     * @param[in]  apExchangeContext   An exchange context that represents the exchange the Report Data came in on.
-     *                                 This can be used to recover the NodeId of the node that sent the Report Data.
-     *                                 It is managed externally and should not be closed by the SDK consumer.
-     * @param[in]  apEventListReader  TLV reader positioned at the list that contains the events.  The
-     *                                implementation of EventStreamReceived is expected to call Next() on the reader to
-     *                                advance it to the first element of the list, then process the elements from beginning to the
-     *                                end. The callee is expected to consume all events.
-     *
-     * @retval  # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
-     */
-    virtual CHIP_ERROR EventStreamReceived(const Messaging::ExchangeContext * apExchangeContext, TLV::TLVReader * apEventListReader)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
-    /**
-     * Notification that the interaction model has received a list of attribute data in response to a Read request. apData might be
-     * nullptr if status is not Status::Success.
-     *
-     * @param[in]  apReadClient   The read client object, the application can use GetAppIdentifier() for the read client to
-     *                            distinguish different read requests.
-     * @param[in]  aPath          The path of the attribute, contains node id, endpoint id, cluster id, field id etc.
-     * @param[in]  apData         The attribute data TLV
-     * @param[in]  status         Interaction model status code
-     *
-     */
-    virtual void OnReportData(const ReadClient * apReadClient, const ClusterInfo & aPath, TLV::TLVReader * apData,
-                              Protocols::InteractionModel::Status status)
-    {}
-
-    /**
-     * Notification that the last message for a Report Data action for the given ReadClient has been received and processed.
-     * @param[in]  apReadClient   A current readClient which can identify the read to the consumer, particularly during
-     *                            multiple read interactions
-     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
-     */
-    virtual CHIP_ERROR ReportProcessed(const ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-
-    /**
-     * Notification that a read attempt encountered an asynchronous failure.
-     * @param[in]  apReadClient   A current readClient which can identify the read to the consumer, particularly during
-     *                            multiple read interactions
-     * @param[in]  aError         A error that could be CHIP_ERROR_TIMEOUT when read client fails to receive, or other error when
-     *                            fail to process report data.
-     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
-     */
-    virtual CHIP_ERROR ReadError(ReadClient * apReadClient, CHIP_ERROR aError) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-
-    /**
-     * Notification that a Subscribe Response has been processed and application can do further work .
-     */
-    virtual CHIP_ERROR SubscribeResponseProcessed(const ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-
-    /**
      * Notification that Subscription has been established successfully and application can do further work in handler.
      */
     virtual CHIP_ERROR SubscriptionEstablished(const ReadHandler * apReadHandler) { return CHIP_ERROR_NOT_IMPLEMENTED; }
@@ -115,14 +59,6 @@ public:
      * Notification that Subscription has been terminated in handler side.
      */
     virtual CHIP_ERROR SubscriptionTerminated(const ReadHandler * apReadHandler) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-
-    /**
-     * Notification that a read interaction was completed on the client successfully.
-     * @param[in]  apReadClient  A current read client which can identify the read client to the consumer, particularly
-     * during multiple read interactions
-     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
-     */
-    virtual CHIP_ERROR ReadDone(ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     virtual ~InteractionModelDelegate() = default;
 };

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -121,14 +121,8 @@ void InteractionModelEngine::Shutdown()
 }
 
 CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClient, ReadClient::InteractionType aInteractionType,
-                                                 uint64_t aAppIdentifier, InteractionModelDelegate * apDelegateOverride)
+                                                 ReadClient::Callback * aCallback)
 {
-
-    if (apDelegateOverride == nullptr)
-    {
-        apDelegateOverride = mpDelegate;
-    }
-
     *apReadClient = nullptr;
 
     for (auto & readClient : mReadClients)
@@ -138,7 +132,7 @@ CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClien
             CHIP_ERROR err;
 
             *apReadClient = &readClient;
-            err           = readClient.Init(mpExchangeMgr, apDelegateOverride, aInteractionType, aAppIdentifier);
+            err           = readClient.Init(mpExchangeMgr, aCallback, aInteractionType);
             if (CHIP_NO_ERROR != err)
             {
                 *apReadClient = nullptr;
@@ -428,11 +422,11 @@ void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
                     ChipLogValueExchange(ec));
 }
 
-CHIP_ERROR InteractionModelEngine::SendReadRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier)
+CHIP_ERROR InteractionModelEngine::SendReadRequest(ReadPrepareParams & aReadPrepareParams, ReadClient::Callback * aCallback)
 {
     ReadClient * client = nullptr;
     CHIP_ERROR err      = CHIP_NO_ERROR;
-    ReturnErrorOnFailure(NewReadClient(&client, ReadClient::InteractionType::Read, aAppIdentifier));
+    ReturnErrorOnFailure(NewReadClient(&client, ReadClient::InteractionType::Read, aCallback));
     err = client->SendReadRequest(aReadPrepareParams);
     if (err != CHIP_NO_ERROR)
     {
@@ -441,10 +435,10 @@ CHIP_ERROR InteractionModelEngine::SendReadRequest(ReadPrepareParams & aReadPrep
     return err;
 }
 
-CHIP_ERROR InteractionModelEngine::SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier)
+CHIP_ERROR InteractionModelEngine::SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, ReadClient::Callback * aCallback)
 {
     ReadClient * client = nullptr;
-    ReturnErrorOnFailure(NewReadClient(&client, ReadClient::InteractionType::Subscribe, aAppIdentifier));
+    ReturnErrorOnFailure(NewReadClient(&client, ReadClient::InteractionType::Subscribe, aCallback));
     ReturnErrorOnFailure(client->SendSubscribeRequest(aReadPrepareParams));
     return CHIP_NO_ERROR;
 }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -101,7 +101,7 @@ public:
      *  @retval #CHIP_ERROR_NO_MEMORY If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier = 0);
+    CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams, ReadClient::Callback * aCallback);
 
     /**
      *  Creates a new read client and sends SubscribeRequest message to the node using the read client.
@@ -110,7 +110,7 @@ public:
      *  @retval #CHIP_ERROR_NO_MEMORY If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, uint64_t aAppIdentifier = 0);
+    CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aReadPrepareParams, ReadClient::Callback * aCallback);
 
     /**
      * Tears down an active subscription.
@@ -151,7 +151,7 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      */
     CHIP_ERROR NewReadClient(ReadClient ** const apReadClient, ReadClient::InteractionType aInteractionType,
-                             uint64_t aAppIdentifier, InteractionModelDelegate * apDelegateOverride = nullptr);
+                             ReadClient::Callback * aCallback);
 
     uint32_t GetNumActiveReadHandlers() const;
     uint32_t GetNumActiveReadClients() const;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -55,6 +55,82 @@ namespace app {
 class ReadClient : public Messaging::ExchangeDelegate
 {
 public:
+    class Callback
+    {
+    public:
+        virtual ~Callback() = default;
+        /**
+         * Notification that a list of events is received on the given read client.
+         * The ReadClient object MUST continue to exist after this call is completed.
+         *
+         * @param[in]  apReadClient The read client which initialized the read transaction.
+         * @param[in]  apEventListReader  TLV reader positioned at the list that contains the events.  The
+         *                                implementation of EventStreamReceived is expected to call Next() on the reader to
+         *                                advance it to the first element of the list, then process the elements from beginning to
+         *                                the end. The callee is expected to consume all events.
+         */
+        virtual void OnEventData(const ReadClient * apReadClient, TLV::TLVReader & aEventList) {}
+
+        /**
+         * OnResponse will be called when a report data response has been received and processed for the given path.
+         *
+         * The ReadClient object MUST continue to exist after this call is completed.
+         *
+         * This callback will be called when:
+         *   - Receiving attribute data as response of Read interactions
+         *   - Receiving attribute data as reports of subscriptions
+         *   - Receiving attribute data as initial reports of subscriptions
+         *
+         * @param[in] apReadClient: The read client object that initiated the read or subscribe transaction.
+         * @param[in] aPath: The attribute path field in report response.
+         * @param[in] apData: The attribute data of the given path, will be a nullptr if status is not Success.
+         * @param[in] aStatus: Attribute-specific status, containing an InteractionModel::Status code as well as an optional
+         *                     cluster-specific status code.
+         */
+        virtual void OnAttributeData(const ReadClient * apReadClient, const ConcreteAttributePath & aPath, TLV::TLVReader * apData,
+                                     const StatusIB & aStatus)
+        {}
+
+        /**
+         * OnSubscriptionEstablished will be called when a subscription is established for the given subscription transaction.
+         *
+         * The ReadClient object MUST continue to exist after this call is completed. The application shall wait until it
+         * receives an OnDone call before it shuts down the object.
+         *
+         * @param[in] apReadClient: The read client object that initiated the read transaction.
+         */
+        virtual void OnSubscriptionEstablished(const ReadClient * apReadClient) {}
+
+        /**
+         * OnError will be called when an error occurs *after* a successful call to SendReadRequest(). The following
+         * errors will be delivered through this call in the aError field:
+         *
+         * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
+         * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
+         * - CHIP_ERROR*: All other cases.
+         *
+         * The ReadClient object MUST continue to exist after this call is completed. The application shall wait until it
+         * receives an OnDone call before it shuts down the object.
+         *
+         * @param[in] apReadClient: The read client object that initiated the attribute read transaction.
+         * @param[in] aError: A system error code that conveys the overall error code.
+         */
+        virtual void OnError(const ReadClient * apReadClient, CHIP_ERROR aError) {}
+
+        /**
+         * OnDone will be called when ReadClient has finished all work and is reserved for future ReadClient ownership change.
+         * (#10366) Users may use this function to release their own objects related to this write interaction.
+         *
+         * This function will:
+         *      - Always be called exactly *once* for a given WriteClient instance.
+         *      - Be called even in error circumstances.
+         *      - Only be called after a successful call to SendWriteRequest as been made.
+         *
+         * @param[in] apReadClient: The read client object of the terminated read transaction.
+         */
+        virtual void OnDone(ReadClient * apReadClient) = 0;
+    };
+
     enum class InteractionType : uint8_t
     {
         Read,
@@ -92,7 +168,6 @@ public:
      */
     CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aSubscribePrepareParams);
     CHIP_ERROR OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
-    uint64_t GetAppIdentifier() const { return mAppIdentifier; }
 
     auto GetSubscriptionId() const
     {
@@ -145,8 +220,7 @@ private:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
-                    InteractionType aInteractionType, uint64_t aAppIdentifier);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback, InteractionType aInteractionType);
 
     virtual ~ReadClient() = default;
 
@@ -187,9 +261,8 @@ private:
     bool IsInitialReport() { return mInitialReport; }
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
-    InteractionModelDelegate * mpDelegate      = nullptr;
+    Callback * mpCallback                      = nullptr;
     ClientState mState                         = ClientState::Uninitialized;
-    uint64_t mAppIdentifier                    = 0;
     bool mInitialReport                        = true;
     uint16_t mMinIntervalFloorSeconds          = 0;
     uint16_t mMaxIntervalCeilingSeconds        = 0;

--- a/src/app/util/im-client-callbacks.h
+++ b/src/app/util/im-client-callbacks.h
@@ -29,8 +29,9 @@
 // instead of IM status code.
 // #6308 should handle IM error code on the application side, either modify this function or remove this.
 bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
-bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
-                                            chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::Status status);
+bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient,
+                                            const chip::app::ConcreteAttributePath * aPath, chip::TLV::TLVReader * apData,
+                                            chip::Protocols::InteractionModel::Status status);
 bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, chip::Protocols::InteractionModel::Status status);
 bool IMSubscribeResponseCallback(const chip::app::ReadClient * apSubscribeClient, EmberAfStatus status);
 void LogStatus(uint8_t status);

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -714,34 +714,23 @@ CHIP_ERROR Device::EstablishConnectivity(Callback::Callback<OnDeviceConnected> *
     return CHIP_NO_ERROR;
 }
 
-void Device::AddResponseHandler(uint8_t seqNum, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                app::TLVDataFilter tlvDataFilter)
-{
-    mCallbacksMgr.AddResponseCallback(mDeviceId, seqNum, onSuccessCallback, onFailureCallback, tlvDataFilter);
-}
-
-void Device::CancelResponseHandler(uint8_t seqNum)
-{
-    mCallbacksMgr.CancelResponseCallback(mDeviceId, seqNum);
-}
-
 void Device::AddIMResponseHandler(void * commandObj, Callback::Cancelable * onSuccessCallback,
-                                  Callback::Cancelable * onFailureCallback)
+                                  Callback::Cancelable * onFailureCallback, app::TLVDataFilter tlvDataFilter)
 {
-    // We are using the pointer to command sender object as the identifier of command transactions. This makes sense as long as
-    // there are only one active command transaction on one command sender object. This is a bit tricky, we try to assume that
-    // chip::NodeId is uint64_t so the pointer can be used as a NodeId for CallbackMgr.
+    // Interaction model uses the object instead of a sequence number as the identifier of transactions.
+    // Since the objects can be identified by its pointer which fits into a uint64 value (the type of NodeId), we use it for the
+    // "node id" field in callback manager.
     static_assert(std::is_same<chip::NodeId, uint64_t>::value, "chip::NodeId is not uint64_t");
     chip::NodeId transactionId = reinterpret_cast<chip::NodeId>(commandObj);
     mCallbacksMgr.AddResponseCallback(transactionId, 0 /* seqNum, always 0 for IM before #6559 */, onSuccessCallback,
-                                      onFailureCallback);
+                                      onFailureCallback, tlvDataFilter);
 }
 
 void Device::CancelIMResponseHandler(void * commandObj)
 {
-    // We are using the pointer to command sender object as the identifier of command transactions. This makes sense as long as
-    // there are only one active command transaction on one command sender object. This is a bit tricky, we try to assume that
-    // chip::NodeId is uint64_t so the pointer can be used as a NodeId for CallbackMgr.
+    // Interaction model uses the object instead of a sequence number as the identifier of transactions.
+    // Since the objects can be identified by its pointer which fits into a uint64 value (the type of NodeId), we use it for the
+    // "node id" field in callback manager.
     static_assert(std::is_same<chip::NodeId, uint64_t>::value, "chip::NodeId is not uint64_t");
     chip::NodeId transactionId = reinterpret_cast<chip::NodeId>(commandObj);
     mCallbacksMgr.CancelResponseCallback(transactionId, 0 /* seqNum, always 0 for IM before #6559 */);
@@ -757,25 +746,28 @@ CHIP_ERROR Device::SendReadAttributeRequest(app::AttributePathParams aPath, Call
                                             Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter)
 {
     bool loadedSecureSession = false;
-    uint8_t seqNum           = GetNextSequenceNumber();
     aPath.mNodeId            = GetDeviceId();
 
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
 
+    app::ReadClient * readClient = nullptr;
+    ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewReadClient(
+        &readClient, app::ReadClient::InteractionType::Read, mpIMDelegate));
+
     if (onSuccessCallback != nullptr || onFailureCallback != nullptr)
     {
-        AddResponseHandler(seqNum, onSuccessCallback, onFailureCallback, aTlvDataFilter);
+        AddIMResponseHandler(readClient, onSuccessCallback, onFailureCallback, aTlvDataFilter);
     }
     // The application context is used to identify different requests from client application the type of it is intptr_t, here we
     // use the seqNum.
     chip::app::ReadPrepareParams readPrepareParams(mSecureSession.Value());
     readPrepareParams.mpAttributePathParamsList    = &aPath;
     readPrepareParams.mAttributePathParamsListSize = 1;
-    CHIP_ERROR err =
-        chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(readPrepareParams, seqNum /* application context */);
+
+    CHIP_ERROR err = readClient->SendReadRequest(readPrepareParams);
     if (err != CHIP_NO_ERROR)
     {
-        CancelResponseHandler(seqNum);
+        CancelIMResponseHandler(readClient);
     }
     return err;
 }
@@ -785,12 +777,15 @@ CHIP_ERROR Device::SendSubscribeAttributeRequest(app::AttributePathParams aPath,
                                                  Callback::Cancelable * onFailureCallback)
 {
     bool loadedSecureSession = false;
-    uint8_t seqNum           = GetNextSequenceNumber();
     aPath.mNodeId            = GetDeviceId();
 
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
 
-    app::AttributePathParams * path = mpIMDelegate->AllocateAttributePathParam(1, seqNum);
+    app::ReadClient * readClient = nullptr;
+    ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewReadClient(
+        &readClient, app::ReadClient::InteractionType::Subscribe, mpIMDelegate));
+
+    app::AttributePathParams * path = mpIMDelegate->AllocateAttributePathParam(1, reinterpret_cast<uint64_t>(readClient));
 
     VerifyOrReturnError(path != nullptr, CHIP_ERROR_NO_MEMORY);
 
@@ -806,17 +801,17 @@ CHIP_ERROR Device::SendSubscribeAttributeRequest(app::AttributePathParams aPath,
     params.mMaxIntervalCeilingSeconds   = mMaxIntervalCeilingSeconds;
     params.mKeepSubscriptions           = false;
 
-    CHIP_ERROR err =
-        chip::app::InteractionModelEngine::GetInstance()->SendSubscribeRequest(params, seqNum /* application context */);
+    CHIP_ERROR err = readClient->SendSubscribeRequest(params);
     if (err != CHIP_NO_ERROR)
     {
-        mpIMDelegate->FreeAttributePathParam(seqNum);
+        mpIMDelegate->FreeAttributePathParam(reinterpret_cast<uint64_t>(readClient));
+        readClient->Shutdown();
         return err;
     }
 
     if (onSuccessCallback != nullptr || onFailureCallback != nullptr)
     {
-        AddResponseHandler(seqNum, onSuccessCallback, onFailureCallback);
+        AddIMResponseHandler(readClient, onSuccessCallback, onFailureCallback);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -386,18 +386,11 @@ public:
     PASESessionSerializable & GetPairing() { return mPairing; }
 
     uint8_t GetNextSequenceNumber() { return mSequenceNumber++; };
-    void AddResponseHandler(uint8_t seqNum, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                            app::TLVDataFilter tlvDataFilter = nullptr);
-    void CancelResponseHandler(uint8_t seqNum);
     void AddReportHandler(EndpointId endpoint, ClusterId cluster, AttributeId attribute, Callback::Cancelable * onReportCallback,
                           app::TLVDataFilter tlvDataFilter);
-
-    // This two functions are pretty tricky, it is used to bridge the response, we need to implement interaction model delegate
-    // on the app side instead of register callbacks here. The IM delegate can provide more infomation then callback and it is
-    // type-safe.
-    // TODO: Implement interaction model delegate in the application.
-    void AddIMResponseHandler(void * commandObj, Callback::Cancelable * onSuccessCallback,
-                              Callback::Cancelable * onFailureCallback);
+    // Interaction model uses the object and callback interface instead of sequence number to mark different transactions.
+    void AddIMResponseHandler(void * commandObj, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
+                              app::TLVDataFilter tlvDataFilter = nullptr);
     void CancelIMResponseHandler(void * commandObj);
 
     void OperationalCertProvisioned();

--- a/src/controller/DeviceControllerInteractionModelDelegate.h
+++ b/src/controller/DeviceControllerInteractionModelDelegate.h
@@ -15,9 +15,10 @@ namespace Controller {
  *
  * TODO:(#8967) Implementation of CommandSender::Callback should be removed after switching to ClusterObjects.
  */
-class DeviceControllerInteractionModelDelegate : public chip::app::InteractionModelDelegate,
+class DeviceControllerInteractionModelDelegate : public chip::app::ReadClient::Callback,
                                                  public chip::app::CommandSender::Callback,
-                                                 public chip::app::WriteClient::Callback
+                                                 public chip::app::WriteClient::Callback,
+                                                 public chip::app::InteractionModelDelegate
 {
 public:
     void OnResponse(app::CommandSender * apCommandSender, const app::ConcreteCommandPath & aPath,
@@ -31,13 +32,12 @@ public:
     void OnError(const app::WriteClient * apWriteClient, CHIP_ERROR aError) override;
     void OnDone(app::WriteClient * apWriteClient) override;
 
-    void OnReportData(const app::ReadClient * apReadClient, const app::ClusterInfo & aPath, TLV::TLVReader * apData,
-                      Protocols::InteractionModel::Status status) override;
-    CHIP_ERROR ReadError(app::ReadClient * apReadClient, CHIP_ERROR aError) override;
-
-    CHIP_ERROR SubscribeResponseProcessed(const app::ReadClient * apSubscribeClient) override;
-
-    CHIP_ERROR ReadDone(app::ReadClient * apReadClient) override;
+    void OnEventData(const app::ReadClient * apReadClient, TLV::TLVReader & aEventList) override {}
+    void OnAttributeData(const app::ReadClient * apReadClient, const app::ConcreteAttributePath & aPath, TLV::TLVReader * apData,
+                         const app::StatusIB & aStatus) override;
+    void OnSubscriptionEstablished(const app::ReadClient * apReadClient) override;
+    void OnError(const app::ReadClient * apReadClient, CHIP_ERROR aError) override;
+    void OnDone(app::ReadClient * apReadClient) override;
 
     // TODO: FreeAttributePathParam and AllocateAttributePathParam are used by CHIPDevice.cpp for getting a long-live attribute path
     // object.

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -57,7 +57,7 @@ CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * aExchangeMgr, const Sessio
     auto callback = chip::Platform::MakeUnique<TypedReadCallback<AttributeTypeInfo>>(onSuccessCb, onErrorCb, onDone);
     VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    ReturnErrorOnFailure(engine->NewReadClient(&readClient, app::ReadClient::InteractionType::Read, 0, callback.get()));
+    ReturnErrorOnFailure(engine->NewReadClient(&readClient, app::ReadClient::InteractionType::Read, callback.get()));
 
     err = readClient->SendReadRequest(readParams);
     if (err != CHIP_NO_ERROR)

--- a/src/controller/python/chip/interaction_model/Delegate.cpp
+++ b/src/controller/python/chip/interaction_model/Delegate.cpp
@@ -80,8 +80,8 @@ void PythonInteractionModelDelegate::OnError(const app::CommandSender * apComman
     DeviceControllerInteractionModelDelegate::OnError(apCommandSender, aStatus, aError);
 }
 
-void PythonInteractionModelDelegate::OnReportData(const app::ReadClient * apReadClient, const app::ClusterInfo & aPath,
-                                                  TLV::TLVReader * apData, Protocols::InteractionModel::Status status)
+void PythonInteractionModelDelegate::OnAttributeData(const app::ReadClient * apReadClient, const app::ConcreteAttributePath & aPath,
+                                                     TLV::TLVReader * apData, const app::StatusIB & status)
 {
     if (onReportDataFunct != nullptr)
     {
@@ -102,10 +102,10 @@ void PythonInteractionModelDelegate::OnReportData(const app::ReadClient * apRead
         }
         if (CHIP_NO_ERROR == err)
         {
-            AttributePath path{ .endpointId = aPath.mEndpointId, .clusterId = aPath.mClusterId, .fieldId = aPath.mFieldId };
-            onReportDataFunct(apReadClient->GetPeerNodeId(), apReadClient->GetAppIdentifier(),
+            AttributePath path{ .endpointId = aPath.mEndpointId, .clusterId = aPath.mClusterId, .fieldId = aPath.mAttributeId };
+            onReportDataFunct(apReadClient->GetPeerNodeId(), 0,
                               /* TODO: Use real SubscriptionId */ apReadClient->IsSubscriptionType() ? 1 : 0, &path, sizeof(path),
-                              writerBuffer, writer.GetLengthWritten(), to_underlying(status));
+                              writerBuffer, writer.GetLengthWritten(), to_underlying(status.mStatus));
         }
         else
         {
@@ -114,7 +114,7 @@ void PythonInteractionModelDelegate::OnReportData(const app::ReadClient * apRead
             ChipLogError(Controller, "Cannot pass TLV data to python: failed to copy TLV: %s", ErrorStr(err));
         }
     }
-    DeviceControllerInteractionModelDelegate::OnReportData(apReadClient, aPath, apData, status);
+    DeviceControllerInteractionModelDelegate::OnAttributeData(apReadClient, aPath, apData, status);
 }
 
 void pychip_InteractionModelDelegate_SetCommandResponseStatusCallback(

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -101,8 +101,8 @@ public:
                     TLV::TLVReader * aData) override;
     void OnError(const app::CommandSender * apCommandSender, const app::StatusIB & aStatus, CHIP_ERROR aError) override;
 
-    void OnReportData(const app::ReadClient * apReadClient, const app::ClusterInfo & aPath, TLV::TLVReader * apData,
-                      Protocols::InteractionModel::Status status) override;
+    void OnAttributeData(const app::ReadClient * apReadClient, const app::ConcreteAttributePath & aPath, TLV::TLVReader * apData,
+                         const app::StatusIB & status) override;
 
     static PythonInteractionModelDelegate & Instance();
 

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -137,8 +137,7 @@ void TestReadInteraction::TestDataResponse(nlTestSuite * apSuite, void * apConte
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteAttributePath * attributePath,
-                                             Protocols::InteractionModel::Status aIMStatus,
+    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteAttributePath * attributePath, app::StatusIB aIMStatus,
                                              CHIP_ERROR aError) { onFailureCbInvoked = true; };
 
     chip::Controller::ReadAttribute<TestCluster::Attributes::ListStructOctetString::TypeInfo>(


### PR DESCRIPTION
#### Problem

Fixes #10573 

Move read / subscribe related callbacks to seperate class.

#### Change overview

- Move Read / Subscribe related callbacks to seperate class.

#### Testing

- This should be covered by existing test cases.
