### PR TITLE
Convert Inet::InterfaceId to a class

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -78,7 +78,7 @@ static bool ParseAddressWithInterface(const char * addressString, Command::Addre
     }
     else
     {
-        address->interfaceId = chip::Inet::InterfaceId();
+        address->interfaceId = chip::Inet::InterfaceId::Null();
     }
 
     return true;

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -74,11 +74,11 @@ static bool ParseAddressWithInterface(const char * addressString, Command::Addre
     if (result->ai_family == AF_INET6)
     {
         struct sockaddr_in6 * addr = reinterpret_cast<struct sockaddr_in6 *>(result->ai_addr);
-        address->interfaceId       = addr->sin6_scope_id;
+        address->interfaceId       = ::chip::Inet::InterfaceId(addr->sin6_scope_id);
     }
     else
     {
-        address->interfaceId = INET_NULL_INTERFACEID;
+        address->interfaceId = chip::Inet::InterfaceId();
     }
 
     return true;

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -437,7 +437,7 @@ void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & 
     // Stop Mdns discovery. Is it the right method ?
     mController.RegisterDeviceDiscoveryDelegate(nullptr);
 
-    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId();
+    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId::Null();
     PeerAddress peerAddress       = PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
     CHIP_ERROR err                = Pair(mNodeId, peerAddress);
     if (CHIP_NO_ERROR != err)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -437,7 +437,7 @@ void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & 
     // Stop Mdns discovery. Is it the right method ?
     mController.RegisterDeviceDiscoveryDelegate(nullptr);
 
-    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : INET_NULL_INTERFACEID;
+    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId();
     PeerAddress peerAddress       = PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
     CHIP_ERROR err                = Pair(mNodeId, peerAddress);
     if (CHIP_NO_ERROR != err)

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -59,7 +59,7 @@ public:
                    chip::Dnssd::DiscoveryFilterType filterType = chip::Dnssd::DiscoveryFilterType::kNone) :
         CHIPCommand(commandName),
         mPairingMode(mode), mNetworkType(networkType),
-        mFilterType(filterType), mRemoteAddr{ IPAddress::Any, INET_NULL_INTERFACEID },
+        mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId() },
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -59,7 +59,7 @@ public:
                    chip::Dnssd::DiscoveryFilterType filterType = chip::Dnssd::DiscoveryFilterType::kNone) :
         CHIPCommand(commandName),
         mPairingMode(mode), mNetworkType(networkType),
-        mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId() },
+        mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() },
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);

--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -39,7 +39,7 @@ public:
         if (mState == State::kIpV4)
         {
 #if INET_CONFIG_ENABLE_IPV4
-            *id   = INET_NULL_INTERFACEID;
+            *id   = Inet::InterfaceId();
             *type = chip::Inet::IPAddressType::kIPv4;
 #endif
             mState = State::kIpV6;
@@ -100,7 +100,7 @@ private:
             return true; // not a usable interface
         }
 
-        char name[chip::Inet::InterfaceIterator::kMaxIfNameLength];
+        char name[chip::Inet::InterfaceId::kMaxIfNameLength];
         if (mIterator.GetInterfaceName(name, sizeof(name)) != CHIP_NO_ERROR)
         {
             printf("!!!! FAILED TO GET INTERFACE NAME\n");

--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -39,7 +39,7 @@ public:
         if (mState == State::kIpV4)
         {
 #if INET_CONFIG_ENABLE_IPV4
-            *id   = Inet::InterfaceId();
+            *id   = Inet::InterfaceId::Null();
             *type = chip::Inet::IPAddressType::kIPv4;
 #endif
             mState = State::kIpV6;

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -144,7 +144,7 @@ Transport::PeerAddress GetEchoPeerAddress()
 #endif
     {
 
-        return Transport::PeerAddress::UDP(gDestAddr, gPingArguments.GetEchoPort(), INET_NULL_INTERFACEID);
+        return Transport::PeerAddress::UDP(gDestAddr, gPingArguments.GetEchoPort(), ::chip::Inet::InterfaceId());
     }
 }
 

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -144,7 +144,7 @@ Transport::PeerAddress GetEchoPeerAddress()
 #endif
     {
 
-        return Transport::PeerAddress::UDP(gDestAddr, gPingArguments.GetEchoPort(), ::chip::Inet::InterfaceId());
+        return Transport::PeerAddress::UDP(gDestAddr, gPingArguments.GetEchoPort(), ::chip::Inet::InterfaceId::Null());
     }
 }
 

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -232,7 +232,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     else
 #endif
     {
-        peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
+        peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), Inet::InterfaceId());
 
         err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
         SuccessOrExit(err);

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -232,7 +232,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     else
 #endif
     {
-        peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), Inet::InterfaceId());
+        peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), Inet::InterfaceId::Null());
 
         err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);
         SuccessOrExit(err);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -430,7 +430,7 @@ CHIP_ERROR EstablishSecureSession()
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
-                                         chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId())),
+                                         chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null())),
                                      chip::kTestDeviceNodeId, testSecurePairingSecret, chip::CryptoContext::SessionRole::kInitiator,
                                      gFabricIndex);
 

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -430,7 +430,7 @@ CHIP_ERROR EstablishSecureSession()
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
-                                         chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, INET_NULL_INTERFACEID)),
+                                         chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId())),
                                      chip::kTestDeviceNodeId, testSecurePairingSecret, chip::CryptoContext::SessionRole::kInitiator,
                                      gFabricIndex);
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -142,8 +142,8 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
 
     serializable.mDeviceTransport = to_underlying(mDeviceAddress.GetTransportType());
 
-    ReturnErrorOnFailure(Inet::GetInterfaceName(mDeviceAddress.GetInterface(), Uint8::to_char(serializable.mInterfaceName),
-                                                sizeof(serializable.mInterfaceName)));
+    ReturnErrorOnFailure(mDeviceAddress.GetInterface().GetInterfaceName(Uint8::to_char(serializable.mInterfaceName),
+                                                                        sizeof(serializable.mInterfaceName)));
     static_assert(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN, "Size of device address must fit within INET6_ADDRSTRLEN");
     mDeviceAddress.GetIPAddress().ToString(Uint8::to_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr));
 
@@ -202,13 +202,13 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
 
     // The InterfaceNameToId() API requires initialization of mInterface, and lock/unlock of
     // LwIP stack.
-    Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+    Inet::InterfaceId interfaceId;
     if (serializable.mInterfaceName[0] != '\0')
     {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         LOCK_TCPIP_CORE();
 #endif
-        CHIP_ERROR inetErr = Inet::InterfaceNameToId(Uint8::to_const_char(serializable.mInterfaceName), interfaceId);
+        CHIP_ERROR inetErr = Inet::InterfaceId::InterfaceNameToId(Uint8::to_const_char(serializable.mInterfaceName), interfaceId);
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         UNLOCK_TCPIP_CORE();
 #endif

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -543,9 +543,9 @@ CHIP_ERROR DeviceController::GetPeerAddressAndPort(PeerId peerId, Inet::IPAddres
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 void DeviceController::OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData)
 {
-    CHIP_ERROR err                = CHIP_NO_ERROR;
-    Device * device               = nullptr;
-    Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    Device * device = nullptr;
+    Inet::InterfaceId interfaceId;
 
     err = GetDevice(nodeData.mPeerId.GetNodeId(), &device);
     SuccessOrExit(err);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -167,7 +167,7 @@ void SetUpCodePairer::OnDiscoveredDevice(const Dnssd::DiscoveredNodeData & nodeD
     LogErrorOnFailure(StopConnectOverIP());
     LogErrorOnFailure(StopConnectOverSoftAP());
 
-    Inet::InterfaceId interfaceId      = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : INET_NULL_INTERFACEID;
+    Inet::InterfaceId interfaceId      = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId();
     Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port, interfaceId);
     RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress);
     OnDeviceDiscovered(params);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -167,7 +167,7 @@ void SetUpCodePairer::OnDiscoveredDevice(const Dnssd::DiscoveredNodeData & nodeD
     LogErrorOnFailure(StopConnectOverIP());
     LogErrorOnFailure(StopConnectOverSoftAP());
 
-    Inet::InterfaceId interfaceId      = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId();
+    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : Inet::InterfaceId::Null();
     Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port, interfaceId);
     RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress);
     OnDeviceDiscovered(params);

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -45,7 +45,7 @@ public:
             mSuccessCallback(                                                         //
                 nodeData.mPeerId.GetCompressedFabricId(),                             //
                 nodeData.mPeerId.GetNodeId(),                                         //
-                nodeData.mInterfaceId,                                                //
+                nodeData.mInterfaceId.GetPlatformInterface(),                         //
                 nodeData.mAddress.ToString(ipAddressBuffer, sizeof(ipAddressBuffer)), //
                 nodeData.mPort                                                        //
             );

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -358,7 +358,7 @@ exit:
 
 void IPEndPointBasis::InitImpl()
 {
-    mBoundIntfId = InterfaceId();
+    mBoundIntfId = InterfaceId::Null();
 }
 
 #if INET_CONFIG_ENABLE_IPV4

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -289,11 +289,12 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
         {
             return CHIP_ERROR_POSIX(errno);
         }
-        if (strlen(intfName) >= nameBufSize)
+        size_t nameLength = strlen(intfName);
+        if (nameLength >= nameBufSize)
         {
             return CHIP_ERROR_BUFFER_TOO_SMALL;
         }
-        strcpy(nameBuf, intfName);
+        strncpy(nameBuf, intfName, nameLength + 1);
         return CHIP_NO_ERROR;
     }
     if (nameBufSize < 1)
@@ -718,11 +719,12 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
             return CHIP_ERROR_INCORRECT_STATE;
         }
         const char * name = net_if_get_device(currentInterface)->name;
-        if (strlen(name) >= nameBufSize)
+        size_t nameLength = strlen(name);
+        if (nameLength >= nameBufSize)
         {
             return CHIP_ERROR_BUFFER_TOO_SMALL;
         }
