### PR TITLE
Add logs to debug Darwin CI failures

### DIFF
--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -28,6 +28,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
+#include <lib/support/Span.h>
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -140,6 +141,37 @@ DLL_EXPORT void Log(uint8_t module, uint8_t category, const char * msg, ...)
     va_start(v, msg);
     LogV(module, category, msg, v);
     va_end(v);
+}
+
+DLL_EXPORT void LogByteSpan(uint8_t module, uint8_t category, const chip::ByteSpan & span)
+{
+    // Maximum number of characters needed to print 8 byte buffer including formatting (0x)
+    // 8 bytes * (2 nibbles per byte + 4 character for ", 0x") + null termination.
+    // Rounding up to 50 bytes.
+    char output[50];
+    size_t offset = 0;
+    for (unsigned int i = 0; i < span.size(); i++)
+    {
+        if (i % 8 == 0 && offset != 0)
+        {
+            Log(module, category, "%s", output);
+            offset = 0;
+        }
+        int result = snprintf(&output[offset], sizeof(output) - offset, "0x%02x, ", (unsigned char) span.data()[i]);
+        if (result > 0)
+        {
+            offset += static_cast<size_t>(result);
+        }
+        else
+        {
+            Log(module, chip::Logging::kLogCategory_Error, "Failed to print ByteSpan buffer");
+            return;
+        }
+    }
+    if (offset != 0)
+    {
+        Log(module, category, "%s", output);
+    }
 }
 
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list args)

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -66,6 +66,11 @@
  */
 
 namespace chip {
+
+template <class T>
+class Span;
+using ByteSpan = Span<const uint8_t>;
+
 namespace Logging {
 
 using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, const char * msg, va_list args);
@@ -87,6 +92,8 @@ void SetLogRedirectCallback(LogRedirectCallback_t callback);
 
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list args);
 void Log(uint8_t module, uint8_t category, const char * msg, ...) ENFORCE_FORMAT(3, 4);
+
+void LogByteSpan(uint8_t module, uint8_t category, const ByteSpan & span);
 
 uint8_t GetLogFilter();
 void SetLogFilter(uint8_t category);
@@ -156,6 +163,15 @@ void SetLogFilter(uint8_t category);
 #endif
 #else
 #define ChipLogDetail(MOD, MSG, ...) ((void) 0)
+#endif
+
+#if CHIP_DETAIL_LOGGING
+#ifndef ChipLogByteSpan
+#define ChipLogByteSpan(MOD, DATA)                                                                                                 \
+    chip::Logging::LogByteSpan(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Detail, DATA)
+#endif
+#else
+#define ChipLogByteSpan(MOD, DATA) ((void) 0)
 #endif
 
 #if CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -181,36 +181,18 @@ exit:
     return err;
 }
 
