### PR TITLE
Use List<const Whatever> for encodable lists.

### DIFF
--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -48,7 +48,13 @@ struct List : public Span<T>
     // List<T> instances as though they were just Spans.
     //
     using Span<T>::Span;
-    using Span<T>::operator=;
+
+    template <size_t N>
+    constexpr List & operator=(T (&databuf)[N])
+    {
+        Span<T>::operator=(databuf);
+        return (*this);
+    }
 };
 
 template <typename X>

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -375,11 +375,19 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
   let promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this));
   if ((this.isList || this.isArray || this.entryType) && !options.hash.forceNotList) {
     passByReference = true;
-    let listType    = isDecodable ? "DecodableList" : "List";
     // If we did not have a namespace provided, we can assume we're inside
     // chip::app.
     let listNamespace = options.hash.ns ? "chip::app::" : ""
-    promise           = promise.then(typeStr => `${listNamespace}DataModel::${listType}<${typeStr}>`);
+    if (isDecodable)
+    {
+      promise = promise.then(typeStr => `${listNamespace}DataModel::DecodableList<${typeStr}>`);
+    }
+    else
+    {
+      // Use const ${typeStr} so that consumers don't have to create non-const
+      // data to encode.
+      promise = promise.then(typeStr => `${listNamespace}DataModel::List<const ${typeStr}>`);
+    }
   }
   if (options.hash.isArgument && passByReference) {
     promise = promise.then(typeStr => `const ${typeStr} &`);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -1090,7 +1090,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Groups::Id; }
 
     uint8_t groupCount;
-    DataModel::List<uint16_t> groupList;
+    DataModel::List<const uint16_t> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1123,7 +1123,7 @@ public:
 
     uint8_t capacity;
     uint8_t groupCount;
-    DataModel::List<uint16_t> groupList;
+    DataModel::List<const uint16_t> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1344,7 +1344,7 @@ public:
     uint8_t sceneId;
     uint16_t transitionTime;
     chip::CharSpan sceneName;
-    DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
+    DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1451,7 +1451,7 @@ public:
     uint8_t sceneId;
     uint16_t transitionTime;
     chip::CharSpan sceneName;
-    DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
+    DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1743,7 +1743,7 @@ public:
     uint8_t capacity;
     uint16_t groupId;
     uint8_t sceneCount;
-    DataModel::List<uint8_t> sceneList;
+    DataModel::List<const uint8_t> sceneList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1783,7 +1783,7 @@ public:
     uint8_t sceneId;
     uint16_t transitionTime;
     chip::CharSpan sceneName;
-    DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
+    DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1890,7 +1890,7 @@ public:
     uint8_t sceneId;
     uint16_t transitionTime;
     chip::CharSpan sceneName;
-    DataModel::List<Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
+    DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3586,7 +3586,7 @@ public:
     uint8_t totalProfileNum;
     uint8_t powerProfileId;
     uint8_t numOfTransferredPhases;
-    DataModel::List<Structs::TransferredPhase::Type> transferredPhases;
+    DataModel::List<const Structs::TransferredPhase::Type> transferredPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3647,7 +3647,7 @@ public:
     uint8_t totalProfileNum;
     uint8_t powerProfileId;
     uint8_t numOfTransferredPhases;
-    DataModel::List<Structs::TransferredPhase::Type> transferredPhases;
+    DataModel::List<const Structs::TransferredPhase::Type> transferredPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3717,7 +3717,7 @@ public:
     static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
 
     uint8_t powerProfileCount;
-    DataModel::List<Structs::PowerProfileRecord::Type> powerProfileRecords;
+    DataModel::List<const Structs::PowerProfileRecord::Type> powerProfileRecords;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3812,7 +3812,7 @@ public:
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
-    DataModel::List<Structs::ScheduledPhase::Type> scheduledPhases;
+    DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3844,7 +3844,7 @@ public:
     static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
 
     uint8_t powerProfileCount;
-    DataModel::List<Structs::PowerProfileRecord::Type> powerProfileRecords;
+    DataModel::List<const Structs::PowerProfileRecord::Type> powerProfileRecords;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3877,7 +3877,7 @@ public:
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
-    DataModel::List<Structs::ScheduledPhase::Type> scheduledPhases;
+    DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4019,7 +4019,7 @@ public:
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
-    DataModel::List<Structs::ScheduledPhase::Type> scheduledPhases;
+    DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4090,7 +4090,7 @@ public:
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
-    DataModel::List<Structs::ScheduledPhase::Type> scheduledPhases;
+    DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4492,7 +4492,7 @@ public:
 
     uint16_t functionId;
     uint8_t functionDataType;