-        strcpy(nameBuf, name);
+        strncpy(nameBuf, name, nameLength + 1);
         return CHIP_NO_ERROR;
     }
     if (nameBufSize < 1)

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -71,31 +71,36 @@ namespace Inet {
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-DLL_EXPORT CHIP_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_t nameBufSize)
+CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) const
 {
-    if (intfId != INET_NULL_INTERFACEID)
+    if (mPlatformInterface)
     {
-        int status = snprintf(nameBuf, nameBufSize, "%c%c%d", intfId->name[0], intfId->name[1], intfId->num);
+        int status = snprintf(nameBuf, nameBufSize, "%c%c%d", mPlatformInterface->name[0], mPlatformInterface->name[1],
+                              mPlatformInterface->num);
         if (status >= static_cast<int>(nameBufSize))
-            return CHIP_ERROR_NO_MEMORY;
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
         return CHIP_NO_ERROR;
     }
-
     if (nameBufSize < 1)
-        return CHIP_ERROR_NO_MEMORY;
-
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
     nameBuf[0] = 0;
     return CHIP_NO_ERROR;
 }
 
-DLL_EXPORT CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & intfId)
+CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
 {
     if (strlen(intfName) < 3)
+    {
         return INET_ERROR_UNKNOWN_INTERFACE;
+    }
     char * parseEnd;
     unsigned long intfNum = strtoul(intfName + 2, &parseEnd, 10);
     if (*parseEnd != 0 || intfNum > UINT8_MAX)
+    {
         return INET_ERROR_UNKNOWN_INTERFACE;
+    }
     struct netif * intf;
 #if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
     NETIF_FOREACH(intf)
@@ -105,17 +110,16 @@ DLL_EXPORT CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & int
     {
         if (intf->name[0] == intfName[0] && intf->name[1] == intfName[1] && intf->num == (uint8_t) intfNum)
         {
-            intfId = intf;
+            interface = InterfaceId(intf);
             return CHIP_NO_ERROR;
         }
     }
-    intfId = INET_NULL_INTERFACEID;
+    interface = InterfaceId();
     return INET_ERROR_UNKNOWN_INTERFACE;
 }
 
 bool InterfaceIterator::Next()
 {
-
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
@@ -144,7 +148,7 @@ bool InterfaceIterator::Next()
 CHIP_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
 {
     VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
-    return ::chip::Inet::GetInterfaceName(mCurNetif, nameBuf, nameBufSize);
+    return InterfaceId(mCurNetif).GetInterfaceName(nameBuf, nameBufSize);
 }
 
 bool InterfaceIterator::IsUp()
@@ -178,7 +182,7 @@ bool InterfaceAddressIterator::Next()
 
     while (mIntfIter.HasCurrent())
     {
-        struct netif * curIntf = mIntfIter.GetInterfaceId();
+        struct netif * curIntf = mIntfIter.GetInterfaceId().GetPlatformInterface();
 
         while (mCurAddrIndex < LWIP_IPV6_NUM_ADDRESSES)
         {
@@ -210,7 +214,7 @@ IPAddress InterfaceAddressIterator::GetAddress()
 {
     if (HasCurrent())
     {
-        struct netif * curIntf = mIntfIter.GetInterfaceId();
+        struct netif * curIntf = mIntfIter.GetInterfaceId().GetPlatformInterface();
 
         if (mCurAddrIndex < LWIP_IPV6_NUM_ADDRESSES)
         {
@@ -238,7 +242,7 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 #if INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
         else
         {
-            struct netif * curIntf = mIntfIter.GetInterfaceId();
+            struct netif * curIntf = mIntfIter.GetInterfaceId().GetPlatformInterface();
             return NetmaskToPrefixLength((const uint8_t *) netif_ip4_netmask(curIntf), 4);
         }
 #endif // INET_CONFIG_ENABLE_IPV4 && LWIP_IPV4
@@ -248,11 +252,7 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 
 InterfaceId InterfaceAddressIterator::GetInterfaceId()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.GetInterfaceId();
-    }
-    return INET_NULL_INTERFACEID;
+    return HasCurrent() ? mIntfIter.GetInterfaceId() : InterfaceId();
 }
 
 CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -263,60 +263,55 @@ CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nam
 
 bool InterfaceAddressIterator::IsUp()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.IsUp();
-    }
-    return false;
+    return HasCurrent() && mIntfIter.IsUp();
 }
 
 bool InterfaceAddressIterator::SupportsMulticast()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.SupportsMulticast();
-    }
-    return false;
+    return HasCurrent() && mIntfIter.SupportsMulticast();
 }
 
 bool InterfaceAddressIterator::HasBroadcastAddress()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.HasBroadcastAddress();
-    }
-    return false;
+    return HasCurrent() && mIntfIter.HasBroadcastAddress();
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
-DLL_EXPORT CHIP_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_t nameBufSize)
+CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) const
 {
-    if (intfId != INET_NULL_INTERFACEID)
+    if (mPlatformInterface)
     {
         char intfName[IF_NAMESIZE];
-        if (if_indextoname(intfId, intfName) == nullptr)
+        if (if_indextoname(mPlatformInterface, intfName) == nullptr)
+        {
             return CHIP_ERROR_POSIX(errno);
+        }
         if (strlen(intfName) >= nameBufSize)
-            return CHIP_ERROR_NO_MEMORY;
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
         strcpy(nameBuf, intfName);
         return CHIP_NO_ERROR;
     }
-
     if (nameBufSize < 1)
-        return CHIP_ERROR_NO_MEMORY;
-
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
     nameBuf[0] = 0;
     return CHIP_NO_ERROR;
 }
 
-DLL_EXPORT CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & intfId)
+CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
 {
-    intfId = if_nametoindex(intfName);
+    unsigned int intfId = if_nametoindex(intfName);
+    interface           = InterfaceId(intfId);
     if (intfId == 0)
+    {
         return (errno == ENXIO) ? INET_ERROR_UNKNOWN_INTERFACE : CHIP_ERROR_POSIX(errno);
+    }
     return CHIP_NO_ERROR;
 }
 
@@ -532,7 +527,6 @@ bool InterfaceIterator::HasCurrent()
 
 bool InterfaceIterator::Next()
 {
-
     if (mIntfArray == nullptr)
     {
 #if __ANDROID__ && __ANDROID_API__ < 24
@@ -552,13 +546,13 @@ bool InterfaceIterator::Next()
 
 InterfaceId InterfaceIterator::GetInterfaceId()
 {
-    return (HasCurrent()) ? mIntfArray[mCurIntf].if_index : INET_NULL_INTERFACEID;
+    return HasCurrent() ? InterfaceId(mIntfArray[mCurIntf].if_index) : InterfaceId();
 }
 
 CHIP_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
 {
     VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(strlen(mIntfArray[mCurIntf].if_name) < nameBufSize, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(strlen(mIntfArray[mCurIntf].if_name) < nameBufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
     strncpy(nameBuf, mIntfArray[mCurIntf].if_name, nameBufSize);
     return CHIP_NO_ERROR;
 }
@@ -593,7 +587,6 @@ short InterfaceIterator::GetFlags()
             mIntfFlags       = intfData.ifr_flags;
             mIntfFlagsCached = true;
         }
-        CloseIOCTLSocket();
     }
 
     return mIntfFlags;
@@ -656,12 +649,7 @@ bool InterfaceAddressIterator::Next()
 
 IPAddress InterfaceAddressIterator::GetAddress()
 {
-    if (HasCurrent())
-    {
-        return IPAddress::FromSockAddr(*mCurAddr->ifa_addr);
-    }
-
-    return IPAddress::Any;
+    return HasCurrent() ? IPAddress::FromSockAddr(*mCurAddr->ifa_addr) : IPAddress::Any;
 }
 
 uint8_t InterfaceAddressIterator::GetPrefixLength()
@@ -690,73 +678,62 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 
 InterfaceId InterfaceAddressIterator::GetInterfaceId()
 {
-    if (HasCurrent())
-    {
-        return if_nametoindex(mCurAddr->ifa_name);
-    }
-    return INET_NULL_INTERFACEID;
+    return HasCurrent() ? InterfaceId(if_nametoindex(mCurAddr->ifa_name)) : InterfaceId();
 }
 
 CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
 {
     VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(strlen(mCurAddr->ifa_name) < nameBufSize, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(strlen(mCurAddr->ifa_name) < nameBufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
     strncpy(nameBuf, mCurAddr->ifa_name, nameBufSize);
     return CHIP_NO_ERROR;
 }
 
 bool InterfaceAddressIterator::IsUp()
 {
-    if (HasCurrent())
-    {
-        return (mCurAddr->ifa_flags & IFF_UP) != 0;
-    }
-    return false;
+    return HasCurrent() && (mCurAddr->ifa_flags & IFF_UP) != 0;
 }
 
 bool InterfaceAddressIterator::SupportsMulticast()
 {
-    if (HasCurrent())
-    {
-        return (mCurAddr->ifa_flags & IFF_MULTICAST) != 0;
-    }
-    return false;
+    return HasCurrent() && (mCurAddr->ifa_flags & IFF_MULTICAST) != 0;
 }
 
 bool InterfaceAddressIterator::HasBroadcastAddress()
 {
-    if (HasCurrent())
-    {
-        return (mCurAddr->ifa_flags & IFF_BROADCAST) != 0;
-    }
-    return false;
+    return HasCurrent() && (mCurAddr->ifa_flags & IFF_BROADCAST) != 0;
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
-DLL_EXPORT CHIP_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_t nameBufSize)
+CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) const
 {
-    if (intfId != INET_NULL_INTERFACEID)
+    if (mPlatformInterface)
     {
-        net_if * currentInterface = net_if_get_by_index(intfId);
+        net_if * currentInterface = net_if_get_by_index(mPlatformInterface);
         if (!currentInterface)
+        {
             return CHIP_ERROR_INCORRECT_STATE;
+        }
         const char * name = net_if_get_device(currentInterface)->name;
         if (strlen(name) >= nameBufSize)
-            return CHIP_ERROR_NO_MEMORY;
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
         strcpy(nameBuf, name);
         return CHIP_NO_ERROR;
     }
-
     if (nameBufSize < 1)
-        return CHIP_ERROR_NO_MEMORY;
-
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
     nameBuf[0] = 0;
     return CHIP_NO_ERROR;
 }
-DLL_EXPORT CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & intfId)
+
+CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
 {
     int currentId = 0;
     net_if * currentInterface;
@@ -765,10 +742,11 @@ DLL_EXPORT CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & int
     {
         if (strcmp(net_if_get_device(currentInterface)->name, intfName) == 0)
         {
-            intfId = currentId;
+            interface = InterfaceId(currentId);
             return CHIP_NO_ERROR;
         }
     }
+    interface = InterfaceId();
     return INET_ERROR_UNKNOWN_INTERFACE;
 }
 
@@ -787,13 +765,13 @@ bool InterfaceIterator::Next()
 
 InterfaceId InterfaceIterator::GetInterfaceId(void)
 {
-    return HasCurrent() ? mCurrentId : INET_NULL_INTERFACEID;
+    return HasCurrent() ? InterfaceId(mCurrentId) : InterfaceId();
 }
 
 CHIP_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
 {
     VerifyOrReturnError(HasCurrent(), CHIP_ERROR_INCORRECT_STATE);
-    return ::chip::Inet::GetInterfaceName(mCurrentId, nameBuf, nameBufSize);
+    return InterfaceId(mCurrentId).GetInterfaceName(nameBuf, nameBufSize);
 }
 
 bool InterfaceIterator::IsUp()
@@ -825,8 +803,9 @@ bool InterfaceAddressIterator::Next()
     {
         if (mCurAddrIndex == -1) // first address for the current interface
         {
-            const net_if_config * config = net_if_get_config(net_if_get_by_index(mIntfIter.GetInterfaceId()));
-            mIpv6                        = config->ip.ipv6;
+            const net_if_config * config =
+                net_if_get_config(net_if_get_by_index(mIntfIter.GetInterfaceId().GetPlatformInterface()));
+            mIpv6 = config->ip.ipv6;
         }
 
         while (++mCurAddrIndex < NET_IF_MAX_IPV6_ADDR)
@@ -842,19 +821,14 @@ bool InterfaceAddressIterator::Next()
 
 IPAddress InterfaceAddressIterator::GetAddress()
 {
-    if (HasCurrent())
-    {
-        return IPAddress(mIpv6->unicast[mCurAddrIndex].address.in6_addr);
-    }
-
-    return IPAddress::Any;
+    return HasCurrent() ? IPAddress(mIpv6->unicast[mCurAddrIndex].address.in6_addr) : IPAddress::Any;
 }
 
 uint8_t InterfaceAddressIterator::GetPrefixLength()
 {
     if (HasCurrent())
     {
-        net_if * const iface              = net_if_get_by_index(mIntfIter.GetInterfaceId());
+        net_if * const iface              = net_if_get_by_index(mIntfIter.GetInterfaceId().GetPlatformInterface());
         net_if_ipv6_prefix * const prefix = net_if_ipv6_prefix_get(iface, &mIpv6->unicast[mCurAddrIndex].address.in6_addr);
         return prefix ? prefix->len : 128;
     }
@@ -863,11 +837,7 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 
 InterfaceId InterfaceAddressIterator::GetInterfaceId()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.GetInterfaceId();
-    }
-    return INET_NULL_INTERFACEID;
+    return HasCurrent() ? mIntfIter.GetInterfaceId() : InterfaceId();
 }
 
 CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -878,29 +848,17 @@ CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nam
 
 bool InterfaceAddressIterator::IsUp()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.IsUp();
-    }
-    return false;
+    return HasCurrent() && mIntfIter.IsUp();
 }
 
 bool InterfaceAddressIterator::SupportsMulticast()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.SupportsMulticast();