-static void print_buffer(const uint8_t * buf, size_t len)
-{
-    char output[50];
-    int offset = 0;
-    for (unsigned int i = 0; i < len; i++)
-    {
-        if (i % 8 == 0 && offset > 0)
-        {
-            printf("%s\n", output);
-            offset = 0;
-        }
-        offset += snprintf(&output[offset], sizeof(output) - (size_t) offset, "0x%02x, ", (unsigned char) buf[i]);
-    }
-    if (offset > 0)
-    {
-        ChipLogDetail(Inet, "%s", output);
-    }
-}
-
 CHIP_ERROR FabricInfo::GetCompressedId(FabricId fabricId, NodeId nodeId, PeerId * compressedPeerId) const
 {
     ReturnErrorCodeIf(compressedPeerId == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     uint8_t compressedFabricIdBuf[sizeof(uint64_t)];
     MutableByteSpan compressedFabricIdSpan(compressedFabricIdBuf);
     P256PublicKey rootPubkey(GetRootPubkey());
-    ChipLogDetail(Inet, "Generating compressed fabric ID. uncompressed fabric ID 0x" ChipLogFormatX64, ChipLogValueX64(fabricId));
-    print_buffer(rootPubkey.ConstBytes(), rootPubkey.Length());
+    ChipLogDetail(Inet, "Generating compressed fabric ID using uncompressed fabric ID 0x" ChipLogFormatX64 " and root pubkey",
+                  ChipLogValueX64(fabricId));
+    ChipLogByteSpan(Inet, ByteSpan(rootPubkey.ConstBytes(), rootPubkey.Length()));
     ReturnErrorOnFailure(GenerateCompressedFabricId(rootPubkey, fabricId, compressedFabricIdSpan));
     ChipLogDetail(Inet, "Generated compressed fabric ID");
-    print_buffer(compressedFabricIdSpan.data(), compressedFabricIdSpan.size());
+    ChipLogByteSpan(Inet, compressedFabricIdSpan);
 
     // Decode compressed fabric ID accounting for endianness, as GenerateCompressedFabricId()
     // returns a binary buffer and is agnostic of usage of the output as an integer type.
@@ -348,9 +330,10 @@ CHIP_ERROR FabricInfo::GenerateDestinationID(const ByteSpan & ipk, const ByteSpa
 
     Encoding::LittleEndian::BufferWriter bbuf(destinationMessage, sizeof(destinationMessage));
 
-    ChipLogDetail(Inet, "GenerateDestinationID was called. Fabric ID 0x" ChipLogFormatX64 " dest node 0x" ChipLogFormatX64,
+    ChipLogDetail(Inet,
+                  "Generating DestinationID. Fabric ID 0x" ChipLogFormatX64 ", Dest node ID 0x" ChipLogFormatX64 ", Random data",
                   ChipLogValueX64(mFabricId), ChipLogValueX64(destNodeId));
-    print_buffer(random.data(), random.size());
+    ChipLogByteSpan(Inet, random);
 
     bbuf.Put(random.data(), random.size());
     // TODO: In the current implementation this check is required because in some cases the
@@ -358,8 +341,8 @@ CHIP_ERROR FabricInfo::GenerateDestinationID(const ByteSpan & ipk, const ByteSpa
     //       empty Span.
     if (!rootPubkeySpan.empty())
     {
-        ChipLogDetail(Inet, "GenerateDestinationID root pubkey");
-        print_buffer(rootPubkeySpan.data(), rootPubkeySpan.size());
+        ChipLogDetail(Inet, "Root pubkey");
+        ChipLogByteSpan(Inet, rootPubkeySpan);
         bbuf.Put(rootPubkeySpan.data(), rootPubkeySpan.size());
     }
     bbuf.Put64(mFabricId);
@@ -368,13 +351,13 @@ CHIP_ERROR FabricInfo::GenerateDestinationID(const ByteSpan & ipk, const ByteSpa
     size_t written = 0;
     VerifyOrReturnError(bbuf.Fit(written), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    ChipLogDetail(Inet, "GenerateDestinationID ipk");
-    print_buffer(ipk.data(), ipk.size());
+    ChipLogDetail(Inet, "IPK");
+    ChipLogByteSpan(Inet, ipk);
 
     CHIP_ERROR err =
         hmac.HMAC_SHA256(ipk.data(), ipk.size(), destinationMessage, written, destinationId.data(), destinationId.size());
-    ChipLogDetail(Inet, "GenerateDestinationID output");
-    print_buffer(destinationId.data(), destinationId.size());
+    ChipLogDetail(Inet, "Generated DestinationID output");
+    ChipLogByteSpan(Inet, destinationId);
     return err;
 }
 


### PR DESCRIPTION
#### Problem

Darwin CI is occasionally failing during CASE sessions setup.

#### Change overview

The logs point at the mismatch of fabric information between the controller and the device. On receiving Sigma1, the device computes destination ID from the commissioned fabrics and matches it against the received value in Sigma1 message. This check is failing. Also, noticed that the compressed fabric ID generated on the device is different than the controller.

This PR adds logs to narrow down the failure cause. It'll log the buffer that's input to computation of compressed fabric ID and the destination ID.

#### Testing

This PR adds some logs and makes no other functional change. It was tested for compilation and correct logging using chip-tool and all-cluster-app.