### PR TITLE
Remove single entrance protection for registerAttributeAccessOverride

### DIFF
--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -142,12 +142,6 @@ CHIP_ERROR DescriptorAttrAccess::Read(const ConcreteAttributePath & aPath, Attri
 void MatterDescriptorPluginServerInitCallback(void)
 {
 #if CHIP_CLUSTER_CONFIG_ENABLE_COMPLEX_ATTRIBUTE_READ
-    static bool attrAccessRegistered = false;
-
-    if (!attrAccessRegistered)
-    {
-        registerAttributeAccessOverride(&gAttrAccess);
-        attrAccessRegistered = true;
-    }
+    registerAttributeAccessOverride(&gAttrAccess);
 #endif
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* This is reland of https://github.com/project-chip/connectedhomeip/pull/10474. Single entrance protection is no more needed after we switch to use MatterDescriptorPluginServerInitCallback to initialize the descriptor cluster server logic since this function is only called once.


#### Change overview
Remove single entrance protection for registerAttributeAccessOverride

#### Testing
How was this tested? (at least one bullet point required)
* confirm MatterDescriptorPluginServerInitCallback is only called once from log