-    }
-    return false;
+    return HasCurrent() && mIntfIter.SupportsMulticast();
 }
 
 bool InterfaceAddressIterator::HasBroadcastAddress()
 {
-    if (HasCurrent())
-    {
-        return mIntfIter.HasBroadcastAddress();
-    }
-    return false;
+    return HasCurrent() && mIntfIter.HasBroadcastAddress();
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & i
             return CHIP_NO_ERROR;
         }
     }
-    interface = InterfaceId();
+    interface = InterfaceId::Null();
     return INET_ERROR_UNKNOWN_INTERFACE;
 }
 
@@ -252,7 +252,7 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 
 InterfaceId InterfaceAddressIterator::GetInterfaceId()
 {
-    return HasCurrent() ? mIntfIter.GetInterfaceId() : InterfaceId();
+    return HasCurrent() ? mIntfIter.GetInterfaceId() : InterfaceId::Null();
 }
 
 CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -546,7 +546,7 @@ bool InterfaceIterator::Next()
 
 InterfaceId InterfaceIterator::GetInterfaceId()
 {
-    return HasCurrent() ? InterfaceId(mIntfArray[mCurIntf].if_index) : InterfaceId();
+    return HasCurrent() ? InterfaceId(mIntfArray[mCurIntf].if_index) : InterfaceId::Null();
 }
 
 CHIP_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -678,7 +678,7 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 
 InterfaceId InterfaceAddressIterator::GetInterfaceId()
 {
-    return HasCurrent() ? InterfaceId(if_nametoindex(mCurAddr->ifa_name)) : InterfaceId();
+    return HasCurrent() ? InterfaceId(if_nametoindex(mCurAddr->ifa_name)) : InterfaceId::Null();
 }
 
 CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -746,7 +746,7 @@ CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & i
             return CHIP_NO_ERROR;
         }
     }
-    interface = InterfaceId();
+    interface = InterfaceId::Null();
     return INET_ERROR_UNKNOWN_INTERFACE;
 }
 
@@ -765,7 +765,7 @@ bool InterfaceIterator::Next()
 
 InterfaceId InterfaceIterator::GetInterfaceId(void)
 {
-    return HasCurrent() ? InterfaceId(mCurrentId) : InterfaceId();
+    return HasCurrent() ? InterfaceId(mCurrentId) : InterfaceId::Null();
 }
 
 CHIP_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -837,7 +837,7 @@ uint8_t InterfaceAddressIterator::GetPrefixLength()
 
 InterfaceId InterfaceAddressIterator::GetInterfaceId()
 {
-    return HasCurrent() ? mIntfIter.GetInterfaceId() : InterfaceId();
+    return HasCurrent() ? mIntfIter.GetInterfaceId() : InterfaceId::Null();
 }
 
 CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -59,91 +59,96 @@ class IPAddress;
 class IPPrefix;
 
 /**
- * @typedef     InterfaceId
- *
- * @brief       Indicator for system network interfaces.
- *
- * @details
- *  Portability depends on never witnessing this alias. It may be replaced by a
- *  concrete opaque class in the future.
- *
- *  Note Well: The term "interface identifier" also conventionally refers to
- *  the lower 64 bits of an IPv6 address in all the relevant IETF standards
- *  documents, where the abbreviation "IID" is often used. In this text, the
- *  term "interface indicator" refers to values of this type alias.
+ * Indicator for system network interfaces.
  */
-
+class InterfaceId
+{
+public:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-typedef struct netif * InterfaceId;
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+    using PlatformType                       = struct netif *;
+    static constexpr size_t kMaxIfNameLength = 13; // Names are formatted as %c%c%d
+#endif                                             // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
-typedef unsigned InterfaceId;
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
+    using PlatformType                       = unsigned int;
+    static constexpr size_t kMaxIfNameLength = IF_NAMESIZE;
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-typedef int InterfaceId;
+    using PlatformType                       = int;
+    static constexpr size_t kMaxIfNameLength = Z_DEVICE_MAX_NAME_LEN;
 #endif
 
-/**
- * @def     INET_NULL_INTERFACEID
- *
- * @brief   The distinguished value indicating no network interface.
- *
- * @details
- *  Note Well: This is not the indicator of a "null" network interface. This
- *  value can be used to indicate the absence of a specific network interface,
- *  or to specify that any applicable network interface is acceptable. Usage
- *  varies depending on context.
- */
+public:
+    ~InterfaceId() = default;
 
+    constexpr InterfaceId() : mPlatformInterface(kPlatformNull) {}
+    explicit constexpr InterfaceId(PlatformType interface) : mPlatformInterface(interface) {}
+
+    constexpr InterfaceId(const InterfaceId & other) : mPlatformInterface(other.mPlatformInterface) {}
+    constexpr InterfaceId & operator=(const InterfaceId & other)
+    {
+        mPlatformInterface = other.mPlatformInterface;
+        return *this;
+    }
+
+    constexpr bool operator==(const InterfaceId & other) const { return mPlatformInterface == other.mPlatformInterface; }
+    constexpr bool operator!=(const InterfaceId & other) const { return mPlatformInterface != other.mPlatformInterface; }
+
+    /**
+     * Test for inequivalence with the null interface.
+     */
+    bool IsPresent() const { return mPlatformInterface != kPlatformNull; }
+
+    /**
+     * Get the underlying platform representation of the interface.
+     */
+    PlatformType GetPlatformInterface() const { return mPlatformInterface; }
+
+    /**
+     * Get the name of the network interface
+     *
+     * @param[in]   nameBuf     Region of memory to write the interface name.
+     * @param[in]   nameBufSize Size of the region denoted by \c nameBuf.
+     *
+     * @retval  CHIP_NO_ERROR               Successful result, interface name written.
+     * @retval  CHIP_ERROR_BUFFER_TOO_SMALL Buffer is too small for the interface name.
+     * @retval  other                       Another system or platform error.
+     *
+     *  Writes the name of the network interface as a \c NUL terminated text string at \c nameBuf.
+     *  The name of the unspecified network interface is the empty string.
+     */
+    CHIP_ERROR GetInterfaceName(char * nameBuf, size_t nameBufSize) const;
+
+    /**
+     * Search the list of network interfaces for the indicated name.
+     *
+     * @param[in]   intfName    Name of the network interface to find.
+     * @param[out]  intfId      Indicator of the network interface to assign.
+     *
+     * @retval  CHIP_NO_ERROR                   Success, network interface indicated.
+     * @retval  INET_ERROR_UNKNOWN_INTERFACE    No network interface found.
+     * @retval  other                           Another system or platform error.
+     *
+     * @note
+     *  On LwIP, this function must be called with the LwIP stack lock acquired.
+     */
+    static CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & intfId);
+
+private:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-#define INET_NULL_INTERFACEID NULL
+    static constexpr PlatformType kPlatformNull = nullptr;
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS || CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-#define INET_NULL_INTERFACEID 0
-#endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS || CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
+#if CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
+    static constexpr PlatformType kPlatformNull = 0;
+#endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
-/**
- * @brief   Test \c ID for inequivalence with \c INET_NULL_INTERFACEID
- *
- * @details
- *  This macro resolves to an expression that evaluates \c false if the
- *  argument is equivalent to \c INET_NULL_INTERFACEID and \c true otherwise.
- */
-#define IsInterfaceIdPresent(intfId) ((intfId) != INET_NULL_INTERFACEID)
-
-/**
- * Get the name of the network interface
- *
- * @param[in]   intfId      A network interface.
- * @param[in]   nameBuf     Region of memory to write the interface name.
- * @param[in]   nameBufSize Size of the region denoted by \c nameBuf.
- *
- * @retval  CHIP_NO_ERROR               Successful result, interface name written.
- * @retval  CHIP_ERROR_BUFFER_TOO_SMALL Buffer is too small for the interface name.
- * @retval  other                       Another system or platform error.
- *
- *  Writes the name of the network interface as a \c NUL terminated text string at \c nameBuf.
- *  The name of the unspecified network interface is the empty string.
- */
-extern CHIP_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_t nameBufSize);
-
-/**
- * Search the list of network interfaces for the indicated name.
- *
- * @param[in]   intfName    Name of the network interface to find.
- * @param[out]  intfId      Indicator of the network interface to assign.
- *
- * @retval  CHIP_NO_ERROR                   Success, network interface indicated.
- * @retval  INET_ERROR_UNKNOWN_INTERFACE    No network interface found.
- * @retval  other                           Another system or platform error.
- *
- * @note
- *  On LwIP, this function must be called with the LwIP stack lock acquired.
- */
-extern CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & intfId);
+#if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
+    static constexpr PlatformType kPlatformNull = 0;
+#endif
+    PlatformType mPlatformInterface;
+};
 
 /**
  * Compute a prefix length from a variable-length netmask.
@@ -211,19 +216,14 @@ public:
     bool Next();
 
     /**
-     * NetworkInterface InterfaceIterator::GetInterfaceId(void)
+     * InterfaceId InterfaceIterator::GetInterfaceId(void)
      *
      * Returns the network interface id at the current iterator position.
      *
      * @retval  id                   The current network interface id.
-     * @retval  NetworkInterface()   If advanced beyond the end of the list.
+     * @retval  InterfaceId()   If advanced beyond the end of the list.
      */
     InterfaceId GetInterfaceId();