-    DataModel::List<uint8_t> functionData;
+    DataModel::List<const uint8_t> functionData;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4669,7 +4669,7 @@ namespace Attributes {
 namespace DeviceList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::DeviceType::Type>;
+    using Type          = DataModel::List<const Structs::DeviceType::Type>;
     using DecodableType = DataModel::DecodableList<Structs::DeviceType::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
@@ -4679,7 +4679,7 @@ struct TypeInfo
 namespace ServerList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<chip::ClusterId>;
+    using Type          = DataModel::List<const chip::ClusterId>;
     using DecodableType = DataModel::DecodableList<chip::ClusterId>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
@@ -4689,7 +4689,7 @@ struct TypeInfo
 namespace ClientList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<chip::ClusterId>;
+    using Type          = DataModel::List<const chip::ClusterId>;
     using DecodableType = DataModel::DecodableList<chip::ClusterId>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
@@ -4699,7 +4699,7 @@ struct TypeInfo
 namespace PartsList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<chip::EndpointId>;
+    using Type          = DataModel::List<const chip::EndpointId>;
     using DecodableType = DataModel::DecodableList<chip::EndpointId>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
@@ -5728,7 +5728,7 @@ struct TypeInfo
 namespace ActiveWiredFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
@@ -5808,7 +5808,7 @@ struct TypeInfo
 namespace ActiveBatteryFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
@@ -5928,7 +5928,7 @@ struct TypeInfo
 namespace ActiveBatteryChargeFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
@@ -6211,7 +6211,7 @@ struct TypeInfo
 namespace BasicCommissioningInfoList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::BasicCommissioningInfoType::Type>;
+    using Type          = DataModel::List<const Structs::BasicCommissioningInfoType::Type>;
     using DecodableType = DataModel::DecodableList<Structs::BasicCommissioningInfoType::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
@@ -6221,7 +6221,7 @@ struct TypeInfo
 namespace RegulatoryConfigList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<RegulatoryLocationType>;
+    using Type          = DataModel::List<const RegulatoryLocationType>;
     using DecodableType = DataModel::DecodableList<RegulatoryLocationType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
@@ -6231,7 +6231,7 @@ struct TypeInfo
 namespace LocationCapabilityList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<RegulatoryLocationType>;
+    using Type          = DataModel::List<const RegulatoryLocationType>;
     using DecodableType = DataModel::DecodableList<RegulatoryLocationType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
@@ -6392,8 +6392,8 @@ public:
 
     uint8_t errorCode;
     chip::CharSpan debugText;
-    DataModel::List<Structs::WiFiInterfaceScanResult::Type> wifiScanResults;
-    DataModel::List<Structs::ThreadInterfaceScanResult::Type> threadScanResults;
+    DataModel::List<const Structs::WiFiInterfaceScanResult::Type> wifiScanResults;
+    DataModel::List<const Structs::ThreadInterfaceScanResult::Type> threadScanResults;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -7185,7 +7185,7 @@ namespace Attributes {
 namespace NetworkInterfaces {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::NetworkInterfaceType::Type>;
+    using Type          = DataModel::List<const Structs::NetworkInterfaceType::Type>;
     using DecodableType = DataModel::DecodableList<Structs::NetworkInterfaceType::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
@@ -7235,7 +7235,7 @@ struct TypeInfo
 namespace ActiveHardwareFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
@@ -7245,7 +7245,7 @@ struct TypeInfo
 namespace ActiveRadioFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
@@ -7255,7 +7255,7 @@ struct TypeInfo
 namespace ActiveNetworkFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
@@ -7346,7 +7346,7 @@ namespace Attributes {
 namespace ThreadMetrics {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::ThreadMetrics::Type>;
+    using Type          = DataModel::List<const Structs::ThreadMetrics::Type>;
     using DecodableType = DataModel::DecodableList<Structs::ThreadMetrics::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
@@ -7682,7 +7682,7 @@ struct TypeInfo
 namespace NeighborTableList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::NeighborTable::Type>;
+    using Type          = DataModel::List<const Structs::NeighborTable::Type>;
     using DecodableType = DataModel::DecodableList<Structs::NeighborTable::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
@@ -7692,7 +7692,7 @@ struct TypeInfo
 namespace RouteTableList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::RouteTable::Type>;
+    using Type          = DataModel::List<const Structs::RouteTable::Type>;
     using DecodableType = DataModel::DecodableList<Structs::RouteTable::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
@@ -8202,7 +8202,7 @@ struct TypeInfo
 namespace SecurityPolicy {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::SecurityPolicy::Type>;
+    using Type          = DataModel::List<const Structs::SecurityPolicy::Type>;
     using DecodableType = DataModel::DecodableList<Structs::SecurityPolicy::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
@@ -8222,7 +8222,7 @@ struct TypeInfo
 namespace OperationalDatasetComponents {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::OperationalDatasetComponents::Type>;
+    using Type          = DataModel::List<const Structs::OperationalDatasetComponents::Type>;
     using DecodableType = DataModel::DecodableList<Structs::OperationalDatasetComponents::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
@@ -8232,7 +8232,7 @@ struct TypeInfo
 namespace ActiveNetworkFaultsList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<NetworkFault>;
+    using Type          = DataModel::List<const NetworkFault>;
     using DecodableType = DataModel::DecodableList<NetworkFault>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
@@ -9563,7 +9563,7 @@ namespace Attributes {
 namespace FabricsList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::FabricDescriptor::Type>;
+    using Type          = DataModel::List<const Structs::FabricDescriptor::Type>;
     using DecodableType = DataModel::DecodableList<Structs::FabricDescriptor::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
@@ -9593,7 +9593,7 @@ struct TypeInfo
 namespace TrustedRootCertificates {
 struct TypeInfo
 {
-    using Type          = DataModel::List<chip::ByteSpan>;
+    using Type          = DataModel::List<const chip::ByteSpan>;
     using DecodableType = DataModel::DecodableList<chip::ByteSpan>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
@@ -9651,7 +9651,7 @@ namespace Attributes {
 namespace LabelList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::LabelStruct::Type>;
+    using Type          = DataModel::List<const Structs::LabelStruct::Type>;
     using DecodableType = DataModel::DecodableList<Structs::LabelStruct::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FixedLabel::Id; }
@@ -13726,7 +13726,7 @@ public:
     uint8_t numberOfTransitionsForSequence;
     chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
     chip::BitFlags<ModeForSequence> modeForSequence;
-    DataModel::List<uint8_t> payload;
+    DataModel::List<const uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13763,7 +13763,7 @@ public:
     uint8_t numberOfTransitionsForSequence;
     chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
     chip::BitFlags<ModeForSequence> modeForSequence;
-    DataModel::List<uint8_t> payload;
+    DataModel::List<const uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19254,7 +19254,7 @@ public:
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
     uint8_t numberOfZones;
-    DataModel::List<uint8_t> zoneIds;
+    DataModel::List<const uint8_t> zoneIds;
     chip::CharSpan armDisarmCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -19632,7 +19632,7 @@ public:
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
     uint8_t numberOfZones;
-    DataModel::List<uint8_t> zoneIds;
+    DataModel::List<const uint8_t> zoneIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19687,7 +19687,7 @@ public:
     static constexpr ClusterId GetClusterId() { return IasAce::Id; }
 
     uint8_t numberOfZones;
-    DataModel::List<IasAceBypassResult> bypassResult;
+    DataModel::List<const IasAceBypassResult> bypassResult;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19744,7 +19744,7 @@ public:
 
     bool zoneStatusComplete;
     uint8_t numberOfZones;
-    DataModel::List<Structs::IasAceZoneStatusResult::Type> zoneStatusResult;
+    DataModel::List<const Structs::IasAceZoneStatusResult::Type> zoneStatusResult;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20098,7 +20098,7 @@ public:
     static constexpr CommandId GetCommandId() { return ChangeChannelResponse::Id; }
     static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
 
-    DataModel::List<Structs::TvChannelInfo::Type> channelMatch;
+    DataModel::List<const Structs::TvChannelInfo::Type> channelMatch;
     TvChannelErrorType errorType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
@@ -20180,7 +20180,7 @@ namespace Attributes {
 namespace TvChannelList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::TvChannelInfo::Type>;
+    using Type          = DataModel::List<const Structs::TvChannelInfo::Type>;
     using DecodableType = DataModel::DecodableList<Structs::TvChannelInfo::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
@@ -20336,7 +20336,7 @@ namespace Attributes {
 namespace TargetNavigatorList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::NavigateTargetTargetInfo::Type>;
+    using Type          = DataModel::List<const Structs::NavigateTargetTargetInfo::Type>;
     using DecodableType = DataModel::DecodableList<Structs::NavigateTargetTargetInfo::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
@@ -21285,7 +21285,7 @@ namespace Attributes {
 namespace MediaInputList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::MediaInputInfo::Type>;
+    using Type          = DataModel::List<const Structs::MediaInputInfo::Type>;
     using DecodableType = DataModel::DecodableList<Structs::MediaInputInfo::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
@@ -21663,7 +21663,7 @@ struct Type
 public:
     ContentLaunchParameterEnum type;
     chip::CharSpan value;
-    DataModel::List<Structs::ContentLaunchAdditionalInfo::Type> externalIDList;
+    DataModel::List<const Structs::ContentLaunchAdditionalInfo::Type> externalIDList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21883,7 +21883,7 @@ namespace Attributes {
 namespace AcceptsHeaderList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<chip::ByteSpan>;
+    using Type          = DataModel::List<const chip::ByteSpan>;
     using DecodableType = DataModel::DecodableList<chip::ByteSpan>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
@@ -21893,7 +21893,7 @@ struct TypeInfo
 namespace SupportedStreamingTypes {
 struct TypeInfo
 {
-    using Type          = DataModel::List<ContentLaunchStreamingType>;
+    using Type          = DataModel::List<const ContentLaunchStreamingType>;
     using DecodableType = DataModel::DecodableList<ContentLaunchStreamingType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
@@ -22031,7 +22031,7 @@ namespace Attributes {
 namespace AudioOutputList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::AudioOutputInfo::Type>;
+    using Type          = DataModel::List<const Structs::AudioOutputInfo::Type>;
     using DecodableType = DataModel::DecodableList<Structs::AudioOutputInfo::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
@@ -22180,7 +22180,7 @@ namespace Attributes {
 namespace ApplicationLauncherList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint16_t>;
+    using Type          = DataModel::List<const uint16_t>;
     using DecodableType = DataModel::DecodableList<uint16_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
@@ -22577,10 +22577,10 @@ public:
     uint8_t a;
     bool b;
     Structs::SimpleStruct::Type c;
-    DataModel::List<Structs::SimpleStruct::Type> d;
-    DataModel::List<uint32_t> e;
-    DataModel::List<chip::ByteSpan> f;
-    DataModel::List<uint8_t> g;
+    DataModel::List<const Structs::SimpleStruct::Type> d;
+    DataModel::List<const uint32_t> e;
+    DataModel::List<const chip::ByteSpan> f;
+    DataModel::List<const uint8_t> g;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -22608,7 +22608,7 @@ enum class Fields
 struct Type
 {
 public:
-    DataModel::List<Structs::NestedStructList::Type> a;
+    DataModel::List<const Structs::NestedStructList::Type> a;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -22842,10 +22842,10 @@ public:
     static constexpr CommandId GetCommandId() { return TestStructArrayArgumentResponse::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<Structs::NestedStructList::Type> arg1;
-    DataModel::List<Structs::SimpleStruct::Type> arg2;
-    DataModel::List<SimpleEnum> arg3;
-    DataModel::List<bool> arg4;
+    DataModel::List<const Structs::NestedStructList::Type> arg1;
+    DataModel::List<const Structs::SimpleStruct::Type> arg2;
+    DataModel::List<const SimpleEnum> arg3;
+    DataModel::List<const bool> arg4;
     SimpleEnum arg5;
     bool arg6;
 
@@ -22911,7 +22911,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestListInt8UReverseResponse::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<uint8_t> arg1;
+    DataModel::List<const uint8_t> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -23003,10 +23003,10 @@ public:
     static constexpr CommandId GetCommandId() { return TestStructArrayArgumentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<Structs::NestedStructList::Type> arg1;
-    DataModel::List<Structs::SimpleStruct::Type> arg2;
-    DataModel::List<SimpleEnum> arg3;
-    DataModel::List<bool> arg4;
+    DataModel::List<const Structs::NestedStructList::Type> arg1;
+    DataModel::List<const Structs::SimpleStruct::Type> arg2;
+    DataModel::List<const SimpleEnum> arg3;
+    DataModel::List<const bool> arg4;
     SimpleEnum arg5;
     bool arg6;
 
@@ -23097,7 +23097,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestListStructArgumentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<Structs::SimpleStruct::Type> arg1;
+    DataModel::List<const Structs::SimpleStruct::Type> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -23125,7 +23125,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestListInt8UArgumentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<uint8_t> arg1;
+    DataModel::List<const uint8_t> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -23181,7 +23181,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestListNestedStructListArgumentRequest::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<Structs::NestedStructList::Type> arg1;
+    DataModel::List<const Structs::NestedStructList::Type> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -23209,7 +23209,7 @@ public:
     static constexpr CommandId GetCommandId() { return TestListInt8UReverseRequest::Id; }
     static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
 
-    DataModel::List<uint8_t> arg1;
+    DataModel::List<const uint8_t> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -23421,7 +23421,7 @@ struct TypeInfo
 namespace ListInt8u {
 struct TypeInfo
 {
-    using Type          = DataModel::List<uint8_t>;
+    using Type          = DataModel::List<const uint8_t>;
     using DecodableType = DataModel::DecodableList<uint8_t>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
@@ -23431,7 +23431,7 @@ struct TypeInfo
 namespace ListOctetString {
 struct TypeInfo
 {
-    using Type          = DataModel::List<chip::ByteSpan>;
+    using Type          = DataModel::List<const chip::ByteSpan>;
     using DecodableType = DataModel::DecodableList<chip::ByteSpan>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
@@ -23441,7 +23441,7 @@ struct TypeInfo
 namespace ListStructOctetString {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::TestListStructOctet::Type>;
+    using Type          = DataModel::List<const Structs::TestListStructOctet::Type>;
     using DecodableType = DataModel::DecodableList<Structs::TestListStructOctet::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
@@ -23565,8 +23565,8 @@ public:
     SimpleEnum arg2;
     bool arg3;
     Structs::SimpleStruct::Type arg4;
-    DataModel::List<Structs::SimpleStruct::Type> arg5;
-    DataModel::List<SimpleEnum> arg6;
+    DataModel::List<const Structs::SimpleStruct::Type> arg5;
+    DataModel::List<const SimpleEnum> arg6;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24379,7 +24379,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
     chip::BitFlags<AlertCount> alertsCount;
-    DataModel::List<chip::BitFlags<AlertStructure>> alertStructures;
+    DataModel::List<const chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24410,7 +24410,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
 
     chip::BitFlags<AlertCount> alertsCount;
-    DataModel::List<chip::BitFlags<AlertStructure>> alertStructures;
+    DataModel::List<const chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24504,7 +24504,7 @@ public:
     uint32_t timeStamp;
     uint32_t logId;
     uint32_t logLength;
-    DataModel::List<uint8_t> logPayload;
+    DataModel::List<const uint8_t> logPayload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24569,7 +24569,7 @@ public:
     uint32_t timeStamp;
     uint32_t logId;
     uint32_t logLength;
-    DataModel::List<uint8_t> logPayload;
+    DataModel::List<const uint8_t> logPayload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24626,7 +24626,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
 
     uint8_t logQueueSize;
-    DataModel::List<uint32_t> logIds;
+    DataModel::List<const uint32_t> logIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24657,7 +24657,7 @@ public:
     static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
 
     uint8_t logQueueSize;
-    DataModel::List<uint32_t> logIds;
+    DataModel::List<const uint32_t> logIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24740,7 +24740,7 @@ public:
     uint8_t profileCount;
     uint8_t profileIntervalPeriod;
     uint8_t maxNumberOfIntervals;
-    DataModel::List<uint16_t> listOfAttributes;
+    DataModel::List<const uint16_t> listOfAttributes;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24805,7 +24805,7 @@ public:
     uint8_t profileIntervalPeriod;
     uint8_t numberOfIntervalsDelivered;
     uint16_t attributeId;
-    DataModel::List<uint8_t> intervals;
+    DataModel::List<const uint8_t> intervals;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -26335,7 +26335,7 @@ namespace Attributes {
 namespace Groups {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::GroupState::Type>;
+    using Type          = DataModel::List<const Structs::GroupState::Type>;
     using DecodableType = DataModel::DecodableList<Structs::GroupState::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
@@ -26345,7 +26345,7 @@ struct TypeInfo
 namespace GroupKeys {
 struct TypeInfo
 {
-    using Type          = DataModel::List<Structs::GroupKey::Type>;
+    using Type          = DataModel::List<const Structs::GroupKey::Type>;
     using DecodableType = DataModel::DecodableList<Structs::GroupKey::DecodableType>;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }


### PR DESCRIPTION
We should not be requiring creation of non-const data to encode a list
if it can be backed by const data instead.

Another option would be to make List<T> inherit from Span<const T>,
but that makes some assumptions about whether people will want to
write to a buffer via its List representation.

The change to the List::operator= is because importing _all_ operator=
from the super-class, including the implicitly-defined ones, causes
assignments from List<T> to List<const T> to be ambiguous.  Forwarding
just the one operator= we want to forward fixes that.

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes.  Tree compiles.