### PR TITLE
Size reports: Improved comments

### DIFF
--- a/scripts/tools/memory/memdf/util/sqlite.py
+++ b/scripts/tools/memory/memdf/util/sqlite.py
@@ -97,14 +97,18 @@ class Database:
         self.connection().execute(q, v)
 
     def get_matching(self, table: str, columns: List[str], **kwargs):
-        return self.connection().execute(
-            f"SELECT {','.join(columns)} FROM {table}"
-            f"  WHERE {'=? AND '.join(kwargs.keys())}=?",
-            list(kwargs.values()))
+        q = (f"SELECT {','.join(columns)} FROM {table}"
+             f"  WHERE {'=? AND '.join(kwargs.keys())}=?")
+        v = list(kwargs.values())
+        return self.connection().execute(q, v)
 
     def get_matching_id(self, table: str, **kwargs):
-        return self.get_matching(table, ['id'], **kwargs).fetchone()[0]
+        cur = self.get_matching(table, ['id'], **kwargs)
+        row = cur.fetchone()
+        if row:
+            return row[0]
+        return None
 
-    def store_and_return_id(self, table: str, **kwargs) -> int:
+    def store_and_return_id(self, table: str, **kwargs) -> Optional[int]:
         self.store(table, **kwargs)
         return self.get_matching_id(table, **kwargs)


### PR DESCRIPTION
#### Problem

It's hard to pick out actual size changes, beyond those called out in
the large-increase tables.

Report information can be distributed across multiple collapsed tables,
since the generator often runs before all builds are complete.

#### Change overview

Read back any existing comment and merge in new reports.

Comments now contain:

1. An open table highlighting large increases, if any.
2. A collapsed table of all increases, if any.
3. A collapsed table of all decreases, if any.
4. A collapsed table of all data.

#### Testing

Tested with manual runs:
https://github.com/project-chip/connectedhomeip/pull/10979#issuecomment-951981745