-
-    /**
-     * @brief    Deprecated alias for \c GetInterfaceId(void)
-     */
-    InterfaceId GetInterface() { return GetInterfaceId(); }
 
     /**
      * Get the name of the current network interface
@@ -264,19 +264,6 @@ public:
      */
     bool HasBroadcastAddress();
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    static constexpr size_t kMaxIfNameLength = 13; // Names are formatted as %c%c%d
-#elif CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
-    static constexpr size_t kMaxIfNameLength = IF_NAMESIZE;
-#elif CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    static constexpr size_t kMaxIfNameLength = Z_DEVICE_MAX_NAME_LEN;
-#elif defined(IFNAMSIZ)
-    static constexpr size_t kMaxIfNameLength = IFNAMSIZ;
-#else
-    // No constant available here - set some reasonable size
-    static constexpr size_t kMaxIfNameLength = 33;
-#endif
-
 protected:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     struct netif * mCurNetif;
@@ -292,8 +279,8 @@ protected:
 #endif // CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    InterfaceId mCurrentId     = 1;
-    net_if * mCurrentInterface = nullptr;
+    InterfaceId::PlatformType mCurrentId = 1;
+    net_if * mCurrentInterface           = nullptr;
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 };
 
@@ -393,11 +380,6 @@ public:
     uint8_t GetPrefixLength();
 
     /**
-     * @brief    Deprecated alias for \c GetPrefixLength(void)
-     */
-    uint8_t GetIPv6PrefixLength() { return GetPrefixLength(); }
-
-    /**
      * @fn       void InterfaceAddressIterator::GetAddressWithPrefix(IPPrefix & addrWithPrefix)
      *
      * @brief    Returns an IPPrefix containing the address and prefix length
@@ -406,20 +388,15 @@ public:
     void GetAddressWithPrefix(IPPrefix & addrWithPrefix);
 
     /**
-     * @fn      NetworkInterface InterfaceAddressIterator::GetInterfaceId(void)
+     * @fn      InterfaceId InterfaceAddressIterator::GetInterfaceId(void)
      *
      * @brief   Returns the network interface id associated with the current
      *          interface address.
      *
-     * @return  the interface id or \c NetworkInterface() if the iterator
+     * @return  the interface id or \c InterfaceId() if the iterator
      *          is positioned beyond the end of the address list.
      */
     InterfaceId GetInterfaceId();
-
-    /**
-     * @brief    Deprecated alias for \c GetInterfaceId(void)
-     */
-    InterfaceId GetInterface() { return GetInterfaceId(); }
 
     /**
      * @fn      CHIP_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
@@ -506,7 +483,7 @@ inline bool InterfaceIterator::HasCurrent(void)
 
 inline InterfaceId InterfaceIterator::GetInterfaceId(void)
 {
-    return mCurNetif;
+    return InterfaceId(mCurNetif);
 }
 
 inline InterfaceAddressIterator::InterfaceAddressIterator(void)

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -92,6 +92,8 @@ public:
         return *this;
     }
 
+    static constexpr InterfaceId Null() { return InterfaceId(); }
+
     constexpr bool operator==(const InterfaceId & other) const { return mPlatformInterface == other.mPlatformInterface; }
     constexpr bool operator!=(const InterfaceId & other) const { return mPlatformInterface != other.mPlatformInterface; }
 

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -345,20 +345,20 @@ bool InetLayer::IsIdleTimerRunning()
 /**
  *  Get the link local IPv6 address for a specified link or interface.
  *
- *  @param[in]    link    The interface for which the link local IPv6
- *                        address is being sought.
+ *  @param[in]    interface The interface for which the link local IPv6
+ *                          address is being sought.
  *
  *  @param[out]   llAddr  The link local IPv6 address for the link.
  *
  *  @retval    #CHIP_ERROR_NOT_IMPLEMENTED      If IPv6 is not supported.
  *  @retval    #CHIP_ERROR_INVALID_ARGUMENT     If the link local address
- *                                              is NULL.
+ *                                              is nullptr.
  *  @retval    #INET_ERROR_ADDRESS_NOT_FOUND    If the link does not have
  *                                              any address configured.
  *  @retval    #CHIP_NO_ERROR                   On success.
  *
  */
-CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
+CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId interface, IPAddress * llAddr)
 {
     VerifyOrReturnError(llAddr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -367,6 +367,7 @@ CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif //! LWIP_IPV6
 
+    struct netif * link = interface.GetPlatformInterface();
     for (struct netif * intf = netif_list; intf != NULL; intf = intf->next)
     {
         if ((link != NULL) && (link != intf))
@@ -399,7 +400,7 @@ CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
         if (ifaddr_iter->ifa_addr != nullptr)
         {
             if ((ifaddr_iter->ifa_addr->sa_family == AF_INET6) &&
-                ((link == INET_NULL_INTERFACEID) || (if_nametoindex(ifaddr_iter->ifa_name) == link)))
+                (!interface.IsPresent() || (if_nametoindex(ifaddr_iter->ifa_name) == interface.GetPlatformInterface())))
             {
                 struct in6_addr * sin6_addr = &(reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr;
                 if (sin6_addr->s6_addr[0] == 0xfe && (sin6_addr->s6_addr[1] & 0xc0) == 0x80) // Link Local Address
@@ -414,7 +415,7 @@ CHIP_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    net_if * const iface = (link == INET_NULL_INTERFACEID) ? net_if_get_default() : net_if_get_by_index(link);
+    net_if * const iface = interface.IsPresent() ? net_if_get_by_index(interface.GetPlatformInterface()) : net_if_get_default();
     VerifyOrReturnError(iface != nullptr, INET_ERROR_ADDRESS_NOT_FOUND);
 
     in6_addr * const ip6_addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
@@ -508,8 +509,8 @@ CHIP_ERROR InetLayer::NewUDPEndPoint(UDPEndPoint ** retEndPoint)
 
 /**
  *  Get the interface identifier for the specified IP address. If the
- *  interface identifier cannot be derived it is set to the
- *  #INET_NULL_INTERFACEID.
+ *  interface identifier cannot be derived it is set to the default
+ *  InterfaceId.
  *
  *  @note
  *    This function fetches the first interface (from the configured list
@@ -531,12 +532,12 @@ CHIP_ERROR InetLayer::GetInterfaceFromAddr(const IPAddress & addr, InterfaceId &
         IPAddress curAddr = addrIter.GetAddress();
         if (addr == curAddr)
         {
-            intfId = addrIter.GetInterface();
+            intfId = addrIter.GetInterfaceId();
             return CHIP_NO_ERROR;
         }
     }
 
-    intfId = INET_NULL_INTERFACEID;
+    intfId = InterfaceId();
 
     return CHIP_NO_ERROR;
 }
@@ -566,7 +567,7 @@ bool InetLayer::MatchLocalIPv6Subnet(const IPAddress & addr)
 #endif // INET_CONFIG_ENABLE_IPV4
         if (addrPrefix.IPAddr.IsIPv6LinkLocal())
             continue;
-        addrPrefix.Length = ifAddrIter.GetIPv6PrefixLength();
+        addrPrefix.Length = ifAddrIter.GetPrefixLength();
         if (addrPrefix.MatchAddress(addr))
             return true;
     }
@@ -674,7 +675,7 @@ void IPPacketInfo::Clear()
 {
     SrcAddress  = IPAddress::Any;
     DestAddress = IPAddress::Any;
-    Interface   = INET_NULL_INTERFACEID;
+    Interface   = InterfaceId();
     SrcPort     = 0;
     DestPort    = 0;
 }

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -537,7 +537,7 @@ CHIP_ERROR InetLayer::GetInterfaceFromAddr(const IPAddress & addr, InterfaceId &
         }
     }
 
-    intfId = InterfaceId();
+    intfId = InterfaceId::Null();
 
     return CHIP_NO_ERROR;
 }
@@ -675,7 +675,7 @@ void IPPacketInfo::Clear()
 {
     SrcAddress  = IPAddress::Any;
     DestAddress = IPAddress::Any;
-    Interface   = InterfaceId();
+    Interface   = InterfaceId::Null();
     SrcPort     = 0;
     DestPort    = 0;
 }

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -328,7 +328,7 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
     // TODO: Does netif_get_by_index(mTCP->netif_idx) do the right thing?  I
     // can't quite tell whether LwIP supports a specific interface id for TCP at
     // all.  For now just claim no particular interface id.
-    *retInterface = InterfaceId();
+    *retInterface = InterfaceId::Null();
     return CHIP_NO_ERROR;
 }
 
@@ -1444,7 +1444,7 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
         else
         {
             // TODO: Is there still a meaningful interface id in this case?
-            *retInterface = InterfaceId();
+            *retInterface = InterfaceId::Null();
         }
         return CHIP_NO_ERROR;
     }
@@ -1453,12 +1453,12 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
     if (sa.any.sa_family == AF_INET)
     {
         // No interface id available for IPv4 sockets.
-        *retInterface = InterfaceId();
+        *retInterface = InterfaceId::Null();
         return CHIP_NO_ERROR;
     }
 #endif // INET_CONFIG_ENABLE_IPV4
 
-    *retInterface = InterfaceId();
+    *retInterface = InterfaceId::Null();
     return INET_ERROR_WRONG_ADDRESS_TYPE;
 }
 

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -140,7 +140,7 @@ public:
      *      destination \c addr (with \c intfId used as the scope
      *      identifier for IPv6 link-local destinations) and \c port.
      */
-    CHIP_ERROR Connect(const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId());
+    CHIP_ERROR Connect(const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId::Null());
 
     /**
      * @brief   Extract IP address and TCP port of remote endpoint.

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -140,7 +140,7 @@ public:
      *      destination \c addr (with \c intfId used as the scope
      *      identifier for IPv6 link-local destinations) and \c port.
      */
-    CHIP_ERROR Connect(const IPAddress & addr, uint16_t port, InterfaceId intfId = INET_NULL_INTERFACEID);
+    CHIP_ERROR Connect(const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId());
 
     /**
      * @brief   Extract IP address and TCP port of remote endpoint.

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -680,7 +680,7 @@ CHIP_ERROR UDPEndPoint::BindInterfaceImpl(IPAddressType addrType, InterfaceId in
 
 InterfaceId UDPEndPoint::GetBoundInterface()
 {
-    return InterfaceId();
+    return InterfaceId::Null();
 }
 
 uint16_t UDPEndPoint::GetBoundPort()

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -78,7 +78,7 @@ public:
      * @retval  INET_ERROR_WRONG_ADDRESS_TYPE   \c addrType is \c IPAddressType::kAny, or not equal to the type of \c addr.
      * @retval  other                           Another system or platform error
      */
-    CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId = INET_NULL_INTERFACEID);
+    CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId());
 
     /**
      * Bind the endpoint to a network interface.
@@ -146,7 +146,7 @@ public:
      * @retval  other                               Another system or platform error.
      */
     CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg,
-                      InterfaceId intfId = INET_NULL_INTERFACEID);
+                      InterfaceId intfId = InterfaceId());
 
     /**
      * Send a UDP message to a specified destination.

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -78,7 +78,7 @@ public:
      * @retval  INET_ERROR_WRONG_ADDRESS_TYPE   \c addrType is \c IPAddressType::kAny, or not equal to the type of \c addr.
      * @retval  other                           Another system or platform error
      */
-    CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId());
+    CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId::Null());
 
     /**
      * Bind the endpoint to a network interface.
@@ -146,7 +146,7 @@ public:
      * @retval  other                               Another system or platform error.
      */
     CHIP_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg,
-                      InterfaceId intfId = InterfaceId());
+                      InterfaceId intfId = InterfaceId::Null());
 
     /**
      * Send a UDP message to a specified destination.

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -174,7 +174,7 @@ void ShutdownSystemLayer()
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 static void PrintNetworkState()
 {
-    char intfName[chip::Inet::InterfaceIterator::kMaxIfNameLength];
+    char intfName[chip::Inet::InterfaceId::kMaxIfNameLength];
 
     for (size_t j = 0; j < gNetworkOptions.TapDeviceName.size(); j++)
     {
@@ -187,7 +187,7 @@ static void PrintNetworkState()
 
         TapInterface * tapIF = &(sTapIFs[j]);
 #endif // CHIP_TARGET_STYLE_UNIX
-        GetInterfaceName(netIF, intfName, sizeof(intfName));
+        InterfaceId(netIF).GetInterfaceName(intfName, sizeof(intfName));
 
         printf("LwIP interface ready\n");
         printf("  Interface Name: %s\n", intfName);

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -136,10 +136,10 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     err = InterfaceId::InterfaceNameToId("0", intId);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
-    err = InterfaceId().GetInterfaceName(intName, 0);
+    err = InterfaceId::Null().GetInterfaceName(intName, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    err = InterfaceId().GetInterfaceName(intName, sizeof(intName));
+    err = InterfaceId::Null().GetInterfaceName(intName, sizeof(intName));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR && intName[0] == '\0');
 
     err = gInet.GetInterfaceFromAddr(addr, intId);
@@ -169,7 +169,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
         gInet.MatchLocalIPv6Subnet(addr);
     }
     NL_TEST_ASSERT(inSuite, !intIterator.Next());
-    NL_TEST_ASSERT(inSuite, intIterator.GetInterfaceId() == InterfaceId());
+    NL_TEST_ASSERT(inSuite, intIterator.GetInterfaceId() == InterfaceId::Null());
     NL_TEST_ASSERT(inSuite, intIterator.GetInterfaceName(intName, sizeof(intName)) == CHIP_ERROR_INCORRECT_STATE);
     NL_TEST_ASSERT(inSuite, !intIterator.SupportsMulticast());
     NL_TEST_ASSERT(inSuite, !intIterator.HasBroadcastAddress());
@@ -201,7 +201,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !addrIterator.Next());
     addrIterator.GetAddressWithPrefix(addrWithPrefix);
     NL_TEST_ASSERT(inSuite, addrWithPrefix.IsZero());
-    NL_TEST_ASSERT(inSuite, addrIterator.GetInterfaceId() == InterfaceId());
+    NL_TEST_ASSERT(inSuite, addrIterator.GetInterfaceId() == InterfaceId::Null());
     NL_TEST_ASSERT(inSuite, addrIterator.GetInterfaceName(intName, sizeof(intName)) == CHIP_ERROR_INCORRECT_STATE);
     NL_TEST_ASSERT(inSuite, !addrIterator.SupportsMulticast());
     NL_TEST_ASSERT(inSuite, !addrIterator.HasBroadcastAddress());
@@ -229,7 +229,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     err = gInet.NewTCPEndPoint(&testTCPEP1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = gInet.GetLinkLocalAddr(InterfaceId(), &addr);
+    err = gInet.GetLinkLocalAddr(InterfaceId::Null(), &addr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     err = gInet.GetInterfaceFromAddr(addr, intId);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -127,23 +127,23 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
 {
     InterfaceIterator intIterator;
     InterfaceAddressIterator addrIterator;
-    char intName[chip::Inet::InterfaceIterator::kMaxIfNameLength];
+    char intName[chip::Inet::InterfaceId::kMaxIfNameLength];
     InterfaceId intId;
     IPAddress addr;
     IPPrefix addrWithPrefix;
     CHIP_ERROR err;
 
-    err = InterfaceNameToId("0", intId);
+    err = InterfaceId::InterfaceNameToId("0", intId);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
-    err = GetInterfaceName(INET_NULL_INTERFACEID, intName, 0);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NO_MEMORY);
+    err = InterfaceId().GetInterfaceName(intName, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    err = GetInterfaceName(INET_NULL_INTERFACEID, intName, sizeof(intName));
+    err = InterfaceId().GetInterfaceName(intName, sizeof(intName));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR && intName[0] == '\0');
 
     err = gInet.GetInterfaceFromAddr(addr, intId);
-    NL_TEST_ASSERT(inSuite, intId == INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, !intId.IsPresent());
 
     err = gInet.GetLinkLocalAddr(intId, nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
@@ -151,16 +151,16 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     printf("    Interfaces:\n");
     for (; intIterator.HasCurrent(); intIterator.Next())
     {
-        intId = intIterator.GetInterface();
-        NL_TEST_ASSERT(inSuite, intId != INET_NULL_INTERFACEID);
+        intId = intIterator.GetInterfaceId();
+        NL_TEST_ASSERT(inSuite, intId.IsPresent());
         memset(intName, 42, sizeof(intName));
         err = intIterator.GetInterfaceName(intName, sizeof(intName));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         printf("     interface id: 0x%" PRIxPTR ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-               reinterpret_cast<uintptr_t>(intId),
+               reinterpret_cast<uintptr_t>(intId.GetPlatformInterface()),
 #else
-               static_cast<uintptr_t>(intId),
+               static_cast<uintptr_t>(intId.GetPlatformInterface()),
 #endif
                intName, intIterator.IsUp() ? "UP" : "DOWN", intIterator.SupportsMulticast() ? "supports" : "no",
                intIterator.HasBroadcastAddress() ? "has" : "no");
@@ -169,7 +169,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
         gInet.MatchLocalIPv6Subnet(addr);
     }
     NL_TEST_ASSERT(inSuite, !intIterator.Next());
-    NL_TEST_ASSERT(inSuite, intIterator.GetInterface() == INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, intIterator.GetInterfaceId() == InterfaceId());
     NL_TEST_ASSERT(inSuite, intIterator.GetInterfaceName(intName, sizeof(intName)) == CHIP_ERROR_INCORRECT_STATE);
     NL_TEST_ASSERT(inSuite, !intIterator.SupportsMulticast());
     NL_TEST_ASSERT(inSuite, !intIterator.HasBroadcastAddress());
@@ -182,7 +182,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
         char addrStr[80];
         addrWithPrefix.IPAddr.ToString(addrStr);
         intId = addrIterator.GetInterfaceId();
-        NL_TEST_ASSERT(inSuite, intId != INET_NULL_INTERFACEID);
+        NL_TEST_ASSERT(inSuite, intId.IsPresent());
         memset(intName, 42, sizeof(intName));
         err = addrIterator.GetInterfaceName(intName, sizeof(intName));
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -191,9 +191,9 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
                ", interface name: %s, interface state: %s, %s multicast, %s broadcast addr\n",
                addrStr, addrWithPrefix.Length,
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-               reinterpret_cast<uintptr_t>(intId),
+               reinterpret_cast<uintptr_t>(intId.GetPlatformInterface()),
 #else
-               static_cast<uintptr_t>(intId),
+               static_cast<uintptr_t>(intId.GetPlatformInterface()),
 #endif
                intName, addrIterator.IsUp() ? "UP" : "DOWN", addrIterator.SupportsMulticast() ? "supports" : "no",
                addrIterator.HasBroadcastAddress() ? "has" : "no");
@@ -201,7 +201,7 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !addrIterator.Next());
     addrIterator.GetAddressWithPrefix(addrWithPrefix);
     NL_TEST_ASSERT(inSuite, addrWithPrefix.IsZero());
-    NL_TEST_ASSERT(inSuite, addrIterator.GetInterface() == INET_NULL_INTERFACEID);
+    NL_TEST_ASSERT(inSuite, addrIterator.GetInterfaceId() == InterfaceId());
     NL_TEST_ASSERT(inSuite, addrIterator.GetInterfaceName(intName, sizeof(intName)) == CHIP_ERROR_INCORRECT_STATE);
     NL_TEST_ASSERT(inSuite, !addrIterator.SupportsMulticast());
     NL_TEST_ASSERT(inSuite, !addrIterator.HasBroadcastAddress());
@@ -229,7 +229,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     err = gInet.NewTCPEndPoint(&testTCPEP1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = gInet.GetLinkLocalAddr(INET_NULL_INTERFACEID, &addr);
+    err = gInet.GetLinkLocalAddr(InterfaceId(), &addr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     err = gInet.GetInterfaceFromAddr(addr, intId);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -277,7 +277,7 @@ int main(int argc, char * argv[])
 
     if (gInterfaceName != nullptr)
     {
-        lStatus = InterfaceNameToId(gInterfaceName, gInterfaceId);
+        lStatus = InterfaceId::InterfaceNameToId(gInterfaceName, gInterfaceId);
         if (lStatus != CHIP_NO_ERROR)
         {
             PrintArgError("%s: unknown network interface %s\n", kToolName, gInterfaceName);
@@ -823,7 +823,7 @@ static void StartTest()
         lStatus = gInet.NewUDPEndPoint(&sUDPIPEndPoint);
         INET_FAIL_ERROR(lStatus, "InetLayer::NewUDPEndPoint failed");
 
-        if (IsInterfaceIdPresent(gInterfaceId))
+        if (gInterfaceId.IsPresent())
         {
             lStatus = sUDPIPEndPoint->BindInterface(lIPAddressType, gInterfaceId);
             INET_FAIL_ERROR(lStatus, "UDPEndPoint::BindInterface failed");

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -85,7 +85,7 @@ uint32_t gSendIntervalMs = 1000;
 
 const char * gInterfaceName = nullptr;
 
-InterfaceId gInterfaceId = INET_NULL_INTERFACEID;
+InterfaceId gInterfaceId = InterfaceId();
 
 uint16_t gSendSize = 59;
 

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -85,7 +85,7 @@ uint32_t gSendIntervalMs = 1000;
 
 const char * gInterfaceName = nullptr;
 
-InterfaceId gInterfaceId = InterfaceId();
+InterfaceId gInterfaceId = InterfaceId::Null();
 
 uint16_t gSendSize = 59;
 

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -288,7 +288,7 @@ int main(int argc, char * argv[])
 
     if (gInterfaceName != nullptr)
     {
-        lStatus = InterfaceNameToId(gInterfaceName, gInterfaceId);
+        lStatus = InterfaceId::InterfaceNameToId(gInterfaceName, gInterfaceId);
         if (lStatus != CHIP_NO_ERROR)
         {
             PrintArgError("%s: unknown network interface %s\n", kToolName, gInterfaceName);
@@ -300,7 +300,7 @@ int main(int argc, char * argv[])
     // If any multicast groups have been specified, ensure that a
     // network interface identifier has been specified and is valid.
 
-    if ((sGroupAddresses.mSize > 0) && !IsInterfaceIdPresent(gInterfaceId))
+    if ((sGroupAddresses.mSize > 0) && !gInterfaceId.IsPresent())
     {
         PrintArgError("%s: a network interface is required when specifying one or more multicast groups\n", kToolName);
         lSuccessful = false;
@@ -749,7 +749,7 @@ static void StartTest()
         lStatus = sUDPIPEndPoint->Bind(lIPAddressType, lAddress, kUDPPort);
         INET_FAIL_ERROR(lStatus, "UDPEndPoint::Bind failed");
 
-        if (IsInterfaceIdPresent(gInterfaceId))
+        if (gInterfaceId.IsPresent())
         {
             lStatus = sUDPIPEndPoint->BindInterface(lIPAddressType, gInterfaceId);
             INET_FAIL_ERROR(lStatus, "UDPEndPoint::BindInterface failed");
@@ -775,7 +775,7 @@ static void StartTest()
         GroupAddress & lGroupAddress  = sGroupAddresses.mAddresses[i];
         IPAddress & lMulticastAddress = lGroupAddress.mMulticastAddress;
 
-        if ((lEndPoint != nullptr) && IsInterfaceIdPresent(gInterfaceId))
+        if ((lEndPoint != nullptr) && gInterfaceId.IsPresent())
         {
             if (gOptFlags & kOptFlagUseIPv4)
             {
@@ -822,7 +822,7 @@ static void CleanupTest()
         GroupAddress & lGroupAddress  = sGroupAddresses.mAddresses[i];
         IPAddress & lMulticastAddress = lGroupAddress.mMulticastAddress;
 
-        if ((lEndPoint != nullptr) && IsInterfaceIdPresent(gInterfaceId))
+        if ((lEndPoint != nullptr) && gInterfaceId.IsPresent())
         {
             lMulticastAddress.ToString(lAddressBuffer, sizeof(lAddressBuffer));
 

--- a/src/lib/dnssd/AllInterfacesListenIterator.h
+++ b/src/lib/dnssd/AllInterfacesListenIterator.h
@@ -33,7 +33,7 @@ bool IsCurrentInterfaceUsable(T & iterator)
     {
         return false; // not a usable interface
     }
-    char name[chip::Inet::InterfaceIterator::kMaxIfNameLength];
+    char name[chip::Inet::InterfaceId::kMaxIfNameLength];
     if (iterator.GetInterfaceName(name, sizeof(name)) != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to get interface name.");

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -345,7 +345,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     service.mTextEntries   = textEntries;
     service.mTextEntrySize = textEntrySize;
     service.mPort          = params.GetPort();
-    service.mInterface     = Inet::InterfaceId();
+    service.mInterface     = Inet::InterfaceId::Null();
     service.mSubTypes      = subTypes;
     service.mSubTypeSize   = subTypeSize;
     service.mAddressType   = Inet::IPAddressType::kAny;
@@ -427,7 +427,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     service.mPort          = params.GetPort();
     service.mTextEntries   = txtEntries;
     service.mTextEntrySize = textEntrySize;
-    service.mInterface     = Inet::InterfaceId();
+    service.mInterface     = Inet::InterfaceId::Null();
     service.mAddressType   = Inet::IPAddressType::kAny;
     service.mSubTypes      = subTypes;
     service.mSubTypeSize   = subTypeSize;
@@ -489,7 +489,7 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPA
     strncpy(service.mType, kOperationalServiceName, sizeof(service.mType));
     service.mProtocol    = DnssdServiceProtocol::kDnssdProtocolTcp;
     service.mAddressType = type;
-    return ChipDnssdResolve(&service, Inet::InterfaceId(), HandleNodeIdResolve, this);
+    return ChipDnssdResolve(&service, Inet::InterfaceId::Null(), HandleNodeIdResolve, this);
 }
 
 void DiscoveryImplPlatform::HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)
@@ -542,8 +542,8 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter
     char serviceName[kMaxCommisisonableServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionableNode));
 
-    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, Inet::InterfaceId(),
-                           HandleNodeBrowse, this);
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny,
+                           Inet::InterfaceId::Null(), HandleNodeBrowse, this);
 }
 
 CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
@@ -552,8 +552,8 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
     char serviceName[kMaxCommisisonerServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionerNode));
 
-    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, Inet::InterfaceId(),
-                           HandleNodeBrowse, this);
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny,
+                           Inet::InterfaceId::Null(), HandleNodeBrowse, this);
 }
 
 void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERROR error)

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -345,7 +345,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     service.mTextEntries   = textEntries;
     service.mTextEntrySize = textEntrySize;
     service.mPort          = params.GetPort();
-    service.mInterface     = INET_NULL_INTERFACEID;
+    service.mInterface     = Inet::InterfaceId();
     service.mSubTypes      = subTypes;
     service.mSubTypeSize   = subTypeSize;
     service.mAddressType   = Inet::IPAddressType::kAny;
@@ -427,7 +427,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     service.mPort          = params.GetPort();
     service.mTextEntries   = txtEntries;
     service.mTextEntrySize = textEntrySize;
-    service.mInterface     = INET_NULL_INTERFACEID;
+    service.mInterface     = Inet::InterfaceId();
     service.mAddressType   = Inet::IPAddressType::kAny;
     service.mSubTypes      = subTypes;
     service.mSubTypeSize   = subTypeSize;
@@ -489,7 +489,7 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPA
     strncpy(service.mType, kOperationalServiceName, sizeof(service.mType));
     service.mProtocol    = DnssdServiceProtocol::kDnssdProtocolTcp;
     service.mAddressType = type;
-    return ChipDnssdResolve(&service, INET_NULL_INTERFACEID, HandleNodeIdResolve, this);
+    return ChipDnssdResolve(&service, Inet::InterfaceId(), HandleNodeIdResolve, this);
 }
 
 void DiscoveryImplPlatform::HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)
@@ -542,7 +542,7 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter
     char serviceName[kMaxCommisisonableServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionableNode));
 
-    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, INET_NULL_INTERFACEID,
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, Inet::InterfaceId(),
                            HandleNodeBrowse, this);
 }
 
@@ -552,7 +552,7 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
     char serviceName[kMaxCommisisonerServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionerNode));
 
-    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, INET_NULL_INTERFACEID,
+    return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny, Inet::InterfaceId(),
                            HandleNodeBrowse, this);
 }
 

--- a/src/lib/dnssd/MinimalMdnsServer.h
+++ b/src/lib/dnssd/MinimalMdnsServer.h
@@ -30,7 +30,7 @@ bool IsCurrentInterfaceUsable(T & iterator)
     {
         return false; // not a usable interface
     }
-    char name[chip::Inet::InterfaceIterator::kMaxIfNameLength];
+    char name[chip::Inet::InterfaceId::kMaxIfNameLength];
     if (iterator.GetInterfaceName(name, sizeof(name)) != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to get interface name.");

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -63,7 +63,7 @@ struct ResolvedNodeData
 
     PeerId mPeerId;
     Inet::IPAddress mAddress               = Inet::IPAddress::Any;
-    Inet::InterfaceId mInterfaceId         = Inet::InterfaceId();
+    Inet::InterfaceId mInterfaceId         = Inet::InterfaceId::Null();
     uint16_t mPort                         = 0;
     char mHostName[kHostNameMaxLength + 1] = {};
     bool mSupportsTcp                      = false;

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -63,7 +63,7 @@ struct ResolvedNodeData
 
     PeerId mPeerId;
     Inet::IPAddress mAddress               = Inet::IPAddress::Any;
-    Inet::InterfaceId mInterfaceId         = INET_NULL_INTERFACEID;
+    Inet::InterfaceId mInterfaceId         = Inet::InterfaceId();
     uint16_t mPort                         = 0;
     char mHostName[kHostNameMaxLength + 1] = {};
     bool mSupportsTcp                      = false;

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -154,7 +154,7 @@ CHIP_ERROR ServerBase::Listen(chip::Inet::InetLayer * inetLayer, ListenIterator 
     Shutdown(); // ensure everything starts fresh
 
     size_t endpointIndex                = 0;
-    chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId();
+    chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
     chip::Inet::IPAddressType addressType;
 
     ShutdownOnError autoShutdown(this);
@@ -234,7 +234,7 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
             continue;
         }
 
-        if ((info->interfaceId != interface) && (info->interfaceId != chip::Inet::InterfaceId()))
+        if ((info->interfaceId != interface) && (info->interfaceId != chip::Inet::InterfaceId::Null()))
         {
             continue;
         }

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -154,7 +154,7 @@ CHIP_ERROR ServerBase::Listen(chip::Inet::InetLayer * inetLayer, ListenIterator 
     Shutdown(); // ensure everything starts fresh
 
     size_t endpointIndex                = 0;
-    chip::Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+    chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId();
     chip::Inet::IPAddressType addressType;
 
     ShutdownOnError autoShutdown(this);
@@ -176,8 +176,8 @@ CHIP_ERROR ServerBase::Listen(chip::Inet::InetLayer * inetLayer, ListenIterator 
         CHIP_ERROR err = JoinMulticastGroup(interfaceId, info->udp, addressType);
         if (err != CHIP_NO_ERROR)
         {
-            char interfaceName[chip::Inet::InterfaceIterator::kMaxIfNameLength];
-            chip::Inet::GetInterfaceName(interfaceId, interfaceName, sizeof(interfaceName));
+            char interfaceName[chip::Inet::InterfaceId::kMaxIfNameLength];
+            interfaceId.GetInterfaceName(interfaceName, sizeof(interfaceName));
 
             // Log only as non-fatal error. Failure to join will mean we reply to unicast queries only.
             ChipLogError(DeviceLayer, "MDNS failed to join multicast group on %s for address type %s: %s", interfaceName,
@@ -211,7 +211,7 @@ CHIP_ERROR ServerBase::DirectSend(chip::System::PacketBufferHandle && data, cons
 
         chip::Inet::InterfaceId boundIf = info->udp->GetBoundInterface();
 
-        if ((boundIf != INET_NULL_INTERFACEID) && (boundIf != interface))
+        if ((boundIf.IsPresent()) && (boundIf != interface))
         {
             continue;
         }
@@ -234,7 +234,7 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
             continue;
         }
 
-        if ((info->interfaceId != interface) && (info->interfaceId != INET_NULL_INTERFACEID))
+        if ((info->interfaceId != interface) && (info->interfaceId != chip::Inet::InterfaceId()))
         {
             continue;
         }

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -44,7 +44,7 @@ void GetIpv4Into(chip::Inet::IPAddress & dest);
 /// interface matters (e.g. FF02::FB will care over which IPv6 interface it is sent)
 ///
 /// For MDNS in particular, you may want:
-///  - IPv4 listen on InterfaceId()
+///  - IPv4 listen on InterfaceId::Null()
 ///  - IPv6 listen on every specific interface id available (except local loopback and other
 ///    not usable interfaces like docker)
 class ListenIterator
@@ -77,7 +77,7 @@ class ServerBase
 public:
     struct EndpointInfo
     {
-        chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId();
+        chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
         chip::Inet::IPAddressType addressType;
         chip::Inet::UDPEndPoint * udp = nullptr;
     };

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -44,7 +44,7 @@ void GetIpv4Into(chip::Inet::IPAddress & dest);
 /// interface matters (e.g. FF02::FB will care over which IPv6 interface it is sent)
 ///
 /// For MDNS in particular, you may want:
-///  - IPv4 listen on INET_NULL_INTERFACEID
+///  - IPv4 listen on InterfaceId()
 ///  - IPv6 listen on every specific interface id available (except local loopback and other
 ///    not usable interfaces like docker)
 class ListenIterator
@@ -77,7 +77,7 @@ class ServerBase
 public:
     struct EndpointInfo
     {
-        chip::Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+        chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId();
         chip::Inet::IPAddressType addressType;
         chip::Inet::UDPEndPoint * udp = nullptr;
     };

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -57,7 +57,7 @@ InterfaceId FindValidInterfaceId()
             return it.GetInterfaceId();
         }
     }
-    return InterfaceId();
+    return InterfaceId::Null();
 }
 
 #if INET_CONFIG_ENABLE_IPV4

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -57,7 +57,7 @@ InterfaceId FindValidInterfaceId()
             return it.GetInterfaceId();
         }
     }
-    return INET_NULL_INTERFACEID;
+    return InterfaceId();
 }
 
 #if INET_CONFIG_ENABLE_IPV4

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -99,7 +99,7 @@ void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
     packetInfo.DestAddress = ipAddress;
     packetInfo.SrcPort     = kMdnsPort;
     packetInfo.DestPort    = kMdnsPort;
-    packetInfo.Interface   = INET_NULL_INTERFACEID;
+    packetInfo.Interface   = InterfaceId();
 
     responder.AddAllResponses(&packetInfo, &acc);
 }

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -99,7 +99,7 @@ void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
     packetInfo.DestAddress = ipAddress;
     packetInfo.SrcPort     = kMdnsPort;
     packetInfo.DestPort    = kMdnsPort;
-    packetInfo.Interface   = InterfaceId();
+    packetInfo.Interface   = InterfaceId::Null();
 
     responder.AddAllResponses(&packetInfo, &acc);
 }

--- a/src/lib/dnssd/tests/TestDnssdCache.cpp
+++ b/src/lib/dnssd/tests/TestDnssdCache.cpp
@@ -51,7 +51,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
     PeerId peerId;
     int64_t id                        = 0x100;
     uint16_t port                     = 2000;
-    constexpr Inet::InterfaceId iface = Inet::InterfaceId();
+    constexpr Inet::InterfaceId iface = Inet::InterfaceId::Null();
 
     Inet::IPAddress addr;
     Inet::IPAddress addrV6;

--- a/src/lib/dnssd/tests/TestDnssdCache.cpp
+++ b/src/lib/dnssd/tests/TestDnssdCache.cpp
@@ -51,7 +51,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
     PeerId peerId;
     int64_t id                        = 0x100;
     uint16_t port                     = 2000;
-    constexpr Inet::InterfaceId iface = INET_NULL_INTERFACEID;
+    constexpr Inet::InterfaceId iface = Inet::InterfaceId();
 
     Inet::IPAddress addr;
     Inet::IPAddress addrV6;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -162,7 +162,7 @@ CHIP_ERROR EstablishSecureSession()
     else
     {
         peerAddr = chip::Optional<chip::Transport::PeerAddress>::Value(
-            chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, INET_NULL_INTERFACEID));
+            chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId()));
     }
 
     // Attempt to connect to the peer.

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -162,7 +162,7 @@ CHIP_ERROR EstablishSecureSession()
     else
     {
         peerAddr = chip::Optional<chip::Transport::PeerAddress>::Value(
-            chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId()));
+            chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, chip::Inet::InterfaceId::Null()));
     }
 
     // Attempt to connect to the peer.

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -46,11 +46,12 @@
 
 #include "esp_event.h"
 
+namespace chip {
+
 namespace Inet {
 class IPAddress;
 } // namespace Inet
 
-namespace chip {
 namespace DeviceLayer {
 
 class PlatformManagerImpl;

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -965,7 +965,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
             // This should be removed or find a better place once we depercate the rendezvous session.
             for (chip::Inet::InterfaceAddressIterator it; it.HasCurrent(); it.Next())
             {
-                char ifName[chip::Inet::InterfaceIterator::kMaxIfNameLength];
+                char ifName[chip::Inet::InterfaceId::kMaxIfNameLength];
                 if (it.IsUp() && CHIP_NO_ERROR == it.GetInterfaceName(ifName, sizeof(ifName)) &&
                     strncmp(ifName, sWiFiIfName, sizeof(ifName)) == 0)
                 {

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -461,7 +461,7 @@ CHIP_ERROR MdnsAvahi::PublishService(const DnssdService & service)
     CHIP_ERROR error       = CHIP_NO_ERROR;
     AvahiStringList * text = nullptr;
     AvahiIfIndex interface =
-        service.mInterface == INET_NULL_INTERFACEID ? AVAHI_IF_UNSPEC : static_cast<AvahiIfIndex>(service.mInterface);
+        service.mInterface.IsPresent() ? static_cast<AvahiIfIndex>(service.mInterface.GetPlatformInterface()) : AVAHI_IF_UNSPEC;
 
     keyBuilder << service.mName << "." << type << service.mPort << "." << interface;
     key = keyBuilder.str();
@@ -530,12 +530,12 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
 {
     AvahiServiceBrowser * browser;
     BrowseContext * browseContext = chip::Platform::New<BrowseContext>();
-    AvahiIfIndex avahiInterface   = static_cast<AvahiIfIndex>(interface);
+    AvahiIfIndex avahiInterface   = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
 
     browseContext->mInstance = this;
     browseContext->mContext  = context;
     browseContext->mCallback = callback;
-    if (interface == INET_NULL_INTERFACEID)
+    if (!interface.IsPresent())
     {
         avahiInterface = AVAHI_IF_UNSPEC;
     }
@@ -615,7 +615,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
             CopyTypeWithoutProtocol(service.mType, type);
             service.mProtocol    = GetProtocolInType(type);
             service.mAddressType = ToAddressType(protocol);
-            service.mInterface   = INET_NULL_INTERFACEID;
+            service.mInterface   = Inet::InterfaceId();
             if (interface != AVAHI_IF_UNSPEC)
             {
                 service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
@@ -650,14 +650,14 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
                               DnssdResolveCallback callback, void * context)
 {
     AvahiServiceResolver * resolver;
-    AvahiIfIndex avahiInterface     = static_cast<AvahiIfIndex>(interface);
+    AvahiIfIndex avahiInterface     = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
     ResolveContext * resolveContext = chip::Platform::New<ResolveContext>();
     CHIP_ERROR error                = CHIP_NO_ERROR;
 
     resolveContext->mInstance = this;
     resolveContext->mCallback = callback;
     resolveContext->mContext  = context;
-    if (interface == INET_NULL_INTERFACEID)
+    if (!interface.IsPresent())
     {
         avahiInterface = AVAHI_IF_UNSPEC;
     }
@@ -700,7 +700,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
         result.mProtocol    = GetProtocolInType(type);
         result.mPort        = port;
         result.mAddressType = ToAddressType(protocol);
-        result.mInterface   = INET_NULL_INTERFACEID;
+        result.mInterface   = Inet::InterfaceId();
         if (interface != AVAHI_IF_UNSPEC)
         {
             result.mInterface = static_cast<chip::Inet::InterfaceId>(interface);

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -615,7 +615,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
             CopyTypeWithoutProtocol(service.mType, type);
             service.mProtocol    = GetProtocolInType(type);
             service.mAddressType = ToAddressType(protocol);
-            service.mInterface   = Inet::InterfaceId();
+            service.mInterface   = Inet::InterfaceId::Null();
             if (interface != AVAHI_IF_UNSPEC)
             {
                 service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
@@ -700,7 +700,7 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
         result.mProtocol    = GetProtocolInType(type);
         result.mPort        = port;
         result.mAddressType = ToAddressType(protocol);
-        result.mInterface   = Inet::InterfaceId();
+        result.mInterface   = Inet::InterfaceId::Null();
         if (interface != AVAHI_IF_UNSPEC)
         {
             result.mInterface = static_cast<chip::Inet::InterfaceId>(interface);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1918,7 +1918,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::FromOtDnsRespons
         mdnsService.mProtocol = chip::Dnssd::DnssdServiceProtocol::kDnssdProtocolUnknown;
     }
     mdnsService.mPort        = serviceInfo.mPort;
-    mdnsService.mInterface   = Inet::InterfaceId();
+    mdnsService.mInterface   = Inet::InterfaceId::Null();
     mdnsService.mAddressType = Inet::IPAddressType::kIPv6;
     mdnsService.mAddress     = chip::Optional<chip::Inet::IPAddress>(ToIPAddress(serviceInfo.mHostAddress));
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1918,7 +1918,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::FromOtDnsRespons
         mdnsService.mProtocol = chip::Dnssd::DnssdServiceProtocol::kDnssdProtocolUnknown;
     }
     mdnsService.mPort        = serviceInfo.mPort;
-    mdnsService.mInterface   = INET_NULL_INTERFACEID;
+    mdnsService.mInterface   = Inet::InterfaceId();
     mdnsService.mAddressType = Inet::IPAddressType::kIPv6;
     mdnsService.mAddress     = chip::Optional<chip::Inet::IPAddress>(ToIPAddress(serviceInfo.mHostAddress));
 

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -42,7 +42,7 @@ static void HandleBrowse(void * context, DnssdService * services, size_t service
         printf("Mdns service size %zu\n", servicesSize);
         printf("Service name %s\n", services->mName);
         printf("Service type %s\n", services->mType);
-        NL_TEST_ASSERT(suite, ChipDnssdResolve(services, INET_NULL_INTERFACEID, HandleResolve, suite) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(suite, ChipDnssdResolve(services, chip::Inet::InterfaceId(), HandleResolve, suite) == CHIP_NO_ERROR);
     }
 }
 
@@ -56,7 +56,7 @@ static void InitCallback(void * context, CHIP_ERROR error)
 
     NL_TEST_ASSERT(suite, error == CHIP_NO_ERROR);
 
-    service.mInterface = INET_NULL_INTERFACEID;
+    service.mInterface = chip::Inet::InterfaceId();
     service.mPort      = 80;
     strcpy(service.mName, "test");
     strcpy(service.mType, "_mock");
@@ -71,7 +71,7 @@ static void InitCallback(void * context, CHIP_ERROR error)
     service.mSubTypeSize   = 0;
 
     NL_TEST_ASSERT(suite, ChipDnssdPublishService(&service) == CHIP_NO_ERROR);
-    ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny, INET_NULL_INTERFACEID,
+    ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny, chip::Inet::InterfaceId(),
                     HandleBrowse, suite);
 }
 

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -42,7 +42,7 @@ static void HandleBrowse(void * context, DnssdService * services, size_t service
         printf("Mdns service size %zu\n", servicesSize);
         printf("Service name %s\n", services->mName);
         printf("Service type %s\n", services->mType);
-        NL_TEST_ASSERT(suite, ChipDnssdResolve(services, chip::Inet::InterfaceId(), HandleResolve, suite) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(suite, ChipDnssdResolve(services, chip::Inet::InterfaceId::Null(), HandleResolve, suite) == CHIP_NO_ERROR);
     }
 }
 
@@ -56,7 +56,7 @@ static void InitCallback(void * context, CHIP_ERROR error)
 
     NL_TEST_ASSERT(suite, error == CHIP_NO_ERROR);
 
-    service.mInterface = chip::Inet::InterfaceId();
+    service.mInterface = chip::Inet::InterfaceId::Null();
     service.mPort      = 80;
     strcpy(service.mName, "test");
     strcpy(service.mType, "_mock");
@@ -71,8 +71,8 @@ static void InitCallback(void * context, CHIP_ERROR error)
     service.mSubTypeSize   = 0;
 
     NL_TEST_ASSERT(suite, ChipDnssdPublishService(&service) == CHIP_NO_ERROR);
-    ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny, chip::Inet::InterfaceId(),
-                    HandleBrowse, suite);
+    ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny,
+                    chip::Inet::InterfaceId::Null(), HandleBrowse, suite);
 }
 
 static void ErrorCallback(void * context, CHIP_ERROR error)

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -178,7 +178,7 @@ private:
     Inet::IPAddress mIPAddress   = {};
     Type mTransportType          = Type::kUndefined;
     uint16_t mPort               = CHIP_PORT; ///< Relevant for UDP data sending.
-    Inet::InterfaceId mInterface = Inet::InterfaceId();
+    Inet::InterfaceId mInterface = Inet::InterfaceId::Null();
 };
 
 } // namespace Transport

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -61,9 +61,8 @@ enum class Type : uint8_t
 class PeerAddress
 {
 public:
-    PeerAddress() : mIPAddress(Inet::IPAddress::Any), mTransportType(Type::kUndefined), mInterface(INET_NULL_INTERFACEID) {}
-    PeerAddress(const Inet::IPAddress & addr, Type type) : mIPAddress(addr), mTransportType(type), mInterface(INET_NULL_INTERFACEID)
-    {}
+    PeerAddress() : mIPAddress(Inet::IPAddress::Any), mTransportType(Type::kUndefined) {}
+    PeerAddress(const Inet::IPAddress & addr, Type type) : mIPAddress(addr), mTransportType(type) {}
     PeerAddress(Type type) : mTransportType(type) {}
 
     PeerAddress(PeerAddress &&)      = default;
@@ -179,7 +178,7 @@ private:
     Inet::IPAddress mIPAddress   = {};
     Type mTransportType          = Type::kUndefined;
     uint16_t mPort               = CHIP_PORT; ///< Relevant for UDP data sending.
-    Inet::InterfaceId mInterface = INET_NULL_INTERFACEID;
+    Inet::InterfaceId mInterface = Inet::InterfaceId();
 };
 
 } // namespace Transport

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -91,7 +91,8 @@ CHIP_ERROR TCPBase::Init(TcpListenParameters & params)
 #endif
     SuccessOrExit(err);
 
-    err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(), params.GetInterfaceId());
+    err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(),
+                              params.GetInterfaceId().IsPresent());
     SuccessOrExit(err);
 
     err = mListenSocket->Listen(kListenBacklogSize);
@@ -357,7 +358,7 @@ CHIP_ERROR TCPBase::OnTcpReceive(Inet::TCPEndPoint * endPoint, System::PacketBuf
 {
     Inet::IPAddress ipAddress;
     uint16_t port;
-    Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+    Inet::InterfaceId interfaceId;
 
     endPoint->GetPeerInfo(&ipAddress, &port);
     endPoint->GetInterfaceId(&interfaceId);
@@ -382,7 +383,7 @@ void TCPBase::OnConnectionComplete(Inet::TCPEndPoint * endPoint, CHIP_ERROR inet
     TCPBase * tcp           = reinterpret_cast<TCPBase *>(endPoint->AppState);
     Inet::IPAddress ipAddress;
     uint16_t port;
-    Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+    Inet::InterfaceId interfaceId;
 
     endPoint->GetPeerInfo(&ipAddress, &port);
     endPoint->GetInterfaceId(&interfaceId);
@@ -512,7 +513,7 @@ void TCPBase::Disconnect(const PeerAddress & address)
         {
             Inet::IPAddress ipAddress;
             uint16_t port;
-            Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
+            Inet::InterfaceId interfaceId;
 
             mActiveConnections[i].mEndPoint->GetPeerInfo(&ipAddress, &port);
             mActiveConnections[i].mEndPoint->GetInterfaceId(&interfaceId);

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -77,7 +77,7 @@ private:
     Inet::InetLayer * mLayer         = nullptr;                    ///< Associated inet layer
     Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
     uint16_t mListenPort             = CHIP_PORT;                  ///< TCP listen port
-    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId();        ///< Interface to listen on
+    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId::Null();  ///< Interface to listen on
 };
 
 /**

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -77,7 +77,7 @@ private:
     Inet::InetLayer * mLayer         = nullptr;                    ///< Associated inet layer
     Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
     uint16_t mListenPort             = CHIP_PORT;                  ///< TCP listen port
-    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;      ///< Interface to listen on
+    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId();        ///< Interface to listen on
 };
 
 /**

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -74,7 +74,7 @@ private:
     Inet::InetLayer * mLayer         = nullptr;                    ///< Associated inet layer
     Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
     uint16_t mListenPort             = CHIP_PORT;                  ///< UDP listen port
-    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId();        ///< Interface to listen on
+    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId::Null();  ///< Interface to listen on
 };
 
 /** Implements a transport using UDP. */

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -74,7 +74,7 @@ private:
     Inet::InetLayer * mLayer         = nullptr;                    ///< Associated inet layer
     Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
     uint16_t mListenPort             = CHIP_PORT;                  ///< UDP listen port
-    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;      ///< Interface to listen on
+    Inet::InterfaceId mInterfaceId   = Inet::InterfaceId();        ///< Interface to listen on
 };
 
 /** Implements a transport using UDP. */


### PR DESCRIPTION
#### Problem

The current `#if`+`typedef` requires the actual definition to be visible
at every appearance, rather than merely an opaque forward class declaration,
which is an obstace to #7715 _Virtualize System and Inet interfaces_.

#### Change overview

Convert `InterfaceId` to a class. Some free functions become class methods,
and `INET_NULL_INTERFACEID` is replaced by a default-constructed
`InterfaceId`.

#### Testing

CI; no changes to functionality intended.
