### PR TITLE
Fix incorrect GetClusterId() in cluster-objects.

### DIFF
--- a/examples/chip-tool/templates/tests.js
+++ b/examples/chip-tool/templates/tests.js
@@ -132,6 +132,7 @@ function getTests()
     'TestLogCommands',
     'TestDescriptorCluster',
     'TestBasicInformation',
+    'TestIdentifyCluster',
     'TestOperationalCredentialsCluster',
   ];
 

--- a/src/app/tests/suites/TestIdentifyCluster.yaml
+++ b/src/app/tests/suites/TestIdentifyCluster.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Identify Cluster Tests
+
+config:
+    cluster: "Identify"
+    endpoint: 0
+
+tests:
+    - label: "Send Identify command and expect success response"
+      command: "identify"
+      arguments:
+          values:
+              - name: "IdentifyTime"
+                value: 0

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -102,8 +102,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return {{asUpperCamelCase name}}::Id; }
-    static constexpr ClusterId GetClusterId() { return {{asUpperCamelCase parent.name}}::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::{{asUpperCamelCase name}}::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
     {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}};
@@ -114,8 +114,8 @@ public:
 
 struct DecodableType {
 public:
-    static constexpr CommandId GetCommandId() { return {{asUpperCamelCase name}}::Id; }
-    static constexpr ClusterId GetClusterId() { return {{asUpperCamelCase parent.name}}::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::{{asUpperCamelCase name}}::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
     {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}};
@@ -171,7 +171,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::{{asUpperCamelCase priority}};
     static constexpr EventId eventId = {{asMEI manufacturerCode code}};
-    static constexpr ClusterId GetClusterId() { return {{asUpperCamelCase parent.name}}::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_event_fields}}
     {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase name}};
@@ -184,7 +184,7 @@ struct DecodableType {
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return {{asUpperCamelCase parent.name}}::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_event_fields}}
     {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase name}};

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -25,4153 +25,4154 @@ from chip.exceptions import *
 
 __all__ = ["ChipClusters"]
 
+
 class ChipClusters:
     SUCCESS_DELEGATE = ctypes.CFUNCTYPE(None)
     FAILURE_DELEGATE = ctypes.CFUNCTYPE(None, ctypes.c_uint8)
 
     _ACCOUNT_LOGIN_CLUSTER_INFO = {
-            "clusterName": "AccountLogin",
-            "clusterId": 0x0000050E,
-            "commands": {
+        "clusterName": "AccountLogin",
+        "clusterId": 0x0000050E,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "GetSetupPIN",
-                    "args": {
-                        "tempAccountIdentifier": "str",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "GetSetupPIN",
+                "args": {
+                    "tempAccountIdentifier": "str",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "Login",
-                    "args": {
-                        "tempAccountIdentifier": "str",
-                        "setupPIN": "str",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "Login",
+                "args": {
+                    "tempAccountIdentifier": "str",
+                    "setupPIN": "str",
                 },
             },
-            "attributes": {
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _ADMINISTRATOR_COMMISSIONING_CLUSTER_INFO = {
-            "clusterName": "AdministratorCommissioning",
-            "clusterId": 0x0000003C,
-            "commands": {
+        "clusterName": "AdministratorCommissioning",
+        "clusterId": 0x0000003C,
+        "commands": {
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "OpenBasicCommissioningWindow",
-                    "args": {
-                        "commissioningTimeout": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "OpenBasicCommissioningWindow",
+                "args": {
+                    "commissioningTimeout": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "OpenCommissioningWindow",
-                    "args": {
-                        "commissioningTimeout": "int",
-                        "PAKEVerifier": "bytes",
-                        "discriminator": "int",
-                        "iterations": "int",
-                        "salt": "bytes",
-                        "passcodeID": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "OpenCommissioningWindow",
+                "args": {
+                    "commissioningTimeout": "int",
+                    "PAKEVerifier": "bytes",
+                    "discriminator": "int",
+                    "iterations": "int",
+                    "salt": "bytes",
+                    "passcodeID": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "RevokeCommissioning",
-                    "args": {
-                    },
+                "commandId": 0x00000002,
+                "commandName": "RevokeCommissioning",
+                "args": {
                 },
             },
-            "attributes": {
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _APPLICATION_BASIC_CLUSTER_INFO = {
-            "clusterName": "ApplicationBasic",
-            "clusterId": 0x0000050D,
-            "commands": {
+        "clusterName": "ApplicationBasic",
+        "clusterId": 0x0000050D,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ChangeStatus",
-                    "args": {
-                        "status": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ChangeStatus",
+                "args": {
+                    "status": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "VendorName",
-                    "attributeId": 0x00000000,
-                    "type": "str",
-                },
-                0x00000001: {
-                    "attributeName": "VendorId",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "ApplicationName",
-                    "attributeId": 0x00000002,
-                    "type": "str",
-                },
-                0x00000003: {
-                    "attributeName": "ProductId",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "ApplicationId",
-                    "attributeId": 0x00000005,
-                    "type": "str",
-                },
-                0x00000006: {
-                    "attributeName": "CatalogVendorId",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "ApplicationStatus",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "VendorName",
+                "attributeId": 0x00000000,
+                "type": "str",
             },
+            0x00000001: {
+                "attributeName": "VendorId",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "ApplicationName",
+                "attributeId": 0x00000002,
+                "type": "str",
+            },
+            0x00000003: {
+                "attributeName": "ProductId",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "ApplicationId",
+                "attributeId": 0x00000005,
+                "type": "str",
+            },
+            0x00000006: {
+                "attributeName": "CatalogVendorId",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "ApplicationStatus",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _APPLICATION_LAUNCHER_CLUSTER_INFO = {
-            "clusterName": "ApplicationLauncher",
-            "clusterId": 0x0000050C,
-            "commands": {
+        "clusterName": "ApplicationLauncher",
+        "clusterId": 0x0000050C,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "LaunchApp",
-                    "args": {
-                        "data": "str",
-                        "catalogVendorId": "int",
-                        "applicationId": "str",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "LaunchApp",
+                "args": {
+                    "data": "str",
+                    "catalogVendorId": "int",
+                    "applicationId": "str",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "ApplicationLauncherList",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "CatalogVendorId",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "ApplicationId",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "ApplicationLauncherList",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000001: {
+                "attributeName": "CatalogVendorId",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "ApplicationId",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _AUDIO_OUTPUT_CLUSTER_INFO = {
-            "clusterName": "AudioOutput",
-            "clusterId": 0x0000050B,
-            "commands": {
+        "clusterName": "AudioOutput",
+        "clusterId": 0x0000050B,
+        "commands": {
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "RenameOutput",
-                    "args": {
-                        "index": "int",
-                        "name": "str",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "RenameOutput",
+                "args": {
+                    "index": "int",
+                    "name": "str",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "SelectOutput",
-                    "args": {
-                        "index": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "SelectOutput",
+                "args": {
+                    "index": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "AudioOutputList",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x00000001: {
-                    "attributeName": "CurrentAudioOutput",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "AudioOutputList",
+                "attributeId": 0x00000000,
+                "type": "",
             },
+            0x00000001: {
+                "attributeName": "CurrentAudioOutput",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _BARRIER_CONTROL_CLUSTER_INFO = {
-            "clusterName": "BarrierControl",
-            "clusterId": 0x00000103,
-            "commands": {
+        "clusterName": "BarrierControl",
+        "clusterId": 0x00000103,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "BarrierControlGoToPercent",
-                    "args": {
-                        "percentOpen": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "BarrierControlGoToPercent",
+                "args": {
+                    "percentOpen": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "BarrierControlStop",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "BarrierControlStop",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000001: {
-                    "attributeName": "BarrierMovingState",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "BarrierSafetyStatus",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "BarrierCapabilities",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x0000000A: {
-                    "attributeName": "BarrierPosition",
-                    "attributeId": 0x0000000A,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000001: {
+                "attributeName": "BarrierMovingState",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "BarrierSafetyStatus",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "BarrierCapabilities",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x0000000A: {
+                "attributeName": "BarrierPosition",
+                "attributeId": 0x0000000A,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _BASIC_CLUSTER_INFO = {
-            "clusterName": "Basic",
-            "clusterId": 0x00000028,
-            "commands": {
+        "clusterName": "Basic",
+        "clusterId": 0x00000028,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "MfgSpecificPing",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "MfgSpecificPing",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "InteractionModelVersion",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "VendorName",
-                    "attributeId": 0x00000001,
-                    "type": "str",
-                },
-                0x00000002: {
-                    "attributeName": "VendorID",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "ProductName",
-                    "attributeId": 0x00000003,
-                    "type": "str",
-                },
-                0x00000004: {
-                    "attributeName": "ProductID",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "UserLabel",
-                    "attributeId": 0x00000005,
-                    "type": "str",
-                    "writable": True,
-                },
-                0x00000006: {
-                    "attributeName": "Location",
-                    "attributeId": 0x00000006,
-                    "type": "str",
-                    "writable": True,
-                },
-                0x00000007: {
-                    "attributeName": "HardwareVersion",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x00000008: {
-                    "attributeName": "HardwareVersionString",
-                    "attributeId": 0x00000008,
-                    "type": "str",
-                },
-                0x00000009: {
-                    "attributeName": "SoftwareVersion",
-                    "attributeId": 0x00000009,
-                    "type": "int",
-                },
-                0x0000000A: {
-                    "attributeName": "SoftwareVersionString",
-                    "attributeId": 0x0000000A,
-                    "type": "str",
-                },
-                0x0000000B: {
-                    "attributeName": "ManufacturingDate",
-                    "attributeId": 0x0000000B,
-                    "type": "str",
-                },
-                0x0000000C: {
-                    "attributeName": "PartNumber",
-                    "attributeId": 0x0000000C,
-                    "type": "str",
-                },
-                0x0000000D: {
-                    "attributeName": "ProductURL",
-                    "attributeId": 0x0000000D,
-                    "type": "str",
-                },
-                0x0000000E: {
-                    "attributeName": "ProductLabel",
-                    "attributeId": 0x0000000E,
-                    "type": "str",
-                },
-                0x0000000F: {
-                    "attributeName": "SerialNumber",
-                    "attributeId": 0x0000000F,
-                    "type": "str",
-                },
-                0x00000010: {
-                    "attributeName": "LocalConfigDisabled",
-                    "attributeId": 0x00000010,
-                    "type": "bool",
-                    "writable": True,
-                },
-                0x00000011: {
-                    "attributeName": "Reachable",
-                    "attributeId": 0x00000011,
-                    "type": "bool",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "InteractionModelVersion",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000001: {
+                "attributeName": "VendorName",
+                "attributeId": 0x00000001,
+                "type": "str",
+            },
+            0x00000002: {
+                "attributeName": "VendorID",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "ProductName",
+                "attributeId": 0x00000003,
+                "type": "str",
+            },
+            0x00000004: {
+                "attributeName": "ProductID",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "UserLabel",
+                "attributeId": 0x00000005,
+                "type": "str",
+                "writable": True,
+            },
+            0x00000006: {
+                "attributeName": "Location",
+                "attributeId": 0x00000006,
+                "type": "str",
+                "writable": True,
+            },
+            0x00000007: {
+                "attributeName": "HardwareVersion",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x00000008: {
+                "attributeName": "HardwareVersionString",
+                "attributeId": 0x00000008,
+                "type": "str",
+            },
+            0x00000009: {
+                "attributeName": "SoftwareVersion",
+                "attributeId": 0x00000009,
+                "type": "int",
+            },
+            0x0000000A: {
+                "attributeName": "SoftwareVersionString",
+                "attributeId": 0x0000000A,
+                "type": "str",
+            },
+            0x0000000B: {
+                "attributeName": "ManufacturingDate",
+                "attributeId": 0x0000000B,
+                "type": "str",
+            },
+            0x0000000C: {
+                "attributeName": "PartNumber",
+                "attributeId": 0x0000000C,
+                "type": "str",
+            },
+            0x0000000D: {
+                "attributeName": "ProductURL",
+                "attributeId": 0x0000000D,
+                "type": "str",
+            },
+            0x0000000E: {
+                "attributeName": "ProductLabel",
+                "attributeId": 0x0000000E,
+                "type": "str",
+            },
+            0x0000000F: {
+                "attributeName": "SerialNumber",
+                "attributeId": 0x0000000F,
+                "type": "str",
+            },
+            0x00000010: {
+                "attributeName": "LocalConfigDisabled",
+                "attributeId": 0x00000010,
+                "type": "bool",
+                "writable": True,
+            },
+            0x00000011: {
+                "attributeName": "Reachable",
+                "attributeId": 0x00000011,
+                "type": "bool",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _BINARY_INPUT_BASIC_CLUSTER_INFO = {
-            "clusterName": "BinaryInputBasic",
-            "clusterId": 0x0000000F,
-            "commands": {
+        "clusterName": "BinaryInputBasic",
+        "clusterId": 0x0000000F,
+        "commands": {
+        },
+        "attributes": {
+            0x00000051: {
+                "attributeName": "OutOfService",
+                "attributeId": 0x00000051,
+                "type": "bool",
+                "writable": True,
             },
-            "attributes": {
-                0x00000051: {
-                    "attributeName": "OutOfService",
-                    "attributeId": 0x00000051,
-                    "type": "bool",
-                    "writable": True,
-                },
-                0x00000055: {
-                    "attributeName": "PresentValue",
-                    "attributeId": 0x00000055,
-                    "type": "bool",
-                    "reportable": True,
-                    "writable": True,
-                },
-                0x0000006F: {
-                    "attributeName": "StatusFlags",
-                    "attributeId": 0x0000006F,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000055: {
+                "attributeName": "PresentValue",
+                "attributeId": 0x00000055,
+                "type": "bool",
+                "reportable": True,
+                "writable": True,
             },
+            0x0000006F: {
+                "attributeName": "StatusFlags",
+                "attributeId": 0x0000006F,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _BINDING_CLUSTER_INFO = {
-            "clusterName": "Binding",
-            "clusterId": 0x0000F000,
-            "commands": {
+        "clusterName": "Binding",
+        "clusterId": 0x0000F000,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "Bind",
-                    "args": {
-                        "nodeId": "int",
-                        "groupId": "int",
-                        "endpointId": "int",
-                        "clusterId": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "Bind",
+                "args": {
+                    "nodeId": "int",
+                    "groupId": "int",
+                    "endpointId": "int",
+                    "clusterId": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "Unbind",
-                    "args": {
-                        "nodeId": "int",
-                        "groupId": "int",
-                        "endpointId": "int",
-                        "clusterId": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "Unbind",
+                "args": {
+                    "nodeId": "int",
+                    "groupId": "int",
+                    "endpointId": "int",
+                    "clusterId": "int",
                 },
             },
-            "attributes": {
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _BOOLEAN_STATE_CLUSTER_INFO = {
-            "clusterName": "BooleanState",
-            "clusterId": 0x00000045,
-            "commands": {
+        "clusterName": "BooleanState",
+        "clusterId": 0x00000045,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "StateValue",
+                "attributeId": 0x00000000,
+                "type": "bool",
+                "reportable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "StateValue",
-                    "attributeId": 0x00000000,
-                    "type": "bool",
-                    "reportable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _BRIDGED_DEVICE_BASIC_CLUSTER_INFO = {
-            "clusterName": "BridgedDeviceBasic",
-            "clusterId": 0x00000039,
-            "commands": {
+        "clusterName": "BridgedDeviceBasic",
+        "clusterId": 0x00000039,
+        "commands": {
+        },
+        "attributes": {
+            0x00000001: {
+                "attributeName": "VendorName",
+                "attributeId": 0x00000001,
+                "type": "str",
             },
-            "attributes": {
-                0x00000001: {
-                    "attributeName": "VendorName",
-                    "attributeId": 0x00000001,
-                    "type": "str",
-                },
-                0x00000002: {
-                    "attributeName": "VendorID",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "ProductName",
-                    "attributeId": 0x00000003,
-                    "type": "str",
-                },
-                0x00000005: {
-                    "attributeName": "UserLabel",
-                    "attributeId": 0x00000005,
-                    "type": "str",
-                    "writable": True,
-                },
-                0x00000007: {
-                    "attributeName": "HardwareVersion",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x00000008: {
-                    "attributeName": "HardwareVersionString",
-                    "attributeId": 0x00000008,
-                    "type": "str",
-                },
-                0x00000009: {
-                    "attributeName": "SoftwareVersion",
-                    "attributeId": 0x00000009,
-                    "type": "int",
-                },
-                0x0000000A: {
-                    "attributeName": "SoftwareVersionString",
-                    "attributeId": 0x0000000A,
-                    "type": "str",
-                },
-                0x0000000B: {
-                    "attributeName": "ManufacturingDate",
-                    "attributeId": 0x0000000B,
-                    "type": "str",
-                },
-                0x0000000C: {
-                    "attributeName": "PartNumber",
-                    "attributeId": 0x0000000C,
-                    "type": "str",
-                },
-                0x0000000D: {
-                    "attributeName": "ProductURL",
-                    "attributeId": 0x0000000D,
-                    "type": "str",
-                },
-                0x0000000E: {
-                    "attributeName": "ProductLabel",
-                    "attributeId": 0x0000000E,
-                    "type": "str",
-                },
-                0x0000000F: {
-                    "attributeName": "SerialNumber",
-                    "attributeId": 0x0000000F,
-                    "type": "str",
-                },
-                0x00000011: {
-                    "attributeName": "Reachable",
-                    "attributeId": 0x00000011,
-                    "type": "bool",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000002: {
+                "attributeName": "VendorID",
+                "attributeId": 0x00000002,
+                "type": "int",
             },
+            0x00000003: {
+                "attributeName": "ProductName",
+                "attributeId": 0x00000003,
+                "type": "str",
+            },
+            0x00000005: {
+                "attributeName": "UserLabel",
+                "attributeId": 0x00000005,
+                "type": "str",
+                "writable": True,
+            },
+            0x00000007: {
+                "attributeName": "HardwareVersion",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x00000008: {
+                "attributeName": "HardwareVersionString",
+                "attributeId": 0x00000008,
+                "type": "str",
+            },
+            0x00000009: {
+                "attributeName": "SoftwareVersion",
+                "attributeId": 0x00000009,
+                "type": "int",
+            },
+            0x0000000A: {
+                "attributeName": "SoftwareVersionString",
+                "attributeId": 0x0000000A,
+                "type": "str",
+            },
+            0x0000000B: {
+                "attributeName": "ManufacturingDate",
+                "attributeId": 0x0000000B,
+                "type": "str",
+            },
+            0x0000000C: {
+                "attributeName": "PartNumber",
+                "attributeId": 0x0000000C,
+                "type": "str",
+            },
+            0x0000000D: {
+                "attributeName": "ProductURL",
+                "attributeId": 0x0000000D,
+                "type": "str",
+            },
+            0x0000000E: {
+                "attributeName": "ProductLabel",
+                "attributeId": 0x0000000E,
+                "type": "str",
+            },
+            0x0000000F: {
+                "attributeName": "SerialNumber",
+                "attributeId": 0x0000000F,
+                "type": "str",
+            },
+            0x00000011: {
+                "attributeName": "Reachable",
+                "attributeId": 0x00000011,
+                "type": "bool",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _COLOR_CONTROL_CLUSTER_INFO = {
-            "clusterName": "ColorControl",
-            "clusterId": 0x00000300,
-            "commands": {
+        "clusterName": "ColorControl",
+        "clusterId": 0x00000300,
+        "commands": {
             0x00000044: {
-                    "commandId": 0x00000044,
-                    "commandName": "ColorLoopSet",
-                    "args": {
-                        "updateFlags": "int",
-                        "action": "int",
-                        "direction": "int",
-                        "time": "int",
-                        "startHue": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000044,
+                "commandName": "ColorLoopSet",
+                "args": {
+                    "updateFlags": "int",
+                    "action": "int",
+                    "direction": "int",
+                    "time": "int",
+                    "startHue": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000041: {
-                    "commandId": 0x00000041,
-                    "commandName": "EnhancedMoveHue",
-                    "args": {
-                        "moveMode": "int",
-                        "rate": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000041,
+                "commandName": "EnhancedMoveHue",
+                "args": {
+                    "moveMode": "int",
+                    "rate": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000040: {
-                    "commandId": 0x00000040,
-                    "commandName": "EnhancedMoveToHue",
-                    "args": {
-                        "enhancedHue": "int",
-                        "direction": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000040,
+                "commandName": "EnhancedMoveToHue",
+                "args": {
+                    "enhancedHue": "int",
+                    "direction": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000043: {
-                    "commandId": 0x00000043,
-                    "commandName": "EnhancedMoveToHueAndSaturation",
-                    "args": {
-                        "enhancedHue": "int",
-                        "saturation": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000043,
+                "commandName": "EnhancedMoveToHueAndSaturation",
+                "args": {
+                    "enhancedHue": "int",
+                    "saturation": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000042: {
-                    "commandId": 0x00000042,
-                    "commandName": "EnhancedStepHue",
-                    "args": {
-                        "stepMode": "int",
-                        "stepSize": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000042,
+                "commandName": "EnhancedStepHue",
+                "args": {
+                    "stepMode": "int",
+                    "stepSize": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000008: {
-                    "commandId": 0x00000008,
-                    "commandName": "MoveColor",
-                    "args": {
-                        "rateX": "int",
-                        "rateY": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000008,
+                "commandName": "MoveColor",
+                "args": {
+                    "rateX": "int",
+                    "rateY": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x0000004B: {
-                    "commandId": 0x0000004B,
-                    "commandName": "MoveColorTemperature",
-                    "args": {
-                        "moveMode": "int",
-                        "rate": "int",
-                        "colorTemperatureMinimum": "int",
-                        "colorTemperatureMaximum": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x0000004B,
+                "commandName": "MoveColorTemperature",
+                "args": {
+                    "moveMode": "int",
+                    "rate": "int",
+                    "colorTemperatureMinimum": "int",
+                    "colorTemperatureMaximum": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "MoveHue",
-                    "args": {
-                        "moveMode": "int",
-                        "rate": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "MoveHue",
+                "args": {
+                    "moveMode": "int",
+                    "rate": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "MoveSaturation",
-                    "args": {
-                        "moveMode": "int",
-                        "rate": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "MoveSaturation",
+                "args": {
+                    "moveMode": "int",
+                    "rate": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "MoveToColor",
-                    "args": {
-                        "colorX": "int",
-                        "colorY": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000007,
+                "commandName": "MoveToColor",
+                "args": {
+                    "colorX": "int",
+                    "colorY": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x0000000A: {
-                    "commandId": 0x0000000A,
-                    "commandName": "MoveToColorTemperature",
-                    "args": {
-                        "colorTemperature": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x0000000A,
+                "commandName": "MoveToColorTemperature",
+                "args": {
+                    "colorTemperature": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "MoveToHue",
-                    "args": {
-                        "hue": "int",
-                        "direction": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "MoveToHue",
+                "args": {
+                    "hue": "int",
+                    "direction": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "MoveToHueAndSaturation",
-                    "args": {
-                        "hue": "int",
-                        "saturation": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000006,
+                "commandName": "MoveToHueAndSaturation",
+                "args": {
+                    "hue": "int",
+                    "saturation": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "MoveToSaturation",
-                    "args": {
-                        "saturation": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000003,
+                "commandName": "MoveToSaturation",
+                "args": {
+                    "saturation": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000009: {
-                    "commandId": 0x00000009,
-                    "commandName": "StepColor",
-                    "args": {
-                        "stepX": "int",
-                        "stepY": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000009,
+                "commandName": "StepColor",
+                "args": {
+                    "stepX": "int",
+                    "stepY": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x0000004C: {
-                    "commandId": 0x0000004C,
-                    "commandName": "StepColorTemperature",
-                    "args": {
-                        "stepMode": "int",
-                        "stepSize": "int",
-                        "transitionTime": "int",
-                        "colorTemperatureMinimum": "int",
-                        "colorTemperatureMaximum": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x0000004C,
+                "commandName": "StepColorTemperature",
+                "args": {
+                    "stepMode": "int",
+                    "stepSize": "int",
+                    "transitionTime": "int",
+                    "colorTemperatureMinimum": "int",
+                    "colorTemperatureMaximum": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "StepHue",
-                    "args": {
-                        "stepMode": "int",
-                        "stepSize": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "StepHue",
+                "args": {
+                    "stepMode": "int",
+                    "stepSize": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "StepSaturation",
-                    "args": {
-                        "stepMode": "int",
-                        "stepSize": "int",
-                        "transitionTime": "int",
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000005,
+                "commandName": "StepSaturation",
+                "args": {
+                    "stepMode": "int",
+                    "stepSize": "int",
+                    "transitionTime": "int",
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
+            },
             0x00000047: {
-                    "commandId": 0x00000047,
-                    "commandName": "StopMoveStep",
-                    "args": {
-                        "optionsMask": "int",
-                        "optionsOverride": "int",
-                    },
+                "commandId": 0x00000047,
+                "commandName": "StopMoveStep",
+                "args": {
+                    "optionsMask": "int",
+                    "optionsOverride": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "CurrentHue",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "CurrentSaturation",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000002: {
-                    "attributeName": "RemainingTime",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "CurrentX",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000004: {
-                    "attributeName": "CurrentY",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000005: {
-                    "attributeName": "DriftCompensation",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "CompensationText",
-                    "attributeId": 0x00000006,
-                    "type": "str",
-                },
-                0x00000007: {
-                    "attributeName": "ColorTemperature",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000008: {
-                    "attributeName": "ColorMode",
-                    "attributeId": 0x00000008,
-                    "type": "int",
-                },
-                0x0000000F: {
-                    "attributeName": "ColorControlOptions",
-                    "attributeId": 0x0000000F,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000010: {
-                    "attributeName": "NumberOfPrimaries",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                },
-                0x00000011: {
-                    "attributeName": "Primary1X",
-                    "attributeId": 0x00000011,
-                    "type": "int",
-                },
-                0x00000012: {
-                    "attributeName": "Primary1Y",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                },
-                0x00000013: {
-                    "attributeName": "Primary1Intensity",
-                    "attributeId": 0x00000013,
-                    "type": "int",
-                },
-                0x00000015: {
-                    "attributeName": "Primary2X",
-                    "attributeId": 0x00000015,
-                    "type": "int",
-                },
-                0x00000016: {
-                    "attributeName": "Primary2Y",
-                    "attributeId": 0x00000016,
-                    "type": "int",
-                },
-                0x00000017: {
-                    "attributeName": "Primary2Intensity",
-                    "attributeId": 0x00000017,
-                    "type": "int",
-                },
-                0x00000019: {
-                    "attributeName": "Primary3X",
-                    "attributeId": 0x00000019,
-                    "type": "int",
-                },
-                0x0000001A: {
-                    "attributeName": "Primary3Y",
-                    "attributeId": 0x0000001A,
-                    "type": "int",
-                },
-                0x0000001B: {
-                    "attributeName": "Primary3Intensity",
-                    "attributeId": 0x0000001B,
-                    "type": "int",
-                },
-                0x00000020: {
-                    "attributeName": "Primary4X",
-                    "attributeId": 0x00000020,
-                    "type": "int",
-                },
-                0x00000021: {
-                    "attributeName": "Primary4Y",
-                    "attributeId": 0x00000021,
-                    "type": "int",
-                },
-                0x00000022: {
-                    "attributeName": "Primary4Intensity",
-                    "attributeId": 0x00000022,
-                    "type": "int",
-                },
-                0x00000024: {
-                    "attributeName": "Primary5X",
-                    "attributeId": 0x00000024,
-                    "type": "int",
-                },
-                0x00000025: {
-                    "attributeName": "Primary5Y",
-                    "attributeId": 0x00000025,
-                    "type": "int",
-                },
-                0x00000026: {
-                    "attributeName": "Primary5Intensity",
-                    "attributeId": 0x00000026,
-                    "type": "int",
-                },
-                0x00000028: {
-                    "attributeName": "Primary6X",
-                    "attributeId": 0x00000028,
-                    "type": "int",
-                },
-                0x00000029: {
-                    "attributeName": "Primary6Y",
-                    "attributeId": 0x00000029,
-                    "type": "int",
-                },
-                0x0000002A: {
-                    "attributeName": "Primary6Intensity",
-                    "attributeId": 0x0000002A,
-                    "type": "int",
-                },
-                0x00000030: {
-                    "attributeName": "WhitePointX",
-                    "attributeId": 0x00000030,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000031: {
-                    "attributeName": "WhitePointY",
-                    "attributeId": 0x00000031,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000032: {
-                    "attributeName": "ColorPointRX",
-                    "attributeId": 0x00000032,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000033: {
-                    "attributeName": "ColorPointRY",
-                    "attributeId": 0x00000033,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000034: {
-                    "attributeName": "ColorPointRIntensity",
-                    "attributeId": 0x00000034,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000036: {
-                    "attributeName": "ColorPointGX",
-                    "attributeId": 0x00000036,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000037: {
-                    "attributeName": "ColorPointGY",
-                    "attributeId": 0x00000037,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000038: {
-                    "attributeName": "ColorPointGIntensity",
-                    "attributeId": 0x00000038,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000003A: {
-                    "attributeName": "ColorPointBX",
-                    "attributeId": 0x0000003A,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000003B: {
-                    "attributeName": "ColorPointBY",
-                    "attributeId": 0x0000003B,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000003C: {
-                    "attributeName": "ColorPointBIntensity",
-                    "attributeId": 0x0000003C,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00004000: {
-                    "attributeName": "EnhancedCurrentHue",
-                    "attributeId": 0x00004000,
-                    "type": "int",
-                },
-                0x00004001: {
-                    "attributeName": "EnhancedColorMode",
-                    "attributeId": 0x00004001,
-                    "type": "int",
-                },
-                0x00004002: {
-                    "attributeName": "ColorLoopActive",
-                    "attributeId": 0x00004002,
-                    "type": "int",
-                },
-                0x00004003: {
-                    "attributeName": "ColorLoopDirection",
-                    "attributeId": 0x00004003,
-                    "type": "int",
-                },
-                0x00004004: {
-                    "attributeName": "ColorLoopTime",
-                    "attributeId": 0x00004004,
-                    "type": "int",
-                },
-                0x00004005: {
-                    "attributeName": "ColorLoopStartEnhancedHue",
-                    "attributeId": 0x00004005,
-                    "type": "int",
-                },
-                0x00004006: {
-                    "attributeName": "ColorLoopStoredEnhancedHue",
-                    "attributeId": 0x00004006,
-                    "type": "int",
-                },
-                0x0000400A: {
-                    "attributeName": "ColorCapabilities",
-                    "attributeId": 0x0000400A,
-                    "type": "int",
-                },
-                0x0000400B: {
-                    "attributeName": "ColorTempPhysicalMin",
-                    "attributeId": 0x0000400B,
-                    "type": "int",
-                },
-                0x0000400C: {
-                    "attributeName": "ColorTempPhysicalMax",
-                    "attributeId": 0x0000400C,
-                    "type": "int",
-                },
-                0x0000400D: {
-                    "attributeName": "CoupleColorTempToLevelMinMireds",
-                    "attributeId": 0x0000400D,
-                    "type": "int",
-                },
-                0x00004010: {
-                    "attributeName": "StartUpColorTemperatureMireds",
-                    "attributeId": 0x00004010,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "CurrentHue",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
+            0x00000001: {
+                "attributeName": "CurrentSaturation",
+                "attributeId": 0x00000001,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000002: {
+                "attributeName": "RemainingTime",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "CurrentX",
+                "attributeId": 0x00000003,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000004: {
+                "attributeName": "CurrentY",
+                "attributeId": 0x00000004,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000005: {
+                "attributeName": "DriftCompensation",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "CompensationText",
+                "attributeId": 0x00000006,
+                "type": "str",
+            },
+            0x00000007: {
+                "attributeName": "ColorTemperature",
+                "attributeId": 0x00000007,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000008: {
+                "attributeName": "ColorMode",
+                "attributeId": 0x00000008,
+                "type": "int",
+            },
+            0x0000000F: {
+                "attributeName": "ColorControlOptions",
+                "attributeId": 0x0000000F,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000010: {
+                "attributeName": "NumberOfPrimaries",
+                "attributeId": 0x00000010,
+                "type": "int",
+            },
+            0x00000011: {
+                "attributeName": "Primary1X",
+                "attributeId": 0x00000011,
+                "type": "int",
+            },
+            0x00000012: {
+                "attributeName": "Primary1Y",
+                "attributeId": 0x00000012,
+                "type": "int",
+            },
+            0x00000013: {
+                "attributeName": "Primary1Intensity",
+                "attributeId": 0x00000013,
+                "type": "int",
+            },
+            0x00000015: {
+                "attributeName": "Primary2X",
+                "attributeId": 0x00000015,
+                "type": "int",
+            },
+            0x00000016: {
+                "attributeName": "Primary2Y",
+                "attributeId": 0x00000016,
+                "type": "int",
+            },
+            0x00000017: {
+                "attributeName": "Primary2Intensity",
+                "attributeId": 0x00000017,
+                "type": "int",
+            },
+            0x00000019: {
+                "attributeName": "Primary3X",
+                "attributeId": 0x00000019,
+                "type": "int",
+            },
+            0x0000001A: {
+                "attributeName": "Primary3Y",
+                "attributeId": 0x0000001A,
+                "type": "int",
+            },
+            0x0000001B: {
+                "attributeName": "Primary3Intensity",
+                "attributeId": 0x0000001B,
+                "type": "int",
+            },
+            0x00000020: {
+                "attributeName": "Primary4X",
+                "attributeId": 0x00000020,
+                "type": "int",
+            },
+            0x00000021: {
+                "attributeName": "Primary4Y",
+                "attributeId": 0x00000021,
+                "type": "int",
+            },
+            0x00000022: {
+                "attributeName": "Primary4Intensity",
+                "attributeId": 0x00000022,
+                "type": "int",
+            },
+            0x00000024: {
+                "attributeName": "Primary5X",
+                "attributeId": 0x00000024,
+                "type": "int",
+            },
+            0x00000025: {
+                "attributeName": "Primary5Y",
+                "attributeId": 0x00000025,
+                "type": "int",
+            },
+            0x00000026: {
+                "attributeName": "Primary5Intensity",
+                "attributeId": 0x00000026,
+                "type": "int",
+            },
+            0x00000028: {
+                "attributeName": "Primary6X",
+                "attributeId": 0x00000028,
+                "type": "int",
+            },
+            0x00000029: {
+                "attributeName": "Primary6Y",
+                "attributeId": 0x00000029,
+                "type": "int",
+            },
+            0x0000002A: {
+                "attributeName": "Primary6Intensity",
+                "attributeId": 0x0000002A,
+                "type": "int",
+            },
+            0x00000030: {
+                "attributeName": "WhitePointX",
+                "attributeId": 0x00000030,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000031: {
+                "attributeName": "WhitePointY",
+                "attributeId": 0x00000031,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000032: {
+                "attributeName": "ColorPointRX",
+                "attributeId": 0x00000032,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000033: {
+                "attributeName": "ColorPointRY",
+                "attributeId": 0x00000033,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000034: {
+                "attributeName": "ColorPointRIntensity",
+                "attributeId": 0x00000034,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000036: {
+                "attributeName": "ColorPointGX",
+                "attributeId": 0x00000036,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000037: {
+                "attributeName": "ColorPointGY",
+                "attributeId": 0x00000037,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000038: {
+                "attributeName": "ColorPointGIntensity",
+                "attributeId": 0x00000038,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000003A: {
+                "attributeName": "ColorPointBX",
+                "attributeId": 0x0000003A,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000003B: {
+                "attributeName": "ColorPointBY",
+                "attributeId": 0x0000003B,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000003C: {
+                "attributeName": "ColorPointBIntensity",
+                "attributeId": 0x0000003C,
+                "type": "int",
+                "writable": True,
+            },
+            0x00004000: {
+                "attributeName": "EnhancedCurrentHue",
+                "attributeId": 0x00004000,
+                "type": "int",
+            },
+            0x00004001: {
+                "attributeName": "EnhancedColorMode",
+                "attributeId": 0x00004001,
+                "type": "int",
+            },
+            0x00004002: {
+                "attributeName": "ColorLoopActive",
+                "attributeId": 0x00004002,
+                "type": "int",
+            },
+            0x00004003: {
+                "attributeName": "ColorLoopDirection",
+                "attributeId": 0x00004003,
+                "type": "int",
+            },
+            0x00004004: {
+                "attributeName": "ColorLoopTime",
+                "attributeId": 0x00004004,
+                "type": "int",
+            },
+            0x00004005: {
+                "attributeName": "ColorLoopStartEnhancedHue",
+                "attributeId": 0x00004005,
+                "type": "int",
+            },
+            0x00004006: {
+                "attributeName": "ColorLoopStoredEnhancedHue",
+                "attributeId": 0x00004006,
+                "type": "int",
+            },
+            0x0000400A: {
+                "attributeName": "ColorCapabilities",
+                "attributeId": 0x0000400A,
+                "type": "int",
+            },
+            0x0000400B: {
+                "attributeName": "ColorTempPhysicalMin",
+                "attributeId": 0x0000400B,
+                "type": "int",
+            },
+            0x0000400C: {
+                "attributeName": "ColorTempPhysicalMax",
+                "attributeId": 0x0000400C,
+                "type": "int",
+            },
+            0x0000400D: {
+                "attributeName": "CoupleColorTempToLevelMinMireds",
+                "attributeId": 0x0000400D,
+                "type": "int",
+            },
+            0x00004010: {
+                "attributeName": "StartUpColorTemperatureMireds",
+                "attributeId": 0x00004010,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _CONTENT_LAUNCHER_CLUSTER_INFO = {
-            "clusterName": "ContentLauncher",
-            "clusterId": 0x0000050A,
-            "commands": {
+        "clusterName": "ContentLauncher",
+        "clusterId": 0x0000050A,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "LaunchContent",
-                    "args": {
-                        "autoPlay": "bool",
-                        "data": "str",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "LaunchContent",
+                "args": {
+                    "autoPlay": "bool",
+                    "data": "str",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "LaunchURL",
-                    "args": {
-                        "contentURL": "str",
-                        "displayString": "str",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "LaunchURL",
+                "args": {
+                    "contentURL": "str",
+                    "displayString": "str",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "AcceptsHeaderList",
-                    "attributeId": 0x00000000,
-                    "type": "bytes",
-                },
-                0x00000001: {
-                    "attributeName": "SupportedStreamingTypes",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "AcceptsHeaderList",
+                "attributeId": 0x00000000,
+                "type": "bytes",
             },
+            0x00000001: {
+                "attributeName": "SupportedStreamingTypes",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _DESCRIPTOR_CLUSTER_INFO = {
-            "clusterName": "Descriptor",
-            "clusterId": 0x0000001D,
-            "commands": {
+        "clusterName": "Descriptor",
+        "clusterId": 0x0000001D,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "DeviceList",
+                "attributeId": 0x00000000,
+                "type": "",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "DeviceList",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x00000001: {
-                    "attributeName": "ServerList",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "ClientList",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "PartsList",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "ServerList",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "ClientList",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "PartsList",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _DIAGNOSTIC_LOGS_CLUSTER_INFO = {
-            "clusterName": "DiagnosticLogs",
-            "clusterId": 0x00000032,
-            "commands": {
+        "clusterName": "DiagnosticLogs",
+        "clusterId": 0x00000032,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "RetrieveLogsRequest",
-                    "args": {
-                        "intent": "int",
-                        "requestedProtocol": "int",
-                        "transferFileDesignator": "bytes",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "RetrieveLogsRequest",
+                "args": {
+                    "intent": "int",
+                    "requestedProtocol": "int",
+                    "transferFileDesignator": "bytes",
                 },
             },
-            "attributes": {
-            },
+        },
+        "attributes": {
+        },
     }
     _DOOR_LOCK_CLUSTER_INFO = {
-            "clusterName": "DoorLock",
-            "clusterId": 0x00000101,
-            "commands": {
+        "clusterName": "DoorLock",
+        "clusterId": 0x00000101,
+        "commands": {
             0x00000008: {
-                    "commandId": 0x00000008,
-                    "commandName": "ClearAllPins",
-                    "args": {
-                    },
+                "commandId": 0x00000008,
+                "commandName": "ClearAllPins",
+                "args": {
                 },
+            },
             0x00000019: {
-                    "commandId": 0x00000019,
-                    "commandName": "ClearAllRfids",
-                    "args": {
-                    },
+                "commandId": 0x00000019,
+                "commandName": "ClearAllRfids",
+                "args": {
                 },
+            },
             0x00000013: {
-                    "commandId": 0x00000013,
-                    "commandName": "ClearHolidaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                    },
+                "commandId": 0x00000013,
+                "commandName": "ClearHolidaySchedule",
+                "args": {
+                    "scheduleId": "int",
                 },
+            },
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "ClearPin",
-                    "args": {
-                        "userId": "int",
-                    },
+                "commandId": 0x00000007,
+                "commandName": "ClearPin",
+                "args": {
+                    "userId": "int",
                 },
+            },
             0x00000018: {
-                    "commandId": 0x00000018,
-                    "commandName": "ClearRfid",
-                    "args": {
-                        "userId": "int",
-                    },
+                "commandId": 0x00000018,
+                "commandName": "ClearRfid",
+                "args": {
+                    "userId": "int",
                 },
+            },
             0x0000000D: {
-                    "commandId": 0x0000000D,
-                    "commandName": "ClearWeekdaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "userId": "int",
-                    },
+                "commandId": 0x0000000D,
+                "commandName": "ClearWeekdaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "userId": "int",
                 },
+            },
             0x00000010: {
-                    "commandId": 0x00000010,
-                    "commandName": "ClearYeardaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "userId": "int",
-                    },
+                "commandId": 0x00000010,
+                "commandName": "ClearYeardaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "userId": "int",
                 },
+            },
             0x00000012: {
-                    "commandId": 0x00000012,
-                    "commandName": "GetHolidaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                    },
+                "commandId": 0x00000012,
+                "commandName": "GetHolidaySchedule",
+                "args": {
+                    "scheduleId": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "GetLogRecord",
-                    "args": {
-                        "logIndex": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "GetLogRecord",
+                "args": {
+                    "logIndex": "int",
                 },
+            },
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "GetPin",
-                    "args": {
-                        "userId": "int",
-                    },
+                "commandId": 0x00000006,
+                "commandName": "GetPin",
+                "args": {
+                    "userId": "int",
                 },
+            },
             0x00000017: {
-                    "commandId": 0x00000017,
-                    "commandName": "GetRfid",
-                    "args": {
-                        "userId": "int",
-                    },
+                "commandId": 0x00000017,
+                "commandName": "GetRfid",
+                "args": {
+                    "userId": "int",
                 },
+            },
             0x00000015: {
-                    "commandId": 0x00000015,
-                    "commandName": "GetUserType",
-                    "args": {
-                        "userId": "int",
-                    },
+                "commandId": 0x00000015,
+                "commandName": "GetUserType",
+                "args": {
+                    "userId": "int",
                 },
+            },
             0x0000000C: {
-                    "commandId": 0x0000000C,
-                    "commandName": "GetWeekdaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "userId": "int",
-                    },
+                "commandId": 0x0000000C,
+                "commandName": "GetWeekdaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "userId": "int",
                 },
+            },
             0x0000000F: {
-                    "commandId": 0x0000000F,
-                    "commandName": "GetYeardaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "userId": "int",
-                    },
+                "commandId": 0x0000000F,
+                "commandName": "GetYeardaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "userId": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "LockDoor",
-                    "args": {
-                        "pin": "bytes",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "LockDoor",
+                "args": {
+                    "pin": "bytes",
                 },
+            },
             0x00000011: {
-                    "commandId": 0x00000011,
-                    "commandName": "SetHolidaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "localStartTime": "int",
-                        "localEndTime": "int",
-                        "operatingModeDuringHoliday": "int",
-                    },
+                "commandId": 0x00000011,
+                "commandName": "SetHolidaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "localStartTime": "int",
+                    "localEndTime": "int",
+                    "operatingModeDuringHoliday": "int",
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "SetPin",
-                    "args": {
-                        "userId": "int",
-                        "userStatus": "int",
-                        "userType": "int",
-                        "pin": "bytes",
-                    },
+                "commandId": 0x00000005,
+                "commandName": "SetPin",
+                "args": {
+                    "userId": "int",
+                    "userStatus": "int",
+                    "userType": "int",
+                    "pin": "bytes",
                 },
+            },
             0x00000016: {
-                    "commandId": 0x00000016,
-                    "commandName": "SetRfid",
-                    "args": {
-                        "userId": "int",
-                        "userStatus": "int",
-                        "userType": "int",
-                        "id": "bytes",
-                    },
+                "commandId": 0x00000016,
+                "commandName": "SetRfid",
+                "args": {
+                    "userId": "int",
+                    "userStatus": "int",
+                    "userType": "int",
+                    "id": "bytes",
                 },
+            },
             0x00000014: {
-                    "commandId": 0x00000014,
-                    "commandName": "SetUserType",
-                    "args": {
-                        "userId": "int",
-                        "userType": "int",
-                    },
+                "commandId": 0x00000014,
+                "commandName": "SetUserType",
+                "args": {
+                    "userId": "int",
+                    "userType": "int",
                 },
+            },
             0x0000000B: {
-                    "commandId": 0x0000000B,
-                    "commandName": "SetWeekdaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "userId": "int",
-                        "daysMask": "int",
-                        "startHour": "int",
-                        "startMinute": "int",
-                        "endHour": "int",
-                        "endMinute": "int",
-                    },
+                "commandId": 0x0000000B,
+                "commandName": "SetWeekdaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "userId": "int",
+                    "daysMask": "int",
+                    "startHour": "int",
+                    "startMinute": "int",
+                    "endHour": "int",
+                    "endMinute": "int",
                 },
+            },
             0x0000000E: {
-                    "commandId": 0x0000000E,
-                    "commandName": "SetYeardaySchedule",
-                    "args": {
-                        "scheduleId": "int",
-                        "userId": "int",
-                        "localStartTime": "int",
-                        "localEndTime": "int",
-                    },
+                "commandId": 0x0000000E,
+                "commandName": "SetYeardaySchedule",
+                "args": {
+                    "scheduleId": "int",
+                    "userId": "int",
+                    "localStartTime": "int",
+                    "localEndTime": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "UnlockDoor",
-                    "args": {
-                        "pin": "bytes",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "UnlockDoor",
+                "args": {
+                    "pin": "bytes",
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "UnlockWithTimeout",
-                    "args": {
-                        "timeoutInSeconds": "int",
-                        "pin": "bytes",
-                    },
+                "commandId": 0x00000003,
+                "commandName": "UnlockWithTimeout",
+                "args": {
+                    "timeoutInSeconds": "int",
+                    "pin": "bytes",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "LockState",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "LockType",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "ActuatorEnabled",
-                    "attributeId": 0x00000002,
-                    "type": "bool",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "LockState",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
+            0x00000001: {
+                "attributeName": "LockType",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "ActuatorEnabled",
+                "attributeId": 0x00000002,
+                "type": "bool",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _ELECTRICAL_MEASUREMENT_CLUSTER_INFO = {
-            "clusterName": "ElectricalMeasurement",
-            "clusterId": 0x00000B04,
-            "commands": {
+        "clusterName": "ElectricalMeasurement",
+        "clusterId": 0x00000B04,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MeasurementType",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MeasurementType",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000304: {
-                    "attributeName": "TotalActivePower",
-                    "attributeId": 0x00000304,
-                    "type": "int",
-                },
-                0x00000505: {
-                    "attributeName": "RmsVoltage",
-                    "attributeId": 0x00000505,
-                    "type": "int",
-                },
-                0x00000506: {
-                    "attributeName": "RmsVoltageMin",
-                    "attributeId": 0x00000506,
-                    "type": "int",
-                },
-                0x00000507: {
-                    "attributeName": "RmsVoltageMax",
-                    "attributeId": 0x00000507,
-                    "type": "int",
-                },
-                0x00000508: {
-                    "attributeName": "RmsCurrent",
-                    "attributeId": 0x00000508,
-                    "type": "int",
-                },
-                0x00000509: {
-                    "attributeName": "RmsCurrentMin",
-                    "attributeId": 0x00000509,
-                    "type": "int",
-                },
-                0x0000050A: {
-                    "attributeName": "RmsCurrentMax",
-                    "attributeId": 0x0000050A,
-                    "type": "int",
-                },
-                0x0000050B: {
-                    "attributeName": "ActivePower",
-                    "attributeId": 0x0000050B,
-                    "type": "int",
-                },
-                0x0000050C: {
-                    "attributeName": "ActivePowerMin",
-                    "attributeId": 0x0000050C,
-                    "type": "int",
-                },
-                0x0000050D: {
-                    "attributeName": "ActivePowerMax",
-                    "attributeId": 0x0000050D,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000304: {
+                "attributeName": "TotalActivePower",
+                "attributeId": 0x00000304,
+                "type": "int",
             },
+            0x00000505: {
+                "attributeName": "RmsVoltage",
+                "attributeId": 0x00000505,
+                "type": "int",
+            },
+            0x00000506: {
+                "attributeName": "RmsVoltageMin",
+                "attributeId": 0x00000506,
+                "type": "int",
+            },
+            0x00000507: {
+                "attributeName": "RmsVoltageMax",
+                "attributeId": 0x00000507,
+                "type": "int",
+            },
+            0x00000508: {
+                "attributeName": "RmsCurrent",
+                "attributeId": 0x00000508,
+                "type": "int",
+            },
+            0x00000509: {
+                "attributeName": "RmsCurrentMin",
+                "attributeId": 0x00000509,
+                "type": "int",
+            },
+            0x0000050A: {
+                "attributeName": "RmsCurrentMax",
+                "attributeId": 0x0000050A,
+                "type": "int",
+            },
+            0x0000050B: {
+                "attributeName": "ActivePower",
+                "attributeId": 0x0000050B,
+                "type": "int",
+            },
+            0x0000050C: {
+                "attributeName": "ActivePowerMin",
+                "attributeId": 0x0000050C,
+                "type": "int",
+            },
+            0x0000050D: {
+                "attributeName": "ActivePowerMax",
+                "attributeId": 0x0000050D,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_INFO = {
-            "clusterName": "EthernetNetworkDiagnostics",
-            "clusterId": 0x00000037,
-            "commands": {
+        "clusterName": "EthernetNetworkDiagnostics",
+        "clusterId": 0x00000037,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ResetCounts",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ResetCounts",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "PHYRate",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "FullDuplex",
-                    "attributeId": 0x00000001,
-                    "type": "bool",
-                },
-                0x00000002: {
-                    "attributeName": "PacketRxCount",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "PacketTxCount",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "TxErrCount",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "CollisionCount",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "OverrunCount",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "CarrierDetect",
-                    "attributeId": 0x00000007,
-                    "type": "bool",
-                },
-                0x00000008: {
-                    "attributeName": "TimeSinceReset",
-                    "attributeId": 0x00000008,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "PHYRate",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000001: {
+                "attributeName": "FullDuplex",
+                "attributeId": 0x00000001,
+                "type": "bool",
+            },
+            0x00000002: {
+                "attributeName": "PacketRxCount",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "PacketTxCount",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "TxErrCount",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "CollisionCount",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "OverrunCount",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "CarrierDetect",
+                "attributeId": 0x00000007,
+                "type": "bool",
+            },
+            0x00000008: {
+                "attributeName": "TimeSinceReset",
+                "attributeId": 0x00000008,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _FIXED_LABEL_CLUSTER_INFO = {
-            "clusterName": "FixedLabel",
-            "clusterId": 0x00000040,
-            "commands": {
+        "clusterName": "FixedLabel",
+        "clusterId": 0x00000040,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "LabelList",
+                "attributeId": 0x00000000,
+                "type": "",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "LabelList",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _FLOW_MEASUREMENT_CLUSTER_INFO = {
-            "clusterName": "FlowMeasurement",
-            "clusterId": 0x00000404,
-            "commands": {
+        "clusterName": "FlowMeasurement",
+        "clusterId": 0x00000404,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MeasuredValue",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MeasuredValue",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "MinMeasuredValue",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MaxMeasuredValue",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "MinMeasuredValue",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "MaxMeasuredValue",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _GENERAL_COMMISSIONING_CLUSTER_INFO = {
-            "clusterName": "GeneralCommissioning",
-            "clusterId": 0x00000030,
-            "commands": {
+        "clusterName": "GeneralCommissioning",
+        "clusterId": 0x00000030,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ArmFailSafe",
-                    "args": {
-                        "expiryLengthSeconds": "int",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ArmFailSafe",
+                "args": {
+                    "expiryLengthSeconds": "int",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "CommissioningComplete",
-                    "args": {
-                    },
+                "commandId": 0x00000004,
+                "commandName": "CommissioningComplete",
+                "args": {
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "SetRegulatoryConfig",
-                    "args": {
-                        "location": "int",
-                        "countryCode": "str",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "SetRegulatoryConfig",
+                "args": {
+                    "location": "int",
+                    "countryCode": "str",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Breadcrumb",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000001: {
-                    "attributeName": "BasicCommissioningInfoList",
-                    "attributeId": 0x00000001,
-                    "type": "",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Breadcrumb",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "writable": True,
             },
+            0x00000001: {
+                "attributeName": "BasicCommissioningInfoList",
+                "attributeId": 0x00000001,
+                "type": "",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _GENERAL_DIAGNOSTICS_CLUSTER_INFO = {
-            "clusterName": "GeneralDiagnostics",
-            "clusterId": 0x00000033,
-            "commands": {
+        "clusterName": "GeneralDiagnostics",
+        "clusterId": 0x00000033,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "NetworkInterfaces",
+                "attributeId": 0x00000000,
+                "type": "",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "NetworkInterfaces",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x00000001: {
-                    "attributeName": "RebootCount",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "UpTime",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "TotalOperationalHours",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "BootReasons",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "RebootCount",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "UpTime",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "TotalOperationalHours",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "BootReasons",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _GROUP_KEY_MANAGEMENT_CLUSTER_INFO = {
-            "clusterName": "GroupKeyManagement",
-            "clusterId": 0x0000F004,
-            "commands": {
+        "clusterName": "GroupKeyManagement",
+        "clusterId": 0x0000F004,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Groups",
+                "attributeId": 0x00000000,
+                "type": "",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Groups",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x00000001: {
-                    "attributeName": "GroupKeys",
-                    "attributeId": 0x00000001,
-                    "type": "",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "GroupKeys",
+                "attributeId": 0x00000001,
+                "type": "",
             },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _GROUPS_CLUSTER_INFO = {
-            "clusterName": "Groups",
-            "clusterId": 0x00000004,
-            "commands": {
+        "clusterName": "Groups",
+        "clusterId": 0x00000004,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "AddGroup",
-                    "args": {
-                        "groupId": "int",
-                        "groupName": "str",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "AddGroup",
+                "args": {
+                    "groupId": "int",
+                    "groupName": "str",
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "AddGroupIfIdentifying",
-                    "args": {
-                        "groupId": "int",
-                        "groupName": "str",
-                    },
+                "commandId": 0x00000005,
+                "commandName": "AddGroupIfIdentifying",
+                "args": {
+                    "groupId": "int",
+                    "groupName": "str",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "GetGroupMembership",
-                    "args": {
-                        "groupCount": "int",
-                        "groupList": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "GetGroupMembership",
+                "args": {
+                    "groupCount": "int",
+                    "groupList": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "RemoveAllGroups",
-                    "args": {
-                    },
+                "commandId": 0x00000004,
+                "commandName": "RemoveAllGroups",
+                "args": {
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "RemoveGroup",
-                    "args": {
-                        "groupId": "int",
-                    },
+                "commandId": 0x00000003,
+                "commandName": "RemoveGroup",
+                "args": {
+                    "groupId": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "ViewGroup",
-                    "args": {
-                        "groupId": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "ViewGroup",
+                "args": {
+                    "groupId": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "NameSupport",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "NameSupport",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _IDENTIFY_CLUSTER_INFO = {
-            "clusterName": "Identify",
-            "clusterId": 0x00000003,
-            "commands": {
+        "clusterName": "Identify",
+        "clusterId": 0x00000003,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "Identify",
-                    "args": {
-                        "identifyTime": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "Identify",
+                "args": {
+                    "identifyTime": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "IdentifyQuery",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "IdentifyQuery",
+                "args": {
                 },
+            },
             0x00000040: {
-                    "commandId": 0x00000040,
-                    "commandName": "TriggerEffect",
-                    "args": {
-                        "effectIdentifier": "int",
-                        "effectVariant": "int",
-                    },
+                "commandId": 0x00000040,
+                "commandName": "TriggerEffect",
+                "args": {
+                    "effectIdentifier": "int",
+                    "effectVariant": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "IdentifyTime",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000001: {
-                    "attributeName": "IdentifyType",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "IdentifyTime",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "writable": True,
             },
+            0x00000001: {
+                "attributeName": "IdentifyType",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _ILLUMINANCE_MEASUREMENT_CLUSTER_INFO = {
-            "clusterName": "IlluminanceMeasurement",
-            "clusterId": 0x00000400,
-            "commands": {
+        "clusterName": "IlluminanceMeasurement",
+        "clusterId": 0x00000400,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MeasuredValue",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MeasuredValue",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "MinMeasuredValue",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MaxMeasuredValue",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "Tolerance",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "LightSensorType",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "MinMeasuredValue",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "MaxMeasuredValue",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "Tolerance",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "LightSensorType",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _KEYPAD_INPUT_CLUSTER_INFO = {
-            "clusterName": "KeypadInput",
-            "clusterId": 0x00000509,
-            "commands": {
+        "clusterName": "KeypadInput",
+        "clusterId": 0x00000509,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "SendKey",
-                    "args": {
-                        "keyCode": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "SendKey",
+                "args": {
+                    "keyCode": "int",
                 },
             },
-            "attributes": {
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _LEVEL_CONTROL_CLUSTER_INFO = {
-            "clusterName": "LevelControl",
-            "clusterId": 0x00000008,
-            "commands": {
+        "clusterName": "LevelControl",
+        "clusterId": 0x00000008,
+        "commands": {
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "Move",
-                    "args": {
-                        "moveMode": "int",
-                        "rate": "int",
-                        "optionMask": "int",
-                        "optionOverride": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "Move",
+                "args": {
+                    "moveMode": "int",
+                    "rate": "int",
+                    "optionMask": "int",
+                    "optionOverride": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "MoveToLevel",
-                    "args": {
-                        "level": "int",
-                        "transitionTime": "int",
-                        "optionMask": "int",
-                        "optionOverride": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "MoveToLevel",
+                "args": {
+                    "level": "int",
+                    "transitionTime": "int",
+                    "optionMask": "int",
+                    "optionOverride": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "MoveToLevelWithOnOff",
-                    "args": {
-                        "level": "int",
-                        "transitionTime": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "MoveToLevelWithOnOff",
+                "args": {
+                    "level": "int",
+                    "transitionTime": "int",
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "MoveWithOnOff",
-                    "args": {
-                        "moveMode": "int",
-                        "rate": "int",
-                    },
+                "commandId": 0x00000005,
+                "commandName": "MoveWithOnOff",
+                "args": {
+                    "moveMode": "int",
+                    "rate": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "Step",
-                    "args": {
-                        "stepMode": "int",
-                        "stepSize": "int",
-                        "transitionTime": "int",
-                        "optionMask": "int",
-                        "optionOverride": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "Step",
+                "args": {
+                    "stepMode": "int",
+                    "stepSize": "int",
+                    "transitionTime": "int",
+                    "optionMask": "int",
+                    "optionOverride": "int",
                 },
+            },
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "StepWithOnOff",
-                    "args": {
-                        "stepMode": "int",
-                        "stepSize": "int",
-                        "transitionTime": "int",
-                    },
+                "commandId": 0x00000006,
+                "commandName": "StepWithOnOff",
+                "args": {
+                    "stepMode": "int",
+                    "stepSize": "int",
+                    "transitionTime": "int",
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "Stop",
-                    "args": {
-                        "optionMask": "int",
-                        "optionOverride": "int",
-                    },
+                "commandId": 0x00000003,
+                "commandName": "Stop",
+                "args": {
+                    "optionMask": "int",
+                    "optionOverride": "int",
                 },
+            },
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "StopWithOnOff",
-                    "args": {
-                    },
+                "commandId": 0x00000007,
+                "commandName": "StopWithOnOff",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "CurrentLevel",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "RemainingTime",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MinLevel",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "MaxLevel",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "CurrentFrequency",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "MinFrequency",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "MaxFrequency",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x0000000F: {
-                    "attributeName": "Options",
-                    "attributeId": 0x0000000F,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000010: {
-                    "attributeName": "OnOffTransitionTime",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000011: {
-                    "attributeName": "OnLevel",
-                    "attributeId": 0x00000011,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000012: {
-                    "attributeName": "OnTransitionTime",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000013: {
-                    "attributeName": "OffTransitionTime",
-                    "attributeId": 0x00000013,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000014: {
-                    "attributeName": "DefaultMoveRate",
-                    "attributeId": 0x00000014,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00004000: {
-                    "attributeName": "StartUpCurrentLevel",
-                    "attributeId": 0x00004000,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "CurrentLevel",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
+            0x00000001: {
+                "attributeName": "RemainingTime",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "MinLevel",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "MaxLevel",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "CurrentFrequency",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "MinFrequency",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "MaxFrequency",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x0000000F: {
+                "attributeName": "Options",
+                "attributeId": 0x0000000F,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000010: {
+                "attributeName": "OnOffTransitionTime",
+                "attributeId": 0x00000010,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000011: {
+                "attributeName": "OnLevel",
+                "attributeId": 0x00000011,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000012: {
+                "attributeName": "OnTransitionTime",
+                "attributeId": 0x00000012,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000013: {
+                "attributeName": "OffTransitionTime",
+                "attributeId": 0x00000013,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000014: {
+                "attributeName": "DefaultMoveRate",
+                "attributeId": 0x00000014,
+                "type": "int",
+                "writable": True,
+            },
+            0x00004000: {
+                "attributeName": "StartUpCurrentLevel",
+                "attributeId": 0x00004000,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _LOW_POWER_CLUSTER_INFO = {
-            "clusterName": "LowPower",
-            "clusterId": 0x00000508,
-            "commands": {
+        "clusterName": "LowPower",
+        "clusterId": 0x00000508,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "Sleep",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "Sleep",
+                "args": {
                 },
             },
-            "attributes": {
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _MEDIA_INPUT_CLUSTER_INFO = {
-            "clusterName": "MediaInput",
-            "clusterId": 0x00000507,
-            "commands": {
+        "clusterName": "MediaInput",
+        "clusterId": 0x00000507,
+        "commands": {
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "HideInputStatus",
-                    "args": {
-                    },
+                "commandId": 0x00000002,
+                "commandName": "HideInputStatus",
+                "args": {
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "RenameInput",
-                    "args": {
-                        "index": "int",
-                        "name": "str",
-                    },
+                "commandId": 0x00000003,
+                "commandName": "RenameInput",
+                "args": {
+                    "index": "int",
+                    "name": "str",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "SelectInput",
-                    "args": {
-                        "index": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "SelectInput",
+                "args": {
+                    "index": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "ShowInputStatus",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "ShowInputStatus",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MediaInputList",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x00000001: {
-                    "attributeName": "CurrentMediaInput",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MediaInputList",
+                "attributeId": 0x00000000,
+                "type": "",
             },
+            0x00000001: {
+                "attributeName": "CurrentMediaInput",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _MEDIA_PLAYBACK_CLUSTER_INFO = {
-            "clusterName": "MediaPlayback",
-            "clusterId": 0x00000506,
-            "commands": {
+        "clusterName": "MediaPlayback",
+        "clusterId": 0x00000506,
+        "commands": {
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "MediaFastForward",
-                    "args": {
-                    },
+                "commandId": 0x00000007,
+                "commandName": "MediaFastForward",
+                "args": {
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "MediaNext",
-                    "args": {
-                    },
+                "commandId": 0x00000005,
+                "commandName": "MediaNext",
+                "args": {
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "MediaPause",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "MediaPause",
+                "args": {
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "MediaPlay",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "MediaPlay",
+                "args": {
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "MediaPrevious",
-                    "args": {
-                    },
+                "commandId": 0x00000004,
+                "commandName": "MediaPrevious",
+                "args": {
                 },
+            },
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "MediaRewind",
-                    "args": {
-                    },
+                "commandId": 0x00000006,
+                "commandName": "MediaRewind",
+                "args": {
                 },
+            },
             0x0000000A: {
-                    "commandId": 0x0000000A,
-                    "commandName": "MediaSeek",
-                    "args": {
-                        "position": "int",
-                    },
+                "commandId": 0x0000000A,
+                "commandName": "MediaSeek",
+                "args": {
+                    "position": "int",
                 },
+            },
             0x00000009: {
-                    "commandId": 0x00000009,
-                    "commandName": "MediaSkipBackward",
-                    "args": {
-                        "deltaPositionMilliseconds": "int",
-                    },
+                "commandId": 0x00000009,
+                "commandName": "MediaSkipBackward",
+                "args": {
+                    "deltaPositionMilliseconds": "int",
                 },
+            },
             0x00000008: {
-                    "commandId": 0x00000008,
-                    "commandName": "MediaSkipForward",
-                    "args": {
-                        "deltaPositionMilliseconds": "int",
-                    },
+                "commandId": 0x00000008,
+                "commandName": "MediaSkipForward",
+                "args": {
+                    "deltaPositionMilliseconds": "int",
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "MediaStartOver",
-                    "args": {
-                    },
+                "commandId": 0x00000003,
+                "commandName": "MediaStartOver",
+                "args": {
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "MediaStop",
-                    "args": {
-                    },
+                "commandId": 0x00000002,
+                "commandName": "MediaStop",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "PlaybackState",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "StartTime",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "Duration",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "PositionUpdatedAt",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "Position",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "PlaybackSpeed",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "SeekRangeEnd",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "SeekRangeStart",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "PlaybackState",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000001: {
+                "attributeName": "StartTime",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "Duration",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "PositionUpdatedAt",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "Position",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "PlaybackSpeed",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "SeekRangeEnd",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "SeekRangeStart",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _NETWORK_COMMISSIONING_CLUSTER_INFO = {
-            "clusterName": "NetworkCommissioning",
-            "clusterId": 0x00000031,
-            "commands": {
+        "clusterName": "NetworkCommissioning",
+        "clusterId": 0x00000031,
+        "commands": {
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "AddThreadNetwork",
-                    "args": {
-                        "operationalDataset": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000006,
+                "commandName": "AddThreadNetwork",
+                "args": {
+                    "operationalDataset": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "AddWiFiNetwork",
-                    "args": {
-                        "ssid": "bytes",
-                        "credentials": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "AddWiFiNetwork",
+                "args": {
+                    "ssid": "bytes",
+                    "credentials": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x0000000E: {
-                    "commandId": 0x0000000E,
-                    "commandName": "DisableNetwork",
-                    "args": {
-                        "networkID": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x0000000E,
+                "commandName": "DisableNetwork",
+                "args": {
+                    "networkID": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x0000000C: {
-                    "commandId": 0x0000000C,
-                    "commandName": "EnableNetwork",
-                    "args": {
-                        "networkID": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x0000000C,
+                "commandName": "EnableNetwork",
+                "args": {
+                    "networkID": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x00000010: {
-                    "commandId": 0x00000010,
-                    "commandName": "GetLastNetworkCommissioningResult",
-                    "args": {
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000010,
+                "commandName": "GetLastNetworkCommissioningResult",
+                "args": {
+                    "timeoutMs": "int",
                 },
+            },
             0x0000000A: {
-                    "commandId": 0x0000000A,
-                    "commandName": "RemoveNetwork",
-                    "args": {
-                        "networkID": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x0000000A,
+                "commandName": "RemoveNetwork",
+                "args": {
+                    "networkID": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ScanNetworks",
-                    "args": {
-                        "ssid": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ScanNetworks",
+                "args": {
+                    "ssid": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x00000008: {
-                    "commandId": 0x00000008,
-                    "commandName": "UpdateThreadNetwork",
-                    "args": {
-                        "operationalDataset": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000008,
+                "commandName": "UpdateThreadNetwork",
+                "args": {
+                    "operationalDataset": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "UpdateWiFiNetwork",
-                    "args": {
-                        "ssid": "bytes",
-                        "credentials": "bytes",
-                        "breadcrumb": "int",
-                        "timeoutMs": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "UpdateWiFiNetwork",
+                "args": {
+                    "ssid": "bytes",
+                    "credentials": "bytes",
+                    "breadcrumb": "int",
+                    "timeoutMs": "int",
                 },
             },
-            "attributes": {
-                0x0000FFFC: {
-                    "attributeName": "FeatureMap",
-                    "attributeId": 0x0000FFFC,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFC: {
+                "attributeName": "FeatureMap",
+                "attributeId": 0x0000FFFC,
+                "type": "int",
             },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _OTA_SOFTWARE_UPDATE_PROVIDER_CLUSTER_INFO = {
-            "clusterName": "OtaSoftwareUpdateProvider",
-            "clusterId": 0x00000029,
-            "commands": {
+        "clusterName": "OtaSoftwareUpdateProvider",
+        "clusterId": 0x00000029,
+        "commands": {
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "ApplyUpdateRequest",
-                    "args": {
-                        "updateToken": "bytes",
-                        "newVersion": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "ApplyUpdateRequest",
+                "args": {
+                    "updateToken": "bytes",
+                    "newVersion": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "NotifyUpdateApplied",
-                    "args": {
-                        "updateToken": "bytes",
-                        "softwareVersion": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "NotifyUpdateApplied",
+                "args": {
+                    "updateToken": "bytes",
+                    "softwareVersion": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "QueryImage",
-                    "args": {
-                        "vendorId": "int",
-                        "productId": "int",
-                        "hardwareVersion": "int",
-                        "softwareVersion": "int",
-                        "protocolsSupported": "int",
-                        "location": "str",
-                        "requestorCanConsent": "bool",
-                        "metadataForProvider": "bytes",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "QueryImage",
+                "args": {
+                    "vendorId": "int",
+                    "productId": "int",
+                    "hardwareVersion": "int",
+                    "softwareVersion": "int",
+                    "protocolsSupported": "int",
+                    "location": "str",
+                    "requestorCanConsent": "bool",
+                    "metadataForProvider": "bytes",
                 },
             },
-            "attributes": {
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _OTA_SOFTWARE_UPDATE_REQUESTOR_CLUSTER_INFO = {
-            "clusterName": "OtaSoftwareUpdateRequestor",
-            "clusterId": 0x0000002A,
-            "commands": {
+        "clusterName": "OtaSoftwareUpdateRequestor",
+        "clusterId": 0x0000002A,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "AnnounceOtaProvider",
-                    "args": {
-                        "providerLocation": "int",
-                        "vendorId": "int",
-                        "announcementReason": "int",
-                        "metadataForNode": "bytes",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "AnnounceOtaProvider",
+                "args": {
+                    "providerLocation": "int",
+                    "vendorId": "int",
+                    "announcementReason": "int",
+                    "metadataForNode": "bytes",
                 },
             },
-            "attributes": {
-                0x00000001: {
-                    "attributeName": "DefaultOtaProvider",
-                    "attributeId": 0x00000001,
-                    "type": "bytes",
-                    "writable": True,
-                },
-                0x00000002: {
-                    "attributeName": "UpdatePossible",
-                    "attributeId": 0x00000002,
-                    "type": "bool",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000001: {
+                "attributeName": "DefaultOtaProvider",
+                "attributeId": 0x00000001,
+                "type": "bytes",
+                "writable": True,
             },
+            0x00000002: {
+                "attributeName": "UpdatePossible",
+                "attributeId": 0x00000002,
+                "type": "bool",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _OCCUPANCY_SENSING_CLUSTER_INFO = {
-            "clusterName": "OccupancySensing",
-            "clusterId": 0x00000406,
-            "commands": {
+        "clusterName": "OccupancySensing",
+        "clusterId": 0x00000406,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Occupancy",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Occupancy",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "OccupancySensorType",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "OccupancySensorTypeBitmap",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "OccupancySensorType",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "OccupancySensorTypeBitmap",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _ON_OFF_CLUSTER_INFO = {
-            "clusterName": "OnOff",
-            "clusterId": 0x00000006,
-            "commands": {
+        "clusterName": "OnOff",
+        "clusterId": 0x00000006,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "Off",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "Off",
+                "args": {
                 },
+            },
             0x00000040: {
-                    "commandId": 0x00000040,
-                    "commandName": "OffWithEffect",
-                    "args": {
-                        "effectId": "int",
-                        "effectVariant": "int",
-                    },
+                "commandId": 0x00000040,
+                "commandName": "OffWithEffect",
+                "args": {
+                    "effectId": "int",
+                    "effectVariant": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "On",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "On",
+                "args": {
                 },
+            },
             0x00000041: {
-                    "commandId": 0x00000041,
-                    "commandName": "OnWithRecallGlobalScene",
-                    "args": {
-                    },
+                "commandId": 0x00000041,
+                "commandName": "OnWithRecallGlobalScene",
+                "args": {
                 },
+            },
             0x00000042: {
-                    "commandId": 0x00000042,
-                    "commandName": "OnWithTimedOff",
-                    "args": {
-                        "onOffControl": "int",
-                        "onTime": "int",
-                        "offWaitTime": "int",
-                    },
+                "commandId": 0x00000042,
+                "commandName": "OnWithTimedOff",
+                "args": {
+                    "onOffControl": "int",
+                    "onTime": "int",
+                    "offWaitTime": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "Toggle",
-                    "args": {
-                    },
+                "commandId": 0x00000002,
+                "commandName": "Toggle",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "OnOff",
-                    "attributeId": 0x00000000,
-                    "type": "bool",
-                    "reportable": True,
-                },
-                0x00004000: {
-                    "attributeName": "GlobalSceneControl",
-                    "attributeId": 0x00004000,
-                    "type": "bool",
-                },
-                0x00004001: {
-                    "attributeName": "OnTime",
-                    "attributeId": 0x00004001,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00004002: {
-                    "attributeName": "OffWaitTime",
-                    "attributeId": 0x00004002,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00004003: {
-                    "attributeName": "StartUpOnOff",
-                    "attributeId": 0x00004003,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000FFFC: {
-                    "attributeName": "FeatureMap",
-                    "attributeId": 0x0000FFFC,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "OnOff",
+                "attributeId": 0x00000000,
+                "type": "bool",
+                "reportable": True,
             },
+            0x00004000: {
+                "attributeName": "GlobalSceneControl",
+                "attributeId": 0x00004000,
+                "type": "bool",
+            },
+            0x00004001: {
+                "attributeName": "OnTime",
+                "attributeId": 0x00004001,
+                "type": "int",
+                "writable": True,
+            },
+            0x00004002: {
+                "attributeName": "OffWaitTime",
+                "attributeId": 0x00004002,
+                "type": "int",
+                "writable": True,
+            },
+            0x00004003: {
+                "attributeName": "StartUpOnOff",
+                "attributeId": 0x00004003,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000FFFC: {
+                "attributeName": "FeatureMap",
+                "attributeId": 0x0000FFFC,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _ON_OFF_SWITCH_CONFIGURATION_CLUSTER_INFO = {
-            "clusterName": "OnOffSwitchConfiguration",
-            "clusterId": 0x00000007,
-            "commands": {
+        "clusterName": "OnOffSwitchConfiguration",
+        "clusterId": 0x00000007,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "SwitchType",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "SwitchType",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000010: {
-                    "attributeName": "SwitchActions",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000010: {
+                "attributeName": "SwitchActions",
+                "attributeId": 0x00000010,
+                "type": "int",
+                "writable": True,
             },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _OPERATIONAL_CREDENTIALS_CLUSTER_INFO = {
-            "clusterName": "OperationalCredentials",
-            "clusterId": 0x0000003E,
-            "commands": {
+        "clusterName": "OperationalCredentials",
+        "clusterId": 0x0000003E,
+        "commands": {
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "AddNOC",
-                    "args": {
-                        "NOCValue": "bytes",
-                        "ICACValue": "bytes",
-                        "IPKValue": "bytes",
-                        "caseAdminNode": "int",
-                        "adminVendorId": "int",
-                    },
+                "commandId": 0x00000006,
+                "commandName": "AddNOC",
+                "args": {
+                    "NOCValue": "bytes",
+                    "ICACValue": "bytes",
+                    "IPKValue": "bytes",
+                    "caseAdminNode": "int",
+                    "adminVendorId": "int",
                 },
+            },
             0x0000000B: {
-                    "commandId": 0x0000000B,
-                    "commandName": "AddTrustedRootCertificate",
-                    "args": {
-                        "rootCertificate": "bytes",
-                    },
+                "commandId": 0x0000000B,
+                "commandName": "AddTrustedRootCertificate",
+                "args": {
+                    "rootCertificate": "bytes",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "AttestationRequest",
-                    "args": {
-                        "attestationNonce": "bytes",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "AttestationRequest",
+                "args": {
+                    "attestationNonce": "bytes",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "CertificateChainRequest",
-                    "args": {
-                        "certificateType": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "CertificateChainRequest",
+                "args": {
+                    "certificateType": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "OpCSRRequest",
-                    "args": {
-                        "CSRNonce": "bytes",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "OpCSRRequest",
+                "args": {
+                    "CSRNonce": "bytes",
                 },
+            },
             0x0000000A: {
-                    "commandId": 0x0000000A,
-                    "commandName": "RemoveFabric",
-                    "args": {
-                        "fabricIndex": "int",
-                    },
+                "commandId": 0x0000000A,
+                "commandName": "RemoveFabric",
+                "args": {
+                    "fabricIndex": "int",
                 },
+            },
             0x0000000C: {
-                    "commandId": 0x0000000C,
-                    "commandName": "RemoveTrustedRootCertificate",
-                    "args": {
-                        "trustedRootIdentifier": "bytes",
-                    },
+                "commandId": 0x0000000C,
+                "commandName": "RemoveTrustedRootCertificate",
+                "args": {
+                    "trustedRootIdentifier": "bytes",
                 },
+            },
             0x00000009: {
-                    "commandId": 0x00000009,
-                    "commandName": "UpdateFabricLabel",
-                    "args": {
-                        "label": "str",
-                    },
+                "commandId": 0x00000009,
+                "commandName": "UpdateFabricLabel",
+                "args": {
+                    "label": "str",
                 },
+            },
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "UpdateNOC",
-                    "args": {
-                        "NOCValue": "bytes",
-                        "ICACValue": "bytes",
-                    },
+                "commandId": 0x00000007,
+                "commandName": "UpdateNOC",
+                "args": {
+                    "NOCValue": "bytes",
+                    "ICACValue": "bytes",
                 },
             },
-            "attributes": {
-                0x00000001: {
-                    "attributeName": "FabricsList",
-                    "attributeId": 0x00000001,
-                    "type": "",
-                },
-                0x00000002: {
-                    "attributeName": "SupportedFabrics",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "CommissionedFabrics",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "TrustedRootCertificates",
-                    "attributeId": 0x00000004,
-                    "type": "bytes",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000001: {
+                "attributeName": "FabricsList",
+                "attributeId": 0x00000001,
+                "type": "",
             },
+            0x00000002: {
+                "attributeName": "SupportedFabrics",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "CommissionedFabrics",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "TrustedRootCertificates",
+                "attributeId": 0x00000004,
+                "type": "bytes",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _POWER_SOURCE_CLUSTER_INFO = {
-            "clusterName": "PowerSource",
-            "clusterId": 0x0000002F,
-            "commands": {
+        "clusterName": "PowerSource",
+        "clusterId": 0x0000002F,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Status",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Status",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "Order",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "Description",
-                    "attributeId": 0x00000002,
-                    "type": "str",
-                },
-                0x0000000B: {
-                    "attributeName": "BatteryVoltage",
-                    "attributeId": 0x0000000B,
-                    "type": "int",
-                },
-                0x0000000C: {
-                    "attributeName": "BatteryPercentRemaining",
-                    "attributeId": 0x0000000C,
-                    "type": "int",
-                },
-                0x0000000D: {
-                    "attributeName": "BatteryTimeRemaining",
-                    "attributeId": 0x0000000D,
-                    "type": "int",
-                },
-                0x0000000E: {
-                    "attributeName": "BatteryChargeLevel",
-                    "attributeId": 0x0000000E,
-                    "type": "int",
-                },
-                0x00000012: {
-                    "attributeName": "ActiveBatteryFaults",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                },
-                0x0000001A: {
-                    "attributeName": "BatteryChargeState",
-                    "attributeId": 0x0000001A,
-                    "type": "int",
-                },
-                0x0000FFFC: {
-                    "attributeName": "FeatureMap",
-                    "attributeId": 0x0000FFFC,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "Order",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "Description",
+                "attributeId": 0x00000002,
+                "type": "str",
+            },
+            0x0000000B: {
+                "attributeName": "BatteryVoltage",
+                "attributeId": 0x0000000B,
+                "type": "int",
+            },
+            0x0000000C: {
+                "attributeName": "BatteryPercentRemaining",
+                "attributeId": 0x0000000C,
+                "type": "int",
+            },
+            0x0000000D: {
+                "attributeName": "BatteryTimeRemaining",
+                "attributeId": 0x0000000D,
+                "type": "int",
+            },
+            0x0000000E: {
+                "attributeName": "BatteryChargeLevel",
+                "attributeId": 0x0000000E,
+                "type": "int",
+            },
+            0x00000012: {
+                "attributeName": "ActiveBatteryFaults",
+                "attributeId": 0x00000012,
+                "type": "int",
+            },
+            0x0000001A: {
+                "attributeName": "BatteryChargeState",
+                "attributeId": 0x0000001A,
+                "type": "int",
+            },
+            0x0000FFFC: {
+                "attributeName": "FeatureMap",
+                "attributeId": 0x0000FFFC,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _PRESSURE_MEASUREMENT_CLUSTER_INFO = {
-            "clusterName": "PressureMeasurement",
-            "clusterId": 0x00000403,
-            "commands": {
+        "clusterName": "PressureMeasurement",
+        "clusterId": 0x00000403,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MeasuredValue",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MeasuredValue",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "MinMeasuredValue",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MaxMeasuredValue",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "MinMeasuredValue",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "MaxMeasuredValue",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _PUMP_CONFIGURATION_AND_CONTROL_CLUSTER_INFO = {
-            "clusterName": "PumpConfigurationAndControl",
-            "clusterId": 0x00000200,
-            "commands": {
+        "clusterName": "PumpConfigurationAndControl",
+        "clusterId": 0x00000200,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MaxPressure",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MaxPressure",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "MaxSpeed",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MaxFlow",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "MinConstPressure",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "MaxConstPressure",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "MinCompPressure",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "MaxCompPressure",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "MinConstSpeed",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x00000008: {
-                    "attributeName": "MaxConstSpeed",
-                    "attributeId": 0x00000008,
-                    "type": "int",
-                },
-                0x00000009: {
-                    "attributeName": "MinConstFlow",
-                    "attributeId": 0x00000009,
-                    "type": "int",
-                },
-                0x0000000A: {
-                    "attributeName": "MaxConstFlow",
-                    "attributeId": 0x0000000A,
-                    "type": "int",
-                },
-                0x0000000B: {
-                    "attributeName": "MinConstTemp",
-                    "attributeId": 0x0000000B,
-                    "type": "int",
-                },
-                0x0000000C: {
-                    "attributeName": "MaxConstTemp",
-                    "attributeId": 0x0000000C,
-                    "type": "int",
-                },
-                0x00000010: {
-                    "attributeName": "PumpStatus",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000011: {
-                    "attributeName": "EffectiveOperationMode",
-                    "attributeId": 0x00000011,
-                    "type": "int",
-                },
-                0x00000012: {
-                    "attributeName": "EffectiveControlMode",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                },
-                0x00000013: {
-                    "attributeName": "Capacity",
-                    "attributeId": 0x00000013,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000014: {
-                    "attributeName": "Speed",
-                    "attributeId": 0x00000014,
-                    "type": "int",
-                },
-                0x00000017: {
-                    "attributeName": "LifetimeEnergyConsumed",
-                    "attributeId": 0x00000017,
-                    "type": "int",
-                },
-                0x00000020: {
-                    "attributeName": "OperationMode",
-                    "attributeId": 0x00000020,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000021: {
-                    "attributeName": "ControlMode",
-                    "attributeId": 0x00000021,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000022: {
-                    "attributeName": "AlarmMask",
-                    "attributeId": 0x00000022,
-                    "type": "int",
-                },
-                0x0000FFFC: {
-                    "attributeName": "FeatureMap",
-                    "attributeId": 0x0000FFFC,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "MaxSpeed",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "MaxFlow",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "MinConstPressure",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "MaxConstPressure",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "MinCompPressure",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "MaxCompPressure",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "MinConstSpeed",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x00000008: {
+                "attributeName": "MaxConstSpeed",
+                "attributeId": 0x00000008,
+                "type": "int",
+            },
+            0x00000009: {
+                "attributeName": "MinConstFlow",
+                "attributeId": 0x00000009,
+                "type": "int",
+            },
+            0x0000000A: {
+                "attributeName": "MaxConstFlow",
+                "attributeId": 0x0000000A,
+                "type": "int",
+            },
+            0x0000000B: {
+                "attributeName": "MinConstTemp",
+                "attributeId": 0x0000000B,
+                "type": "int",
+            },
+            0x0000000C: {
+                "attributeName": "MaxConstTemp",
+                "attributeId": 0x0000000C,
+                "type": "int",
+            },
+            0x00000010: {
+                "attributeName": "PumpStatus",
+                "attributeId": 0x00000010,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000011: {
+                "attributeName": "EffectiveOperationMode",
+                "attributeId": 0x00000011,
+                "type": "int",
+            },
+            0x00000012: {
+                "attributeName": "EffectiveControlMode",
+                "attributeId": 0x00000012,
+                "type": "int",
+            },
+            0x00000013: {
+                "attributeName": "Capacity",
+                "attributeId": 0x00000013,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000014: {
+                "attributeName": "Speed",
+                "attributeId": 0x00000014,
+                "type": "int",
+            },
+            0x00000017: {
+                "attributeName": "LifetimeEnergyConsumed",
+                "attributeId": 0x00000017,
+                "type": "int",
+            },
+            0x00000020: {
+                "attributeName": "OperationMode",
+                "attributeId": 0x00000020,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000021: {
+                "attributeName": "ControlMode",
+                "attributeId": 0x00000021,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000022: {
+                "attributeName": "AlarmMask",
+                "attributeId": 0x00000022,
+                "type": "int",
+            },
+            0x0000FFFC: {
+                "attributeName": "FeatureMap",
+                "attributeId": 0x0000FFFC,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_INFO = {
-            "clusterName": "RelativeHumidityMeasurement",
-            "clusterId": 0x00000405,
-            "commands": {
+        "clusterName": "RelativeHumidityMeasurement",
+        "clusterId": 0x00000405,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MeasuredValue",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MeasuredValue",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "MinMeasuredValue",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MaxMeasuredValue",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "MinMeasuredValue",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "MaxMeasuredValue",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _SCENES_CLUSTER_INFO = {
-            "clusterName": "Scenes",
-            "clusterId": 0x00000005,
-            "commands": {
+        "clusterName": "Scenes",
+        "clusterId": 0x00000005,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "AddScene",
-                    "args": {
-                        "groupId": "int",
-                        "sceneId": "int",
-                        "transitionTime": "int",
-                        "sceneName": "str",
-                        "clusterId": "int",
-                        "length": "int",
-                        "value": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "AddScene",
+                "args": {
+                    "groupId": "int",
+                    "sceneId": "int",
+                    "transitionTime": "int",
+                    "sceneName": "str",
+                    "clusterId": "int",
+                    "length": "int",
+                    "value": "int",
                 },
+            },
             0x00000006: {
-                    "commandId": 0x00000006,
-                    "commandName": "GetSceneMembership",
-                    "args": {
-                        "groupId": "int",
-                    },
+                "commandId": 0x00000006,
+                "commandName": "GetSceneMembership",
+                "args": {
+                    "groupId": "int",
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "RecallScene",
-                    "args": {
-                        "groupId": "int",
-                        "sceneId": "int",
-                        "transitionTime": "int",
-                    },
+                "commandId": 0x00000005,
+                "commandName": "RecallScene",
+                "args": {
+                    "groupId": "int",
+                    "sceneId": "int",
+                    "transitionTime": "int",
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "RemoveAllScenes",
-                    "args": {
-                        "groupId": "int",
-                    },
+                "commandId": 0x00000003,
+                "commandName": "RemoveAllScenes",
+                "args": {
+                    "groupId": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "RemoveScene",
-                    "args": {
-                        "groupId": "int",
-                        "sceneId": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "RemoveScene",
+                "args": {
+                    "groupId": "int",
+                    "sceneId": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "StoreScene",
-                    "args": {
-                        "groupId": "int",
-                        "sceneId": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "StoreScene",
+                "args": {
+                    "groupId": "int",
+                    "sceneId": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "ViewScene",
-                    "args": {
-                        "groupId": "int",
-                        "sceneId": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "ViewScene",
+                "args": {
+                    "groupId": "int",
+                    "sceneId": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "SceneCount",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "CurrentScene",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "CurrentGroup",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "SceneValid",
-                    "attributeId": 0x00000003,
-                    "type": "bool",
-                },
-                0x00000004: {
-                    "attributeName": "NameSupport",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "SceneCount",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000001: {
+                "attributeName": "CurrentScene",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "CurrentGroup",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "SceneValid",
+                "attributeId": 0x00000003,
+                "type": "bool",
+            },
+            0x00000004: {
+                "attributeName": "NameSupport",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _SOFTWARE_DIAGNOSTICS_CLUSTER_INFO = {
-            "clusterName": "SoftwareDiagnostics",
-            "clusterId": 0x00000034,
-            "commands": {
+        "clusterName": "SoftwareDiagnostics",
+        "clusterId": 0x00000034,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ResetWatermarks",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ResetWatermarks",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000001: {
-                    "attributeName": "CurrentHeapFree",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "CurrentHeapUsed",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "CurrentHeapHighWatermark",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000001: {
+                "attributeName": "CurrentHeapFree",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "CurrentHeapUsed",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "CurrentHeapHighWatermark",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _SWITCH_CLUSTER_INFO = {
-            "clusterName": "Switch",
-            "clusterId": 0x0000003B,
-            "commands": {
+        "clusterName": "Switch",
+        "clusterId": 0x0000003B,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "NumberOfPositions",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "NumberOfPositions",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "CurrentPosition",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "CurrentPosition",
+                "attributeId": 0x00000001,
+                "type": "int",
+                "reportable": True,
             },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _TV_CHANNEL_CLUSTER_INFO = {
-            "clusterName": "TvChannel",
-            "clusterId": 0x00000504,
-            "commands": {
+        "clusterName": "TvChannel",
+        "clusterId": 0x00000504,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ChangeChannel",
-                    "args": {
-                        "match": "str",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ChangeChannel",
+                "args": {
+                    "match": "str",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "ChangeChannelByNumber",
-                    "args": {
-                        "majorNumber": "int",
-                        "minorNumber": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "ChangeChannelByNumber",
+                "args": {
+                    "majorNumber": "int",
+                    "minorNumber": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "SkipChannel",
-                    "args": {
-                        "count": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "SkipChannel",
+                "args": {
+                    "count": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "TvChannelList",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x00000001: {
-                    "attributeName": "TvChannelLineup",
-                    "attributeId": 0x00000001,
-                    "type": "bytes",
-                },
-                0x00000002: {
-                    "attributeName": "CurrentTvChannel",
-                    "attributeId": 0x00000002,
-                    "type": "bytes",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "TvChannelList",
+                "attributeId": 0x00000000,
+                "type": "",
             },
+            0x00000001: {
+                "attributeName": "TvChannelLineup",
+                "attributeId": 0x00000001,
+                "type": "bytes",
+            },
+            0x00000002: {
+                "attributeName": "CurrentTvChannel",
+                "attributeId": 0x00000002,
+                "type": "bytes",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _TARGET_NAVIGATOR_CLUSTER_INFO = {
-            "clusterName": "TargetNavigator",
-            "clusterId": 0x00000505,
-            "commands": {
+        "clusterName": "TargetNavigator",
+        "clusterId": 0x00000505,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "NavigateTarget",
-                    "args": {
-                        "target": "int",
-                        "data": "str",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "NavigateTarget",
+                "args": {
+                    "target": "int",
+                    "data": "str",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "TargetNavigatorList",
-                    "attributeId": 0x00000000,
-                    "type": "",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "TargetNavigatorList",
+                "attributeId": 0x00000000,
+                "type": "",
             },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _TEMPERATURE_MEASUREMENT_CLUSTER_INFO = {
-            "clusterName": "TemperatureMeasurement",
-            "clusterId": 0x00000402,
-            "commands": {
+        "clusterName": "TemperatureMeasurement",
+        "clusterId": 0x00000402,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "MeasuredValue",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "MeasuredValue",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000001: {
-                    "attributeName": "MinMeasuredValue",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "MaxMeasuredValue",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "MinMeasuredValue",
+                "attributeId": 0x00000001,
+                "type": "int",
             },
+            0x00000002: {
+                "attributeName": "MaxMeasuredValue",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _TEST_CLUSTER_CLUSTER_INFO = {
-            "clusterName": "TestCluster",
-            "clusterId": 0x0000050F,
-            "commands": {
+        "clusterName": "TestCluster",
+        "clusterId": 0x0000050F,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "Test",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "Test",
+                "args": {
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "TestAddArguments",
-                    "args": {
-                        "arg1": "int",
-                        "arg2": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "TestAddArguments",
+                "args": {
+                    "arg1": "int",
+                    "arg2": "int",
                 },
+            },
             0x0000000E: {
-                    "commandId": 0x0000000E,
-                    "commandName": "TestEnumsRequest",
-                    "args": {
-                        "arg1": "int",
-                        "arg2": "int",
-                    },
+                "commandId": 0x0000000E,
+                "commandName": "TestEnumsRequest",
+                "args": {
+                    "arg1": "int",
+                    "arg2": "int",
                 },
+            },
             0x0000000A: {
-                    "commandId": 0x0000000A,
-                    "commandName": "TestListInt8UArgumentRequest",
-                    "args": {
-                        "arg1": "int",
-                    },
+                "commandId": 0x0000000A,
+                "commandName": "TestListInt8UArgumentRequest",
+                "args": {
+                    "arg1": "int",
                 },
+            },
             0x0000000D: {
-                    "commandId": 0x0000000D,
-                    "commandName": "TestListInt8UReverseRequest",
-                    "args": {
-                        "arg1": "int",
-                    },
+                "commandId": 0x0000000D,
+                "commandName": "TestListInt8UReverseRequest",
+                "args": {
+                    "arg1": "int",
                 },
+            },
             0x00000009: {
-                    "commandId": 0x00000009,
-                    "commandName": "TestListStructArgumentRequest",
-                    "args": {
-                        "a": "int",
-                        "b": "bool",
-                        "c": "int",
-                        "d": "bytes",
-                        "e": "str",
-                        "f": "int",
-                    },
+                "commandId": 0x00000009,
+                "commandName": "TestListStructArgumentRequest",
+                "args": {
+                    "a": "int",
+                    "b": "bool",
+                    "c": "int",
+                    "d": "bytes",
+                    "e": "str",
+                    "f": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "TestNotHandled",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "TestNotHandled",
+                "args": {
                 },
+            },
             0x0000000F: {
-                    "commandId": 0x0000000F,
-                    "commandName": "TestNullableOptionalRequest",
-                    "args": {
-                        "arg1": "int",
-                    },
+                "commandId": 0x0000000F,
+                "commandName": "TestNullableOptionalRequest",
+                "args": {
+                    "arg1": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "TestSpecific",
-                    "args": {
-                    },
+                "commandId": 0x00000002,
+                "commandName": "TestSpecific",
+                "args": {
                 },
+            },
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "TestStructArgumentRequest",
-                    "args": {
-                        "a": "int",
-                        "b": "bool",
-                        "c": "int",
-                        "d": "bytes",
-                        "e": "str",
-                        "f": "int",
-                    },
+                "commandId": 0x00000007,
+                "commandName": "TestStructArgumentRequest",
+                "args": {
+                    "a": "int",
+                    "b": "bool",
+                    "c": "int",
+                    "d": "bytes",
+                    "e": "str",
+                    "f": "int",
                 },
+            },
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "TestUnknownCommand",
-                    "args": {
-                    },
+                "commandId": 0x00000003,
+                "commandName": "TestUnknownCommand",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Boolean",
-                    "attributeId": 0x00000000,
-                    "type": "bool",
-                    "writable": True,
-                },
-                0x00000001: {
-                    "attributeName": "Bitmap8",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000002: {
-                    "attributeName": "Bitmap16",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000003: {
-                    "attributeName": "Bitmap32",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000004: {
-                    "attributeName": "Bitmap64",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000005: {
-                    "attributeName": "Int8u",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000006: {
-                    "attributeName": "Int16u",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000008: {
-                    "attributeName": "Int32u",
-                    "attributeId": 0x00000008,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000000C: {
-                    "attributeName": "Int64u",
-                    "attributeId": 0x0000000C,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000000D: {
-                    "attributeName": "Int8s",
-                    "attributeId": 0x0000000D,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000000E: {
-                    "attributeName": "Int16s",
-                    "attributeId": 0x0000000E,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000010: {
-                    "attributeName": "Int32s",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000014: {
-                    "attributeName": "Int64s",
-                    "attributeId": 0x00000014,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000015: {
-                    "attributeName": "Enum8",
-                    "attributeId": 0x00000015,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000016: {
-                    "attributeName": "Enum16",
-                    "attributeId": 0x00000016,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000019: {
-                    "attributeName": "OctetString",
-                    "attributeId": 0x00000019,
-                    "type": "bytes",
-                    "writable": True,
-                },
-                0x0000001A: {
-                    "attributeName": "ListInt8u",
-                    "attributeId": 0x0000001A,
-                    "type": "int",
-                },
-                0x0000001B: {
-                    "attributeName": "ListOctetString",
-                    "attributeId": 0x0000001B,
-                    "type": "bytes",
-                },
-                0x0000001C: {
-                    "attributeName": "ListStructOctetString",
-                    "attributeId": 0x0000001C,
-                    "type": "",
-                },
-                0x0000001D: {
-                    "attributeName": "LongOctetString",
-                    "attributeId": 0x0000001D,
-                    "type": "bytes",
-                    "writable": True,
-                },
-                0x0000001E: {
-                    "attributeName": "CharString",
-                    "attributeId": 0x0000001E,
-                    "type": "str",
-                    "writable": True,
-                },
-                0x0000001F: {
-                    "attributeName": "LongCharString",
-                    "attributeId": 0x0000001F,
-                    "type": "str",
-                    "writable": True,
-                },
-                0x00000020: {
-                    "attributeName": "EpochUs",
-                    "attributeId": 0x00000020,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000021: {
-                    "attributeName": "EpochS",
-                    "attributeId": 0x00000021,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000022: {
-                    "attributeName": "VendorId",
-                    "attributeId": 0x00000022,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x000000FF: {
-                    "attributeName": "Unsupported",
-                    "attributeId": 0x000000FF,
-                    "type": "bool",
-                    "writable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Boolean",
+                "attributeId": 0x00000000,
+                "type": "bool",
+                "writable": True,
             },
+            0x00000001: {
+                "attributeName": "Bitmap8",
+                "attributeId": 0x00000001,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000002: {
+                "attributeName": "Bitmap16",
+                "attributeId": 0x00000002,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000003: {
+                "attributeName": "Bitmap32",
+                "attributeId": 0x00000003,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000004: {
+                "attributeName": "Bitmap64",
+                "attributeId": 0x00000004,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000005: {
+                "attributeName": "Int8u",
+                "attributeId": 0x00000005,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000006: {
+                "attributeName": "Int16u",
+                "attributeId": 0x00000006,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000008: {
+                "attributeName": "Int32u",
+                "attributeId": 0x00000008,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000000C: {
+                "attributeName": "Int64u",
+                "attributeId": 0x0000000C,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000000D: {
+                "attributeName": "Int8s",
+                "attributeId": 0x0000000D,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000000E: {
+                "attributeName": "Int16s",
+                "attributeId": 0x0000000E,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000010: {
+                "attributeName": "Int32s",
+                "attributeId": 0x00000010,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000014: {
+                "attributeName": "Int64s",
+                "attributeId": 0x00000014,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000015: {
+                "attributeName": "Enum8",
+                "attributeId": 0x00000015,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000016: {
+                "attributeName": "Enum16",
+                "attributeId": 0x00000016,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000019: {
+                "attributeName": "OctetString",
+                "attributeId": 0x00000019,
+                "type": "bytes",
+                "writable": True,
+            },
+            0x0000001A: {
+                "attributeName": "ListInt8u",
+                "attributeId": 0x0000001A,
+                "type": "int",
+            },
+            0x0000001B: {
+                "attributeName": "ListOctetString",
+                "attributeId": 0x0000001B,
+                "type": "bytes",
+            },
+            0x0000001C: {
+                "attributeName": "ListStructOctetString",
+                "attributeId": 0x0000001C,
+                "type": "",
+            },
+            0x0000001D: {
+                "attributeName": "LongOctetString",
+                "attributeId": 0x0000001D,
+                "type": "bytes",
+                "writable": True,
+            },
+            0x0000001E: {
+                "attributeName": "CharString",
+                "attributeId": 0x0000001E,
+                "type": "str",
+                "writable": True,
+            },
+            0x0000001F: {
+                "attributeName": "LongCharString",
+                "attributeId": 0x0000001F,
+                "type": "str",
+                "writable": True,
+            },
+            0x00000020: {
+                "attributeName": "EpochUs",
+                "attributeId": 0x00000020,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000021: {
+                "attributeName": "EpochS",
+                "attributeId": 0x00000021,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000022: {
+                "attributeName": "VendorId",
+                "attributeId": 0x00000022,
+                "type": "int",
+                "writable": True,
+            },
+            0x000000FF: {
+                "attributeName": "Unsupported",
+                "attributeId": 0x000000FF,
+                "type": "bool",
+                "writable": True,
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _THERMOSTAT_CLUSTER_INFO = {
-            "clusterName": "Thermostat",
-            "clusterId": 0x00000201,
-            "commands": {
+        "clusterName": "Thermostat",
+        "clusterId": 0x00000201,
+        "commands": {
             0x00000003: {
-                    "commandId": 0x00000003,
-                    "commandName": "ClearWeeklySchedule",
-                    "args": {
-                    },
+                "commandId": 0x00000003,
+                "commandName": "ClearWeeklySchedule",
+                "args": {
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "GetRelayStatusLog",
-                    "args": {
-                    },
+                "commandId": 0x00000004,
+                "commandName": "GetRelayStatusLog",
+                "args": {
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "GetWeeklySchedule",
-                    "args": {
-                        "daysToReturn": "int",
-                        "modeToReturn": "int",
-                    },
+                "commandId": 0x00000002,
+                "commandName": "GetWeeklySchedule",
+                "args": {
+                    "daysToReturn": "int",
+                    "modeToReturn": "int",
                 },
+            },
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "SetWeeklySchedule",
-                    "args": {
-                        "numberOfTransitionsForSequence": "int",
-                        "dayOfWeekForSequence": "int",
-                        "modeForSequence": "int",
-                        "payload": "int",
-                    },
+                "commandId": 0x00000001,
+                "commandName": "SetWeeklySchedule",
+                "args": {
+                    "numberOfTransitionsForSequence": "int",
+                    "dayOfWeekForSequence": "int",
+                    "modeForSequence": "int",
+                    "payload": "int",
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "SetpointRaiseLower",
-                    "args": {
-                        "mode": "int",
-                        "amount": "int",
-                    },
+                "commandId": 0x00000000,
+                "commandName": "SetpointRaiseLower",
+                "args": {
+                    "mode": "int",
+                    "amount": "int",
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "LocalTemperature",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000003: {
-                    "attributeName": "AbsMinHeatSetpointLimit",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "AbsMaxHeatSetpointLimit",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "AbsMinCoolSetpointLimit",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "AbsMaxCoolSetpointLimit",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000011: {
-                    "attributeName": "OccupiedCoolingSetpoint",
-                    "attributeId": 0x00000011,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000012: {
-                    "attributeName": "OccupiedHeatingSetpoint",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000015: {
-                    "attributeName": "MinHeatSetpointLimit",
-                    "attributeId": 0x00000015,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000016: {
-                    "attributeName": "MaxHeatSetpointLimit",
-                    "attributeId": 0x00000016,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000017: {
-                    "attributeName": "MinCoolSetpointLimit",
-                    "attributeId": 0x00000017,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000018: {
-                    "attributeName": "MaxCoolSetpointLimit",
-                    "attributeId": 0x00000018,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000019: {
-                    "attributeName": "MinSetpointDeadBand",
-                    "attributeId": 0x00000019,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000001B: {
-                    "attributeName": "ControlSequenceOfOperation",
-                    "attributeId": 0x0000001B,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000001C: {
-                    "attributeName": "SystemMode",
-                    "attributeId": 0x0000001C,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000020: {
-                    "attributeName": "StartOfWeek",
-                    "attributeId": 0x00000020,
-                    "type": "int",
-                },
-                0x00000021: {
-                    "attributeName": "NumberOfWeeklyTransitions",
-                    "attributeId": 0x00000021,
-                    "type": "int",
-                },
-                0x00000022: {
-                    "attributeName": "NumberOfDailyTransitions",
-                    "attributeId": 0x00000022,
-                    "type": "int",
-                },
-                0x0000FFFC: {
-                    "attributeName": "FeatureMap",
-                    "attributeId": 0x0000FFFC,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "LocalTemperature",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "reportable": True,
             },
+            0x00000003: {
+                "attributeName": "AbsMinHeatSetpointLimit",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "AbsMaxHeatSetpointLimit",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "AbsMinCoolSetpointLimit",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "AbsMaxCoolSetpointLimit",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000011: {
+                "attributeName": "OccupiedCoolingSetpoint",
+                "attributeId": 0x00000011,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000012: {
+                "attributeName": "OccupiedHeatingSetpoint",
+                "attributeId": 0x00000012,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000015: {
+                "attributeName": "MinHeatSetpointLimit",
+                "attributeId": 0x00000015,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000016: {
+                "attributeName": "MaxHeatSetpointLimit",
+                "attributeId": 0x00000016,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000017: {
+                "attributeName": "MinCoolSetpointLimit",
+                "attributeId": 0x00000017,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000018: {
+                "attributeName": "MaxCoolSetpointLimit",
+                "attributeId": 0x00000018,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000019: {
+                "attributeName": "MinSetpointDeadBand",
+                "attributeId": 0x00000019,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000001B: {
+                "attributeName": "ControlSequenceOfOperation",
+                "attributeId": 0x0000001B,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000001C: {
+                "attributeName": "SystemMode",
+                "attributeId": 0x0000001C,
+                "type": "int",
+                "writable": True,
+            },
+            0x00000020: {
+                "attributeName": "StartOfWeek",
+                "attributeId": 0x00000020,
+                "type": "int",
+            },
+            0x00000021: {
+                "attributeName": "NumberOfWeeklyTransitions",
+                "attributeId": 0x00000021,
+                "type": "int",
+            },
+            0x00000022: {
+                "attributeName": "NumberOfDailyTransitions",
+                "attributeId": 0x00000022,
+                "type": "int",
+            },
+            0x0000FFFC: {
+                "attributeName": "FeatureMap",
+                "attributeId": 0x0000FFFC,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _THERMOSTAT_USER_INTERFACE_CONFIGURATION_CLUSTER_INFO = {
-            "clusterName": "ThermostatUserInterfaceConfiguration",
-            "clusterId": 0x00000204,
-            "commands": {
+        "clusterName": "ThermostatUserInterfaceConfiguration",
+        "clusterId": 0x00000204,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "TemperatureDisplayMode",
+                "attributeId": 0x00000000,
+                "type": "int",
+                "writable": True,
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "TemperatureDisplayMode",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000001: {
-                    "attributeName": "KeypadLockout",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x00000002: {
-                    "attributeName": "ScheduleProgrammingVisibility",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x00000001: {
+                "attributeName": "KeypadLockout",
+                "attributeId": 0x00000001,
+                "type": "int",
+                "writable": True,
             },
+            0x00000002: {
+                "attributeName": "ScheduleProgrammingVisibility",
+                "attributeId": 0x00000002,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _THREAD_NETWORK_DIAGNOSTICS_CLUSTER_INFO = {
-            "clusterName": "ThreadNetworkDiagnostics",
-            "clusterId": 0x00000035,
-            "commands": {
+        "clusterName": "ThreadNetworkDiagnostics",
+        "clusterId": 0x00000035,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ResetCounts",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ResetCounts",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Channel",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000001: {
-                    "attributeName": "RoutingRole",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "NetworkName",
-                    "attributeId": 0x00000002,
-                    "type": "bytes",
-                },
-                0x00000003: {
-                    "attributeName": "PanId",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "ExtendedPanId",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "MeshLocalPrefix",
-                    "attributeId": 0x00000005,
-                    "type": "bytes",
-                },
-                0x00000006: {
-                    "attributeName": "OverrunCount",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "NeighborTableList",
-                    "attributeId": 0x00000007,
-                    "type": "",
-                },
-                0x00000008: {
-                    "attributeName": "RouteTableList",
-                    "attributeId": 0x00000008,
-                    "type": "",
-                },
-                0x00000009: {
-                    "attributeName": "PartitionId",
-                    "attributeId": 0x00000009,
-                    "type": "int",
-                },
-                0x0000000A: {
-                    "attributeName": "Weighting",
-                    "attributeId": 0x0000000A,
-                    "type": "int",
-                },
-                0x0000000B: {
-                    "attributeName": "DataVersion",
-                    "attributeId": 0x0000000B,
-                    "type": "int",
-                },
-                0x0000000C: {
-                    "attributeName": "StableDataVersion",
-                    "attributeId": 0x0000000C,
-                    "type": "int",
-                },
-                0x0000000D: {
-                    "attributeName": "LeaderRouterId",
-                    "attributeId": 0x0000000D,
-                    "type": "int",
-                },
-                0x0000000E: {
-                    "attributeName": "DetachedRoleCount",
-                    "attributeId": 0x0000000E,
-                    "type": "int",
-                },
-                0x0000000F: {
-                    "attributeName": "ChildRoleCount",
-                    "attributeId": 0x0000000F,
-                    "type": "int",
-                },
-                0x00000010: {
-                    "attributeName": "RouterRoleCount",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                },
-                0x00000011: {
-                    "attributeName": "LeaderRoleCount",
-                    "attributeId": 0x00000011,
-                    "type": "int",
-                },
-                0x00000012: {
-                    "attributeName": "AttachAttemptCount",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                },
-                0x00000013: {
-                    "attributeName": "PartitionIdChangeCount",
-                    "attributeId": 0x00000013,
-                    "type": "int",
-                },
-                0x00000014: {
-                    "attributeName": "BetterPartitionAttachAttemptCount",
-                    "attributeId": 0x00000014,
-                    "type": "int",
-                },
-                0x00000015: {
-                    "attributeName": "ParentChangeCount",
-                    "attributeId": 0x00000015,
-                    "type": "int",
-                },
-                0x00000016: {
-                    "attributeName": "TxTotalCount",
-                    "attributeId": 0x00000016,
-                    "type": "int",
-                },
-                0x00000017: {
-                    "attributeName": "TxUnicastCount",
-                    "attributeId": 0x00000017,
-                    "type": "int",
-                },
-                0x00000018: {
-                    "attributeName": "TxBroadcastCount",
-                    "attributeId": 0x00000018,
-                    "type": "int",
-                },
-                0x00000019: {
-                    "attributeName": "TxAckRequestedCount",
-                    "attributeId": 0x00000019,
-                    "type": "int",
-                },
-                0x0000001A: {
-                    "attributeName": "TxAckedCount",
-                    "attributeId": 0x0000001A,
-                    "type": "int",
-                },
-                0x0000001B: {
-                    "attributeName": "TxNoAckRequestedCount",
-                    "attributeId": 0x0000001B,
-                    "type": "int",
-                },
-                0x0000001C: {
-                    "attributeName": "TxDataCount",
-                    "attributeId": 0x0000001C,
-                    "type": "int",
-                },
-                0x0000001D: {
-                    "attributeName": "TxDataPollCount",
-                    "attributeId": 0x0000001D,
-                    "type": "int",
-                },
-                0x0000001E: {
-                    "attributeName": "TxBeaconCount",
-                    "attributeId": 0x0000001E,
-                    "type": "int",
-                },
-                0x0000001F: {
-                    "attributeName": "TxBeaconRequestCount",
-                    "attributeId": 0x0000001F,
-                    "type": "int",
-                },
-                0x00000020: {
-                    "attributeName": "TxOtherCount",
-                    "attributeId": 0x00000020,
-                    "type": "int",
-                },
-                0x00000021: {
-                    "attributeName": "TxRetryCount",
-                    "attributeId": 0x00000021,
-                    "type": "int",
-                },
-                0x00000022: {
-                    "attributeName": "TxDirectMaxRetryExpiryCount",
-                    "attributeId": 0x00000022,
-                    "type": "int",
-                },
-                0x00000023: {
-                    "attributeName": "TxIndirectMaxRetryExpiryCount",
-                    "attributeId": 0x00000023,
-                    "type": "int",
-                },
-                0x00000024: {
-                    "attributeName": "TxErrCcaCount",
-                    "attributeId": 0x00000024,
-                    "type": "int",
-                },
-                0x00000025: {
-                    "attributeName": "TxErrAbortCount",
-                    "attributeId": 0x00000025,
-                    "type": "int",
-                },
-                0x00000026: {
-                    "attributeName": "TxErrBusyChannelCount",
-                    "attributeId": 0x00000026,
-                    "type": "int",
-                },
-                0x00000027: {
-                    "attributeName": "RxTotalCount",
-                    "attributeId": 0x00000027,
-                    "type": "int",
-                },
-                0x00000028: {
-                    "attributeName": "RxUnicastCount",
-                    "attributeId": 0x00000028,
-                    "type": "int",
-                },
-                0x00000029: {
-                    "attributeName": "RxBroadcastCount",
-                    "attributeId": 0x00000029,
-                    "type": "int",
-                },
-                0x0000002A: {
-                    "attributeName": "RxDataCount",
-                    "attributeId": 0x0000002A,
-                    "type": "int",
-                },
-                0x0000002B: {
-                    "attributeName": "RxDataPollCount",
-                    "attributeId": 0x0000002B,
-                    "type": "int",
-                },
-                0x0000002C: {
-                    "attributeName": "RxBeaconCount",
-                    "attributeId": 0x0000002C,
-                    "type": "int",
-                },
-                0x0000002D: {
-                    "attributeName": "RxBeaconRequestCount",
-                    "attributeId": 0x0000002D,
-                    "type": "int",
-                },
-                0x0000002E: {
-                    "attributeName": "RxOtherCount",
-                    "attributeId": 0x0000002E,
-                    "type": "int",
-                },
-                0x0000002F: {
-                    "attributeName": "RxAddressFilteredCount",
-                    "attributeId": 0x0000002F,
-                    "type": "int",
-                },
-                0x00000030: {
-                    "attributeName": "RxDestAddrFilteredCount",
-                    "attributeId": 0x00000030,
-                    "type": "int",
-                },
-                0x00000031: {
-                    "attributeName": "RxDuplicatedCount",
-                    "attributeId": 0x00000031,
-                    "type": "int",
-                },
-                0x00000032: {
-                    "attributeName": "RxErrNoFrameCount",
-                    "attributeId": 0x00000032,
-                    "type": "int",
-                },
-                0x00000033: {
-                    "attributeName": "RxErrUnknownNeighborCount",
-                    "attributeId": 0x00000033,
-                    "type": "int",
-                },
-                0x00000034: {
-                    "attributeName": "RxErrInvalidSrcAddrCount",
-                    "attributeId": 0x00000034,
-                    "type": "int",
-                },
-                0x00000035: {
-                    "attributeName": "RxErrSecCount",
-                    "attributeId": 0x00000035,
-                    "type": "int",
-                },
-                0x00000036: {
-                    "attributeName": "RxErrFcsCount",
-                    "attributeId": 0x00000036,
-                    "type": "int",
-                },
-                0x00000037: {
-                    "attributeName": "RxErrOtherCount",
-                    "attributeId": 0x00000037,
-                    "type": "int",
-                },
-                0x00000038: {
-                    "attributeName": "ActiveTimestamp",
-                    "attributeId": 0x00000038,
-                    "type": "int",
-                },
-                0x00000039: {
-                    "attributeName": "PendingTimestamp",
-                    "attributeId": 0x00000039,
-                    "type": "int",
-                },
-                0x0000003A: {
-                    "attributeName": "Delay",
-                    "attributeId": 0x0000003A,
-                    "type": "int",
-                },
-                0x0000003B: {
-                    "attributeName": "SecurityPolicy",
-                    "attributeId": 0x0000003B,
-                    "type": "",
-                },
-                0x0000003C: {
-                    "attributeName": "ChannelMask",
-                    "attributeId": 0x0000003C,
-                    "type": "bytes",
-                },
-                0x0000003D: {
-                    "attributeName": "OperationalDatasetComponents",
-                    "attributeId": 0x0000003D,
-                    "type": "",
-                },
-                0x0000003E: {
-                    "attributeName": "ActiveNetworkFaultsList",
-                    "attributeId": 0x0000003E,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Channel",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000001: {
+                "attributeName": "RoutingRole",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "NetworkName",
+                "attributeId": 0x00000002,
+                "type": "bytes",
+            },
+            0x00000003: {
+                "attributeName": "PanId",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "ExtendedPanId",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "MeshLocalPrefix",
+                "attributeId": 0x00000005,
+                "type": "bytes",
+            },
+            0x00000006: {
+                "attributeName": "OverrunCount",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "NeighborTableList",
+                "attributeId": 0x00000007,
+                "type": "",
+            },
+            0x00000008: {
+                "attributeName": "RouteTableList",
+                "attributeId": 0x00000008,
+                "type": "",
+            },
+            0x00000009: {
+                "attributeName": "PartitionId",
+                "attributeId": 0x00000009,
+                "type": "int",
+            },
+            0x0000000A: {
+                "attributeName": "Weighting",
+                "attributeId": 0x0000000A,
+                "type": "int",
+            },
+            0x0000000B: {
+                "attributeName": "DataVersion",
+                "attributeId": 0x0000000B,
+                "type": "int",
+            },
+            0x0000000C: {
+                "attributeName": "StableDataVersion",
+                "attributeId": 0x0000000C,
+                "type": "int",
+            },
+            0x0000000D: {
+                "attributeName": "LeaderRouterId",
+                "attributeId": 0x0000000D,
+                "type": "int",
+            },
+            0x0000000E: {
+                "attributeName": "DetachedRoleCount",
+                "attributeId": 0x0000000E,
+                "type": "int",
+            },
+            0x0000000F: {
+                "attributeName": "ChildRoleCount",
+                "attributeId": 0x0000000F,
+                "type": "int",
+            },
+            0x00000010: {
+                "attributeName": "RouterRoleCount",
+                "attributeId": 0x00000010,
+                "type": "int",
+            },
+            0x00000011: {
+                "attributeName": "LeaderRoleCount",
+                "attributeId": 0x00000011,
+                "type": "int",
+            },
+            0x00000012: {
+                "attributeName": "AttachAttemptCount",
+                "attributeId": 0x00000012,
+                "type": "int",
+            },
+            0x00000013: {
+                "attributeName": "PartitionIdChangeCount",
+                "attributeId": 0x00000013,
+                "type": "int",
+            },
+            0x00000014: {
+                "attributeName": "BetterPartitionAttachAttemptCount",
+                "attributeId": 0x00000014,
+                "type": "int",
+            },
+            0x00000015: {
+                "attributeName": "ParentChangeCount",
+                "attributeId": 0x00000015,
+                "type": "int",
+            },
+            0x00000016: {
+                "attributeName": "TxTotalCount",
+                "attributeId": 0x00000016,
+                "type": "int",
+            },
+            0x00000017: {
+                "attributeName": "TxUnicastCount",
+                "attributeId": 0x00000017,
+                "type": "int",
+            },
+            0x00000018: {
+                "attributeName": "TxBroadcastCount",
+                "attributeId": 0x00000018,
+                "type": "int",
+            },
+            0x00000019: {
+                "attributeName": "TxAckRequestedCount",
+                "attributeId": 0x00000019,
+                "type": "int",
+            },
+            0x0000001A: {
+                "attributeName": "TxAckedCount",
+                "attributeId": 0x0000001A,
+                "type": "int",
+            },
+            0x0000001B: {
+                "attributeName": "TxNoAckRequestedCount",
+                "attributeId": 0x0000001B,
+                "type": "int",
+            },
+            0x0000001C: {
+                "attributeName": "TxDataCount",
+                "attributeId": 0x0000001C,
+                "type": "int",
+            },
+            0x0000001D: {
+                "attributeName": "TxDataPollCount",
+                "attributeId": 0x0000001D,
+                "type": "int",
+            },
+            0x0000001E: {
+                "attributeName": "TxBeaconCount",
+                "attributeId": 0x0000001E,
+                "type": "int",
+            },
+            0x0000001F: {
+                "attributeName": "TxBeaconRequestCount",
+                "attributeId": 0x0000001F,
+                "type": "int",
+            },
+            0x00000020: {
+                "attributeName": "TxOtherCount",
+                "attributeId": 0x00000020,
+                "type": "int",
+            },
+            0x00000021: {
+                "attributeName": "TxRetryCount",
+                "attributeId": 0x00000021,
+                "type": "int",
+            },
+            0x00000022: {
+                "attributeName": "TxDirectMaxRetryExpiryCount",
+                "attributeId": 0x00000022,
+                "type": "int",
+            },
+            0x00000023: {
+                "attributeName": "TxIndirectMaxRetryExpiryCount",
+                "attributeId": 0x00000023,
+                "type": "int",
+            },
+            0x00000024: {
+                "attributeName": "TxErrCcaCount",
+                "attributeId": 0x00000024,
+                "type": "int",
+            },
+            0x00000025: {
+                "attributeName": "TxErrAbortCount",
+                "attributeId": 0x00000025,
+                "type": "int",
+            },
+            0x00000026: {
+                "attributeName": "TxErrBusyChannelCount",
+                "attributeId": 0x00000026,
+                "type": "int",
+            },
+            0x00000027: {
+                "attributeName": "RxTotalCount",
+                "attributeId": 0x00000027,
+                "type": "int",
+            },
+            0x00000028: {
+                "attributeName": "RxUnicastCount",
+                "attributeId": 0x00000028,
+                "type": "int",
+            },
+            0x00000029: {
+                "attributeName": "RxBroadcastCount",
+                "attributeId": 0x00000029,
+                "type": "int",
+            },
+            0x0000002A: {
+                "attributeName": "RxDataCount",
+                "attributeId": 0x0000002A,
+                "type": "int",
+            },
+            0x0000002B: {
+                "attributeName": "RxDataPollCount",
+                "attributeId": 0x0000002B,
+                "type": "int",
+            },
+            0x0000002C: {
+                "attributeName": "RxBeaconCount",
+                "attributeId": 0x0000002C,
+                "type": "int",
+            },
+            0x0000002D: {
+                "attributeName": "RxBeaconRequestCount",
+                "attributeId": 0x0000002D,
+                "type": "int",
+            },
+            0x0000002E: {
+                "attributeName": "RxOtherCount",
+                "attributeId": 0x0000002E,
+                "type": "int",
+            },
+            0x0000002F: {
+                "attributeName": "RxAddressFilteredCount",
+                "attributeId": 0x0000002F,
+                "type": "int",
+            },
+            0x00000030: {
+                "attributeName": "RxDestAddrFilteredCount",
+                "attributeId": 0x00000030,
+                "type": "int",
+            },
+            0x00000031: {
+                "attributeName": "RxDuplicatedCount",
+                "attributeId": 0x00000031,
+                "type": "int",
+            },
+            0x00000032: {
+                "attributeName": "RxErrNoFrameCount",
+                "attributeId": 0x00000032,
+                "type": "int",
+            },
+            0x00000033: {
+                "attributeName": "RxErrUnknownNeighborCount",
+                "attributeId": 0x00000033,
+                "type": "int",
+            },
+            0x00000034: {
+                "attributeName": "RxErrInvalidSrcAddrCount",
+                "attributeId": 0x00000034,
+                "type": "int",
+            },
+            0x00000035: {
+                "attributeName": "RxErrSecCount",
+                "attributeId": 0x00000035,
+                "type": "int",
+            },
+            0x00000036: {
+                "attributeName": "RxErrFcsCount",
+                "attributeId": 0x00000036,
+                "type": "int",
+            },
+            0x00000037: {
+                "attributeName": "RxErrOtherCount",
+                "attributeId": 0x00000037,
+                "type": "int",
+            },
+            0x00000038: {
+                "attributeName": "ActiveTimestamp",
+                "attributeId": 0x00000038,
+                "type": "int",
+            },
+            0x00000039: {
+                "attributeName": "PendingTimestamp",
+                "attributeId": 0x00000039,
+                "type": "int",
+            },
+            0x0000003A: {
+                "attributeName": "Delay",
+                "attributeId": 0x0000003A,
+                "type": "int",
+            },
+            0x0000003B: {
+                "attributeName": "SecurityPolicy",
+                "attributeId": 0x0000003B,
+                "type": "",
+            },
+            0x0000003C: {
+                "attributeName": "ChannelMask",
+                "attributeId": 0x0000003C,
+                "type": "bytes",
+            },
+            0x0000003D: {
+                "attributeName": "OperationalDatasetComponents",
+                "attributeId": 0x0000003D,
+                "type": "",
+            },
+            0x0000003E: {
+                "attributeName": "ActiveNetworkFaultsList",
+                "attributeId": 0x0000003E,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _WAKE_ON_LAN_CLUSTER_INFO = {
-            "clusterName": "WakeOnLan",
-            "clusterId": 0x00000503,
-            "commands": {
+        "clusterName": "WakeOnLan",
+        "clusterId": 0x00000503,
+        "commands": {
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "WakeOnLanMacAddress",
+                "attributeId": 0x00000000,
+                "type": "str",
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "WakeOnLanMacAddress",
-                    "attributeId": 0x00000000,
-                    "type": "str",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
             },
+        },
     }
     _WI_FI_NETWORK_DIAGNOSTICS_CLUSTER_INFO = {
-            "clusterName": "WiFiNetworkDiagnostics",
-            "clusterId": 0x00000036,
-            "commands": {
+        "clusterName": "WiFiNetworkDiagnostics",
+        "clusterId": 0x00000036,
+        "commands": {
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "ResetCounts",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "ResetCounts",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Bssid",
-                    "attributeId": 0x00000000,
-                    "type": "bytes",
-                },
-                0x00000001: {
-                    "attributeName": "SecurityType",
-                    "attributeId": 0x00000001,
-                    "type": "int",
-                },
-                0x00000002: {
-                    "attributeName": "WiFiVersion",
-                    "attributeId": 0x00000002,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "ChannelNumber",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "Rssi",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000005: {
-                    "attributeName": "BeaconLostCount",
-                    "attributeId": 0x00000005,
-                    "type": "int",
-                },
-                0x00000006: {
-                    "attributeName": "BeaconRxCount",
-                    "attributeId": 0x00000006,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "PacketMulticastRxCount",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x00000008: {
-                    "attributeName": "PacketMulticastTxCount",
-                    "attributeId": 0x00000008,
-                    "type": "int",
-                },
-                0x00000009: {
-                    "attributeName": "PacketUnicastRxCount",
-                    "attributeId": 0x00000009,
-                    "type": "int",
-                },
-                0x0000000A: {
-                    "attributeName": "PacketUnicastTxCount",
-                    "attributeId": 0x0000000A,
-                    "type": "int",
-                },
-                0x0000000B: {
-                    "attributeName": "CurrentMaxRate",
-                    "attributeId": 0x0000000B,
-                    "type": "int",
-                },
-                0x0000000C: {
-                    "attributeName": "OverrunCount",
-                    "attributeId": 0x0000000C,
-                    "type": "int",
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Bssid",
+                "attributeId": 0x00000000,
+                "type": "bytes",
             },
+            0x00000001: {
+                "attributeName": "SecurityType",
+                "attributeId": 0x00000001,
+                "type": "int",
+            },
+            0x00000002: {
+                "attributeName": "WiFiVersion",
+                "attributeId": 0x00000002,
+                "type": "int",
+            },
+            0x00000003: {
+                "attributeName": "ChannelNumber",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "Rssi",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000005: {
+                "attributeName": "BeaconLostCount",
+                "attributeId": 0x00000005,
+                "type": "int",
+            },
+            0x00000006: {
+                "attributeName": "BeaconRxCount",
+                "attributeId": 0x00000006,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "PacketMulticastRxCount",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x00000008: {
+                "attributeName": "PacketMulticastTxCount",
+                "attributeId": 0x00000008,
+                "type": "int",
+            },
+            0x00000009: {
+                "attributeName": "PacketUnicastRxCount",
+                "attributeId": 0x00000009,
+                "type": "int",
+            },
+            0x0000000A: {
+                "attributeName": "PacketUnicastTxCount",
+                "attributeId": 0x0000000A,
+                "type": "int",
+            },
+            0x0000000B: {
+                "attributeName": "CurrentMaxRate",
+                "attributeId": 0x0000000B,
+                "type": "int",
+            },
+            0x0000000C: {
+                "attributeName": "OverrunCount",
+                "attributeId": 0x0000000C,
+                "type": "int",
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
     _WINDOW_COVERING_CLUSTER_INFO = {
-            "clusterName": "WindowCovering",
-            "clusterId": 0x00000102,
-            "commands": {
+        "clusterName": "WindowCovering",
+        "clusterId": 0x00000102,
+        "commands": {
             0x00000001: {
-                    "commandId": 0x00000001,
-                    "commandName": "DownOrClose",
-                    "args": {
-                    },
+                "commandId": 0x00000001,
+                "commandName": "DownOrClose",
+                "args": {
                 },
+            },
             0x00000005: {
-                    "commandId": 0x00000005,
-                    "commandName": "GoToLiftPercentage",
-                    "args": {
-                        "liftPercentageValue": "int",
-                        "liftPercent100thsValue": "int",
-                    },
+                "commandId": 0x00000005,
+                "commandName": "GoToLiftPercentage",
+                "args": {
+                    "liftPercentageValue": "int",
+                    "liftPercent100thsValue": "int",
                 },
+            },
             0x00000004: {
-                    "commandId": 0x00000004,
-                    "commandName": "GoToLiftValue",
-                    "args": {
-                        "liftValue": "int",
-                    },
+                "commandId": 0x00000004,
+                "commandName": "GoToLiftValue",
+                "args": {
+                    "liftValue": "int",
                 },
+            },
             0x00000008: {
-                    "commandId": 0x00000008,
-                    "commandName": "GoToTiltPercentage",
-                    "args": {
-                        "tiltPercentageValue": "int",
-                        "tiltPercent100thsValue": "int",
-                    },
+                "commandId": 0x00000008,
+                "commandName": "GoToTiltPercentage",
+                "args": {
+                    "tiltPercentageValue": "int",
+                    "tiltPercent100thsValue": "int",
                 },
+            },
             0x00000007: {
-                    "commandId": 0x00000007,
-                    "commandName": "GoToTiltValue",
-                    "args": {
-                        "tiltValue": "int",
-                    },
+                "commandId": 0x00000007,
+                "commandName": "GoToTiltValue",
+                "args": {
+                    "tiltValue": "int",
                 },
+            },
             0x00000002: {
-                    "commandId": 0x00000002,
-                    "commandName": "StopMotion",
-                    "args": {
-                    },
+                "commandId": 0x00000002,
+                "commandName": "StopMotion",
+                "args": {
                 },
+            },
             0x00000000: {
-                    "commandId": 0x00000000,
-                    "commandName": "UpOrOpen",
-                    "args": {
-                    },
+                "commandId": 0x00000000,
+                "commandName": "UpOrOpen",
+                "args": {
                 },
             },
-            "attributes": {
-                0x00000000: {
-                    "attributeName": "Type",
-                    "attributeId": 0x00000000,
-                    "type": "int",
-                },
-                0x00000003: {
-                    "attributeName": "CurrentPositionLift",
-                    "attributeId": 0x00000003,
-                    "type": "int",
-                },
-                0x00000004: {
-                    "attributeName": "CurrentPositionTilt",
-                    "attributeId": 0x00000004,
-                    "type": "int",
-                },
-                0x00000007: {
-                    "attributeName": "ConfigStatus",
-                    "attributeId": 0x00000007,
-                    "type": "int",
-                },
-                0x00000008: {
-                    "attributeName": "CurrentPositionLiftPercentage",
-                    "attributeId": 0x00000008,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000009: {
-                    "attributeName": "CurrentPositionTiltPercentage",
-                    "attributeId": 0x00000009,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000000A: {
-                    "attributeName": "OperationalStatus",
-                    "attributeId": 0x0000000A,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000000B: {
-                    "attributeName": "TargetPositionLiftPercent100ths",
-                    "attributeId": 0x0000000B,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000000C: {
-                    "attributeName": "TargetPositionTiltPercent100ths",
-                    "attributeId": 0x0000000C,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000000D: {
-                    "attributeName": "EndProductType",
-                    "attributeId": 0x0000000D,
-                    "type": "int",
-                },
-                0x0000000E: {
-                    "attributeName": "CurrentPositionLiftPercent100ths",
-                    "attributeId": 0x0000000E,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000000F: {
-                    "attributeName": "CurrentPositionTiltPercent100ths",
-                    "attributeId": 0x0000000F,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x00000010: {
-                    "attributeName": "InstalledOpenLimitLift",
-                    "attributeId": 0x00000010,
-                    "type": "int",
-                },
-                0x00000011: {
-                    "attributeName": "InstalledClosedLimitLift",
-                    "attributeId": 0x00000011,
-                    "type": "int",
-                },
-                0x00000012: {
-                    "attributeName": "InstalledOpenLimitTilt",
-                    "attributeId": 0x00000012,
-                    "type": "int",
-                },
-                0x00000013: {
-                    "attributeName": "InstalledClosedLimitTilt",
-                    "attributeId": 0x00000013,
-                    "type": "int",
-                },
-                0x00000017: {
-                    "attributeName": "Mode",
-                    "attributeId": 0x00000017,
-                    "type": "int",
-                    "writable": True,
-                },
-                0x0000001A: {
-                    "attributeName": "SafetyStatus",
-                    "attributeId": 0x0000001A,
-                    "type": "int",
-                    "reportable": True,
-                },
-                0x0000FFFD: {
-                    "attributeName": "ClusterRevision",
-                    "attributeId": 0x0000FFFD,
-                    "type": "int",
-                },
+        },
+        "attributes": {
+            0x00000000: {
+                "attributeName": "Type",
+                "attributeId": 0x00000000,
+                "type": "int",
             },
+            0x00000003: {
+                "attributeName": "CurrentPositionLift",
+                "attributeId": 0x00000003,
+                "type": "int",
+            },
+            0x00000004: {
+                "attributeName": "CurrentPositionTilt",
+                "attributeId": 0x00000004,
+                "type": "int",
+            },
+            0x00000007: {
+                "attributeName": "ConfigStatus",
+                "attributeId": 0x00000007,
+                "type": "int",
+            },
+            0x00000008: {
+                "attributeName": "CurrentPositionLiftPercentage",
+                "attributeId": 0x00000008,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000009: {
+                "attributeName": "CurrentPositionTiltPercentage",
+                "attributeId": 0x00000009,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000000A: {
+                "attributeName": "OperationalStatus",
+                "attributeId": 0x0000000A,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000000B: {
+                "attributeName": "TargetPositionLiftPercent100ths",
+                "attributeId": 0x0000000B,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000000C: {
+                "attributeName": "TargetPositionTiltPercent100ths",
+                "attributeId": 0x0000000C,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000000D: {
+                "attributeName": "EndProductType",
+                "attributeId": 0x0000000D,
+                "type": "int",
+            },
+            0x0000000E: {
+                "attributeName": "CurrentPositionLiftPercent100ths",
+                "attributeId": 0x0000000E,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000000F: {
+                "attributeName": "CurrentPositionTiltPercent100ths",
+                "attributeId": 0x0000000F,
+                "type": "int",
+                "reportable": True,
+            },
+            0x00000010: {
+                "attributeName": "InstalledOpenLimitLift",
+                "attributeId": 0x00000010,
+                "type": "int",
+            },
+            0x00000011: {
+                "attributeName": "InstalledClosedLimitLift",
+                "attributeId": 0x00000011,
+                "type": "int",
+            },
+            0x00000012: {
+                "attributeName": "InstalledOpenLimitTilt",
+                "attributeId": 0x00000012,
+                "type": "int",
+            },
+            0x00000013: {
+                "attributeName": "InstalledClosedLimitTilt",
+                "attributeId": 0x00000013,
+                "type": "int",
+            },
+            0x00000017: {
+                "attributeName": "Mode",
+                "attributeId": 0x00000017,
+                "type": "int",
+                "writable": True,
+            },
+            0x0000001A: {
+                "attributeName": "SafetyStatus",
+                "attributeId": 0x0000001A,
+                "type": "int",
+                "reportable": True,
+            },
+            0x0000FFFD: {
+                "attributeName": "ClusterRevision",
+                "attributeId": 0x0000FFFD,
+                "type": "int",
+            },
+        },
     }
 
     _CLUSTER_ID_DICT = {
-    0x0000050E: _ACCOUNT_LOGIN_CLUSTER_INFO,
-    0x0000003C: _ADMINISTRATOR_COMMISSIONING_CLUSTER_INFO,
-    0x0000050D: _APPLICATION_BASIC_CLUSTER_INFO,
-    0x0000050C: _APPLICATION_LAUNCHER_CLUSTER_INFO,
-    0x0000050B: _AUDIO_OUTPUT_CLUSTER_INFO,
-    0x00000103: _BARRIER_CONTROL_CLUSTER_INFO,
-    0x00000028: _BASIC_CLUSTER_INFO,
-    0x0000000F: _BINARY_INPUT_BASIC_CLUSTER_INFO,
-    0x0000F000: _BINDING_CLUSTER_INFO,
-    0x00000045: _BOOLEAN_STATE_CLUSTER_INFO,
-    0x00000039: _BRIDGED_DEVICE_BASIC_CLUSTER_INFO,
-    0x00000300: _COLOR_CONTROL_CLUSTER_INFO,
-    0x0000050A: _CONTENT_LAUNCHER_CLUSTER_INFO,
-    0x0000001D: _DESCRIPTOR_CLUSTER_INFO,
-    0x00000032: _DIAGNOSTIC_LOGS_CLUSTER_INFO,
-    0x00000101: _DOOR_LOCK_CLUSTER_INFO,
-    0x00000B04: _ELECTRICAL_MEASUREMENT_CLUSTER_INFO,
-    0x00000037: _ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_INFO,
-    0x00000040: _FIXED_LABEL_CLUSTER_INFO,
-    0x00000404: _FLOW_MEASUREMENT_CLUSTER_INFO,
-    0x00000030: _GENERAL_COMMISSIONING_CLUSTER_INFO,
-    0x00000033: _GENERAL_DIAGNOSTICS_CLUSTER_INFO,
-    0x0000F004: _GROUP_KEY_MANAGEMENT_CLUSTER_INFO,
-    0x00000004: _GROUPS_CLUSTER_INFO,
-    0x00000003: _IDENTIFY_CLUSTER_INFO,
-    0x00000400: _ILLUMINANCE_MEASUREMENT_CLUSTER_INFO,
-    0x00000509: _KEYPAD_INPUT_CLUSTER_INFO,
-    0x00000008: _LEVEL_CONTROL_CLUSTER_INFO,
-    0x00000508: _LOW_POWER_CLUSTER_INFO,
-    0x00000507: _MEDIA_INPUT_CLUSTER_INFO,
-    0x00000506: _MEDIA_PLAYBACK_CLUSTER_INFO,
-    0x00000031: _NETWORK_COMMISSIONING_CLUSTER_INFO,
-    0x00000029: _OTA_SOFTWARE_UPDATE_PROVIDER_CLUSTER_INFO,
-    0x0000002A: _OTA_SOFTWARE_UPDATE_REQUESTOR_CLUSTER_INFO,
-    0x00000406: _OCCUPANCY_SENSING_CLUSTER_INFO,
-    0x00000006: _ON_OFF_CLUSTER_INFO,
-    0x00000007: _ON_OFF_SWITCH_CONFIGURATION_CLUSTER_INFO,
-    0x0000003E: _OPERATIONAL_CREDENTIALS_CLUSTER_INFO,
-    0x0000002F: _POWER_SOURCE_CLUSTER_INFO,
-    0x00000403: _PRESSURE_MEASUREMENT_CLUSTER_INFO,
-    0x00000200: _PUMP_CONFIGURATION_AND_CONTROL_CLUSTER_INFO,
-    0x00000405: _RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_INFO,
-    0x00000005: _SCENES_CLUSTER_INFO,
-    0x00000034: _SOFTWARE_DIAGNOSTICS_CLUSTER_INFO,
-    0x0000003B: _SWITCH_CLUSTER_INFO,
-    0x00000504: _TV_CHANNEL_CLUSTER_INFO,
-    0x00000505: _TARGET_NAVIGATOR_CLUSTER_INFO,
-    0x00000402: _TEMPERATURE_MEASUREMENT_CLUSTER_INFO,
-    0x0000050F: _TEST_CLUSTER_CLUSTER_INFO,
-    0x00000201: _THERMOSTAT_CLUSTER_INFO,
-    0x00000204: _THERMOSTAT_USER_INTERFACE_CONFIGURATION_CLUSTER_INFO,
-    0x00000035: _THREAD_NETWORK_DIAGNOSTICS_CLUSTER_INFO,
-    0x00000503: _WAKE_ON_LAN_CLUSTER_INFO,
-    0x00000036: _WI_FI_NETWORK_DIAGNOSTICS_CLUSTER_INFO,
-    0x00000102: _WINDOW_COVERING_CLUSTER_INFO,
+        0x0000050E: _ACCOUNT_LOGIN_CLUSTER_INFO,
+        0x0000003C: _ADMINISTRATOR_COMMISSIONING_CLUSTER_INFO,
+        0x0000050D: _APPLICATION_BASIC_CLUSTER_INFO,
+        0x0000050C: _APPLICATION_LAUNCHER_CLUSTER_INFO,
+        0x0000050B: _AUDIO_OUTPUT_CLUSTER_INFO,
+        0x00000103: _BARRIER_CONTROL_CLUSTER_INFO,
+        0x00000028: _BASIC_CLUSTER_INFO,
+        0x0000000F: _BINARY_INPUT_BASIC_CLUSTER_INFO,
+        0x0000F000: _BINDING_CLUSTER_INFO,
+        0x00000045: _BOOLEAN_STATE_CLUSTER_INFO,
+        0x00000039: _BRIDGED_DEVICE_BASIC_CLUSTER_INFO,
+        0x00000300: _COLOR_CONTROL_CLUSTER_INFO,
+        0x0000050A: _CONTENT_LAUNCHER_CLUSTER_INFO,
+        0x0000001D: _DESCRIPTOR_CLUSTER_INFO,
+        0x00000032: _DIAGNOSTIC_LOGS_CLUSTER_INFO,
+        0x00000101: _DOOR_LOCK_CLUSTER_INFO,
+        0x00000B04: _ELECTRICAL_MEASUREMENT_CLUSTER_INFO,
+        0x00000037: _ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_INFO,
+        0x00000040: _FIXED_LABEL_CLUSTER_INFO,
+        0x00000404: _FLOW_MEASUREMENT_CLUSTER_INFO,
+        0x00000030: _GENERAL_COMMISSIONING_CLUSTER_INFO,
+        0x00000033: _GENERAL_DIAGNOSTICS_CLUSTER_INFO,
+        0x0000F004: _GROUP_KEY_MANAGEMENT_CLUSTER_INFO,
+        0x00000004: _GROUPS_CLUSTER_INFO,
+        0x00000003: _IDENTIFY_CLUSTER_INFO,
+        0x00000400: _ILLUMINANCE_MEASUREMENT_CLUSTER_INFO,
+        0x00000509: _KEYPAD_INPUT_CLUSTER_INFO,
+        0x00000008: _LEVEL_CONTROL_CLUSTER_INFO,
+        0x00000508: _LOW_POWER_CLUSTER_INFO,
+        0x00000507: _MEDIA_INPUT_CLUSTER_INFO,
+        0x00000506: _MEDIA_PLAYBACK_CLUSTER_INFO,
+        0x00000031: _NETWORK_COMMISSIONING_CLUSTER_INFO,
+        0x00000029: _OTA_SOFTWARE_UPDATE_PROVIDER_CLUSTER_INFO,
+        0x0000002A: _OTA_SOFTWARE_UPDATE_REQUESTOR_CLUSTER_INFO,
+        0x00000406: _OCCUPANCY_SENSING_CLUSTER_INFO,
+        0x00000006: _ON_OFF_CLUSTER_INFO,
+        0x00000007: _ON_OFF_SWITCH_CONFIGURATION_CLUSTER_INFO,
+        0x0000003E: _OPERATIONAL_CREDENTIALS_CLUSTER_INFO,
+        0x0000002F: _POWER_SOURCE_CLUSTER_INFO,
+        0x00000403: _PRESSURE_MEASUREMENT_CLUSTER_INFO,
+        0x00000200: _PUMP_CONFIGURATION_AND_CONTROL_CLUSTER_INFO,
+        0x00000405: _RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_INFO,
+        0x00000005: _SCENES_CLUSTER_INFO,
+        0x00000034: _SOFTWARE_DIAGNOSTICS_CLUSTER_INFO,
+        0x0000003B: _SWITCH_CLUSTER_INFO,
+        0x00000504: _TV_CHANNEL_CLUSTER_INFO,
+        0x00000505: _TARGET_NAVIGATOR_CLUSTER_INFO,
+        0x00000402: _TEMPERATURE_MEASUREMENT_CLUSTER_INFO,
+        0x0000050F: _TEST_CLUSTER_CLUSTER_INFO,
+        0x00000201: _THERMOSTAT_CLUSTER_INFO,
+        0x00000204: _THERMOSTAT_USER_INTERFACE_CONFIGURATION_CLUSTER_INFO,
+        0x00000035: _THREAD_NETWORK_DIAGNOSTICS_CLUSTER_INFO,
+        0x00000503: _WAKE_ON_LAN_CLUSTER_INFO,
+        0x00000036: _WI_FI_NETWORK_DIAGNOSTICS_CLUSTER_INFO,
+        0x00000102: _WINDOW_COVERING_CLUSTER_INFO,
     }
 
     _CLUSTER_NAME_DICT = {
@@ -4245,17 +4246,18 @@ class ChipClusters:
         return ChipClusters._CLUSTER_NAME_DICT
 
     def ListClusterCommands(self):
-        return { clusterName: {
+        return {clusterName: {
             command["commandName"]: command["args"] for command in clusterInfo["commands"].values()
-        } for clusterName, clusterInfo in ChipClusters._CLUSTER_NAME_DICT.items() }
+        } for clusterName, clusterInfo in ChipClusters._CLUSTER_NAME_DICT.items()}
 
     def ListClusterAttributes(self):
-        return { clusterName: {
+        return {clusterName: {
             attribute["attributeName"]: attribute for attribute in clusterInfo["attributes"].values()
-        } for clusterName, clusterInfo in ChipClusters._CLUSTER_NAME_DICT.items() }
+        } for clusterName, clusterInfo in ChipClusters._CLUSTER_NAME_DICT.items()}
 
     def SendCommand(self, device: ctypes.c_void_p, cluster: str, command: str, endpoint: int, groupid: int, args, imEnabled):
-        func = getattr(self, "Cluster{}_Command{}".format(cluster, command), None)
+        func = getattr(self, "Cluster{}_Command{}".format(
+            cluster, command), None)
         if not func:
             raise UnknownCommand(cluster, command)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
@@ -4264,7 +4266,8 @@ class ChipClusters:
             raise self._ChipStack.ErrorToException(res)
 
     def ReadAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, imEnabled):
-        func = getattr(self, "Cluster{}_ReadAttribute{}".format(cluster, attribute), None)
+        func = getattr(self, "Cluster{}_ReadAttribute{}".format(
+            cluster, attribute), None)
         if not func:
             raise UnknownAttribute(cluster, attribute)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
@@ -4273,14 +4276,16 @@ class ChipClusters:
             raise self._ChipStack.ErrorToException(res)
 
     def SubscribeAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, minInterval: int, maxInterval: int, imEnabled):
-        func = getattr(self, "Cluster{}_SubscribeAttribute{}".format(cluster, attribute), None)
+        func = getattr(self, "Cluster{}_SubscribeAttribute{}".format(
+            cluster, attribute), None)
         if not func:
             raise UnknownAttribute(cluster, attribute)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
         funcCaller(lambda: func(device, endpoint, minInterval, maxInterval))
 
     def WriteAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, value, imEnabled):
-        func = getattr(self, "Cluster{}_WriteAttribute{}".format(cluster, attribute), None)
+        func = getattr(self, "Cluster{}_WriteAttribute{}".format(
+            cluster, attribute), None)
         if not func:
             raise UnknownAttribute(cluster, attribute)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
@@ -4293,1771 +4298,2505 @@ class ChipClusters:
     def ClusterAccountLogin_CommandGetSetupPIN(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: str):
         tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN(
-                device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(tempAccountIdentifier)
+            device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(
+                tempAccountIdentifier)
         )
+
     def ClusterAccountLogin_CommandLogin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: str, setupPIN: str):
         tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
         setupPIN = setupPIN.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AccountLogin_Login(
-                device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(tempAccountIdentifier), setupPIN, len(setupPIN)
+            device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(
+                tempAccountIdentifier), setupPIN, len(setupPIN)
         )
+
     def ClusterAdministratorCommissioning_CommandOpenBasicCommissioningWindow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, commissioningTimeout: int):
         return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow(
-                device, ZCLendpoint, ZCLgroupid, commissioningTimeout
+            device, ZCLendpoint, ZCLgroupid, commissioningTimeout
         )
+
     def ClusterAdministratorCommissioning_CommandOpenCommissioningWindow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, commissioningTimeout: int, PAKEVerifier: bytes, discriminator: int, iterations: int, salt: bytes, passcodeID: int):
         return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow(
-                device, ZCLendpoint, ZCLgroupid, commissioningTimeout, PAKEVerifier, len(PAKEVerifier), discriminator, iterations, salt, len(salt), passcodeID
+            device, ZCLendpoint, ZCLgroupid, commissioningTimeout, PAKEVerifier, len(
+                PAKEVerifier), discriminator, iterations, salt, len(salt), passcodeID
         )
+
     def ClusterAdministratorCommissioning_CommandRevokeCommissioning(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterApplicationBasic_CommandChangeStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, status: int):
         return self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus(
-                device, ZCLendpoint, ZCLgroupid, status
+            device, ZCLendpoint, ZCLgroupid, status
         )
+
     def ClusterApplicationLauncher_CommandLaunchApp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, data: str, catalogVendorId: int, applicationId: str):
         data = data.encode("utf-8") + b'\x00'
         applicationId = applicationId.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(
-                device, ZCLendpoint, ZCLgroupid, data, len(data), catalogVendorId, applicationId, len(applicationId)
+            device, ZCLendpoint, ZCLgroupid, data, len(
+                data), catalogVendorId, applicationId, len(applicationId)
         )
+
     def ClusterAudioOutput_CommandRenameOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: str):
         name = name.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput(
-                device, ZCLendpoint, ZCLgroupid, index, name, len(name)
+            device, ZCLendpoint, ZCLgroupid, index, name, len(name)
         )
+
     def ClusterAudioOutput_CommandSelectOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int):
         return self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput(
-                device, ZCLendpoint, ZCLgroupid, index
+            device, ZCLendpoint, ZCLgroupid, index
         )
+
     def ClusterBarrierControl_CommandBarrierControlGoToPercent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, percentOpen: int):
         return self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent(
-                device, ZCLendpoint, ZCLgroupid, percentOpen
+            device, ZCLendpoint, ZCLgroupid, percentOpen
         )
+
     def ClusterBarrierControl_CommandBarrierControlStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterBasic_CommandMfgSpecificPing(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterBinding_CommandBind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
         return self._chipLib.chip_ime_AppendCommand_Binding_Bind(
-                device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
+            device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
         )
+
     def ClusterBinding_CommandUnbind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
         return self._chipLib.chip_ime_AppendCommand_Binding_Unbind(
-                device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
+            device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
         )
+
     def ClusterColorControl_CommandColorLoopSet(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, updateFlags: int, action: int, direction: int, time: int, startHue: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet(
-                device, ZCLendpoint, ZCLgroupid, updateFlags, action, direction, time, startHue, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, updateFlags, action, direction, time, startHue, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandEnhancedMoveHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandEnhancedMoveToHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, enhancedHue: int, direction: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue(
-                device, ZCLendpoint, ZCLgroupid, enhancedHue, direction, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, enhancedHue, direction, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandEnhancedMoveToHueAndSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, enhancedHue: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation(
-                device, ZCLendpoint, ZCLgroupid, enhancedHue, saturation, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, enhancedHue, saturation, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandEnhancedStepHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rateX: int, rateY: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor(
-                device, ZCLendpoint, ZCLgroupid, rateX, rateY, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, rateX, rateY, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveToColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, colorX: int, colorY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor(
-                device, ZCLendpoint, ZCLgroupid, colorX, colorY, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, colorX, colorY, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveToColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, colorTemperature: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature(
-                device, ZCLendpoint, ZCLgroupid, colorTemperature, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, colorTemperature, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveToHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, hue: int, direction: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue(
-                device, ZCLendpoint, ZCLgroupid, hue, direction, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, hue, direction, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveToHueAndSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, hue: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation(
-                device, ZCLendpoint, ZCLgroupid, hue, saturation, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, hue, saturation, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandMoveToSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation(
-                device, ZCLendpoint, ZCLgroupid, saturation, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, saturation, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandStepColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepX: int, stepY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor(
-                device, ZCLendpoint, ZCLgroupid, stepX, stepY, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, stepX, stepY, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandStepColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandStepHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandStepSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
         )
+
     def ClusterColorControl_CommandStopMoveStep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep(
-                device, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
+            device, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
         )
+
     def ClusterContentLauncher_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: bool, data: str):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent(
-                device, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
+            device, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
         )
+
     def ClusterContentLauncher_CommandLaunchURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, contentURL: str, displayString: str):
         contentURL = contentURL.encode("utf-8") + b'\x00'
         displayString = displayString.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL(
-                device, ZCLendpoint, ZCLgroupid, contentURL, len(contentURL), displayString, len(displayString)
+            device, ZCLendpoint, ZCLgroupid, contentURL, len(
+                contentURL), displayString, len(displayString)
         )
+
     def ClusterDiagnosticLogs_CommandRetrieveLogsRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, intent: int, requestedProtocol: int, transferFileDesignator: bytes):
         return self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest(
-                device, ZCLendpoint, ZCLgroupid, intent, requestedProtocol, transferFileDesignator, len(transferFileDesignator)
+            device, ZCLendpoint, ZCLgroupid, intent, requestedProtocol, transferFileDesignator, len(
+                transferFileDesignator)
         )
+
     def ClusterDoorLock_CommandClearAllPins(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterDoorLock_CommandClearAllRfids(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterDoorLock_CommandClearHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId
+            device, ZCLendpoint, ZCLgroupid, scheduleId
         )
+
     def ClusterDoorLock_CommandClearPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin(
-                device, ZCLendpoint, ZCLgroupid, userId
+            device, ZCLendpoint, ZCLgroupid, userId
         )
+
     def ClusterDoorLock_CommandClearRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid(
-                device, ZCLendpoint, ZCLgroupid, userId
+            device, ZCLendpoint, ZCLgroupid, userId
         )
+
     def ClusterDoorLock_CommandClearWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
+
     def ClusterDoorLock_CommandClearYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
+
     def ClusterDoorLock_CommandGetHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId
+            device, ZCLendpoint, ZCLgroupid, scheduleId
         )
+
     def ClusterDoorLock_CommandGetLogRecord(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, logIndex: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord(
-                device, ZCLendpoint, ZCLgroupid, logIndex
+            device, ZCLendpoint, ZCLgroupid, logIndex
         )
+
     def ClusterDoorLock_CommandGetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin(
-                device, ZCLendpoint, ZCLgroupid, userId
+            device, ZCLendpoint, ZCLgroupid, userId
         )
+
     def ClusterDoorLock_CommandGetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid(
-                device, ZCLendpoint, ZCLgroupid, userId
+            device, ZCLendpoint, ZCLgroupid, userId
         )
+
     def ClusterDoorLock_CommandGetUserType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType(
-                device, ZCLendpoint, ZCLgroupid, userId
+            device, ZCLendpoint, ZCLgroupid, userId
         )
+
     def ClusterDoorLock_CommandGetWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
+
     def ClusterDoorLock_CommandGetYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
+
     def ClusterDoorLock_CommandLockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor(
-                device, ZCLendpoint, ZCLgroupid, pin, len(pin)
+            device, ZCLendpoint, ZCLgroupid, pin, len(pin)
         )
+
     def ClusterDoorLock_CommandSetHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, localStartTime: int, localEndTime: int, operatingModeDuringHoliday: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday
+            device, ZCLendpoint, ZCLgroupid, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday
         )
+
     def ClusterDoorLock_CommandSetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, pin: bytes):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin(
-                device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, pin, len(pin)
+            device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, pin, len(
+                pin)
         )
+
     def ClusterDoorLock_CommandSetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, id: bytes):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid(
-                device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, id, len(id)
+            device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, id, len(
+                id)
         )
+
     def ClusterDoorLock_CommandSetUserType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userType: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType(
-                device, ZCLendpoint, ZCLgroupid, userId, userType
+            device, ZCLendpoint, ZCLgroupid, userId, userType
         )
+
     def ClusterDoorLock_CommandSetWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, daysMask: int, startHour: int, startMinute: int, endHour: int, endMinute: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute
+            device, ZCLendpoint, ZCLgroupid, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute
         )
+
     def ClusterDoorLock_CommandSetYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, localStartTime: int, localEndTime: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId, localStartTime, localEndTime
+            device, ZCLendpoint, ZCLgroupid, scheduleId, userId, localStartTime, localEndTime
         )
+
     def ClusterDoorLock_CommandUnlockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor(
-                device, ZCLendpoint, ZCLgroupid, pin, len(pin)
+            device, ZCLendpoint, ZCLgroupid, pin, len(pin)
         )
+
     def ClusterDoorLock_CommandUnlockWithTimeout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, timeoutInSeconds: int, pin: bytes):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(
-                device, ZCLendpoint, ZCLgroupid, timeoutInSeconds, pin, len(pin)
+            device, ZCLendpoint, ZCLgroupid, timeoutInSeconds, pin, len(pin)
         )
+
     def ClusterEthernetNetworkDiagnostics_CommandResetCounts(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterGeneralCommissioning_CommandArmFailSafe(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, expiryLengthSeconds: int, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe(
-                device, ZCLendpoint, ZCLgroupid, expiryLengthSeconds, breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, expiryLengthSeconds, breadcrumb, timeoutMs
         )
+
     def ClusterGeneralCommissioning_CommandCommissioningComplete(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterGeneralCommissioning_CommandSetRegulatoryConfig(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, location: int, countryCode: str, breadcrumb: int, timeoutMs: int):
         countryCode = countryCode.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(
-                device, ZCLendpoint, ZCLgroupid, location, countryCode, len(countryCode), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, location, countryCode, len(
+                countryCode), breadcrumb, timeoutMs
         )
+
     def ClusterGroups_CommandAddGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: str):
         groupName = groupName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Groups_AddGroup(
-                device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
+            device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
         )
+
     def ClusterGroups_CommandAddGroupIfIdentifying(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: str):
         groupName = groupName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(
-                device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
+            device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
         )
+
     def ClusterGroups_CommandGetGroupMembership(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupCount: int, groupList: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership(
-                device, ZCLendpoint, ZCLgroupid, groupCount, groupList
+            device, ZCLendpoint, ZCLgroupid, groupCount, groupList
         )
+
     def ClusterGroups_CommandRemoveAllGroups(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterGroups_CommandRemoveGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup(
-                device, ZCLendpoint, ZCLgroupid, groupId
+            device, ZCLendpoint, ZCLgroupid, groupId
         )
+
     def ClusterGroups_CommandViewGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup(
-                device, ZCLendpoint, ZCLgroupid, groupId
+            device, ZCLendpoint, ZCLgroupid, groupId
         )
+
     def ClusterIdentify_CommandIdentify(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, identifyTime: int):
         return self._chipLib.chip_ime_AppendCommand_Identify_Identify(
-                device, ZCLendpoint, ZCLgroupid, identifyTime
+            device, ZCLendpoint, ZCLgroupid, identifyTime
         )
+
     def ClusterIdentify_CommandIdentifyQuery(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterIdentify_CommandTriggerEffect(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, effectIdentifier: int, effectVariant: int):
         return self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect(
-                device, ZCLendpoint, ZCLgroupid, effectIdentifier, effectVariant
+            device, ZCLendpoint, ZCLgroupid, effectIdentifier, effectVariant
         )
+
     def ClusterKeypadInput_CommandSendKey(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, keyCode: int):
         return self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey(
-                device, ZCLendpoint, ZCLgroupid, keyCode
+            device, ZCLendpoint, ZCLgroupid, keyCode
         )
+
     def ClusterLevelControl_CommandMove(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_Move(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionMask, optionOverride
+            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionMask, optionOverride
         )
+
     def ClusterLevelControl_CommandMoveToLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel(
-                device, ZCLendpoint, ZCLgroupid, level, transitionTime, optionMask, optionOverride
+            device, ZCLendpoint, ZCLgroupid, level, transitionTime, optionMask, optionOverride
         )
+
     def ClusterLevelControl_CommandMoveToLevelWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff(
-                device, ZCLendpoint, ZCLgroupid, level, transitionTime
+            device, ZCLendpoint, ZCLgroupid, level, transitionTime
         )
+
     def ClusterLevelControl_CommandMoveWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate
+            device, ZCLendpoint, ZCLgroupid, moveMode, rate
         )
+
     def ClusterLevelControl_CommandStep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_Step(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionMask, optionOverride
+            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionMask, optionOverride
         )
+
     def ClusterLevelControl_CommandStepWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime
+            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime
         )
+
     def ClusterLevelControl_CommandStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_Stop(
-                device, ZCLendpoint, ZCLgroupid, optionMask, optionOverride
+            device, ZCLendpoint, ZCLgroupid, optionMask, optionOverride
         )
+
     def ClusterLevelControl_CommandStopWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterLowPower_CommandSleep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_LowPower_Sleep(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaInput_CommandHideInputStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaInput_CommandRenameInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: str):
         name = name.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput(
-                device, ZCLendpoint, ZCLgroupid, index, name, len(name)
+            device, ZCLendpoint, ZCLgroupid, index, name, len(name)
         )
+
     def ClusterMediaInput_CommandSelectInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int):
         return self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput(
-                device, ZCLendpoint, ZCLgroupid, index
+            device, ZCLendpoint, ZCLgroupid, index
         )
+
     def ClusterMediaInput_CommandShowInputStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaFastForward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaNext(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaPause(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaPlay(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaPrevious(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaRewind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaSeek(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, position: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek(
-                device, ZCLendpoint, ZCLgroupid, position
+            device, ZCLendpoint, ZCLgroupid, position
         )
+
     def ClusterMediaPlayback_CommandMediaSkipBackward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward(
-                device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
+            device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
         )
+
     def ClusterMediaPlayback_CommandMediaSkipForward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward(
-                device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
+            device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
         )
+
     def ClusterMediaPlayback_CommandMediaStartOver(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterMediaPlayback_CommandMediaStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterNetworkCommissioning_CommandAddThreadNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork(
-                device, ZCLendpoint, ZCLgroupid, operationalDataset, len(operationalDataset), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, operationalDataset, len(
+                operationalDataset), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandAddWiFiNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork(
-                device, ZCLendpoint, ZCLgroupid, ssid, len(ssid), credentials, len(credentials), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, ssid, len(
+                ssid), credentials, len(credentials), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandDisableNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork(
-                device, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, networkID, len(
+                networkID), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandEnableNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork(
-                device, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, networkID, len(
+                networkID), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandGetLastNetworkCommissioningResult(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult(
-                device, ZCLendpoint, ZCLgroupid, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandRemoveNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork(
-                device, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, networkID, len(
+                networkID), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandScanNetworks(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks(
-                device, ZCLendpoint, ZCLgroupid, ssid, len(ssid), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, ssid, len(
+                ssid), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandUpdateThreadNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork(
-                device, ZCLendpoint, ZCLgroupid, operationalDataset, len(operationalDataset), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, operationalDataset, len(
+                operationalDataset), breadcrumb, timeoutMs
         )
+
     def ClusterNetworkCommissioning_CommandUpdateWiFiNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork(
-                device, ZCLendpoint, ZCLgroupid, ssid, len(ssid), credentials, len(credentials), breadcrumb, timeoutMs
+            device, ZCLendpoint, ZCLgroupid, ssid, len(
+                ssid), credentials, len(credentials), breadcrumb, timeoutMs
         )
+
     def ClusterOtaSoftwareUpdateProvider_CommandApplyUpdateRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, updateToken: bytes, newVersion: int):
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest(
-                device, ZCLendpoint, ZCLgroupid, updateToken, len(updateToken), newVersion
+            device, ZCLendpoint, ZCLgroupid, updateToken, len(
+                updateToken), newVersion
         )
+
     def ClusterOtaSoftwareUpdateProvider_CommandNotifyUpdateApplied(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, updateToken: bytes, softwareVersion: int):
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied(
-                device, ZCLendpoint, ZCLgroupid, updateToken, len(updateToken), softwareVersion
+            device, ZCLendpoint, ZCLgroupid, updateToken, len(
+                updateToken), softwareVersion
         )
+
     def ClusterOtaSoftwareUpdateProvider_CommandQueryImage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int, productId: int, hardwareVersion: int, softwareVersion: int, protocolsSupported: int, location: str, requestorCanConsent: bool, metadataForProvider: bytes):
         location = location.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage(
-                device, ZCLendpoint, ZCLgroupid, vendorId, productId, hardwareVersion, softwareVersion, protocolsSupported, location, len(location), requestorCanConsent, metadataForProvider, len(metadataForProvider)
+            device, ZCLendpoint, ZCLgroupid, vendorId, productId, hardwareVersion, softwareVersion, protocolsSupported, location, len(
+                location), requestorCanConsent, metadataForProvider, len(metadataForProvider)
         )
+
     def ClusterOtaSoftwareUpdateRequestor_CommandAnnounceOtaProvider(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, providerLocation: int, vendorId: int, announcementReason: int, metadataForNode: bytes):
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider(
-                device, ZCLendpoint, ZCLgroupid, providerLocation, vendorId, announcementReason, metadataForNode, len(metadataForNode)
+            device, ZCLendpoint, ZCLgroupid, providerLocation, vendorId, announcementReason, metadataForNode, len(
+                metadataForNode)
         )
+
     def ClusterOnOff_CommandOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_Off(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterOnOff_CommandOffWithEffect(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, effectId: int, effectVariant: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect(
-                device, ZCLendpoint, ZCLgroupid, effectId, effectVariant
+            device, ZCLendpoint, ZCLgroupid, effectId, effectVariant
         )
+
     def ClusterOnOff_CommandOn(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_On(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterOnOff_CommandOnWithRecallGlobalScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterOnOff_CommandOnWithTimedOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, onOffControl: int, onTime: int, offWaitTime: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff(
-                device, ZCLendpoint, ZCLgroupid, onOffControl, onTime, offWaitTime
+            device, ZCLendpoint, ZCLgroupid, onOffControl, onTime, offWaitTime
         )
+
     def ClusterOnOff_CommandToggle(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_Toggle(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterOperationalCredentials_CommandAddNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, NOCValue: bytes, ICACValue: bytes, IPKValue: bytes, caseAdminNode: int, adminVendorId: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC(
-                device, ZCLendpoint, ZCLgroupid, NOCValue, len(NOCValue), ICACValue, len(ICACValue), IPKValue, len(IPKValue), caseAdminNode, adminVendorId
+            device, ZCLendpoint, ZCLgroupid, NOCValue, len(NOCValue), ICACValue, len(
+                ICACValue), IPKValue, len(IPKValue), caseAdminNode, adminVendorId
         )
+
     def ClusterOperationalCredentials_CommandAddTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rootCertificate: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate(
-                device, ZCLendpoint, ZCLgroupid, rootCertificate, len(rootCertificate)
+            device, ZCLendpoint, ZCLgroupid, rootCertificate, len(
+                rootCertificate)
         )
+
     def ClusterOperationalCredentials_CommandAttestationRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, attestationNonce: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest(
-                device, ZCLendpoint, ZCLgroupid, attestationNonce, len(attestationNonce)
+            device, ZCLendpoint, ZCLgroupid, attestationNonce, len(
+                attestationNonce)
         )
+
     def ClusterOperationalCredentials_CommandCertificateChainRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, certificateType: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest(
-                device, ZCLendpoint, ZCLgroupid, certificateType
+            device, ZCLendpoint, ZCLgroupid, certificateType
         )
+
     def ClusterOperationalCredentials_CommandOpCSRRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, CSRNonce: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(
-                device, ZCLendpoint, ZCLgroupid, CSRNonce, len(CSRNonce)
+            device, ZCLendpoint, ZCLgroupid, CSRNonce, len(CSRNonce)
         )
+
     def ClusterOperationalCredentials_CommandRemoveFabric(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, fabricIndex: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(
-                device, ZCLendpoint, ZCLgroupid, fabricIndex
+            device, ZCLendpoint, ZCLgroupid, fabricIndex
         )
+
     def ClusterOperationalCredentials_CommandRemoveTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, trustedRootIdentifier: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate(
-                device, ZCLendpoint, ZCLgroupid, trustedRootIdentifier, len(trustedRootIdentifier)
+            device, ZCLendpoint, ZCLgroupid, trustedRootIdentifier, len(
+                trustedRootIdentifier)
         )
+
     def ClusterOperationalCredentials_CommandUpdateFabricLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, label: str):
         label = label.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(
-                device, ZCLendpoint, ZCLgroupid, label, len(label)
+            device, ZCLendpoint, ZCLgroupid, label, len(label)
         )
+
     def ClusterOperationalCredentials_CommandUpdateNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, NOCValue: bytes, ICACValue: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC(
-                device, ZCLendpoint, ZCLgroupid, NOCValue, len(NOCValue), ICACValue, len(ICACValue)
+            device, ZCLendpoint, ZCLgroupid, NOCValue, len(
+                NOCValue), ICACValue, len(ICACValue)
         )
+
     def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: str, clusterId: int, length: int, value: int):
         sceneName = sceneName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Scenes_AddScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime, sceneName, len(sceneName), clusterId, length, value
+            device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime, sceneName, len(
+                sceneName), clusterId, length, value
         )
+
     def ClusterScenes_CommandGetSceneMembership(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership(
-                device, ZCLendpoint, ZCLgroupid, groupId
+            device, ZCLendpoint, ZCLgroupid, groupId
         )
+
     def ClusterScenes_CommandRecallScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime
+            device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime
         )
+
     def ClusterScenes_CommandRemoveAllScenes(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes(
-                device, ZCLendpoint, ZCLgroupid, groupId
+            device, ZCLendpoint, ZCLgroupid, groupId
         )
+
     def ClusterScenes_CommandRemoveScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId
+            device, ZCLendpoint, ZCLgroupid, groupId, sceneId
         )
+
     def ClusterScenes_CommandStoreScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId
+            device, ZCLendpoint, ZCLgroupid, groupId, sceneId
         )
+
     def ClusterScenes_CommandViewScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId
+            device, ZCLendpoint, ZCLgroupid, groupId, sceneId
         )
+
     def ClusterSoftwareDiagnostics_CommandResetWatermarks(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterTvChannel_CommandChangeChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, match: str):
         match = match.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel(
-                device, ZCLendpoint, ZCLgroupid, match, len(match)
+            device, ZCLendpoint, ZCLgroupid, match, len(match)
         )
+
     def ClusterTvChannel_CommandChangeChannelByNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, majorNumber: int, minorNumber: int):
         return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(
-                device, ZCLendpoint, ZCLgroupid, majorNumber, minorNumber
+            device, ZCLendpoint, ZCLgroupid, majorNumber, minorNumber
         )
+
     def ClusterTvChannel_CommandSkipChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, count: int):
         return self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel(
-                device, ZCLendpoint, ZCLgroupid, count
+            device, ZCLendpoint, ZCLgroupid, count
         )
+
     def ClusterTargetNavigator_CommandNavigateTarget(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, target: int, data: str):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget(
-                device, ZCLendpoint, ZCLgroupid, target, data, len(data)
+            device, ZCLendpoint, ZCLgroupid, target, data, len(data)
         )
+
     def ClusterTestCluster_CommandTest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_Test(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterTestCluster_CommandTestAddArguments(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int, arg2: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments(
-                device, ZCLendpoint, ZCLgroupid, arg1, arg2
+            device, ZCLendpoint, ZCLgroupid, arg1, arg2
         )
+
     def ClusterTestCluster_CommandTestEnumsRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int, arg2: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest(
-                device, ZCLendpoint, ZCLgroupid, arg1, arg2
+            device, ZCLendpoint, ZCLgroupid, arg1, arg2
         )
+
     def ClusterTestCluster_CommandTestListInt8UArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest(
-                device, ZCLendpoint, ZCLgroupid, arg1
+            device, ZCLendpoint, ZCLgroupid, arg1
         )
+
     def ClusterTestCluster_CommandTestListInt8UReverseRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest(
-                device, ZCLendpoint, ZCLgroupid, arg1
+            device, ZCLendpoint, ZCLgroupid, arg1
         )
+
     def ClusterTestCluster_CommandTestListStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: str, f: int):
         e = e.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest(
-                device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
+            device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
         )
+
     def ClusterTestCluster_CommandTestNotHandled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterTestCluster_CommandTestNullableOptionalRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest(
-                device, ZCLendpoint, ZCLgroupid, arg1
+            device, ZCLendpoint, ZCLgroupid, arg1
         )
+
     def ClusterTestCluster_CommandTestSpecific(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterTestCluster_CommandTestStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: str, f: int):
         e = e.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest(
-                device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
+            device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
         )
+
     def ClusterTestCluster_CommandTestUnknownCommand(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterThermostat_CommandClearWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterThermostat_CommandGetRelayStatusLog(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterThermostat_CommandGetWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, daysToReturn: int, modeToReturn: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule(
-                device, ZCLendpoint, ZCLgroupid, daysToReturn, modeToReturn
+            device, ZCLendpoint, ZCLgroupid, daysToReturn, modeToReturn
         )
+
     def ClusterThermostat_CommandSetWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, numberOfTransitionsForSequence: int, dayOfWeekForSequence: int, modeForSequence: int, payload: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule(
-                device, ZCLendpoint, ZCLgroupid, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload
+            device, ZCLendpoint, ZCLgroupid, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload
         )
+
     def ClusterThermostat_CommandSetpointRaiseLower(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, mode: int, amount: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower(
-                device, ZCLendpoint, ZCLgroupid, mode, amount
+            device, ZCLendpoint, ZCLgroupid, mode, amount
         )
+
     def ClusterThreadNetworkDiagnostics_CommandResetCounts(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterWiFiNetworkDiagnostics_CommandResetCounts(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterWindowCovering_CommandDownOrClose(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterWindowCovering_CommandGoToLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, liftPercentageValue: int, liftPercent100thsValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage(
-                device, ZCLendpoint, ZCLgroupid, liftPercentageValue, liftPercent100thsValue
+            device, ZCLendpoint, ZCLgroupid, liftPercentageValue, liftPercent100thsValue
         )
+
     def ClusterWindowCovering_CommandGoToLiftValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, liftValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue(
-                device, ZCLendpoint, ZCLgroupid, liftValue
+            device, ZCLendpoint, ZCLgroupid, liftValue
         )
+
     def ClusterWindowCovering_CommandGoToTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tiltPercentageValue: int, tiltPercent100thsValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage(
-                device, ZCLendpoint, ZCLgroupid, tiltPercentageValue, tiltPercent100thsValue
+            device, ZCLendpoint, ZCLgroupid, tiltPercentageValue, tiltPercent100thsValue
         )
+
     def ClusterWindowCovering_CommandGoToTiltValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tiltValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue(
-                device, ZCLendpoint, ZCLgroupid, tiltValue
+            device, ZCLendpoint, ZCLgroupid, tiltValue
         )
+
     def ClusterWindowCovering_CommandStopMotion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
+
     def ClusterWindowCovering_CommandUpOrOpen(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen(
-                device, ZCLendpoint, ZCLgroupid
+            device, ZCLendpoint, ZCLgroupid
         )
 
     # Cluster attributes
 
     def ClusterAccountLogin_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterAdministratorCommissioning_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeVendorName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeApplicationName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeProductId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ProductId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeApplicationId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeCatalogVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_CatalogVendorId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeApplicationStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationStatus(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationBasic_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationLauncher_ReadAttributeApplicationLauncherList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationLauncher_ReadAttributeCatalogVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_CatalogVendorId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationLauncher_ReadAttributeApplicationId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterApplicationLauncher_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterAudioOutput_ReadAttributeAudioOutputList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_AudioOutput_AudioOutputList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterAudioOutput_ReadAttributeCurrentAudioOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_AudioOutput_CurrentAudioOutput(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterAudioOutput_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_AudioOutput_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBarrierControl_ReadAttributeBarrierMovingState(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierMovingState(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBarrierControl_ReadAttributeBarrierSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierSafetyStatus(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBarrierControl_ReadAttributeBarrierCapabilities(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierCapabilities(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBarrierControl_ReadAttributeBarrierPosition(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierPosition(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBarrierControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BarrierControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeInteractionModelVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_InteractionModelVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeVendorName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_VendorName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeVendorID(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_VendorID(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeProductName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_ProductName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeProductID(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_ProductID(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterBasic_ReadAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_WriteAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterBasic_ReadAttributeHardwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeHardwareVersionString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersionString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeSoftwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeSoftwareVersionString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersionString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeManufacturingDate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_ManufacturingDate(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributePartNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_PartNumber(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeProductURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_ProductURL(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeProductLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_ProductLabel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeSerialNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_SerialNumber(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_WriteAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterBasic_ReadAttributeReachable(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Reachable(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBasic_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBinaryInputBasic_ReadAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBinaryInputBasic_WriteAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterBinaryInputBasic_ReadAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBinaryInputBasic_SubscribeAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterBinaryInputBasic_WriteAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterBinaryInputBasic_ReadAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBinaryInputBasic_SubscribeAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterBinaryInputBasic_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBinding_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBooleanState_ReadAttributeStateValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BooleanState_StateValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBooleanState_SubscribeAttributeStateValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_BooleanState_StateValue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterBooleanState_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BooleanState_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeVendorName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeVendorID(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorID(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeProductName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterBridgedDeviceBasic_ReadAttributeHardwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeHardwareVersionString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersionString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeSoftwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeSoftwareVersionString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersionString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeManufacturingDate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ManufacturingDate(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributePartNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_PartNumber(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeProductURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductURL(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeProductLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductLabel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeSerialNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SerialNumber(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeReachable(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_Reachable(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterBridgedDeviceBasic_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_SubscribeAttributeCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentHue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterColorControl_ReadAttributeCurrentSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_SubscribeAttributeCurrentSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentSaturation(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterColorControl_ReadAttributeRemainingTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_RemainingTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeCurrentX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_SubscribeAttributeCurrentX(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentX(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterColorControl_ReadAttributeCurrentY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_SubscribeAttributeCurrentY(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentY(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterColorControl_ReadAttributeDriftCompensation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_DriftCompensation(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeCompensationText(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CompensationText(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_SubscribeAttributeColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_ColorControl_ColorTemperature(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterColorControl_ReadAttributeColorMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorControlOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorControlOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeNumberOfPrimaries(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary1X(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1X(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary1Y(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Y(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary1Intensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Intensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary2X(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2X(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary2Y(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Y(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary2Intensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Intensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary3X(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3X(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary3Y(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Y(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary3Intensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Intensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary4X(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4X(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary4Y(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Y(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary4Intensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Intensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary5X(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5X(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary5Y(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Y(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary5Intensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Intensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary6X(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6X(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary6Y(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Y(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributePrimary6Intensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Intensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeWhitePointX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeWhitePointX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeWhitePointY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeWhitePointY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointRX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointRX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointRY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointRY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointRIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointRIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointGX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointGX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointGY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointGY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointGIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointGIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointBX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointBX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointBY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointBY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeColorPointBIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeColorPointBIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeEnhancedCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeEnhancedColorMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedColorMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorLoopActive(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopActive(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorLoopDirection(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopDirection(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorLoopTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorLoopStartEnhancedHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStartEnhancedHue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorLoopStoredEnhancedHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStoredEnhancedHue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorCapabilities(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorCapabilities(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorTempPhysicalMin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMin(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeColorTempPhysicalMax(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMax(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeCoupleColorTempToLevelMinMireds(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CoupleColorTempToLevelMinMireds(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_ReadAttributeStartUpColorTemperatureMireds(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterColorControl_WriteAttributeStartUpColorTemperatureMireds(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterColorControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterContentLauncher_ReadAttributeAcceptsHeaderList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ContentLauncher_AcceptsHeaderList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterContentLauncher_ReadAttributeSupportedStreamingTypes(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ContentLauncher_SupportedStreamingTypes(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterContentLauncher_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ContentLauncher_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDescriptor_ReadAttributeDeviceList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Descriptor_DeviceList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDescriptor_ReadAttributeServerList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Descriptor_ServerList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDescriptor_ReadAttributeClientList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Descriptor_ClientList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDescriptor_ReadAttributePartsList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Descriptor_PartsList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDescriptor_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDoorLock_ReadAttributeLockState(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDoorLock_SubscribeAttributeLockState(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_DoorLock_LockState(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterDoorLock_ReadAttributeLockType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_DoorLock_LockType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDoorLock_ReadAttributeActuatorEnabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_DoorLock_ActuatorEnabled(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterDoorLock_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_DoorLock_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeMeasurementType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_MeasurementType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeTotalActivePower(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_TotalActivePower(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeRmsVoltage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltage(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeRmsVoltageMin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMin(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeRmsVoltageMax(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMax(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeRmsCurrent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrent(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeRmsCurrentMin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMin(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeRmsCurrentMax(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMax(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeActivePower(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePower(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeActivePowerMin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMin(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeActivePowerMax(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMax(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterElectricalMeasurement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributePHYRate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PHYRate(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeFullDuplex(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_FullDuplex(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributePacketRxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketRxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributePacketTxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketTxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeTxErrCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TxErrCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeCollisionCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CollisionCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeOverrunCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_OverrunCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeCarrierDetect(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CarrierDetect(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeTimeSinceReset(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TimeSinceReset(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterEthernetNetworkDiagnostics_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterFixedLabel_ReadAttributeLabelList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_FixedLabel_LabelList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterFixedLabel_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_FixedLabel_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterFlowMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterFlowMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterFlowMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MaxMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterFlowMeasurement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralCommissioning_ReadAttributeBreadcrumb(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralCommissioning_WriteAttributeBreadcrumb(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterGeneralCommissioning_ReadAttributeBasicCommissioningInfoList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralCommissioning_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralDiagnostics_ReadAttributeNetworkInterfaces(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_NetworkInterfaces(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralDiagnostics_ReadAttributeRebootCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_RebootCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralDiagnostics_ReadAttributeUpTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_UpTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralDiagnostics_ReadAttributeTotalOperationalHours(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_TotalOperationalHours(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralDiagnostics_ReadAttributeBootReasons(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_BootReasons(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGeneralDiagnostics_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGroupKeyManagement_ReadAttributeGroups(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_Groups(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGroupKeyManagement_ReadAttributeGroupKeys(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_GroupKeys(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGroupKeyManagement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGroups_ReadAttributeNameSupport(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Groups_NameSupport(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterGroups_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Groups_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIdentify_ReadAttributeIdentifyTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIdentify_WriteAttributeIdentifyTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterIdentify_ReadAttributeIdentifyType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIdentify_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Identify_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIlluminanceMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIlluminanceMeasurement_SubscribeAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_IlluminanceMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterIlluminanceMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIlluminanceMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MaxMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIlluminanceMeasurement_ReadAttributeTolerance(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_Tolerance(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIlluminanceMeasurement_ReadAttributeLightSensorType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_LightSensorType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterIlluminanceMeasurement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterKeypadInput_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_SubscribeAttributeCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_LevelControl_CurrentLevel(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterLevelControl_ReadAttributeRemainingTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_RemainingTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeMinLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_MinLevel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeMaxLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxLevel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeCurrentFrequency(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentFrequency(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeMinFrequency(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_MinFrequency(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeMaxFrequency(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxFrequency(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_ReadAttributeOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_Options(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_Options(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeOnOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeOnOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeOnLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeOnLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeOnTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeOnTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeDefaultMoveRate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeDefaultMoveRate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeStartUpCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLevelControl_WriteAttributeStartUpCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterLevelControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterLowPower_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaInput_ReadAttributeMediaInputList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaInput_MediaInputList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaInput_ReadAttributeCurrentMediaInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaInput_CurrentMediaInput(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaInput_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaInput_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributePlaybackState(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackState(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributeStartTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_StartTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributeDuration(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Duration(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributePositionUpdatedAt(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PositionUpdatedAt(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributePosition(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Position(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributePlaybackSpeed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackSpeed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributeSeekRangeEnd(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeEnd(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributeSeekRangeStart(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeStart(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterMediaPlayback_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterNetworkCommissioning_ReadAttributeFeatureMap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_FeatureMap(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterNetworkCommissioning_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOtaSoftwareUpdateProvider_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOtaSoftwareUpdateRequestor_ReadAttributeDefaultOtaProvider(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOtaSoftwareUpdateRequestor_WriteAttributeDefaultOtaProvider(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
         return self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterOtaSoftwareUpdateRequestor_ReadAttributeUpdatePossible(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOtaSoftwareUpdateRequestor_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOccupancySensing_ReadAttributeOccupancy(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOccupancySensing_SubscribeAttributeOccupancy(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_OccupancySensing_Occupancy(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterOccupancySensing_ReadAttributeOccupancySensorType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOccupancySensing_ReadAttributeOccupancySensorTypeBitmap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorTypeBitmap(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOccupancySensing_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_ReadAttributeOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_SubscribeAttributeOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_OnOff_OnOff(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterOnOff_ReadAttributeGlobalSceneControl(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_GlobalSceneControl(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_ReadAttributeOnTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_WriteAttributeOnTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterOnOff_ReadAttributeOffWaitTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_WriteAttributeOffWaitTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterOnOff_ReadAttributeStartUpOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_WriteAttributeStartUpOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterOnOff_ReadAttributeFeatureMap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_FeatureMap(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOff_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOffSwitchConfiguration_ReadAttributeSwitchType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOffSwitchConfiguration_ReadAttributeSwitchActions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOnOffSwitchConfiguration_WriteAttributeSwitchActions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterOnOffSwitchConfiguration_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOperationalCredentials_ReadAttributeFabricsList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_FabricsList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOperationalCredentials_ReadAttributeSupportedFabrics(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_SupportedFabrics(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOperationalCredentials_ReadAttributeCommissionedFabrics(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOperationalCredentials_ReadAttributeTrustedRootCertificates(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterOperationalCredentials_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_Status(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeOrder(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_Order(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeDescription(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_Description(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeBatteryVoltage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryVoltage(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeBatteryPercentRemaining(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryPercentRemaining(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeBatteryTimeRemaining(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryTimeRemaining(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeBatteryChargeLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeLevel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeActiveBatteryFaults(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_ActiveBatteryFaults(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeBatteryChargeState(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeState(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeFeatureMap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_FeatureMap(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPowerSource_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PowerSource_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPressureMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPressureMeasurement_SubscribeAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_PressureMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterPressureMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPressureMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MaxMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPressureMeasurement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxPressure(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxPressure(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxSpeed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxSpeed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxFlow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxFlow(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMinConstPressure(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstPressure(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxConstPressure(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstPressure(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMinCompPressure(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinCompPressure(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxCompPressure(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxCompPressure(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMinConstSpeed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstSpeed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxConstSpeed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstSpeed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMinConstFlow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstFlow(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxConstFlow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstFlow(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMinConstTemp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstTemp(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeMaxConstTemp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstTemp(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributePumpStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_PumpStatus(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_SubscribeAttributePumpStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_PumpStatus(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeEffectiveOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveOperationMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeEffectiveControlMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveControlMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeCapacity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_SubscribeAttributeCapacity(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_Capacity(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeSpeed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Speed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeLifetimeEnergyConsumed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_LifetimeEnergyConsumed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_WriteAttributeOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeControlMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_WriteAttributeControlMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeAlarmMask(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeFeatureMap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_FeatureMap(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterPumpConfigurationAndControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterRelativeHumidityMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterRelativeHumidityMeasurement_SubscribeAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_RelativeHumidityMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterRelativeHumidityMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterRelativeHumidityMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MaxMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterRelativeHumidityMeasurement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterScenes_ReadAttributeSceneCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Scenes_SceneCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterScenes_ReadAttributeCurrentScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentScene(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterScenes_ReadAttributeCurrentGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentGroup(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterScenes_ReadAttributeSceneValid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Scenes_SceneValid(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterScenes_ReadAttributeNameSupport(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Scenes_NameSupport(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterScenes_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Scenes_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSoftwareDiagnostics_ReadAttributeCurrentHeapFree(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapFree(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSoftwareDiagnostics_ReadAttributeCurrentHeapUsed(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapUsed(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSoftwareDiagnostics_ReadAttributeCurrentHeapHighWatermark(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapHighWatermark(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSoftwareDiagnostics_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSwitch_ReadAttributeNumberOfPositions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Switch_NumberOfPositions(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSwitch_ReadAttributeCurrentPosition(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterSwitch_SubscribeAttributeCurrentPosition(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_Switch_CurrentPosition(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterSwitch_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTvChannel_ReadAttributeTvChannelList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTvChannel_ReadAttributeTvChannelLineup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelLineup(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTvChannel_ReadAttributeCurrentTvChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TvChannel_CurrentTvChannel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTvChannel_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TvChannel_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTargetNavigator_ReadAttributeTargetNavigatorList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTargetNavigator_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TargetNavigator_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTemperatureMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTemperatureMeasurement_SubscribeAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_TemperatureMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterTemperatureMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTemperatureMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MaxMeasuredValue(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTemperatureMeasurement_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_ReadAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeBitmap16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeBitmap16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeBitmap32(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeBitmap32(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeBitmap64(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeBitmap64(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt16u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt16u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt32u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt32u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt64u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt64u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt8s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt8s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt16s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt16s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt32s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt32s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeInt64s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeInt64s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeEnum8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeEnum8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeEnum16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeEnum16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterTestCluster_ReadAttributeListInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ListInt8u(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_ReadAttributeListOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ListOctetString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_ReadAttributeListStructOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ListStructOctetString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_ReadAttributeLongOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeLongOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterTestCluster_ReadAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterTestCluster_ReadAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
         value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
+
     def ClusterTestCluster_ReadAttributeEpochUs(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeEpochUs(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeEpochS(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeEpochS(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterTestCluster_WriteAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterTestCluster_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeLocalTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_SubscribeAttributeLocalTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_Thermostat_LocalTemperature(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterThermostat_ReadAttributeAbsMinHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeAbsMaxHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeAbsMinCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeAbsMaxCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeOccupiedCoolingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeOccupiedCoolingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeOccupiedHeatingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeOccupiedHeatingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeMinHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeMinHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeMaxHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeMaxHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeMinCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeMinCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeMaxCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeMaxCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeMinSetpointDeadBand(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeMinSetpointDeadBand(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeControlSequenceOfOperation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeControlSequenceOfOperation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeSystemMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_WriteAttributeSystemMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostat_ReadAttributeStartOfWeek(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_StartOfWeek(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeNumberOfWeeklyTransitions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfWeeklyTransitions(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeNumberOfDailyTransitions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfDailyTransitions(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeFeatureMap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_FeatureMap(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostat_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeTemperatureDisplayMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostatUserInterfaceConfiguration_WriteAttributeTemperatureDisplayMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeKeypadLockout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostatUserInterfaceConfiguration_WriteAttributeKeypadLockout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeScheduleProgrammingVisibility(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThermostatUserInterfaceConfiguration_WriteAttributeScheduleProgrammingVisibility(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Channel(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRoutingRole(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RoutingRole(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeNetworkName(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NetworkName(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributePanId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PanId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeExtendedPanId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ExtendedPanId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeMeshLocalPrefix(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_MeshLocalPrefix(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeOverrunCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OverrunCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeNeighborTableList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NeighborTableList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRouteTableList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouteTableList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributePartitionId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeWeighting(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Weighting(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeDataVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DataVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeStableDataVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_StableDataVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeLeaderRouterId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRouterId(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeDetachedRoleCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DetachedRoleCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeChildRoleCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChildRoleCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRouterRoleCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouterRoleCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeLeaderRoleCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRoleCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeAttachAttemptCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_AttachAttemptCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributePartitionIdChangeCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionIdChangeCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeBetterPartitionAttachAttemptCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_BetterPartitionAttachAttemptCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeParentChangeCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ParentChangeCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxTotalCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxTotalCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxUnicastCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxUnicastCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxBroadcastCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBroadcastCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxAckRequestedCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckRequestedCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxAckedCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckedCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxNoAckRequestedCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxNoAckRequestedCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxDataCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxDataPollCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataPollCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxBeaconCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxBeaconRequestCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconRequestCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxOtherCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxOtherCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxRetryCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxRetryCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxDirectMaxRetryExpiryCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDirectMaxRetryExpiryCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxIndirectMaxRetryExpiryCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxIndirectMaxRetryExpiryCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxErrCcaCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrCcaCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxErrAbortCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrAbortCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeTxErrBusyChannelCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrBusyChannelCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxTotalCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxTotalCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxUnicastCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxUnicastCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxBroadcastCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBroadcastCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxDataCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxDataPollCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataPollCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxBeaconCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxBeaconRequestCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconRequestCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxOtherCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxOtherCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxAddressFilteredCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxAddressFilteredCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxDestAddrFilteredCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDestAddrFilteredCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxDuplicatedCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDuplicatedCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxErrNoFrameCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrNoFrameCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxErrUnknownNeighborCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrUnknownNeighborCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxErrInvalidSrcAddrCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrInvalidSrcAddrCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxErrSecCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrSecCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxErrFcsCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrFcsCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeRxErrOtherCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrOtherCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeActiveTimestamp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveTimestamp(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributePendingTimestamp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PendingTimestamp(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeDelay(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Delay(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeSecurityPolicy(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_SecurityPolicy(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeChannelMask(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChannelMask(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeOperationalDatasetComponents(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OperationalDatasetComponents(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeActiveNetworkFaultsList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveNetworkFaultsList(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterThreadNetworkDiagnostics_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWakeOnLan_ReadAttributeWakeOnLanMacAddress(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WakeOnLan_WakeOnLanMacAddress(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWakeOnLan_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WakeOnLan_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeBssid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Bssid(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeSecurityType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_SecurityType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeWiFiVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_WiFiVersion(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeChannelNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ChannelNumber(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeRssi(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Rssi(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeBeaconLostCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconLostCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeBeaconRxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconRxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributePacketMulticastRxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastRxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributePacketMulticastTxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastTxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributePacketUnicastRxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastRxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributePacketUnicastTxCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastTxCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeCurrentMaxRate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_CurrentMaxRate(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeOverrunCount(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_OverrunCount(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWiFiNetworkDiagnostics_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_Type(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeCurrentPositionLift(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLift(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeCurrentPositionTilt(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTilt(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeConfigStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_ConfigStatus(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeCurrentPositionLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeCurrentPositionLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercentage(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeCurrentPositionTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeCurrentPositionTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercentage(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeOperationalStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeOperationalStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_OperationalStatus(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeTargetPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeTargetPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionLiftPercent100ths(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeTargetPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeTargetPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionTiltPercent100ths(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeEndProductType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_EndProductType(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeCurrentPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeCurrentPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercent100ths(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeCurrentPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeCurrentPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercent100ths(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeInstalledOpenLimitLift(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitLift(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeInstalledClosedLimitLift(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitLift(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeInstalledOpenLimitTilt(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitTilt(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeInstalledClosedLimitTilt(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitTilt(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_ReadAttributeMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_WriteAttributeMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
         return self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode(device, ZCLendpoint, ZCLgroupid, value)
+
     def ClusterWindowCovering_ReadAttributeSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus(device, ZCLendpoint, ZCLgroupid)
+
     def ClusterWindowCovering_SubscribeAttributeSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_SafetyStatus(device, ZCLendpoint, minInterval, maxInterval)
+
     def ClusterWindowCovering_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
 
@@ -6066,2193 +6805,2905 @@ class ChipClusters:
     def InitLib(self, chipLib):
         self._chipLib = chipLib
         # Response delegate setters
-        self._chipLib.chip_ime_SetSuccessResponseDelegate.argtypes = [ChipClusters.SUCCESS_DELEGATE]
+        self._chipLib.chip_ime_SetSuccessResponseDelegate.argtypes = [
+            ChipClusters.SUCCESS_DELEGATE]
         self._chipLib.chip_ime_SetSuccessResponseDelegate.restype = None
-        self._chipLib.chip_ime_SetFailureResponseDelegate.argtypes = [ChipClusters.FAILURE_DELEGATE]
+        self._chipLib.chip_ime_SetFailureResponseDelegate.argtypes = [
+            ChipClusters.FAILURE_DELEGATE]
         self._chipLib.chip_ime_SetFailureResponseDelegate.res = None
         # Cluster AccountLogin
         # Cluster AccountLogin Command GetSetupPIN
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.restype = ctypes.c_uint32
         # Cluster AccountLogin Command Login
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.restype = ctypes.c_uint32
         # Cluster AccountLogin ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision.restype = ctypes.c_uint32
         # Cluster AdministratorCommissioning
         # Cluster AdministratorCommissioning Command OpenBasicCommissioningWindow
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow.restype = ctypes.c_uint32
         # Cluster AdministratorCommissioning Command OpenCommissioningWindow
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow.restype = ctypes.c_uint32
         # Cluster AdministratorCommissioning Command RevokeCommissioning
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning.restype = ctypes.c_uint32
         # Cluster AdministratorCommissioning ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ApplicationBasic
         # Cluster ApplicationBasic Command ChangeStatus
-        self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute VendorName
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorName.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute VendorId
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorId.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute ApplicationName
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationName.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute ProductId
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ProductId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ProductId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ProductId.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute ApplicationId
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationId.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute CatalogVendorId
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_CatalogVendorId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_CatalogVendorId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_CatalogVendorId.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute ApplicationStatus
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ApplicationStatus.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher
         # Cluster ApplicationLauncher Command LaunchApp
-        self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher ReadAttribute ApplicationLauncherList
-        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher ReadAttribute CatalogVendorId
-        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_CatalogVendorId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_CatalogVendorId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_CatalogVendorId.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher ReadAttribute ApplicationId
-        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationId.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision.restype = ctypes.c_uint32
         # Cluster AudioOutput
         # Cluster AudioOutput Command RenameOutput
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.restype = ctypes.c_uint32
         # Cluster AudioOutput Command SelectOutput
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.restype = ctypes.c_uint32
         # Cluster AudioOutput ReadAttribute AudioOutputList
-        self._chipLib.chip_ime_ReadAttribute_AudioOutput_AudioOutputList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_AudioOutput_AudioOutputList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_AudioOutputList.restype = ctypes.c_uint32
         # Cluster AudioOutput ReadAttribute CurrentAudioOutput
-        self._chipLib.chip_ime_ReadAttribute_AudioOutput_CurrentAudioOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_AudioOutput_CurrentAudioOutput.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_CurrentAudioOutput.restype = ctypes.c_uint32
         # Cluster AudioOutput ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_AudioOutput_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_AudioOutput_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BarrierControl
         # Cluster BarrierControl Command BarrierControlGoToPercent
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.restype = ctypes.c_uint32
         # Cluster BarrierControl Command BarrierControlStop
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute BarrierMovingState
-        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierMovingState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierMovingState.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierMovingState.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute BarrierSafetyStatus
-        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierSafetyStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierSafetyStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierSafetyStatus.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute BarrierCapabilities
-        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierCapabilities.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierCapabilities.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierCapabilities.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute BarrierPosition
-        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierPosition.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierPosition.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierPosition.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_BarrierControl_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BarrierControl_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Basic
         # Cluster Basic Command MfgSpecificPing
-        self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute InteractionModelVersion
-        self._chipLib.chip_ime_ReadAttribute_Basic_InteractionModelVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_InteractionModelVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_InteractionModelVersion.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute VendorName
-        self._chipLib.chip_ime_ReadAttribute_Basic_VendorName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_VendorName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_VendorName.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute VendorID
-        self._chipLib.chip_ime_ReadAttribute_Basic_VendorID.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_VendorID.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_VendorID.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute ProductName
-        self._chipLib.chip_ime_ReadAttribute_Basic_ProductName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_ProductName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_ProductName.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute ProductID
-        self._chipLib.chip_ime_ReadAttribute_Basic_ProductID.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_ProductID.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_ProductID.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute UserLabel
-        self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel.restype = ctypes.c_uint32
         # Cluster Basic WriteAttribute UserLabel
-        self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute Location
-        self._chipLib.chip_ime_ReadAttribute_Basic_Location.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_Location.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_Location.restype = ctypes.c_uint32
         # Cluster Basic WriteAttribute Location
-        self._chipLib.chip_ime_WriteAttribute_Basic_Location.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_Basic_Location.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_Basic_Location.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute HardwareVersion
-        self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute HardwareVersionString
-        self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersionString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersionString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersionString.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute SoftwareVersion
-        self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersion.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute SoftwareVersionString
-        self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersionString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersionString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_SoftwareVersionString.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute ManufacturingDate
-        self._chipLib.chip_ime_ReadAttribute_Basic_ManufacturingDate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_ManufacturingDate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_ManufacturingDate.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute PartNumber
-        self._chipLib.chip_ime_ReadAttribute_Basic_PartNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_PartNumber.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_PartNumber.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute ProductURL
-        self._chipLib.chip_ime_ReadAttribute_Basic_ProductURL.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_ProductURL.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_ProductURL.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute ProductLabel
-        self._chipLib.chip_ime_ReadAttribute_Basic_ProductLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_ProductLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_ProductLabel.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute SerialNumber
-        self._chipLib.chip_ime_ReadAttribute_Basic_SerialNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_SerialNumber.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_SerialNumber.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute LocalConfigDisabled
-        self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.restype = ctypes.c_uint32
         # Cluster Basic WriteAttribute LocalConfigDisabled
-        self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
+        self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute Reachable
-        self._chipLib.chip_ime_ReadAttribute_Basic_Reachable.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_Reachable.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_Reachable.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Basic_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Basic_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic
         # Cluster BinaryInputBasic ReadAttribute OutOfService
-        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic WriteAttribute OutOfService
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
+        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute PresentValue
-        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic SubscribeAttribute PresentValue
-        self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic WriteAttribute PresentValue
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
+        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute StatusFlags
-        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic SubscribeAttribute StatusFlags
-        self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_StatusFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_StatusFlags.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_StatusFlags.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Binding
         # Cluster Binding Command Bind
-        self._chipLib.chip_ime_AppendCommand_Binding_Bind.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_Binding_Bind.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_Binding_Bind.restype = ctypes.c_uint32
         # Cluster Binding Command Unbind
-        self._chipLib.chip_ime_AppendCommand_Binding_Unbind.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_Binding_Unbind.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_Binding_Unbind.restype = ctypes.c_uint32
         # Cluster Binding ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BooleanState
         # Cluster BooleanState ReadAttribute StateValue
-        self._chipLib.chip_ime_ReadAttribute_BooleanState_StateValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BooleanState_StateValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BooleanState_StateValue.restype = ctypes.c_uint32
         # Cluster BooleanState SubscribeAttribute StateValue
-        self._chipLib.chip_ime_SubscribeAttribute_BooleanState_StateValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_BooleanState_StateValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_BooleanState_StateValue.restype = ctypes.c_uint32
         # Cluster BooleanState ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_BooleanState_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BooleanState_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BooleanState_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic
         # Cluster BridgedDeviceBasic ReadAttribute VendorName
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorName.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute VendorID
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorID.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorID.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_VendorID.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute ProductName
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductName.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute UserLabel
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic WriteAttribute UserLabel
-        self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute HardwareVersion
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute HardwareVersionString
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersionString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersionString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersionString.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute SoftwareVersion
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersion.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute SoftwareVersionString
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersionString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersionString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SoftwareVersionString.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute ManufacturingDate
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ManufacturingDate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ManufacturingDate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ManufacturingDate.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute PartNumber
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_PartNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_PartNumber.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_PartNumber.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute ProductURL
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductURL.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductURL.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductURL.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute ProductLabel
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ProductLabel.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute SerialNumber
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SerialNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SerialNumber.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_SerialNumber.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute Reachable
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_Reachable.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_Reachable.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_Reachable.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ColorControl
         # Cluster ColorControl Command ColorLoopSet
-        self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet.restype = ctypes.c_uint32
         # Cluster ColorControl Command EnhancedMoveHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command EnhancedMoveToHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command EnhancedMoveToHueAndSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command EnhancedStepHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToHueAndSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command StopMoveStep
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentHue
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.restype = ctypes.c_uint32
         # Cluster ColorControl SubscribeAttribute CurrentHue
-        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentHue.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentSaturation
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl SubscribeAttribute CurrentSaturation
-        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentSaturation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute RemainingTime
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_RemainingTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_RemainingTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_RemainingTime.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentX
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX.restype = ctypes.c_uint32
         # Cluster ColorControl SubscribeAttribute CurrentX
-        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentY
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY.restype = ctypes.c_uint32
         # Cluster ColorControl SubscribeAttribute CurrentY
-        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_ColorControl_CurrentY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute DriftCompensation
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_DriftCompensation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_DriftCompensation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_DriftCompensation.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CompensationText
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_CompensationText.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_CompensationText.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CompensationText.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorTemperature
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl SubscribeAttribute ColorTemperature
-        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_ColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_ColorControl_ColorTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_ColorControl_ColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorMode
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorMode.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorControlOptions
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorControlOptions
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute NumberOfPrimaries
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary1X
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1X.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1X.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1X.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary1Y
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Y.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Y.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Y.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary1Intensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Intensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Intensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary1Intensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary2X
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2X.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2X.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2X.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary2Y
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Y.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Y.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Y.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary2Intensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Intensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Intensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary2Intensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary3X
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3X.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3X.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3X.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary3Y
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Y.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Y.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Y.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary3Intensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Intensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Intensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary3Intensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary4X
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4X.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4X.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4X.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary4Y
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Y.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Y.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Y.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary4Intensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Intensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Intensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary4Intensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary5X
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5X.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5X.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5X.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary5Y
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Y.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Y.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Y.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary5Intensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Intensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Intensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary5Intensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary6X
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6X.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6X.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6X.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary6Y
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Y.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Y.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Y.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute Primary6Intensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Intensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Intensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_Primary6Intensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute WhitePointX
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute WhitePointX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute WhitePointY
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute WhitePointY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointRX
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointRX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointRY
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointRY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointRIntensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointRIntensity
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointGX
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointGX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointGY
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointGY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointGIntensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointGIntensity
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointBX
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointBX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointBY
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointBY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointBIntensity
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute ColorPointBIntensity
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute EnhancedCurrentHue
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute EnhancedColorMode
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedColorMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedColorMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedColorMode.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorLoopActive
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopActive.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopActive.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopActive.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorLoopDirection
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopDirection.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopDirection.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopDirection.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorLoopTime
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopTime.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorLoopStartEnhancedHue
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStartEnhancedHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStartEnhancedHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStartEnhancedHue.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorLoopStoredEnhancedHue
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStoredEnhancedHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStoredEnhancedHue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorLoopStoredEnhancedHue.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorCapabilities
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorCapabilities.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorCapabilities.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorCapabilities.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorTempPhysicalMin
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMin.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorTempPhysicalMax
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMax.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMax.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTempPhysicalMax.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CoupleColorTempToLevelMinMireds
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_CoupleColorTempToLevelMinMireds.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_CoupleColorTempToLevelMinMireds.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CoupleColorTempToLevelMinMireds.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute StartUpColorTemperatureMireds
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds.restype = ctypes.c_uint32
         # Cluster ColorControl WriteAttribute StartUpColorTemperatureMireds
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ContentLauncher
         # Cluster ContentLauncher Command LaunchContent
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.restype = ctypes.c_uint32
         # Cluster ContentLauncher Command LaunchURL
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL.restype = ctypes.c_uint32
         # Cluster ContentLauncher ReadAttribute AcceptsHeaderList
-        self._chipLib.chip_ime_ReadAttribute_ContentLauncher_AcceptsHeaderList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ContentLauncher_AcceptsHeaderList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ContentLauncher_AcceptsHeaderList.restype = ctypes.c_uint32
         # Cluster ContentLauncher ReadAttribute SupportedStreamingTypes
-        self._chipLib.chip_ime_ReadAttribute_ContentLauncher_SupportedStreamingTypes.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ContentLauncher_SupportedStreamingTypes.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ContentLauncher_SupportedStreamingTypes.restype = ctypes.c_uint32
         # Cluster ContentLauncher ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ContentLauncher_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ContentLauncher_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ContentLauncher_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Descriptor
         # Cluster Descriptor ReadAttribute DeviceList
-        self._chipLib.chip_ime_ReadAttribute_Descriptor_DeviceList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Descriptor_DeviceList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Descriptor_DeviceList.restype = ctypes.c_uint32
         # Cluster Descriptor ReadAttribute ServerList
-        self._chipLib.chip_ime_ReadAttribute_Descriptor_ServerList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Descriptor_ServerList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Descriptor_ServerList.restype = ctypes.c_uint32
         # Cluster Descriptor ReadAttribute ClientList
-        self._chipLib.chip_ime_ReadAttribute_Descriptor_ClientList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Descriptor_ClientList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Descriptor_ClientList.restype = ctypes.c_uint32
         # Cluster Descriptor ReadAttribute PartsList
-        self._chipLib.chip_ime_ReadAttribute_Descriptor_PartsList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Descriptor_PartsList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Descriptor_PartsList.restype = ctypes.c_uint32
         # Cluster Descriptor ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision.restype = ctypes.c_uint32
         # Cluster DiagnosticLogs
         # Cluster DiagnosticLogs Command RetrieveLogsRequest
-        self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest.restype = ctypes.c_uint32
         # Cluster DoorLock
         # Cluster DoorLock Command ClearAllPins
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearAllRfids
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetLogRecord
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetUserType
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command LockDoor
-        self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetUserType
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command UnlockDoor
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.restype = ctypes.c_uint32
         # Cluster DoorLock Command UnlockWithTimeout
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute LockState
-        self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.restype = ctypes.c_uint32
         # Cluster DoorLock SubscribeAttribute LockState
-        self._chipLib.chip_ime_SubscribeAttribute_DoorLock_LockState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_DoorLock_LockState.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_DoorLock_LockState.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute LockType
-        self._chipLib.chip_ime_ReadAttribute_DoorLock_LockType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_DoorLock_LockType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockType.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute ActuatorEnabled
-        self._chipLib.chip_ime_ReadAttribute_DoorLock_ActuatorEnabled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_DoorLock_ActuatorEnabled.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_DoorLock_ActuatorEnabled.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_DoorLock_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_DoorLock_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_DoorLock_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement
         # Cluster ElectricalMeasurement ReadAttribute MeasurementType
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_MeasurementType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_MeasurementType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_MeasurementType.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute TotalActivePower
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_TotalActivePower.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_TotalActivePower.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_TotalActivePower.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute RmsVoltage
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltage.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute RmsVoltageMin
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMin.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute RmsVoltageMax
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMax.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMax.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsVoltageMax.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute RmsCurrent
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrent.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrent.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute RmsCurrentMin
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMin.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute RmsCurrentMax
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMax.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMax.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_RmsCurrentMax.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute ActivePower
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePower.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePower.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePower.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute ActivePowerMin
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMin.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMin.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute ActivePowerMax
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMax.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMax.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ActivePowerMax.restype = ctypes.c_uint32
         # Cluster ElectricalMeasurement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics
         # Cluster EthernetNetworkDiagnostics Command ResetCounts
-        self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute PHYRate
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PHYRate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PHYRate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PHYRate.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute FullDuplex
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_FullDuplex.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_FullDuplex.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_FullDuplex.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute PacketRxCount
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketRxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketRxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketRxCount.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute PacketTxCount
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketTxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketTxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PacketTxCount.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute TxErrCount
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TxErrCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TxErrCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TxErrCount.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute CollisionCount
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CollisionCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CollisionCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CollisionCount.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute OverrunCount
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_OverrunCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_OverrunCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_OverrunCount.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute CarrierDetect
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CarrierDetect.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CarrierDetect.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_CarrierDetect.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute TimeSinceReset
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TimeSinceReset.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TimeSinceReset.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_TimeSinceReset.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_ClusterRevision.restype = ctypes.c_uint32
         # Cluster FixedLabel
         # Cluster FixedLabel ReadAttribute LabelList
-        self._chipLib.chip_ime_ReadAttribute_FixedLabel_LabelList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_FixedLabel_LabelList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FixedLabel_LabelList.restype = ctypes.c_uint32
         # Cluster FixedLabel ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_FixedLabel_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_FixedLabel_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FixedLabel_ClusterRevision.restype = ctypes.c_uint32
         # Cluster FlowMeasurement
         # Cluster FlowMeasurement ReadAttribute MeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster FlowMeasurement ReadAttribute MinMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MinMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MinMeasuredValue.restype = ctypes.c_uint32
         # Cluster FlowMeasurement ReadAttribute MaxMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MaxMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MaxMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_MaxMeasuredValue.restype = ctypes.c_uint32
         # Cluster FlowMeasurement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning
         # Cluster GeneralCommissioning Command ArmFailSafe
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning Command CommissioningComplete
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning Command SetRegulatoryConfig
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning ReadAttribute Breadcrumb
-        self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning WriteAttribute Breadcrumb
-        self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning ReadAttribute BasicCommissioningInfoList
-        self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_ClusterRevision.restype = ctypes.c_uint32
         # Cluster GeneralDiagnostics
         # Cluster GeneralDiagnostics ReadAttribute NetworkInterfaces
-        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_NetworkInterfaces.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_NetworkInterfaces.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_NetworkInterfaces.restype = ctypes.c_uint32
         # Cluster GeneralDiagnostics ReadAttribute RebootCount
-        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_RebootCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_RebootCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_RebootCount.restype = ctypes.c_uint32
         # Cluster GeneralDiagnostics ReadAttribute UpTime
-        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_UpTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_UpTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_UpTime.restype = ctypes.c_uint32
         # Cluster GeneralDiagnostics ReadAttribute TotalOperationalHours
-        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_TotalOperationalHours.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_TotalOperationalHours.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_TotalOperationalHours.restype = ctypes.c_uint32
         # Cluster GeneralDiagnostics ReadAttribute BootReasons
-        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_BootReasons.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_BootReasons.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_BootReasons.restype = ctypes.c_uint32
         # Cluster GeneralDiagnostics ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralDiagnostics_ClusterRevision.restype = ctypes.c_uint32
         # Cluster GroupKeyManagement
         # Cluster GroupKeyManagement ReadAttribute Groups
-        self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_Groups.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_Groups.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_Groups.restype = ctypes.c_uint32
         # Cluster GroupKeyManagement ReadAttribute GroupKeys
-        self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_GroupKeys.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_GroupKeys.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_GroupKeys.restype = ctypes.c_uint32
         # Cluster GroupKeyManagement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Groups
         # Cluster Groups Command AddGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.restype = ctypes.c_uint32
         # Cluster Groups Command AddGroupIfIdentifying
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.restype = ctypes.c_uint32
         # Cluster Groups Command GetGroupMembership
-        self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.restype = ctypes.c_uint32
         # Cluster Groups Command RemoveAllGroups
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.restype = ctypes.c_uint32
         # Cluster Groups Command RemoveGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.restype = ctypes.c_uint32
         # Cluster Groups Command ViewGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.restype = ctypes.c_uint32
         # Cluster Groups ReadAttribute NameSupport
-        self._chipLib.chip_ime_ReadAttribute_Groups_NameSupport.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Groups_NameSupport.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Groups_NameSupport.restype = ctypes.c_uint32
         # Cluster Groups ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Groups_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Groups_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Groups_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Identify
         # Cluster Identify Command Identify
-        self._chipLib.chip_ime_AppendCommand_Identify_Identify.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Identify_Identify.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Identify_Identify.restype = ctypes.c_uint32
         # Cluster Identify Command IdentifyQuery
-        self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.restype = ctypes.c_uint32
         # Cluster Identify Command TriggerEffect
-        self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect.restype = ctypes.c_uint32
         # Cluster Identify ReadAttribute IdentifyTime
-        self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime.restype = ctypes.c_uint32
         # Cluster Identify WriteAttribute IdentifyTime
-        self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime.restype = ctypes.c_uint32
         # Cluster Identify ReadAttribute IdentifyType
-        self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyType.restype = ctypes.c_uint32
         # Cluster Identify ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Identify_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Identify_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Identify_ClusterRevision.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement
         # Cluster IlluminanceMeasurement ReadAttribute MeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement SubscribeAttribute MeasuredValue
-        self._chipLib.chip_ime_SubscribeAttribute_IlluminanceMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_IlluminanceMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_IlluminanceMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement ReadAttribute MinMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MinMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MinMeasuredValue.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement ReadAttribute MaxMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MaxMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MaxMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_MaxMeasuredValue.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement ReadAttribute Tolerance
-        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_Tolerance.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_Tolerance.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_Tolerance.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement ReadAttribute LightSensorType
-        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_LightSensorType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_LightSensorType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_LightSensorType.restype = ctypes.c_uint32
         # Cluster IlluminanceMeasurement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster KeypadInput
         # Cluster KeypadInput Command SendKey
-        self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.restype = ctypes.c_uint32
         # Cluster KeypadInput ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster LevelControl
         # Cluster LevelControl Command Move
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Move.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_Move.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_Move.restype = ctypes.c_uint32
         # Cluster LevelControl Command MoveToLevel
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.restype = ctypes.c_uint32
         # Cluster LevelControl Command MoveToLevelWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl Command MoveWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl Command Step
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Step.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_Step.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_Step.restype = ctypes.c_uint32
         # Cluster LevelControl Command StepWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl Command Stop
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.restype = ctypes.c_uint32
         # Cluster LevelControl Command StopWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute CurrentLevel
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl SubscribeAttribute CurrentLevel
-        self._chipLib.chip_ime_SubscribeAttribute_LevelControl_CurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_LevelControl_CurrentLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_LevelControl_CurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute RemainingTime
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_RemainingTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_RemainingTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_RemainingTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute MinLevel
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_MinLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_MinLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_MinLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute MaxLevel
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute CurrentFrequency
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentFrequency.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentFrequency.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentFrequency.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute MinFrequency
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_MinFrequency.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_MinFrequency.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_MinFrequency.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute MaxFrequency
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxFrequency.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxFrequency.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_MaxFrequency.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute Options
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_Options.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_Options.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_Options.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute Options
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_Options.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_Options.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_Options.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OnOffTransitionTime
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute OnOffTransitionTime
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OnLevel
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute OnLevel
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OnTransitionTime
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute OnTransitionTime
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OffTransitionTime
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute OffTransitionTime
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute DefaultMoveRate
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute DefaultMoveRate
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute StartUpCurrentLevel
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl WriteAttribute StartUpCurrentLevel
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster LowPower
         # Cluster LowPower Command Sleep
-        self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.restype = ctypes.c_uint32
         # Cluster LowPower ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.restype = ctypes.c_uint32
         # Cluster MediaInput
         # Cluster MediaInput Command HideInputStatus
-        self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.restype = ctypes.c_uint32
         # Cluster MediaInput Command RenameInput
-        self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.restype = ctypes.c_uint32
         # Cluster MediaInput Command SelectInput
-        self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.restype = ctypes.c_uint32
         # Cluster MediaInput Command ShowInputStatus
-        self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.restype = ctypes.c_uint32
         # Cluster MediaInput ReadAttribute MediaInputList
-        self._chipLib.chip_ime_ReadAttribute_MediaInput_MediaInputList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaInput_MediaInputList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaInput_MediaInputList.restype = ctypes.c_uint32
         # Cluster MediaInput ReadAttribute CurrentMediaInput
-        self._chipLib.chip_ime_ReadAttribute_MediaInput_CurrentMediaInput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaInput_CurrentMediaInput.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaInput_CurrentMediaInput.restype = ctypes.c_uint32
         # Cluster MediaInput ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_MediaInput_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaInput_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaInput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster MediaPlayback
         # Cluster MediaPlayback Command MediaFastForward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaNext
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaPause
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaPlay
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaPrevious
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaRewind
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaSeek
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaSkipBackward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaSkipForward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaStartOver
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaStop
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute PlaybackState
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackState.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackState.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute StartTime
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_StartTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_StartTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_StartTime.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute Duration
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Duration.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Duration.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Duration.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute PositionUpdatedAt
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PositionUpdatedAt.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PositionUpdatedAt.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PositionUpdatedAt.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute Position
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Position.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Position.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_Position.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute PlaybackSpeed
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackSpeed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackSpeed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackSpeed.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute SeekRangeEnd
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeEnd.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeEnd.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeEnd.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute SeekRangeStart
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeStart.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeStart.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_SeekRangeStart.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning
         # Cluster NetworkCommissioning Command AddThreadNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command AddWiFiNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command DisableNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command EnableNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command GetLastNetworkCommissioningResult
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command RemoveNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command ScanNetworks
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command UpdateThreadNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command UpdateWiFiNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning ReadAttribute FeatureMap
-        self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_FeatureMap.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_FeatureMap.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_FeatureMap.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider
         # Cluster OtaSoftwareUpdateProvider Command ApplyUpdateRequest
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider Command NotifyUpdateApplied
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider Command QueryImage
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor
         # Cluster OtaSoftwareUpdateRequestor Command AnnounceOtaProvider
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor ReadAttribute DefaultOtaProvider
-        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor WriteAttribute DefaultOtaProvider
-        self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor ReadAttribute UpdatePossible
-        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OccupancySensing
         # Cluster OccupancySensing ReadAttribute Occupancy
-        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy.restype = ctypes.c_uint32
         # Cluster OccupancySensing SubscribeAttribute Occupancy
-        self._chipLib.chip_ime_SubscribeAttribute_OccupancySensing_Occupancy.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_OccupancySensing_Occupancy.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_OccupancySensing_Occupancy.restype = ctypes.c_uint32
         # Cluster OccupancySensing ReadAttribute OccupancySensorType
-        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorType.restype = ctypes.c_uint32
         # Cluster OccupancySensing ReadAttribute OccupancySensorTypeBitmap
-        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorTypeBitmap.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorTypeBitmap.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorTypeBitmap.restype = ctypes.c_uint32
         # Cluster OccupancySensing ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OccupancySensing_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OnOff
         # Cluster OnOff Command Off
-        self._chipLib.chip_ime_AppendCommand_OnOff_Off.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_Off.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_Off.restype = ctypes.c_uint32
         # Cluster OnOff Command OffWithEffect
-        self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.restype = ctypes.c_uint32
         # Cluster OnOff Command On
-        self._chipLib.chip_ime_AppendCommand_OnOff_On.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_On.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_On.restype = ctypes.c_uint32
         # Cluster OnOff Command OnWithRecallGlobalScene
-        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.restype = ctypes.c_uint32
         # Cluster OnOff Command OnWithTimedOff
-        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.restype = ctypes.c_uint32
         # Cluster OnOff Command Toggle
-        self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute OnOff
-        self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.restype = ctypes.c_uint32
         # Cluster OnOff SubscribeAttribute OnOff
-        self._chipLib.chip_ime_SubscribeAttribute_OnOff_OnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_OnOff_OnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_OnOff_OnOff.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute GlobalSceneControl
-        self._chipLib.chip_ime_ReadAttribute_OnOff_GlobalSceneControl.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_GlobalSceneControl.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_GlobalSceneControl.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute OnTime
-        self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime.restype = ctypes.c_uint32
         # Cluster OnOff WriteAttribute OnTime
-        self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute OffWaitTime
-        self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime.restype = ctypes.c_uint32
         # Cluster OnOff WriteAttribute OffWaitTime
-        self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute StartUpOnOff
-        self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff.restype = ctypes.c_uint32
         # Cluster OnOff WriteAttribute StartUpOnOff
-        self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute FeatureMap
-        self._chipLib.chip_ime_ReadAttribute_OnOff_FeatureMap.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_FeatureMap.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_FeatureMap.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_OnOff_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOff_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OnOffSwitchConfiguration
         # Cluster OnOffSwitchConfiguration ReadAttribute SwitchType
-        self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchType.restype = ctypes.c_uint32
         # Cluster OnOffSwitchConfiguration ReadAttribute SwitchActions
-        self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions.restype = ctypes.c_uint32
         # Cluster OnOffSwitchConfiguration WriteAttribute SwitchActions
-        self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions.restype = ctypes.c_uint32
         # Cluster OnOffSwitchConfiguration ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OperationalCredentials
         # Cluster OperationalCredentials Command AddNOC
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command AddTrustedRootCertificate
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command AttestationRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command CertificateChainRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command OpCSRRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command RemoveFabric
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command RemoveTrustedRootCertificate
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command UpdateFabricLabel
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command UpdateNOC
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute FabricsList
-        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_FabricsList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_FabricsList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_FabricsList.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute SupportedFabrics
-        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_SupportedFabrics.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_SupportedFabrics.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_SupportedFabrics.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute CommissionedFabrics
-        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_CommissionedFabrics.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute TrustedRootCertificates
-        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_TrustedRootCertificates.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision.restype = ctypes.c_uint32
         # Cluster PowerSource
         # Cluster PowerSource ReadAttribute Status
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_Status.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_Status.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_Status.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute Order
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_Order.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_Order.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_Order.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute Description
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_Description.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_Description.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_Description.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute BatteryVoltage
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryVoltage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryVoltage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryVoltage.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute BatteryPercentRemaining
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryPercentRemaining.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryPercentRemaining.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryPercentRemaining.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute BatteryTimeRemaining
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryTimeRemaining.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryTimeRemaining.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryTimeRemaining.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute BatteryChargeLevel
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeLevel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeLevel.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute ActiveBatteryFaults
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_ActiveBatteryFaults.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_ActiveBatteryFaults.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_ActiveBatteryFaults.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute BatteryChargeState
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeState.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_BatteryChargeState.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute FeatureMap
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_FeatureMap.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_FeatureMap.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_FeatureMap.restype = ctypes.c_uint32
         # Cluster PowerSource ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_PowerSource_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PowerSource_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PowerSource_ClusterRevision.restype = ctypes.c_uint32
         # Cluster PressureMeasurement
         # Cluster PressureMeasurement ReadAttribute MeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster PressureMeasurement SubscribeAttribute MeasuredValue
-        self._chipLib.chip_ime_SubscribeAttribute_PressureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_PressureMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_PressureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster PressureMeasurement ReadAttribute MinMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MinMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MinMeasuredValue.restype = ctypes.c_uint32
         # Cluster PressureMeasurement ReadAttribute MaxMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MaxMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MaxMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MaxMeasuredValue.restype = ctypes.c_uint32
         # Cluster PressureMeasurement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl
         # Cluster PumpConfigurationAndControl ReadAttribute MaxPressure
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxPressure.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxPressure.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxPressure.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxSpeed
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxSpeed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxSpeed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxSpeed.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxFlow
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxFlow.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxFlow.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxFlow.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MinConstPressure
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstPressure.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstPressure.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstPressure.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxConstPressure
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstPressure.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstPressure.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstPressure.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MinCompPressure
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinCompPressure.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinCompPressure.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinCompPressure.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxCompPressure
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxCompPressure.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxCompPressure.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxCompPressure.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MinConstSpeed
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstSpeed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstSpeed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstSpeed.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxConstSpeed
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstSpeed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstSpeed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstSpeed.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MinConstFlow
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstFlow.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstFlow.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstFlow.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxConstFlow
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstFlow.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstFlow.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstFlow.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MinConstTemp
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstTemp.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstTemp.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MinConstTemp.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute MaxConstTemp
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstTemp.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstTemp.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_MaxConstTemp.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute PumpStatus
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_PumpStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_PumpStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_PumpStatus.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl SubscribeAttribute PumpStatus
-        self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_PumpStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_PumpStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_PumpStatus.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute EffectiveOperationMode
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveOperationMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveOperationMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveOperationMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute EffectiveControlMode
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveControlMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveControlMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveControlMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute Capacity
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl SubscribeAttribute Capacity
-        self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_Capacity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_Capacity.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_PumpConfigurationAndControl_Capacity.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute Speed
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Speed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Speed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Speed.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute LifetimeEnergyConsumed
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_LifetimeEnergyConsumed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_LifetimeEnergyConsumed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_LifetimeEnergyConsumed.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute OperationMode
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl WriteAttribute OperationMode
-        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute ControlMode
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl WriteAttribute ControlMode
-        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute AlarmMask
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute FeatureMap
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_FeatureMap.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_FeatureMap.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_FeatureMap.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement
         # Cluster RelativeHumidityMeasurement ReadAttribute MeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement SubscribeAttribute MeasuredValue
-        self._chipLib.chip_ime_SubscribeAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_RelativeHumidityMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement ReadAttribute MinMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MinMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MinMeasuredValue.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement ReadAttribute MaxMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MaxMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MaxMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MaxMeasuredValue.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Scenes
         # Cluster Scenes Command AddScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16,
+                                                                         ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.restype = ctypes.c_uint32
         # Cluster Scenes Command GetSceneMembership
-        self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.restype = ctypes.c_uint32
         # Cluster Scenes Command RecallScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.restype = ctypes.c_uint32
         # Cluster Scenes Command RemoveAllScenes
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.restype = ctypes.c_uint32
         # Cluster Scenes Command RemoveScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.restype = ctypes.c_uint32
         # Cluster Scenes Command StoreScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.restype = ctypes.c_uint32
         # Cluster Scenes Command ViewScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute SceneCount
-        self._chipLib.chip_ime_ReadAttribute_Scenes_SceneCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Scenes_SceneCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_SceneCount.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute CurrentScene
-        self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentScene.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentScene.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute CurrentGroup
-        self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentGroup.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_CurrentGroup.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute SceneValid
-        self._chipLib.chip_ime_ReadAttribute_Scenes_SceneValid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Scenes_SceneValid.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_SceneValid.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute NameSupport
-        self._chipLib.chip_ime_ReadAttribute_Scenes_NameSupport.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Scenes_NameSupport.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_NameSupport.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Scenes_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Scenes_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_ClusterRevision.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics
         # Cluster SoftwareDiagnostics Command ResetWatermarks
-        self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics ReadAttribute CurrentHeapFree
-        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapFree.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapFree.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapFree.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics ReadAttribute CurrentHeapUsed
-        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapUsed.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapUsed.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapUsed.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics ReadAttribute CurrentHeapHighWatermark
-        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapHighWatermark.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapHighWatermark.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_CurrentHeapHighWatermark.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Switch
         # Cluster Switch ReadAttribute NumberOfPositions
-        self._chipLib.chip_ime_ReadAttribute_Switch_NumberOfPositions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Switch_NumberOfPositions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Switch_NumberOfPositions.restype = ctypes.c_uint32
         # Cluster Switch ReadAttribute CurrentPosition
-        self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition.restype = ctypes.c_uint32
         # Cluster Switch SubscribeAttribute CurrentPosition
-        self._chipLib.chip_ime_SubscribeAttribute_Switch_CurrentPosition.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_Switch_CurrentPosition.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_Switch_CurrentPosition.restype = ctypes.c_uint32
         # Cluster Switch ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TvChannel
         # Cluster TvChannel Command ChangeChannel
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.restype = ctypes.c_uint32
         # Cluster TvChannel Command ChangeChannelByNumber
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.restype = ctypes.c_uint32
         # Cluster TvChannel Command SkipChannel
-        self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.restype = ctypes.c_uint32
         # Cluster TvChannel ReadAttribute TvChannelList
-        self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelList.restype = ctypes.c_uint32
         # Cluster TvChannel ReadAttribute TvChannelLineup
-        self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelLineup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelLineup.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelLineup.restype = ctypes.c_uint32
         # Cluster TvChannel ReadAttribute CurrentTvChannel
-        self._chipLib.chip_ime_ReadAttribute_TvChannel_CurrentTvChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TvChannel_CurrentTvChannel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TvChannel_CurrentTvChannel.restype = ctypes.c_uint32
         # Cluster TvChannel ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_TvChannel_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TvChannel_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TvChannel_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TargetNavigator
         # Cluster TargetNavigator Command NavigateTarget
-        self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.restype = ctypes.c_uint32
         # Cluster TargetNavigator ReadAttribute TargetNavigatorList
-        self._chipLib.chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList.restype = ctypes.c_uint32
         # Cluster TargetNavigator ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_TargetNavigator_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TargetNavigator_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TargetNavigator_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement
         # Cluster TemperatureMeasurement ReadAttribute MeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement SubscribeAttribute MeasuredValue
-        self._chipLib.chip_ime_SubscribeAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_TemperatureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement ReadAttribute MinMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MinMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MinMeasuredValue.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement ReadAttribute MaxMeasuredValue
-        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MaxMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MaxMeasuredValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MaxMeasuredValue.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TestCluster
         # Cluster TestCluster Command Test
-        self._chipLib.chip_ime_AppendCommand_TestCluster_Test.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_Test.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_Test.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestAddArguments
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestEnumsRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestListInt8UArgumentRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestListInt8UReverseRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestListStructArgumentRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_bool, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_bool, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestNotHandled
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestNullableOptionalRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestSpecific
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestStructArgumentRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_bool, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_bool, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestUnknownCommand
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Boolean
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Boolean
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap8
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Bitmap8
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap16
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Bitmap16
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap32
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Bitmap32
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap64
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Bitmap64
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int8u
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int8u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int16u
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int16u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int32u
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int32u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int64u
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int64u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int8s
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int8s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int16s
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int16s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int32s
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int32s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int64s
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Int64s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int64]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int64]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Enum8
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Enum8
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Enum16
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Enum16
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute OctetString
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute OctetString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ListInt8u
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_ListInt8u.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_ListInt8u.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ListInt8u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ListOctetString
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_ListOctetString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_ListOctetString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ListOctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ListStructOctetString
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_ListStructOctetString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_ListStructOctetString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ListStructOctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute LongOctetString
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute LongOctetString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute CharString
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute CharString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute LongCharString
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute LongCharString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute EpochUs
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute EpochUs
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute EpochS
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute EpochS
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute VendorId
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute VendorId
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Unsupported
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Unsupported
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Thermostat
         # Cluster Thermostat Command ClearWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.restype = ctypes.c_uint32
         # Cluster Thermostat Command GetRelayStatusLog
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.restype = ctypes.c_uint32
         # Cluster Thermostat Command GetWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.restype = ctypes.c_uint32
         # Cluster Thermostat Command SetWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.restype = ctypes.c_uint32
         # Cluster Thermostat Command SetpointRaiseLower
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_int8]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_int8]
         self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute LocalTemperature
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.restype = ctypes.c_uint32
         # Cluster Thermostat SubscribeAttribute LocalTemperature
-        self._chipLib.chip_ime_SubscribeAttribute_Thermostat_LocalTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_Thermostat_LocalTemperature.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_Thermostat_LocalTemperature.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute AbsMinHeatSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinHeatSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute AbsMaxHeatSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxHeatSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute AbsMinCoolSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinCoolSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinCoolSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute AbsMaxCoolSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxCoolSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxCoolSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMaxCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute OccupiedCoolingSetpoint
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute OccupiedCoolingSetpoint
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute OccupiedHeatingSetpoint
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute OccupiedHeatingSetpoint
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MinHeatSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute MinHeatSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MaxHeatSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute MaxHeatSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MinCoolSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute MinCoolSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MaxCoolSetpointLimit
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute MaxCoolSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MinSetpointDeadBand
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute MinSetpointDeadBand
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute ControlSequenceOfOperation
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute ControlSequenceOfOperation
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute SystemMode
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode.restype = ctypes.c_uint32
         # Cluster Thermostat WriteAttribute SystemMode
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute StartOfWeek
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_StartOfWeek.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_StartOfWeek.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_StartOfWeek.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute NumberOfWeeklyTransitions
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfWeeklyTransitions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfWeeklyTransitions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfWeeklyTransitions.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute NumberOfDailyTransitions
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfDailyTransitions.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfDailyTransitions.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_NumberOfDailyTransitions.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute FeatureMap
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_FeatureMap.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_FeatureMap.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_FeatureMap.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_Thermostat_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_Thermostat_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute TemperatureDisplayMode
-        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration WriteAttribute TemperatureDisplayMode
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute KeypadLockout
-        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration WriteAttribute KeypadLockout
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute ScheduleProgrammingVisibility
-        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration WriteAttribute ScheduleProgrammingVisibility
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics
         # Cluster ThreadNetworkDiagnostics Command ResetCounts
-        self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute Channel
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Channel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Channel.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Channel.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RoutingRole
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RoutingRole.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RoutingRole.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RoutingRole.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute NetworkName
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NetworkName.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NetworkName.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NetworkName.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute PanId
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PanId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PanId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PanId.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ExtendedPanId
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ExtendedPanId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ExtendedPanId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ExtendedPanId.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute MeshLocalPrefix
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_MeshLocalPrefix.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_MeshLocalPrefix.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_MeshLocalPrefix.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute OverrunCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OverrunCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OverrunCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OverrunCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute NeighborTableList
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NeighborTableList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NeighborTableList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_NeighborTableList.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RouteTableList
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouteTableList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouteTableList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouteTableList.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute PartitionId
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionId.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute Weighting
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Weighting.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Weighting.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Weighting.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute DataVersion
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DataVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DataVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DataVersion.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute StableDataVersion
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_StableDataVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_StableDataVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_StableDataVersion.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute LeaderRouterId
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRouterId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRouterId.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRouterId.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute DetachedRoleCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DetachedRoleCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DetachedRoleCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_DetachedRoleCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ChildRoleCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChildRoleCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChildRoleCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChildRoleCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RouterRoleCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouterRoleCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouterRoleCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RouterRoleCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute LeaderRoleCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRoleCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRoleCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_LeaderRoleCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute AttachAttemptCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_AttachAttemptCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_AttachAttemptCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_AttachAttemptCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute PartitionIdChangeCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionIdChangeCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionIdChangeCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PartitionIdChangeCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute BetterPartitionAttachAttemptCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_BetterPartitionAttachAttemptCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_BetterPartitionAttachAttemptCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_BetterPartitionAttachAttemptCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ParentChangeCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ParentChangeCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ParentChangeCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ParentChangeCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxTotalCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxTotalCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxTotalCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxTotalCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxUnicastCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxUnicastCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxUnicastCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxUnicastCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxBroadcastCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBroadcastCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBroadcastCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBroadcastCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxAckRequestedCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckRequestedCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckRequestedCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckRequestedCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxAckedCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckedCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckedCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxAckedCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxNoAckRequestedCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxNoAckRequestedCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxNoAckRequestedCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxNoAckRequestedCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxDataCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxDataPollCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataPollCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataPollCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDataPollCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxBeaconCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxBeaconRequestCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconRequestCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconRequestCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxBeaconRequestCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxOtherCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxOtherCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxOtherCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxOtherCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxRetryCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxRetryCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxRetryCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxRetryCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxDirectMaxRetryExpiryCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDirectMaxRetryExpiryCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDirectMaxRetryExpiryCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxDirectMaxRetryExpiryCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxIndirectMaxRetryExpiryCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxIndirectMaxRetryExpiryCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxIndirectMaxRetryExpiryCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxIndirectMaxRetryExpiryCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxErrCcaCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrCcaCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrCcaCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrCcaCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxErrAbortCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrAbortCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrAbortCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrAbortCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute TxErrBusyChannelCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrBusyChannelCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrBusyChannelCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_TxErrBusyChannelCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxTotalCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxTotalCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxTotalCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxTotalCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxUnicastCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxUnicastCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxUnicastCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxUnicastCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxBroadcastCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBroadcastCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBroadcastCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBroadcastCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxDataCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxDataPollCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataPollCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataPollCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDataPollCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxBeaconCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxBeaconRequestCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconRequestCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconRequestCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxBeaconRequestCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxOtherCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxOtherCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxOtherCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxOtherCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxAddressFilteredCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxAddressFilteredCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxAddressFilteredCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxAddressFilteredCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxDestAddrFilteredCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDestAddrFilteredCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDestAddrFilteredCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDestAddrFilteredCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxDuplicatedCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDuplicatedCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDuplicatedCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxDuplicatedCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxErrNoFrameCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrNoFrameCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrNoFrameCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrNoFrameCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxErrUnknownNeighborCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrUnknownNeighborCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrUnknownNeighborCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrUnknownNeighborCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxErrInvalidSrcAddrCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrInvalidSrcAddrCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrInvalidSrcAddrCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrInvalidSrcAddrCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxErrSecCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrSecCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrSecCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrSecCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxErrFcsCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrFcsCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrFcsCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrFcsCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute RxErrOtherCount
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrOtherCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrOtherCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_RxErrOtherCount.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ActiveTimestamp
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveTimestamp.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveTimestamp.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveTimestamp.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute PendingTimestamp
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PendingTimestamp.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PendingTimestamp.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_PendingTimestamp.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute Delay
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Delay.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Delay.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Delay.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute SecurityPolicy
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_SecurityPolicy.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_SecurityPolicy.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_SecurityPolicy.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ChannelMask
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChannelMask.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChannelMask.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ChannelMask.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute OperationalDatasetComponents
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OperationalDatasetComponents.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OperationalDatasetComponents.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_OperationalDatasetComponents.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ActiveNetworkFaultsList
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveNetworkFaultsList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveNetworkFaultsList.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ActiveNetworkFaultsList.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_ClusterRevision.restype = ctypes.c_uint32
         # Cluster WakeOnLan
         # Cluster WakeOnLan ReadAttribute WakeOnLanMacAddress
-        self._chipLib.chip_ime_ReadAttribute_WakeOnLan_WakeOnLanMacAddress.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WakeOnLan_WakeOnLanMacAddress.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WakeOnLan_WakeOnLanMacAddress.restype = ctypes.c_uint32
         # Cluster WakeOnLan ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_WakeOnLan_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WakeOnLan_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WakeOnLan_ClusterRevision.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics
         # Cluster WiFiNetworkDiagnostics Command ResetCounts
-        self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute Bssid
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Bssid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Bssid.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Bssid.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute SecurityType
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_SecurityType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_SecurityType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_SecurityType.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute WiFiVersion
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_WiFiVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_WiFiVersion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_WiFiVersion.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute ChannelNumber
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ChannelNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ChannelNumber.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ChannelNumber.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute Rssi
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Rssi.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Rssi.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Rssi.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute BeaconLostCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconLostCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconLostCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconLostCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute BeaconRxCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconRxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconRxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_BeaconRxCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute PacketMulticastRxCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastRxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastRxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastRxCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute PacketMulticastTxCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastTxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastTxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketMulticastTxCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute PacketUnicastRxCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastRxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastRxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastRxCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute PacketUnicastTxCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastTxCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastTxCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_PacketUnicastTxCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute CurrentMaxRate
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_CurrentMaxRate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_CurrentMaxRate.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_CurrentMaxRate.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute OverrunCount
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_OverrunCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_OverrunCount.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_OverrunCount.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ClusterRevision.restype = ctypes.c_uint32
         # Cluster WindowCovering
         # Cluster WindowCovering Command DownOrClose
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose.restype = ctypes.c_uint32
         # Cluster WindowCovering Command GoToLiftPercentage
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering Command GoToLiftValue
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue.restype = ctypes.c_uint32
         # Cluster WindowCovering Command GoToTiltPercentage
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering Command GoToTiltValue
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue.restype = ctypes.c_uint32
         # Cluster WindowCovering Command StopMotion
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion.restype = ctypes.c_uint32
         # Cluster WindowCovering Command UpOrOpen
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute Type
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_Type.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_Type.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_Type.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionLift
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLift.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLift.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLift.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionTilt
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTilt.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTilt.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTilt.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute ConfigStatus
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_ConfigStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_ConfigStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_ConfigStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionLiftPercentage
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute CurrentPositionLiftPercentage
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionTiltPercentage
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute CurrentPositionTiltPercentage
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute OperationalStatus
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute OperationalStatus
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_OperationalStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_OperationalStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_OperationalStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute TargetPositionLiftPercent100ths
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute TargetPositionLiftPercent100ths
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute TargetPositionTiltPercent100ths
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute TargetPositionTiltPercent100ths
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_TargetPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute EndProductType
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_EndProductType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_EndProductType.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_EndProductType.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionLiftPercent100ths
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute CurrentPositionLiftPercent100ths
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionTiltPercent100ths
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute CurrentPositionTiltPercent100ths
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_CurrentPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute InstalledOpenLimitLift
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitLift.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitLift.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitLift.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute InstalledClosedLimitLift
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitLift.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitLift.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitLift.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute InstalledOpenLimitTilt
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitTilt.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitTilt.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitTilt.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute InstalledClosedLimitTilt
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitTilt.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitTilt.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledClosedLimitTilt.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute Mode
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode.restype = ctypes.c_uint32
         # Cluster WindowCovering WriteAttribute Mode
-        self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute SafetyStatus
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering SubscribeAttribute SafetyStatus
-        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_SafetyStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_SafetyStatus.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_WindowCovering_SafetyStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute ClusterRevision
-        self._chipLib.chip_ime_ReadAttribute_WindowCovering_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_WindowCovering_ClusterRevision.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_ClusterRevision.restype = ctypes.c_uint32
         # Init response delegates
+
         def HandleSuccess():
             self._ChipStack.callbackRes = 0
             self._ChipStack.completeEvent.set()

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -36,9 +36,6 @@ from .ClusterObjects import ClusterObject, ClusterObjectDescriptor, ClusterObjec
 class PowerConfiguration:
     id: typing.ClassVar[int] = 0x0001
 
-
-
-
     class Attributes:
         class MainsVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -53,7 +50,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MainsFrequency(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -66,7 +62,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MainsAlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -81,7 +76,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MainsVoltageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -94,7 +88,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MainsVoltageMaxThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -109,7 +102,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MainsVoltageDwellTrip(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -122,7 +114,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -137,7 +128,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryPercentageRemaining(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -150,7 +140,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryManufacturer(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -165,7 +154,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class BatterySize(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -178,7 +166,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryAhrRating(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -193,7 +180,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryQuantity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -206,7 +192,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryRatedVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -221,7 +206,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryAlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -234,7 +218,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryVoltageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -249,7 +232,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryVoltageThreshold1(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -262,7 +244,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryVoltageThreshold2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -277,7 +258,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryVoltageThreshold3(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -290,7 +270,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryPercentageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -305,7 +284,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryPercentageThreshold1(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -318,7 +296,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryPercentageThreshold2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -333,7 +310,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryPercentageThreshold3(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -346,7 +322,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryAlarmState(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -361,7 +336,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2Voltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -374,7 +348,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2PercentageRemaining(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -389,7 +362,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2Manufacturer(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -402,7 +374,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class Battery2Size(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -417,7 +388,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2AhrRating(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -430,7 +400,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2Quantity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -445,7 +414,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2RatedVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -458,7 +426,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2AlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -473,7 +440,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2VoltageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -486,7 +452,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2VoltageThreshold1(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -501,7 +466,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2VoltageThreshold2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -514,7 +478,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2VoltageThreshold3(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -529,7 +492,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2PercentageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -542,7 +504,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2PercentageThreshold1(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -557,7 +518,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2PercentageThreshold2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -570,7 +530,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery2PercentageThreshold3(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -585,7 +544,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery2AlarmState(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -598,7 +556,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3Voltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -613,7 +570,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3PercentageRemaining(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -626,7 +582,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3Manufacturer(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -641,7 +596,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class Battery3Size(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -654,7 +608,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3AhrRating(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -669,7 +622,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3Quantity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -682,7 +634,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3RatedVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -697,7 +648,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3AlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -710,7 +660,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3VoltageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -725,7 +674,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3VoltageThreshold1(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -738,7 +686,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3VoltageThreshold2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -753,7 +700,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3VoltageThreshold3(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -766,7 +712,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3PercentageMinThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -781,7 +726,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3PercentageThreshold1(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -794,7 +738,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3PercentageThreshold2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -809,7 +752,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Battery3PercentageThreshold3(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -822,7 +764,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Battery3AlarmState(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -837,7 +778,6 @@ class PowerConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -850,7 +790,6 @@ class PowerConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -866,14 +805,9 @@ class PowerConfiguration:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class DeviceTemperatureConfiguration:
     id: typing.ClassVar[int] = 0x0002
-
-
-
 
     class Attributes:
         class CurrentTemperature(ClusterAttributeDescriptor):
@@ -889,7 +823,6 @@ class DeviceTemperatureConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinTempExperienced(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -902,7 +835,6 @@ class DeviceTemperatureConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxTempExperienced(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -917,7 +849,6 @@ class DeviceTemperatureConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class OverTempTotalDwell(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -930,7 +861,6 @@ class DeviceTemperatureConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DeviceTempAlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -945,7 +875,6 @@ class DeviceTemperatureConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LowTempThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -958,7 +887,6 @@ class DeviceTemperatureConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class HighTempThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -973,7 +901,6 @@ class DeviceTemperatureConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class LowTempDwellTripPoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -986,7 +913,6 @@ class DeviceTemperatureConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class HighTempDwellTripPoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -1001,7 +927,6 @@ class DeviceTemperatureConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1015,7 +940,6 @@ class DeviceTemperatureConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1028,8 +952,6 @@ class DeviceTemperatureConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -1056,8 +978,6 @@ class Identify:
             kDisplay = 0x04
             kActuator = 0x05
 
-
-
     class Commands:
         @dataclass
         class Identify(ClusterCommand):
@@ -1067,8 +987,9 @@ class Identify:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="IdentifyTime", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="IdentifyTime", Tag=0, Type=uint),
                     ])
 
             IdentifyTime: 'uint' = None
@@ -1081,8 +1002,9 @@ class Identify:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Timeout", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Timeout", Tag=0, Type=uint),
                     ])
 
             Timeout: 'uint' = None
@@ -1095,9 +1017,8 @@ class Identify:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class TriggerEffect(ClusterCommand):
@@ -1107,14 +1028,15 @@ class Identify:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EffectIdentifier", Tag=0, Type=Identify.Enums.IdentifyEffectIdentifier),
-                            ClusterObjectFieldDescriptor(Label="EffectVariant", Tag=1, Type=Identify.Enums.IdentifyEffectVariant),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EffectIdentifier", Tag=0, Type=Identify.Enums.IdentifyEffectIdentifier),
+                        ClusterObjectFieldDescriptor(
+                            Label="EffectVariant", Tag=1, Type=Identify.Enums.IdentifyEffectVariant),
                     ])
 
             EffectIdentifier: 'Identify.Enums.IdentifyEffectIdentifier' = None
             EffectVariant: 'Identify.Enums.IdentifyEffectVariant' = None
-
 
     class Attributes:
         class IdentifyTime(ClusterAttributeDescriptor):
@@ -1130,7 +1052,6 @@ class Identify:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class IdentifyType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1144,7 +1065,6 @@ class Identify:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1157,7 +1077,6 @@ class Identify:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -1173,13 +1092,9 @@ class Identify:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Groups:
     id: typing.ClassVar[int] = 0x0004
-
-
 
     class Commands:
         @dataclass
@@ -1190,9 +1105,11 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupName", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupName", Tag=1, Type=str),
                     ])
 
             GroupId: 'uint' = None
@@ -1206,9 +1123,11 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1222,8 +1141,9 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1236,10 +1156,13 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupName", Tag=2, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupName", Tag=2, Type=str),
                     ])
 
             Status: 'uint' = None
@@ -1254,9 +1177,11 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupCount", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupList", Tag=1, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupCount", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupList", Tag=1, Type=uint, IsArray=True),
                     ])
 
             GroupCount: 'uint' = None
@@ -1270,10 +1195,13 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Capacity", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupCount", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupList", Tag=2, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Capacity", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupCount", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupList", Tag=2, Type=uint, IsArray=True),
                     ])
 
             Capacity: 'uint' = None
@@ -1288,8 +1216,9 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1302,9 +1231,11 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1318,9 +1249,8 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class AddGroupIfIdentifying(ClusterCommand):
@@ -1330,14 +1260,15 @@ class Groups:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupName", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupName", Tag=1, Type=str),
                     ])
 
             GroupId: 'uint' = None
             GroupName: 'str' = None
-
 
     class Attributes:
         class NameSupport(ClusterAttributeDescriptor):
@@ -1353,7 +1284,6 @@ class Groups:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1366,7 +1296,6 @@ class Groups:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -1382,12 +1311,9 @@ class Groups:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Scenes:
     id: typing.ClassVar[int] = 0x0005
-
 
     class Structs:
         @dataclass
@@ -1395,17 +1321,18 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ClusterId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Length", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Value", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ClusterId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Length", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Value", Tag=2, Type=uint),
                     ])
 
             ClusterId: 'uint' = None
             Length: 'uint' = None
             Value: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -1416,12 +1343,17 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneName", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ExtensionFieldSets", Tag=4, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneName", Tag=3, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtensionFieldSets", Tag=4, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
                     ])
 
             GroupId: 'uint' = None
@@ -1438,10 +1370,13 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=2, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1456,9 +1391,11 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1472,13 +1409,19 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneName", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ExtensionFieldSets", Tag=5, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneName", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtensionFieldSets", Tag=5, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
                     ])
 
             Status: 'uint' = None
@@ -1496,9 +1439,11 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1512,10 +1457,13 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=2, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1530,8 +1478,9 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1544,9 +1493,11 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1560,9 +1511,11 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1576,10 +1529,13 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=2, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1594,10 +1550,13 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1612,8 +1571,9 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1626,12 +1586,17 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Capacity", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneCount", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneList", Tag=4, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Capacity", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneCount", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneList", Tag=4, Type=uint, IsArray=True),
                     ])
 
             Status: 'uint' = None
@@ -1648,12 +1613,17 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneName", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ExtensionFieldSets", Tag=4, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneName", Tag=3, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtensionFieldSets", Tag=4, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
                     ])
 
             GroupId: 'uint' = None
@@ -1670,10 +1640,13 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=2, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -1688,9 +1661,11 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=1, Type=uint),
                     ])
 
             GroupId: 'uint' = None
@@ -1704,13 +1679,19 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneName", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ExtensionFieldSets", Tag=5, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneName", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtensionFieldSets", Tag=5, Type=Scenes.Structs.SceneExtensionFieldSet, IsArray=True),
                     ])
 
             Status: 'uint' = None
@@ -1728,12 +1709,17 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Mode", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="GroupIdFrom", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneIdFrom", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupIdTo", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneIdTo", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Mode", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupIdFrom", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneIdFrom", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupIdTo", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneIdTo", Tag=4, Type=uint),
                     ])
 
             Mode: 'int' = None
@@ -1750,16 +1736,18 @@ class Scenes:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupIdFrom", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SceneIdFrom", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupIdFrom", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SceneIdFrom", Tag=2, Type=uint),
                     ])
 
             Status: 'uint' = None
             GroupIdFrom: 'uint' = None
             SceneIdFrom: 'uint' = None
-
 
     class Attributes:
         class SceneCount(ClusterAttributeDescriptor):
@@ -1775,7 +1763,6 @@ class Scenes:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentScene(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1788,7 +1775,6 @@ class Scenes:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentGroup(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -1803,7 +1789,6 @@ class Scenes:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SceneValid(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1816,7 +1801,6 @@ class Scenes:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class NameSupport(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -1831,7 +1815,6 @@ class Scenes:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LastConfiguredBy(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1844,7 +1827,6 @@ class Scenes:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -1859,7 +1841,6 @@ class Scenes:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -1872,8 +1853,6 @@ class Scenes:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -1893,8 +1872,6 @@ class OnOff:
             kDelayedAllOff = 0x00
             kDyingLight = 0x01
 
-
-
     class Commands:
         @dataclass
         class Off(ClusterCommand):
@@ -1904,9 +1881,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SampleMfgSpecificOffWithTransition(ClusterCommand):
@@ -1916,9 +1892,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class On(ClusterCommand):
@@ -1928,9 +1903,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SampleMfgSpecificOnWithTransition(ClusterCommand):
@@ -1940,9 +1914,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SampleMfgSpecificOnWithTransition2(ClusterCommand):
@@ -1952,9 +1925,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class Toggle(ClusterCommand):
@@ -1964,9 +1936,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SampleMfgSpecificToggleWithTransition(ClusterCommand):
@@ -1976,9 +1947,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SampleMfgSpecificToggleWithTransition2(ClusterCommand):
@@ -1988,9 +1958,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class OffWithEffect(ClusterCommand):
@@ -2000,9 +1969,11 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EffectId", Tag=0, Type=OnOff.Enums.OnOffEffectIdentifier),
-                            ClusterObjectFieldDescriptor(Label="EffectVariant", Tag=1, Type=OnOff.Enums.OnOffDelayedAllOffEffectVariant),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EffectId", Tag=0, Type=OnOff.Enums.OnOffEffectIdentifier),
+                        ClusterObjectFieldDescriptor(
+                            Label="EffectVariant", Tag=1, Type=OnOff.Enums.OnOffDelayedAllOffEffectVariant),
                     ])
 
             EffectId: 'OnOff.Enums.OnOffEffectIdentifier' = None
@@ -2016,9 +1987,8 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class OnWithTimedOff(ClusterCommand):
@@ -2028,16 +1998,18 @@ class OnOff:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="OnOffControl", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="OnTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OffWaitTime", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="OnOffControl", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="OnTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OffWaitTime", Tag=2, Type=uint),
                     ])
 
             OnOffControl: 'int' = None
             OnTime: 'uint' = None
             OffWaitTime: 'uint' = None
-
 
     class Attributes:
         class OnOff(ClusterAttributeDescriptor):
@@ -2053,7 +2025,6 @@ class OnOff:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class SampleMfgSpecificAttribute0x00000x1002(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2066,7 +2037,6 @@ class OnOff:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SampleMfgSpecificAttribute0x00000x1049(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2081,7 +2051,6 @@ class OnOff:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SampleMfgSpecificAttribute0x00010x1002(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2094,7 +2063,6 @@ class OnOff:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SampleMfgSpecificAttribute0x00010x1040(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2109,7 +2077,6 @@ class OnOff:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class GlobalSceneControl(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2122,7 +2089,6 @@ class OnOff:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class OnTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2137,7 +2103,6 @@ class OnOff:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OffWaitTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2150,7 +2115,6 @@ class OnOff:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class StartUpOnOff(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2165,7 +2129,6 @@ class OnOff:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2178,7 +2141,6 @@ class OnOff:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2194,14 +2156,9 @@ class OnOff:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class OnOffSwitchConfiguration:
     id: typing.ClassVar[int] = 0x0007
-
-
-
 
     class Attributes:
         class SwitchType(ClusterAttributeDescriptor):
@@ -2217,7 +2174,6 @@ class OnOffSwitchConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SwitchActions(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2231,7 +2187,6 @@ class OnOffSwitchConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2244,7 +2199,6 @@ class OnOffSwitchConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2260,8 +2214,6 @@ class OnOffSwitchConfiguration:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class LevelControl:
     id: typing.ClassVar[int] = 0x0008
@@ -2275,8 +2227,6 @@ class LevelControl:
             kUp = 0x00
             kDown = 0x01
 
-
-
     class Commands:
         @dataclass
         class MoveToLevel(ClusterCommand):
@@ -2286,11 +2236,15 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Level", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Level", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionOverride", Tag=3, Type=uint),
                     ])
 
             Level: 'uint' = None
@@ -2306,11 +2260,15 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MoveMode", Tag=0, Type=LevelControl.Enums.MoveMode),
-                            ClusterObjectFieldDescriptor(Label="Rate", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MoveMode", Tag=0, Type=LevelControl.Enums.MoveMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rate", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionOverride", Tag=3, Type=uint),
                     ])
 
             MoveMode: 'LevelControl.Enums.MoveMode' = None
@@ -2326,12 +2284,17 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepMode", Tag=0, Type=LevelControl.Enums.StepMode),
-                            ClusterObjectFieldDescriptor(Label="StepSize", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepMode", Tag=0, Type=LevelControl.Enums.StepMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepSize", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionOverride", Tag=4, Type=uint),
                     ])
 
             StepMode: 'LevelControl.Enums.StepMode' = None
@@ -2348,9 +2311,11 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="OptionMask", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionOverride", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionMask", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionOverride", Tag=1, Type=uint),
                     ])
 
             OptionMask: 'uint' = None
@@ -2364,9 +2329,11 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Level", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Level", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=1, Type=uint),
                     ])
 
             Level: 'uint' = None
@@ -2380,9 +2347,11 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MoveMode", Tag=0, Type=LevelControl.Enums.MoveMode),
-                            ClusterObjectFieldDescriptor(Label="Rate", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MoveMode", Tag=0, Type=LevelControl.Enums.MoveMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rate", Tag=1, Type=uint),
                     ])
 
             MoveMode: 'LevelControl.Enums.MoveMode' = None
@@ -2396,10 +2365,13 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepMode", Tag=0, Type=LevelControl.Enums.StepMode),
-                            ClusterObjectFieldDescriptor(Label="StepSize", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepMode", Tag=0, Type=LevelControl.Enums.StepMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepSize", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
                     ])
 
             StepMode: 'LevelControl.Enums.StepMode' = None
@@ -2414,10 +2386,8 @@ class LevelControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class CurrentLevel(ClusterAttributeDescriptor):
@@ -2433,7 +2403,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RemainingTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2446,7 +2415,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MinLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2461,7 +2429,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MaxLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2474,7 +2441,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentFrequency(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2489,7 +2455,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinFrequency(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2502,7 +2467,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxFrequency(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2517,7 +2481,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Options(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2530,7 +2493,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OnOffTransitionTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2545,7 +2507,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OnLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2558,7 +2519,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OnTransitionTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2573,7 +2533,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OffTransitionTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2586,7 +2545,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DefaultMoveRate(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2601,7 +2559,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class StartUpCurrentLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2615,7 +2572,6 @@ class LevelControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2628,7 +2584,6 @@ class LevelControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2644,13 +2599,9 @@ class LevelControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Alarms:
     id: typing.ClassVar[int] = 0x0009
-
-
 
     class Commands:
         @dataclass
@@ -2661,9 +2612,11 @@ class Alarms:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AlarmCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ClusterId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AlarmCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ClusterId", Tag=1, Type=uint),
                     ])
 
             AlarmCode: 'uint' = None
@@ -2677,9 +2630,11 @@ class Alarms:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AlarmCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ClusterId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AlarmCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ClusterId", Tag=1, Type=uint),
                     ])
 
             AlarmCode: 'uint' = None
@@ -2693,9 +2648,8 @@ class Alarms:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetAlarmResponse(ClusterCommand):
@@ -2705,11 +2659,15 @@ class Alarms:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AlarmCode", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ClusterId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeStamp", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AlarmCode", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ClusterId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeStamp", Tag=3, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -2725,9 +2683,8 @@ class Alarms:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ResetAlarmLog(ClusterCommand):
@@ -2737,10 +2694,8 @@ class Alarms:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class AlarmCount(ClusterAttributeDescriptor):
@@ -2756,7 +2711,6 @@ class Alarms:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2769,7 +2723,6 @@ class Alarms:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2785,14 +2738,9 @@ class Alarms:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Time:
     id: typing.ClassVar[int] = 0x000A
-
-
-
 
     class Attributes:
         class Time(ClusterAttributeDescriptor):
@@ -2808,7 +2756,6 @@ class Time:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TimeStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2821,7 +2768,6 @@ class Time:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TimeZone(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2836,7 +2782,6 @@ class Time:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class DstStart(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2849,7 +2794,6 @@ class Time:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DstEnd(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2864,7 +2808,6 @@ class Time:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DstShift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2877,7 +2820,6 @@ class Time:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class StandardTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2892,7 +2834,6 @@ class Time:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LocalTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2905,7 +2846,6 @@ class Time:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LastSetTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2920,7 +2860,6 @@ class Time:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ValidUntilTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2934,7 +2873,6 @@ class Time:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2947,7 +2885,6 @@ class Time:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -2963,14 +2900,9 @@ class Time:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class BinaryInputBasic:
     id: typing.ClassVar[int] = 0x000F
-
-
-
 
     class Attributes:
         class ActiveText(ClusterAttributeDescriptor):
@@ -2986,7 +2918,6 @@ class BinaryInputBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class Description(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -2999,7 +2930,6 @@ class BinaryInputBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class InactiveText(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3014,7 +2944,6 @@ class BinaryInputBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class OutOfService(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3027,7 +2956,6 @@ class BinaryInputBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class Polarity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3042,7 +2970,6 @@ class BinaryInputBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PresentValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3055,7 +2982,6 @@ class BinaryInputBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class Reliability(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3070,7 +2996,6 @@ class BinaryInputBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class StatusFlags(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3083,7 +3008,6 @@ class BinaryInputBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ApplicationType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3098,7 +3022,6 @@ class BinaryInputBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3111,7 +3034,6 @@ class BinaryInputBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3127,12 +3049,9 @@ class BinaryInputBasic:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class PowerProfile:
     id: typing.ClassVar[int] = 0x001A
-
 
     class Structs:
         @dataclass
@@ -3140,11 +3059,15 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EnergyPhaseId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileRemoteControl", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileState", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EnergyPhaseId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileRemoteControl", Tag=2, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileState", Tag=3, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3157,9 +3080,11 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EnergyPhaseId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ScheduledTime", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EnergyPhaseId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduledTime", Tag=1, Type=uint),
                     ])
 
             EnergyPhaseId: 'uint' = None
@@ -3170,13 +3095,19 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EnergyPhaseId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MacroPhaseId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ExpectedDuration", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PeakPower", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Energy", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MaxActivationDelay", Tag=5, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EnergyPhaseId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MacroPhaseId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExpectedDuration", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PeakPower", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Energy", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MaxActivationDelay", Tag=5, Type=uint),
                     ])
 
             EnergyPhaseId: 'uint' = None
@@ -3185,8 +3116,6 @@ class PowerProfile:
             PeakPower: 'uint' = None
             Energy: 'uint' = None
             MaxActivationDelay: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -3197,8 +3126,9 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3211,11 +3141,15 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TotalProfileNum", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumOfTransferredPhases", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransferredPhases", Tag=3, Type=PowerProfile.Structs.TransferredPhase, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TotalProfileNum", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumOfTransferredPhases", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransferredPhases", Tag=3, Type=PowerProfile.Structs.TransferredPhase, IsArray=True),
                     ])
 
             TotalProfileNum: 'uint' = None
@@ -3231,9 +3165,8 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class PowerProfileResponse(ClusterCommand):
@@ -3243,11 +3176,15 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TotalProfileNum", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumOfTransferredPhases", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransferredPhases", Tag=3, Type=PowerProfile.Structs.TransferredPhase, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TotalProfileNum", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumOfTransferredPhases", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransferredPhases", Tag=3, Type=PowerProfile.Structs.TransferredPhase, IsArray=True),
                     ])
 
             TotalProfileNum: 'uint' = None
@@ -3263,11 +3200,15 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Currency", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Price", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PriceTrailingDigit", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Currency", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Price", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PriceTrailingDigit", Tag=3, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3283,9 +3224,11 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileCount", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileRecords", Tag=1, Type=PowerProfile.Structs.PowerProfileRecord, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileCount", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileRecords", Tag=1, Type=PowerProfile.Structs.PowerProfileRecord, IsArray=True),
                     ])
 
             PowerProfileCount: 'uint' = None
@@ -3299,10 +3242,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Currency", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Price", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PriceTrailingDigit", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Currency", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Price", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PriceTrailingDigit", Tag=2, Type=uint),
                     ])
 
             Currency: 'uint' = None
@@ -3317,8 +3263,9 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3331,10 +3278,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumOfScheduledPhases", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumOfScheduledPhases", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3349,9 +3299,11 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileCount", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileRecords", Tag=1, Type=PowerProfile.Structs.PowerProfileRecord, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileCount", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileRecords", Tag=1, Type=PowerProfile.Structs.PowerProfileRecord, IsArray=True),
                     ])
 
             PowerProfileCount: 'uint' = None
@@ -3365,10 +3317,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumOfScheduledPhases", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumOfScheduledPhases", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3383,9 +3338,8 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class PowerProfileScheduleConstraintsRequest(ClusterCommand):
@@ -3395,8 +3349,9 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3409,8 +3364,9 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3423,8 +3379,9 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3437,10 +3394,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumOfScheduledPhases", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumOfScheduledPhases", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3455,11 +3415,15 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Currency", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Price", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PriceTrailingDigit", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Currency", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Price", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PriceTrailingDigit", Tag=3, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3475,10 +3439,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumOfScheduledPhases", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumOfScheduledPhases", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduledPhases", Tag=2, Type=PowerProfile.Structs.ScheduledPhase, IsArray=True),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3493,10 +3460,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartAfter", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StopBefore", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartAfter", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StopBefore", Tag=2, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3511,10 +3481,13 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartAfter", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StopBefore", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartAfter", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StopBefore", Tag=2, Type=uint),
                     ])
 
             PowerProfileId: 'uint' = None
@@ -3529,16 +3502,18 @@ class PowerProfile:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Options", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PowerProfileStartTime", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Options", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PowerProfileStartTime", Tag=2, Type=uint),
                     ])
 
             Options: 'uint' = None
             PowerProfileId: 'uint' = None
             PowerProfileStartTime: 'uint' = None
-
 
     class Attributes:
         class TotalProfileNum(ClusterAttributeDescriptor):
@@ -3554,7 +3529,6 @@ class PowerProfile:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MultipleScheduling(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3567,7 +3541,6 @@ class PowerProfile:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class EnergyFormatting(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3582,7 +3555,6 @@ class PowerProfile:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EnergyRemote(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3595,7 +3567,6 @@ class PowerProfile:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class ScheduleMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3610,7 +3581,6 @@ class PowerProfile:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3624,7 +3594,6 @@ class PowerProfile:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3637,8 +3606,6 @@ class PowerProfile:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -3683,8 +3650,6 @@ class ApplianceControl:
             kWarning4OverallPowerBackBelowThePowerThresholdLevel = 0x03
             kWarning5OverallPowerWillBePotentiallyAboveAvailablePowerLevelIfTheApplianceStarts = 0x04
 
-
-
     class Commands:
         @dataclass
         class ExecutionOfACommand(ClusterCommand):
@@ -3694,8 +3659,9 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="CommandId", Tag=0, Type=ApplianceControl.Enums.CommandIdentification),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="CommandId", Tag=0, Type=ApplianceControl.Enums.CommandIdentification),
                     ])
 
             CommandId: 'ApplianceControl.Enums.CommandIdentification' = None
@@ -3708,10 +3674,13 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ApplianceStatus", Tag=0, Type=ApplianceControl.Enums.ApplianceStatus),
-                            ClusterObjectFieldDescriptor(Label="RemoteEnableFlagsAndDeviceStatus2", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="ApplianceStatus2", Tag=2, Type=ApplianceControl.Enums.ApplianceStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ApplianceStatus", Tag=0, Type=ApplianceControl.Enums.ApplianceStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="RemoteEnableFlagsAndDeviceStatus2", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="ApplianceStatus2", Tag=2, Type=ApplianceControl.Enums.ApplianceStatus),
                     ])
 
             ApplianceStatus: 'ApplianceControl.Enums.ApplianceStatus' = None
@@ -3726,9 +3695,8 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SignalStateNotification(ClusterCommand):
@@ -3738,10 +3706,13 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ApplianceStatus", Tag=0, Type=ApplianceControl.Enums.ApplianceStatus),
-                            ClusterObjectFieldDescriptor(Label="RemoteEnableFlagsAndDeviceStatus2", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="ApplianceStatus2", Tag=2, Type=ApplianceControl.Enums.ApplianceStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ApplianceStatus", Tag=0, Type=ApplianceControl.Enums.ApplianceStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="RemoteEnableFlagsAndDeviceStatus2", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="ApplianceStatus2", Tag=2, Type=ApplianceControl.Enums.ApplianceStatus),
                     ])
 
             ApplianceStatus: 'ApplianceControl.Enums.ApplianceStatus' = None
@@ -3756,10 +3727,13 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="FunctionId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="FunctionDataType", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="FunctionData", Tag=2, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="FunctionId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="FunctionDataType", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="FunctionData", Tag=2, Type=uint, IsArray=True),
                     ])
 
             FunctionId: 'uint' = None
@@ -3774,9 +3748,8 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class OverloadPause(ClusterCommand):
@@ -3786,9 +3759,8 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class OverloadWarning(ClusterCommand):
@@ -3798,12 +3770,12 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="WarningEvent", Tag=0, Type=ApplianceControl.Enums.WarningEvent),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="WarningEvent", Tag=0, Type=ApplianceControl.Enums.WarningEvent),
                     ])
 
             WarningEvent: 'ApplianceControl.Enums.WarningEvent' = None
-
 
     class Attributes:
         class StartTime(ClusterAttributeDescriptor):
@@ -3819,7 +3791,6 @@ class ApplianceControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FinishTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3832,7 +3803,6 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RemainingTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3847,7 +3817,6 @@ class ApplianceControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3860,7 +3829,6 @@ class ApplianceControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3876,12 +3844,9 @@ class ApplianceControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Descriptor:
     id: typing.ClassVar[int] = 0x001D
-
 
     class Structs:
         @dataclass
@@ -3889,16 +3854,15 @@ class Descriptor:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Type", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Revision", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Type", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Revision", Tag=1, Type=uint),
                     ])
 
             Type: 'uint' = None
             Revision: 'uint' = None
-
-
-
 
     class Attributes:
         class DeviceList(ClusterAttributeDescriptor):
@@ -3914,7 +3878,6 @@ class Descriptor:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=Descriptor.Structs.DeviceType, IsArray=True)
 
-
         class ServerList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3927,7 +3890,6 @@ class Descriptor:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
-
 
         class ClientList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3942,7 +3904,6 @@ class Descriptor:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class PartsList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3956,7 +3917,6 @@ class Descriptor:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -3969,7 +3929,6 @@ class Descriptor:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -3985,13 +3944,9 @@ class Descriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class PollControl:
     id: typing.ClassVar[int] = 0x0020
-
-
 
     class Commands:
         @dataclass
@@ -4002,9 +3957,8 @@ class PollControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class CheckInResponse(ClusterCommand):
@@ -4014,9 +3968,11 @@ class PollControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StartFastPolling", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="FastPollTimeout", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StartFastPolling", Tag=0, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="FastPollTimeout", Tag=1, Type=uint),
                     ])
 
             StartFastPolling: 'bool' = None
@@ -4030,9 +3986,8 @@ class PollControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class SetLongPollInterval(ClusterCommand):
@@ -4042,8 +3997,9 @@ class PollControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NewLongPollInterval", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NewLongPollInterval", Tag=0, Type=uint),
                     ])
 
             NewLongPollInterval: 'uint' = None
@@ -4056,12 +4012,12 @@ class PollControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NewShortPollInterval", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NewShortPollInterval", Tag=0, Type=uint),
                     ])
 
             NewShortPollInterval: 'uint' = None
-
 
     class Attributes:
         class CheckInInterval(ClusterAttributeDescriptor):
@@ -4077,7 +4033,6 @@ class PollControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LongPollInterval(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4090,7 +4045,6 @@ class PollControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ShortPollInterval(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4105,7 +4059,6 @@ class PollControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FastPollTimeout(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4118,7 +4071,6 @@ class PollControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CheckInIntervalMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4133,7 +4085,6 @@ class PollControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LongPollIntervalMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4146,7 +4097,6 @@ class PollControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FastPollTimeoutMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4161,7 +4111,6 @@ class PollControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4174,7 +4123,6 @@ class PollControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4190,13 +4138,9 @@ class PollControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Basic:
     id: typing.ClassVar[int] = 0x0028
-
-
 
     class Commands:
         @dataclass
@@ -4207,9 +4151,8 @@ class Basic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MfgSpecificPing(ClusterCommand):
@@ -4219,9 +4162,8 @@ class Basic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ShutDown(ClusterCommand):
@@ -4231,9 +4173,8 @@ class Basic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class Leave(ClusterCommand):
@@ -4243,10 +4184,8 @@ class Basic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class InteractionModelVersion(ClusterAttributeDescriptor):
@@ -4262,7 +4201,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class VendorName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4275,7 +4213,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class VendorID(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4290,7 +4227,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ProductName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4303,7 +4239,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class ProductID(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4318,7 +4253,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class UserLabel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4331,7 +4265,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class Location(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4346,7 +4279,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class HardwareVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4359,7 +4291,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class HardwareVersionString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4374,7 +4305,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class SoftwareVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4387,7 +4317,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SoftwareVersionString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4402,7 +4331,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class ManufacturingDate(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4415,7 +4343,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class PartNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4430,7 +4357,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class ProductURL(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4443,7 +4369,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class ProductLabel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4458,7 +4383,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class SerialNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4471,7 +4395,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class LocalConfigDisabled(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4486,7 +4409,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class Reachable(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4499,7 +4421,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4514,7 +4435,6 @@ class Basic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4527,8 +4447,6 @@ class Basic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -4552,8 +4470,6 @@ class OtaSoftwareUpdateProvider:
             kBusy = 0x01
             kNotAvailable = 0x02
 
-
-
     class Commands:
         @dataclass
         class QueryImage(ClusterCommand):
@@ -4563,15 +4479,23 @@ class OtaSoftwareUpdateProvider:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="VendorId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ProductId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="HardwareVersion", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SoftwareVersion", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ProtocolsSupported", Tag=4, Type=OtaSoftwareUpdateProvider.Enums.OTADownloadProtocol),
-                            ClusterObjectFieldDescriptor(Label="Location", Tag=5, Type=str),
-                            ClusterObjectFieldDescriptor(Label="RequestorCanConsent", Tag=6, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="MetadataForProvider", Tag=7, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="VendorId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ProductId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="HardwareVersion", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SoftwareVersion", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ProtocolsSupported", Tag=4, Type=OtaSoftwareUpdateProvider.Enums.OTADownloadProtocol),
+                        ClusterObjectFieldDescriptor(
+                            Label="Location", Tag=5, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="RequestorCanConsent", Tag=6, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="MetadataForProvider", Tag=7, Type=bytes),
                     ])
 
             VendorId: 'uint' = None
@@ -4591,9 +4515,11 @@ class OtaSoftwareUpdateProvider:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UpdateToken", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="NewVersion", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UpdateToken", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="NewVersion", Tag=1, Type=uint),
                     ])
 
             UpdateToken: 'bytes' = None
@@ -4607,9 +4533,11 @@ class OtaSoftwareUpdateProvider:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UpdateToken", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="SoftwareVersion", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UpdateToken", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="SoftwareVersion", Tag=1, Type=uint),
                     ])
 
             UpdateToken: 'bytes' = None
@@ -4623,15 +4551,23 @@ class OtaSoftwareUpdateProvider:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=OtaSoftwareUpdateProvider.Enums.OTAQueryStatus),
-                            ClusterObjectFieldDescriptor(Label="DelayedActionTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ImageURI", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="SoftwareVersion", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="SoftwareVersionString", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="UpdateToken", Tag=5, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="UserConsentNeeded", Tag=6, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="MetadataForRequestor", Tag=7, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=OtaSoftwareUpdateProvider.Enums.OTAQueryStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="DelayedActionTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ImageURI", Tag=2, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="SoftwareVersion", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="SoftwareVersionString", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="UpdateToken", Tag=5, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserConsentNeeded", Tag=6, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="MetadataForRequestor", Tag=7, Type=bytes),
                     ])
 
             Status: 'OtaSoftwareUpdateProvider.Enums.OTAQueryStatus' = None
@@ -4651,14 +4587,15 @@ class OtaSoftwareUpdateProvider:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Action", Tag=0, Type=OtaSoftwareUpdateProvider.Enums.OTAApplyUpdateAction),
-                            ClusterObjectFieldDescriptor(Label="DelayedActionTime", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Action", Tag=0, Type=OtaSoftwareUpdateProvider.Enums.OTAApplyUpdateAction),
+                        ClusterObjectFieldDescriptor(
+                            Label="DelayedActionTime", Tag=1, Type=uint),
                     ])
 
             Action: 'OtaSoftwareUpdateProvider.Enums.OTAApplyUpdateAction' = None
             DelayedActionTime: 'uint' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -4674,7 +4611,6 @@ class OtaSoftwareUpdateProvider:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4689,8 +4625,6 @@ class OtaSoftwareUpdateProvider:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class OtaSoftwareUpdateRequestor:
     id: typing.ClassVar[int] = 0x002A
@@ -4701,8 +4635,6 @@ class OtaSoftwareUpdateRequestor:
             kUpdateAvailable = 0x01
             kUrgentUpdateAvailable = 0x02
 
-
-
     class Commands:
         @dataclass
         class AnnounceOtaProvider(ClusterCommand):
@@ -4712,18 +4644,21 @@ class OtaSoftwareUpdateRequestor:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ProviderLocation", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="VendorId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AnnouncementReason", Tag=2, Type=OtaSoftwareUpdateRequestor.Enums.OTAAnnouncementReason),
-                            ClusterObjectFieldDescriptor(Label="MetadataForNode", Tag=3, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ProviderLocation", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="VendorId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AnnouncementReason", Tag=2, Type=OtaSoftwareUpdateRequestor.Enums.OTAAnnouncementReason),
+                        ClusterObjectFieldDescriptor(
+                            Label="MetadataForNode", Tag=3, Type=bytes),
                     ])
 
             ProviderLocation: 'uint' = None
             VendorId: 'uint' = None
             AnnouncementReason: 'OtaSoftwareUpdateRequestor.Enums.OTAAnnouncementReason' = None
             MetadataForNode: 'bytes' = None
-
 
     class Attributes:
         class DefaultOtaProvider(ClusterAttributeDescriptor):
@@ -4739,7 +4674,6 @@ class OtaSoftwareUpdateRequestor:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class UpdatePossible(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4753,7 +4687,6 @@ class OtaSoftwareUpdateRequestor:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4766,7 +4699,6 @@ class OtaSoftwareUpdateRequestor:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4782,14 +4714,9 @@ class OtaSoftwareUpdateRequestor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class PowerSource:
     id: typing.ClassVar[int] = 0x002F
-
-
-
 
     class Attributes:
         class Status(ClusterAttributeDescriptor):
@@ -4805,7 +4732,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Order(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4818,7 +4744,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Description(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4833,7 +4758,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class WiredAssessedInputVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4846,7 +4770,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class WiredAssessedInputFrequency(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4861,7 +4784,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class WiredCurrentType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4874,7 +4796,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class WiredAssessedCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4889,7 +4810,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class WiredNominalVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4902,7 +4822,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class WiredMaximumCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4917,7 +4836,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class WiredPresent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4930,7 +4848,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class ActiveWiredFaults(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4945,7 +4862,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class BatteryVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4958,7 +4874,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryPercentRemaining(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -4973,7 +4888,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryTimeRemaining(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -4986,7 +4900,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryChargeLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5001,7 +4914,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryReplacementNeeded(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5014,7 +4926,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class BatteryReplaceability(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5029,7 +4940,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryPresent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5042,7 +4952,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class ActiveBatteryFaults(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5057,7 +4966,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class BatteryReplacementDescription(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5070,7 +4978,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class BatteryCommonDesignation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5085,7 +4992,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryANSIDesignation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5098,7 +5004,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class BatteryIECDesignation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5113,7 +5018,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class BatteryApprovedChemistry(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5126,7 +5030,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryCapacity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5141,7 +5044,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryQuantity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5154,7 +5056,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryChargeState(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5169,7 +5070,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BatteryTimeToFullCharge(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5182,7 +5082,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BatteryFunctionalWhileCharging(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5197,7 +5096,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class BatteryChargingCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5210,7 +5108,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ActiveBatteryChargeFaults(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5225,7 +5122,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5239,7 +5135,6 @@ class PowerSource:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5252,8 +5147,6 @@ class PowerSource:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -5271,20 +5164,18 @@ class GeneralCommissioning:
             kOutdoor = 0x01
             kIndoorOutdoor = 0x02
 
-
     class Structs:
         @dataclass
         class BasicCommissioningInfoType(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="FailSafeExpiryLengthMs", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="FailSafeExpiryLengthMs", Tag=0, Type=uint),
                     ])
 
             FailSafeExpiryLengthMs: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -5295,10 +5186,13 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ExpiryLengthSeconds", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ExpiryLengthSeconds", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             ExpiryLengthSeconds: 'uint' = None
@@ -5313,9 +5207,11 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=GeneralCommissioning.Enums.GeneralCommissioningError),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=GeneralCommissioning.Enums.GeneralCommissioningError),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'GeneralCommissioning.Enums.GeneralCommissioningError' = None
@@ -5329,11 +5225,15 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Location", Tag=0, Type=GeneralCommissioning.Enums.RegulatoryLocationType),
-                            ClusterObjectFieldDescriptor(Label="CountryCode", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Location", Tag=0, Type=GeneralCommissioning.Enums.RegulatoryLocationType),
+                        ClusterObjectFieldDescriptor(
+                            Label="CountryCode", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=3, Type=uint),
                     ])
 
             Location: 'GeneralCommissioning.Enums.RegulatoryLocationType' = None
@@ -5349,9 +5249,11 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=GeneralCommissioning.Enums.GeneralCommissioningError),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=GeneralCommissioning.Enums.GeneralCommissioningError),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'GeneralCommissioning.Enums.GeneralCommissioningError' = None
@@ -5365,9 +5267,8 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class CommissioningCompleteResponse(ClusterCommand):
@@ -5377,14 +5278,15 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=GeneralCommissioning.Enums.GeneralCommissioningError),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=GeneralCommissioning.Enums.GeneralCommissioningError),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'GeneralCommissioning.Enums.GeneralCommissioningError' = None
             DebugText: 'str' = None
-
 
     class Attributes:
         class Breadcrumb(ClusterAttributeDescriptor):
@@ -5400,7 +5302,6 @@ class GeneralCommissioning:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BasicCommissioningInfoList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5413,7 +5314,6 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=GeneralCommissioning.Structs.BasicCommissioningInfoType, IsArray=True)
-
 
         class RegulatoryConfigList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5428,7 +5328,6 @@ class GeneralCommissioning:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=GeneralCommissioning.Enums.RegulatoryLocationType, IsArray=True)
 
-
         class LocationCapabilityList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5441,7 +5340,6 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=GeneralCommissioning.Enums.RegulatoryLocationType, IsArray=True)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -5456,7 +5354,6 @@ class GeneralCommissioning:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5469,8 +5366,6 @@ class GeneralCommissioning:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -5500,15 +5395,15 @@ class NetworkCommissioning:
             kLabel15 = 0x12
             kUnknownError = 0x13
 
-
     class Structs:
         @dataclass
         class ThreadInterfaceScanResult(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="DiscoveryResponse", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="DiscoveryResponse", Tag=0, Type=bytes),
                     ])
 
             DiscoveryResponse: 'bytes' = None
@@ -5518,12 +5413,17 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Security", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Ssid", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Bssid", Tag=2, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Channel", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="FrequencyBand", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Security", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Ssid", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Bssid", Tag=2, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Channel", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="FrequencyBand", Tag=4, Type=uint),
                     ])
 
             Security: 'uint' = None
@@ -5531,8 +5431,6 @@ class NetworkCommissioning:
             Bssid: 'bytes' = None
             Channel: 'uint' = None
             FrequencyBand: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -5543,10 +5441,13 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Ssid", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Ssid", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             Ssid: 'bytes' = None
@@ -5561,11 +5462,15 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="WifiScanResults", Tag=2, Type=NetworkCommissioning.Structs.WiFiInterfaceScanResult, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="ThreadScanResults", Tag=3, Type=NetworkCommissioning.Structs.ThreadInterfaceScanResult, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="WifiScanResults", Tag=2, Type=NetworkCommissioning.Structs.WiFiInterfaceScanResult, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="ThreadScanResults", Tag=3, Type=NetworkCommissioning.Structs.ThreadInterfaceScanResult, IsArray=True),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5581,11 +5486,15 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Ssid", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Credentials", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Ssid", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Credentials", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=3, Type=uint),
                     ])
 
             Ssid: 'bytes' = None
@@ -5601,9 +5510,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5617,11 +5528,15 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Ssid", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Credentials", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Ssid", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Credentials", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=3, Type=uint),
                     ])
 
             Ssid: 'bytes' = None
@@ -5637,9 +5552,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5653,10 +5570,13 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="OperationalDataset", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="OperationalDataset", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             OperationalDataset: 'bytes' = None
@@ -5671,9 +5591,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5687,10 +5609,13 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="OperationalDataset", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="OperationalDataset", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             OperationalDataset: 'bytes' = None
@@ -5705,9 +5630,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5721,10 +5648,13 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NetworkID", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NetworkID", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             NetworkID: 'bytes' = None
@@ -5739,9 +5669,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5755,10 +5687,13 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NetworkID", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NetworkID", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             NetworkID: 'bytes' = None
@@ -5773,9 +5708,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5789,10 +5726,13 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NetworkID", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Breadcrumb", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NetworkID", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Breadcrumb", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=2, Type=uint),
                     ])
 
             NetworkID: 'bytes' = None
@@ -5807,9 +5747,11 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ErrorCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=1, Type=str),
                     ])
 
             ErrorCode: 'uint' = None
@@ -5823,12 +5765,12 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TimeoutMs", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutMs", Tag=0, Type=uint),
                     ])
 
             TimeoutMs: 'uint' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -5844,7 +5786,6 @@ class NetworkCommissioning:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5857,8 +5798,6 @@ class NetworkCommissioning:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -5882,8 +5821,6 @@ class DiagnosticLogs:
             kResponsePayload = 0x00
             kBdx = 0x01
 
-
-
     class Commands:
         @dataclass
         class RetrieveLogsRequest(ClusterCommand):
@@ -5893,10 +5830,13 @@ class DiagnosticLogs:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Intent", Tag=0, Type=DiagnosticLogs.Enums.LogsIntent),
-                            ClusterObjectFieldDescriptor(Label="RequestedProtocol", Tag=1, Type=DiagnosticLogs.Enums.LogsTransferProtocol),
-                            ClusterObjectFieldDescriptor(Label="TransferFileDesignator", Tag=2, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Intent", Tag=0, Type=DiagnosticLogs.Enums.LogsIntent),
+                        ClusterObjectFieldDescriptor(
+                            Label="RequestedProtocol", Tag=1, Type=DiagnosticLogs.Enums.LogsTransferProtocol),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransferFileDesignator", Tag=2, Type=bytes),
                     ])
 
             Intent: 'DiagnosticLogs.Enums.LogsIntent' = None
@@ -5911,18 +5851,21 @@ class DiagnosticLogs:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=DiagnosticLogs.Enums.LogsStatus),
-                            ClusterObjectFieldDescriptor(Label="Content", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="TimeStamp", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TimeSinceBoot", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=DiagnosticLogs.Enums.LogsStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="Content", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeStamp", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeSinceBoot", Tag=3, Type=uint),
                     ])
 
             Status: 'DiagnosticLogs.Enums.LogsStatus' = None
             Content: 'bytes' = None
             TimeStamp: 'uint' = None
             TimeSinceBoot: 'uint' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -5938,7 +5881,6 @@ class DiagnosticLogs:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -5951,8 +5893,6 @@ class DiagnosticLogs:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -6004,20 +5944,25 @@ class GeneralDiagnostics:
             kBLEFault = 0x05
             kEthernetFault = 0x06
 
-
     class Structs:
         @dataclass
         class NetworkInterfaceType(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="FabricConnected", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="OffPremiseServicesReachableIPv4", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="OffPremiseServicesReachableIPv6", Tag=3, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="HardwareAddress", Tag=4, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Type", Tag=5, Type=GeneralDiagnostics.Enums.InterfaceType),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricConnected", Tag=1, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="OffPremiseServicesReachableIPv4", Tag=2, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="OffPremiseServicesReachableIPv6", Tag=3, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="HardwareAddress", Tag=4, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Type", Tag=5, Type=GeneralDiagnostics.Enums.InterfaceType),
                     ])
 
             Name: 'str' = None
@@ -6026,9 +5971,6 @@ class GeneralDiagnostics:
             OffPremiseServicesReachableIPv6: 'bool' = None
             HardwareAddress: 'bytes' = None
             Type: 'GeneralDiagnostics.Enums.InterfaceType' = None
-
-
-
 
     class Attributes:
         class NetworkInterfaces(ClusterAttributeDescriptor):
@@ -6044,7 +5986,6 @@ class GeneralDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=GeneralDiagnostics.Structs.NetworkInterfaceType, IsArray=True)
 
-
         class RebootCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6057,7 +5998,6 @@ class GeneralDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class UpTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6072,7 +6012,6 @@ class GeneralDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TotalOperationalHours(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6085,7 +6024,6 @@ class GeneralDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BootReasons(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6100,7 +6038,6 @@ class GeneralDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ActiveHardwareFaults(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6113,7 +6050,6 @@ class GeneralDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
-
 
         class ActiveRadioFaults(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6128,7 +6064,6 @@ class GeneralDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class ActiveNetworkFaults(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6142,7 +6077,6 @@ class GeneralDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6155,7 +6089,6 @@ class GeneralDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6171,12 +6104,9 @@ class GeneralDiagnostics:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class SoftwareDiagnostics:
     id: typing.ClassVar[int] = 0x0034
-
 
     class Structs:
         @dataclass
@@ -6184,12 +6114,17 @@ class SoftwareDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Id", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="StackFreeCurrent", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StackFreeMinimum", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StackSize", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Id", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="StackFreeCurrent", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StackFreeMinimum", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StackSize", Tag=4, Type=uint),
                     ])
 
             Id: 'uint' = None
@@ -6197,8 +6132,6 @@ class SoftwareDiagnostics:
             StackFreeCurrent: 'uint' = None
             StackFreeMinimum: 'uint' = None
             StackSize: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -6209,10 +6142,8 @@ class SoftwareDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class ThreadMetrics(ClusterAttributeDescriptor):
@@ -6228,7 +6159,6 @@ class SoftwareDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=SoftwareDiagnostics.Structs.ThreadMetrics, IsArray=True)
 
-
         class CurrentHeapFree(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6241,7 +6171,6 @@ class SoftwareDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentHeapUsed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6256,7 +6185,6 @@ class SoftwareDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentHeapHighWatermark(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6269,7 +6197,6 @@ class SoftwareDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6284,7 +6211,6 @@ class SoftwareDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6297,8 +6223,6 @@ class SoftwareDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -6321,28 +6245,41 @@ class ThreadNetworkDiagnostics:
             kRouter = 0x05
             kLeader = 0x06
 
-
     class Structs:
         @dataclass
         class NeighborTable(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ExtAddress", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Age", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Rloc16", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LinkFrameCounter", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MleFrameCounter", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Lqi", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AverageRssi", Tag=6, Type=int),
-                            ClusterObjectFieldDescriptor(Label="LastRssi", Tag=7, Type=int),
-                            ClusterObjectFieldDescriptor(Label="FrameErrorRate", Tag=8, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MessageErrorRate", Tag=9, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="RxOnWhenIdle", Tag=10, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="FullThreadDevice", Tag=11, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="FullNetworkData", Tag=12, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="IsChild", Tag=13, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtAddress", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Age", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rloc16", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LinkFrameCounter", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MleFrameCounter", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Lqi", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AverageRssi", Tag=6, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="LastRssi", Tag=7, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="FrameErrorRate", Tag=8, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageErrorRate", Tag=9, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="RxOnWhenIdle", Tag=10, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="FullThreadDevice", Tag=11, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="FullNetworkData", Tag=12, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="IsChild", Tag=13, Type=bool),
                     ])
 
             ExtAddress: 'uint' = None
@@ -6365,19 +6302,31 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ActiveTimestampPresent", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="PendingTimestampPresent", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="MasterKeyPresent", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NetworkNamePresent", Tag=3, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="ExtendedPanIdPresent", Tag=4, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="MeshLocalPrefixPresent", Tag=5, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="DelayPresent", Tag=6, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="PanIdPresent", Tag=7, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="ChannelPresent", Tag=8, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="PskcPresent", Tag=9, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="SecurityPolicyPresent", Tag=10, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="ChannelMaskPresent", Tag=11, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ActiveTimestampPresent", Tag=0, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="PendingTimestampPresent", Tag=1, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="MasterKeyPresent", Tag=2, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NetworkNamePresent", Tag=3, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtendedPanIdPresent", Tag=4, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="MeshLocalPrefixPresent", Tag=5, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="DelayPresent", Tag=6, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="PanIdPresent", Tag=7, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="ChannelPresent", Tag=8, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="PskcPresent", Tag=9, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="SecurityPolicyPresent", Tag=10, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="ChannelMaskPresent", Tag=11, Type=bool),
                     ])
 
             ActiveTimestampPresent: 'bool' = None
@@ -6398,17 +6347,27 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ExtAddress", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Rloc16", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="RouterId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NextHop", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PathCost", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LQIIn", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LQIOut", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Age", Tag=7, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Allocated", Tag=8, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="LinkEstablished", Tag=9, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtAddress", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rloc16", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="RouterId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NextHop", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PathCost", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LQIIn", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LQIOut", Tag=6, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Age", Tag=7, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Allocated", Tag=8, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="LinkEstablished", Tag=9, Type=bool),
                     ])
 
             ExtAddress: 'uint' = None
@@ -6427,15 +6386,15 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="RotationTime", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Flags", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="RotationTime", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Flags", Tag=1, Type=uint),
                     ])
 
             RotationTime: 'uint' = None
             Flags: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -6446,10 +6405,8 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class Channel(ClusterAttributeDescriptor):
@@ -6465,7 +6422,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RoutingRole(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6478,7 +6434,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NetworkName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6493,7 +6448,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class PanId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6506,7 +6460,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ExtendedPanId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6521,7 +6474,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MeshLocalPrefix(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6534,7 +6486,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class OverrunCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6549,7 +6500,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NeighborTableList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6562,7 +6512,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=ThreadNetworkDiagnostics.Structs.NeighborTable, IsArray=True)
-
 
         class RouteTableList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6577,7 +6526,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=ThreadNetworkDiagnostics.Structs.RouteTable, IsArray=True)
 
-
         class PartitionId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6590,7 +6538,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Weighting(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6605,7 +6552,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DataVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6618,7 +6564,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class StableDataVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6633,7 +6578,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LeaderRouterId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6646,7 +6590,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DetachedRoleCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6661,7 +6604,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ChildRoleCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6674,7 +6616,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RouterRoleCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6689,7 +6630,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LeaderRoleCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6702,7 +6642,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AttachAttemptCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6717,7 +6656,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PartitionIdChangeCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6730,7 +6668,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BetterPartitionAttachAttemptCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6745,7 +6682,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ParentChangeCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6758,7 +6694,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxTotalCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6773,7 +6708,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxUnicastCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6786,7 +6720,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxBroadcastCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6801,7 +6734,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxAckRequestedCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6814,7 +6746,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxAckedCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6829,7 +6760,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxNoAckRequestedCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6842,7 +6772,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxDataCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6857,7 +6786,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxDataPollCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6870,7 +6798,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxBeaconCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6885,7 +6812,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxBeaconRequestCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6898,7 +6824,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxOtherCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6913,7 +6838,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxRetryCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6926,7 +6850,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxDirectMaxRetryExpiryCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6941,7 +6864,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxIndirectMaxRetryExpiryCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6954,7 +6876,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxErrCcaCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6969,7 +6890,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TxErrAbortCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -6982,7 +6902,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxErrBusyChannelCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -6997,7 +6916,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxTotalCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7010,7 +6928,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxUnicastCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7025,7 +6942,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxBroadcastCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7038,7 +6954,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxDataCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7053,7 +6968,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxDataPollCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7066,7 +6980,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxBeaconCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7081,7 +6994,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxBeaconRequestCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7094,7 +7006,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxOtherCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7109,7 +7020,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxAddressFilteredCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7122,7 +7032,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxDestAddrFilteredCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7137,7 +7046,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxDuplicatedCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7150,7 +7058,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxErrNoFrameCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7165,7 +7072,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxErrUnknownNeighborCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7178,7 +7084,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxErrInvalidSrcAddrCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7193,7 +7098,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxErrSecCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7206,7 +7110,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RxErrFcsCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7221,7 +7124,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RxErrOtherCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7234,7 +7136,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ActiveTimestamp(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7249,7 +7150,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PendingTimestamp(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7262,7 +7162,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Delay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7277,7 +7176,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SecurityPolicy(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7290,7 +7188,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=ThreadNetworkDiagnostics.Structs.SecurityPolicy, IsArray=True)
-
 
         class ChannelMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7305,7 +7202,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class OperationalDatasetComponents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7318,7 +7214,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=ThreadNetworkDiagnostics.Structs.OperationalDatasetComponents, IsArray=True)
-
 
         class ActiveNetworkFaultsList(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7333,7 +7228,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=ThreadNetworkDiagnostics.Enums.NetworkFault, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7347,7 +7241,6 @@ class ThreadNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7360,8 +7253,6 @@ class ThreadNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -7385,8 +7276,6 @@ class WiFiNetworkDiagnostics:
             k80211ac = 0x04
             k80211ax = 0x05
 
-
-
     class Commands:
         @dataclass
         class ResetCounts(ClusterCommand):
@@ -7396,10 +7285,8 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class Bssid(ClusterAttributeDescriptor):
@@ -7415,7 +7302,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class SecurityType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7428,7 +7314,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class WiFiVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7443,7 +7328,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ChannelNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7456,7 +7340,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Rssi(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7471,7 +7354,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class BeaconLostCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7484,7 +7366,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BeaconRxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7499,7 +7380,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PacketMulticastRxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7512,7 +7392,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PacketMulticastTxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7527,7 +7406,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PacketUnicastRxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7540,7 +7418,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PacketUnicastTxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7555,7 +7432,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentMaxRate(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7568,7 +7444,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OverrunCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7583,7 +7458,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7597,7 +7471,6 @@ class WiFiNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7610,8 +7483,6 @@ class WiFiNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -7631,8 +7502,6 @@ class EthernetNetworkDiagnostics:
             k200g = 0x08
             k400g = 0x09
 
-
-
     class Commands:
         @dataclass
         class ResetCounts(ClusterCommand):
@@ -7642,10 +7511,8 @@ class EthernetNetworkDiagnostics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class PHYRate(ClusterAttributeDescriptor):
@@ -7661,7 +7528,6 @@ class EthernetNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FullDuplex(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7674,7 +7540,6 @@ class EthernetNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class PacketRxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7689,7 +7554,6 @@ class EthernetNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PacketTxCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7702,7 +7566,6 @@ class EthernetNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TxErrCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7717,7 +7580,6 @@ class EthernetNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CollisionCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7730,7 +7592,6 @@ class EthernetNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OverrunCount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7745,7 +7606,6 @@ class EthernetNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CarrierDetect(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7758,7 +7618,6 @@ class EthernetNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class TimeSinceReset(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7773,7 +7632,6 @@ class EthernetNetworkDiagnostics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7786,7 +7644,6 @@ class EthernetNetworkDiagnostics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7802,13 +7659,9 @@ class EthernetNetworkDiagnostics:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class BridgedDeviceBasic:
     id: typing.ClassVar[int] = 0x0039
-
-
 
     class Commands:
         @dataclass
@@ -7819,9 +7672,8 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ShutDown(ClusterCommand):
@@ -7831,9 +7683,8 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class Leave(ClusterCommand):
@@ -7843,9 +7694,8 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ReachableChanged(ClusterCommand):
@@ -7855,10 +7705,8 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class VendorName(ClusterAttributeDescriptor):
@@ -7874,7 +7722,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class VendorID(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7887,7 +7734,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ProductName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7902,7 +7748,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class UserLabel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7915,7 +7760,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class HardwareVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7930,7 +7774,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class HardwareVersionString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7943,7 +7786,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class SoftwareVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7958,7 +7800,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SoftwareVersionString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7971,7 +7812,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class ManufacturingDate(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -7986,7 +7826,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class PartNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -7999,7 +7838,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class ProductURL(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8014,7 +7852,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class ProductLabel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8027,7 +7864,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class SerialNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8042,7 +7878,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class Reachable(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8056,7 +7891,6 @@ class BridgedDeviceBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8069,7 +7903,6 @@ class BridgedDeviceBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8085,14 +7918,9 @@ class BridgedDeviceBasic:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Switch:
     id: typing.ClassVar[int] = 0x003B
-
-
-
 
     class Attributes:
         class NumberOfPositions(ClusterAttributeDescriptor):
@@ -8108,7 +7936,6 @@ class Switch:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentPosition(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8121,7 +7948,6 @@ class Switch:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MultiPressMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8136,7 +7962,6 @@ class Switch:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8149,7 +7974,6 @@ class Switch:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8165,8 +7989,6 @@ class Switch:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class AdministratorCommissioning:
     id: typing.ClassVar[int] = 0x003C
@@ -8177,8 +7999,6 @@ class AdministratorCommissioning:
             kBusy = 0x01
             kGeneralError = 0x02
 
-
-
     class Commands:
         @dataclass
         class OpenCommissioningWindow(ClusterCommand):
@@ -8188,13 +8008,19 @@ class AdministratorCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="CommissioningTimeout", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="PAKEVerifier", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Discriminator", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Iterations", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Salt", Tag=4, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="PasscodeID", Tag=5, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="CommissioningTimeout", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="PAKEVerifier", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Discriminator", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Iterations", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Salt", Tag=4, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="PasscodeID", Tag=5, Type=uint),
                     ])
 
             CommissioningTimeout: 'uint' = None
@@ -8212,8 +8038,9 @@ class AdministratorCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="CommissioningTimeout", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="CommissioningTimeout", Tag=0, Type=uint),
                     ])
 
             CommissioningTimeout: 'uint' = None
@@ -8226,10 +8053,8 @@ class AdministratorCommissioning:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -8245,7 +8070,6 @@ class AdministratorCommissioning:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8258,8 +8082,6 @@ class AdministratorCommissioning:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -8279,20 +8101,25 @@ class OperationalCredentials:
             kLabelConflict = 0x0A
             kInvalidFabricIndex = 0x0B
 
-
     class Structs:
         @dataclass
         class FabricDescriptor(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="FabricIndex", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="RootPublicKey", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="VendorId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="FabricId", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NodeId", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Label", Tag=5, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricIndex", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="RootPublicKey", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="VendorId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricId", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NodeId", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Label", Tag=5, Type=str),
                     ])
 
             FabricIndex: 'uint' = None
@@ -8307,15 +8134,15 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="FabricIndex", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Noc", Tag=1, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricIndex", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Noc", Tag=1, Type=bytes),
                     ])
 
             FabricIndex: 'uint' = None
             Noc: 'bytes' = None
-
-
 
     class Commands:
         @dataclass
@@ -8326,8 +8153,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AttestationNonce", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AttestationNonce", Tag=0, Type=bytes),
                     ])
 
             AttestationNonce: 'bytes' = None
@@ -8340,9 +8168,11 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AttestationElements", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="Signature", Tag=1, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AttestationElements", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="Signature", Tag=1, Type=bytes),
                     ])
 
             AttestationElements: 'bytes' = None
@@ -8356,8 +8186,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="CertificateType", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="CertificateType", Tag=0, Type=uint),
                     ])
 
             CertificateType: 'uint' = None
@@ -8370,8 +8201,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Certificate", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Certificate", Tag=0, Type=bytes),
                     ])
 
             Certificate: 'bytes' = None
@@ -8384,8 +8216,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="CSRNonce", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="CSRNonce", Tag=0, Type=bytes),
                     ])
 
             CSRNonce: 'bytes' = None
@@ -8398,9 +8231,11 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NOCSRElements", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="AttestationSignature", Tag=1, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NOCSRElements", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="AttestationSignature", Tag=1, Type=bytes),
                     ])
 
             NOCSRElements: 'bytes' = None
@@ -8414,12 +8249,17 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NOCValue", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="ICACValue", Tag=1, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="IPKValue", Tag=2, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="CaseAdminNode", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AdminVendorId", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NOCValue", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="ICACValue", Tag=1, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="IPKValue", Tag=2, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="CaseAdminNode", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AdminVendorId", Tag=4, Type=uint),
                     ])
 
             NOCValue: 'bytes' = None
@@ -8436,9 +8276,11 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NOCValue", Tag=0, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="ICACValue", Tag=1, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NOCValue", Tag=0, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="ICACValue", Tag=1, Type=bytes),
                     ])
 
             NOCValue: 'bytes' = None
@@ -8452,10 +8294,13 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StatusCode", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="FabricIndex", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DebugText", Tag=2, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StatusCode", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricIndex", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DebugText", Tag=2, Type=str),
                     ])
 
             StatusCode: 'uint' = None
@@ -8470,8 +8315,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Label", Tag=0, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Label", Tag=0, Type=str),
                     ])
 
             Label: 'str' = None
@@ -8484,8 +8330,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="FabricIndex", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricIndex", Tag=0, Type=uint),
                     ])
 
             FabricIndex: 'uint' = None
@@ -8498,8 +8345,9 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="RootCertificate", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="RootCertificate", Tag=0, Type=bytes),
                     ])
 
             RootCertificate: 'bytes' = None
@@ -8512,12 +8360,12 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TrustedRootIdentifier", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TrustedRootIdentifier", Tag=0, Type=bytes),
                     ])
 
             TrustedRootIdentifier: 'bytes' = None
-
 
     class Attributes:
         class FabricsList(ClusterAttributeDescriptor):
@@ -8533,7 +8381,6 @@ class OperationalCredentials:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=OperationalCredentials.Structs.FabricDescriptor, IsArray=True)
 
-
         class SupportedFabrics(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8546,7 +8393,6 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CommissionedFabrics(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8561,7 +8407,6 @@ class OperationalCredentials:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TrustedRootCertificates(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8575,7 +8420,6 @@ class OperationalCredentials:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8588,7 +8432,6 @@ class OperationalCredentials:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8604,12 +8447,9 @@ class OperationalCredentials:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class FixedLabel:
     id: typing.ClassVar[int] = 0x0040
-
 
     class Structs:
         @dataclass
@@ -8617,16 +8457,15 @@ class FixedLabel:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Label", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Value", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Label", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Value", Tag=1, Type=str),
                     ])
 
             Label: 'str' = None
             Value: 'str' = None
-
-
-
 
     class Attributes:
         class LabelList(ClusterAttributeDescriptor):
@@ -8642,7 +8481,6 @@ class FixedLabel:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=FixedLabel.Structs.LabelStruct, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8655,7 +8493,6 @@ class FixedLabel:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8671,14 +8508,9 @@ class FixedLabel:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class BooleanState:
     id: typing.ClassVar[int] = 0x0045
-
-
-
 
     class Attributes:
         class StateValue(ClusterAttributeDescriptor):
@@ -8694,7 +8526,6 @@ class BooleanState:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8707,7 +8538,6 @@ class BooleanState:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8723,14 +8553,9 @@ class BooleanState:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ShadeConfiguration:
     id: typing.ClassVar[int] = 0x0100
-
-
-
 
     class Attributes:
         class PhysicalClosedLimit(ClusterAttributeDescriptor):
@@ -8746,7 +8571,6 @@ class ShadeConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MotorStepSize(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8759,7 +8583,6 @@ class ShadeConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Status(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8774,7 +8597,6 @@ class ShadeConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClosedLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8787,7 +8609,6 @@ class ShadeConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Mode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -8802,7 +8623,6 @@ class ShadeConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8816,7 +8636,6 @@ class ShadeConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -8829,8 +8648,6 @@ class ShadeConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -8884,8 +8701,6 @@ class DoorLock:
             kNonAccessUser = 0x04
             kNotSupported = 0xFF
 
-
-
     class Commands:
         @dataclass
         class LockDoor(ClusterCommand):
@@ -8895,8 +8710,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=0, Type=bytes),
                     ])
 
             Pin: 'bytes' = None
@@ -8909,8 +8725,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -8923,8 +8740,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=0, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=0, Type=bytes),
                     ])
 
             Pin: 'bytes' = None
@@ -8937,8 +8755,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -8951,8 +8770,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=0, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=0, Type=str),
                     ])
 
             Pin: 'str' = None
@@ -8965,8 +8785,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -8979,9 +8800,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TimeoutInSeconds", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=1, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeoutInSeconds", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=1, Type=bytes),
                     ])
 
             TimeoutInSeconds: 'uint' = None
@@ -8995,8 +8818,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9009,8 +8833,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LogIndex", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LogIndex", Tag=0, Type=uint),
                     ])
 
             LogIndex: 'uint' = None
@@ -9023,14 +8848,21 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LogEntryId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Timestamp", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EventType", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Source", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EventIdOrAlarmCode", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=6, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LogEntryId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Timestamp", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EventType", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Source", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EventIdOrAlarmCode", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=6, Type=bytes),
                     ])
 
             LogEntryId: 'uint' = None
@@ -9049,11 +8881,15 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=3, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=3, Type=bytes),
                     ])
 
             UserId: 'uint' = None
@@ -9069,8 +8905,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=DoorLock.Enums.DoorLockSetPinOrIdStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=DoorLock.Enums.DoorLockSetPinOrIdStatus),
                     ])
 
             Status: 'DoorLock.Enums.DoorLockSetPinOrIdStatus' = None
@@ -9083,8 +8920,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9097,11 +8935,15 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=3, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=3, Type=bytes),
                     ])
 
             UserId: 'uint' = None
@@ -9117,8 +8959,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9131,8 +8974,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9145,9 +8989,8 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ClearAllPinsResponse(ClusterCommand):
@@ -9157,8 +9000,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9171,9 +9015,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserStatus", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserStatus", Tag=1, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9187,8 +9033,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9201,8 +9048,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9215,9 +9063,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=1, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9231,14 +9081,21 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DaysMask", Tag=2, Type=int),
-                            ClusterObjectFieldDescriptor(Label="StartHour", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartMinute", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EndHour", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EndMinute", Tag=6, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DaysMask", Tag=2, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartHour", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartMinute", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EndHour", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EndMinute", Tag=6, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9257,8 +9114,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9271,9 +9129,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9287,15 +9147,23 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DaysMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartHour", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartMinute", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EndHour", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EndMinute", Tag=7, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DaysMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartHour", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartMinute", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EndHour", Tag=6, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EndMinute", Tag=7, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9315,9 +9183,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9331,8 +9201,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9345,11 +9216,15 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalStartTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalEndTime", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalStartTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalEndTime", Tag=3, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9365,8 +9240,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9379,9 +9255,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9395,12 +9273,17 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalStartTime", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalEndTime", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalStartTime", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalEndTime", Tag=4, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9417,9 +9300,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=1, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9433,8 +9318,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9447,11 +9333,15 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalStartTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalEndTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OperatingModeDuringHoliday", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalStartTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalEndTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OperatingModeDuringHoliday", Tag=3, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9467,8 +9357,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9481,8 +9372,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9495,12 +9387,17 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalStartTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalEndTime", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OperatingModeDuringHoliday", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalStartTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalEndTime", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OperatingModeDuringHoliday", Tag=4, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9517,8 +9414,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ScheduleId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ScheduleId", Tag=0, Type=uint),
                     ])
 
             ScheduleId: 'uint' = None
@@ -9531,8 +9429,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9545,9 +9444,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=1, Type=DoorLock.Enums.DoorLockUserType),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=1, Type=DoorLock.Enums.DoorLockUserType),
                     ])
 
             UserId: 'uint' = None
@@ -9561,8 +9462,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9575,8 +9477,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9589,9 +9492,11 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=1, Type=DoorLock.Enums.DoorLockUserType),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=1, Type=DoorLock.Enums.DoorLockUserType),
                     ])
 
             UserId: 'uint' = None
@@ -9605,11 +9510,15 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
-                            ClusterObjectFieldDescriptor(Label="Id", Tag=3, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
+                        ClusterObjectFieldDescriptor(
+                            Label="Id", Tag=3, Type=bytes),
                     ])
 
             UserId: 'uint' = None
@@ -9625,8 +9534,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=DoorLock.Enums.DoorLockSetPinOrIdStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=DoorLock.Enums.DoorLockSetPinOrIdStatus),
                     ])
 
             Status: 'DoorLock.Enums.DoorLockSetPinOrIdStatus' = None
@@ -9639,8 +9549,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9653,11 +9564,15 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
-                            ClusterObjectFieldDescriptor(Label="Rfid", Tag=3, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserStatus", Tag=1, Type=DoorLock.Enums.DoorLockUserStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=2, Type=DoorLock.Enums.DoorLockUserType),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rfid", Tag=3, Type=bytes),
                     ])
 
             UserId: 'uint' = None
@@ -9673,8 +9588,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=0, Type=uint),
                     ])
 
             UserId: 'uint' = None
@@ -9687,8 +9603,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9701,9 +9618,8 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ClearAllRfidsResponse(ClusterCommand):
@@ -9713,8 +9629,9 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=uint),
                     ])
 
             Status: 'uint' = None
@@ -9727,13 +9644,19 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Source", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EventCode", Tag=1, Type=DoorLock.Enums.DoorLockOperationEventCode),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=3, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="TimeStamp", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=5, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Source", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EventCode", Tag=1, Type=DoorLock.Enums.DoorLockOperationEventCode),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=3, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeStamp", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=5, Type=str),
                     ])
 
             Source: 'uint' = None
@@ -9751,15 +9674,23 @@ class DoorLock:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Source", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EventCode", Tag=1, Type=DoorLock.Enums.DoorLockProgrammingEventCode),
-                            ClusterObjectFieldDescriptor(Label="UserId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Pin", Tag=3, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="UserType", Tag=4, Type=DoorLock.Enums.DoorLockUserType),
-                            ClusterObjectFieldDescriptor(Label="UserStatus", Tag=5, Type=DoorLock.Enums.DoorLockUserStatus),
-                            ClusterObjectFieldDescriptor(Label="TimeStamp", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=7, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Source", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EventCode", Tag=1, Type=DoorLock.Enums.DoorLockProgrammingEventCode),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Pin", Tag=3, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserType", Tag=4, Type=DoorLock.Enums.DoorLockUserType),
+                        ClusterObjectFieldDescriptor(
+                            Label="UserStatus", Tag=5, Type=DoorLock.Enums.DoorLockUserStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeStamp", Tag=6, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=7, Type=str),
                     ])
 
             Source: 'uint' = None
@@ -9770,7 +9701,6 @@ class DoorLock:
             UserStatus: 'DoorLock.Enums.DoorLockUserStatus' = None
             TimeStamp: 'uint' = None
             Data: 'str' = None
-
 
     class Attributes:
         class LockState(ClusterAttributeDescriptor):
@@ -9786,7 +9716,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LockType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9799,7 +9728,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ActuatorEnabled(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9814,7 +9742,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class DoorState(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9827,7 +9754,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DoorOpenEvents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9842,7 +9768,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DoorClosedEvents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9855,7 +9780,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OpenPeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9870,7 +9794,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumLockRecordsSupported(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9883,7 +9806,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NumTotalUsersSupported(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9898,7 +9820,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumPinUsersSupported(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9911,7 +9832,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NumRfidUsersSupported(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9926,7 +9846,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumWeekdaySchedulesSupportedPerUser(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9939,7 +9858,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NumYeardaySchedulesSupportedPerUser(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9954,7 +9872,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumHolidaySchedulesSupportedPerUser(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9967,7 +9884,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxPinLength(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -9982,7 +9898,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinPinLength(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -9995,7 +9910,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxRfidCodeLength(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10010,7 +9924,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinRfidCodeLength(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10023,7 +9936,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class EnableLogging(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10038,7 +9950,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class Language(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10051,7 +9962,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class LedSettings(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10066,7 +9976,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AutoRelockTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10079,7 +9988,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SoundVolume(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10094,7 +10002,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OperatingMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10107,7 +10014,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SupportedOperatingModes(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10122,7 +10028,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DefaultConfigurationRegister(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10135,7 +10040,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class EnableLocalProgramming(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10150,7 +10054,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class EnableOneTouchLocking(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10163,7 +10066,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class EnableInsideStatusLed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10178,7 +10080,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class EnablePrivacyModeButton(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10191,7 +10092,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class WrongCodeEntryLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10206,7 +10106,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class UserCodeTemporaryDisableTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10219,7 +10118,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SendPinOverTheAir(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10234,7 +10132,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class RequirePinForRfOperation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10247,7 +10144,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class ZigbeeSecurityLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10262,7 +10158,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10275,7 +10170,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class KeypadOperationEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10290,7 +10184,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RfOperationEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10303,7 +10196,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ManualOperationEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10318,7 +10210,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RfidOperationEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10331,7 +10222,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class KeypadProgrammingEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10346,7 +10236,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RfProgrammingEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10359,7 +10248,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RfidProgrammingEventMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10374,7 +10262,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10388,7 +10275,6 @@ class DoorLock:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10401,8 +10287,6 @@ class DoorLock:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -10450,8 +10334,6 @@ class WindowCovering:
             kProjectorScreen = 0x09
             kUnknown = 0xFF
 
-
-
     class Commands:
         @dataclass
         class UpOrOpen(ClusterCommand):
@@ -10461,9 +10343,8 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class DownOrClose(ClusterCommand):
@@ -10473,9 +10354,8 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class StopMotion(ClusterCommand):
@@ -10485,9 +10365,8 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GoToLiftValue(ClusterCommand):
@@ -10497,8 +10376,9 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LiftValue", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LiftValue", Tag=0, Type=uint),
                     ])
 
             LiftValue: 'uint' = None
@@ -10511,9 +10391,11 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LiftPercentageValue", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LiftPercent100thsValue", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LiftPercentageValue", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LiftPercent100thsValue", Tag=1, Type=uint),
                     ])
 
             LiftPercentageValue: 'uint' = None
@@ -10527,8 +10409,9 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TiltValue", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TiltValue", Tag=0, Type=uint),
                     ])
 
             TiltValue: 'uint' = None
@@ -10541,14 +10424,15 @@ class WindowCovering:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TiltPercentageValue", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TiltPercent100thsValue", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TiltPercentageValue", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TiltPercent100thsValue", Tag=1, Type=uint),
                     ])
 
             TiltPercentageValue: 'uint' = None
             TiltPercent100thsValue: 'uint' = None
-
 
     class Attributes:
         class Type(ClusterAttributeDescriptor):
@@ -10564,7 +10448,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PhysicalClosedLimitLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10577,7 +10460,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PhysicalClosedLimitTilt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10592,7 +10474,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentPositionLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10605,7 +10486,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentPositionTilt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10620,7 +10500,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumberOfActuationsLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10633,7 +10512,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NumberOfActuationsTilt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10648,7 +10526,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ConfigStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10661,7 +10538,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentPositionLiftPercentage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10676,7 +10552,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentPositionTiltPercentage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10689,7 +10564,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OperationalStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10704,7 +10578,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TargetPositionLiftPercent100ths(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10717,7 +10590,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TargetPositionTiltPercent100ths(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10732,7 +10604,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EndProductType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10745,7 +10616,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentPositionLiftPercent100ths(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10760,7 +10630,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentPositionTiltPercent100ths(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10773,7 +10642,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class InstalledOpenLimitLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10788,7 +10656,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class InstalledClosedLimitLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10801,7 +10668,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class InstalledOpenLimitTilt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10816,7 +10682,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class InstalledClosedLimitTilt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10829,7 +10694,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class VelocityLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10844,7 +10708,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AccelerationTimeLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10857,7 +10720,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DecelerationTimeLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10872,7 +10734,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Mode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10885,7 +10746,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class IntermediateSetpointsLift(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10900,7 +10760,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class IntermediateSetpointsTilt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10913,7 +10772,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class SafetyStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10928,7 +10786,6 @@ class WindowCovering:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -10941,7 +10798,6 @@ class WindowCovering:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -10957,13 +10813,9 @@ class WindowCovering:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class BarrierControl:
     id: typing.ClassVar[int] = 0x0103
-
-
 
     class Commands:
         @dataclass
@@ -10974,8 +10826,9 @@ class BarrierControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PercentOpen", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PercentOpen", Tag=0, Type=uint),
                     ])
 
             PercentOpen: 'uint' = None
@@ -10988,10 +10841,8 @@ class BarrierControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class BarrierMovingState(ClusterAttributeDescriptor):
@@ -11007,7 +10858,6 @@ class BarrierControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BarrierSafetyStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11020,7 +10870,6 @@ class BarrierControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BarrierCapabilities(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11035,7 +10884,6 @@ class BarrierControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BarrierOpenEvents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11048,7 +10896,6 @@ class BarrierControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BarrierCloseEvents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11063,7 +10910,6 @@ class BarrierControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BarrierCommandOpenEvents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11076,7 +10922,6 @@ class BarrierControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BarrierCommandCloseEvents(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11091,7 +10936,6 @@ class BarrierControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BarrierOpenPeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11104,7 +10948,6 @@ class BarrierControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BarrierClosePeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11119,7 +10962,6 @@ class BarrierControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BarrierPosition(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11132,7 +10974,6 @@ class BarrierControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11147,7 +10988,6 @@ class BarrierControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11160,8 +11000,6 @@ class BarrierControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -11183,9 +11021,6 @@ class PumpConfigurationAndControl:
             kMaximum = 0x02
             kLocal = 0x03
 
-
-
-
     class Attributes:
         class MaxPressure(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11200,7 +11035,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MaxSpeed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11213,7 +11047,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxFlow(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11228,7 +11061,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinConstPressure(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11241,7 +11073,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxConstPressure(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11256,7 +11087,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinCompPressure(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11269,7 +11099,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxCompPressure(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11284,7 +11113,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinConstSpeed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11297,7 +11125,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxConstSpeed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11312,7 +11139,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinConstFlow(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11325,7 +11151,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxConstFlow(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11340,7 +11165,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinConstTemp(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11353,7 +11177,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxConstTemp(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11368,7 +11191,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class PumpStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11381,7 +11203,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class EffectiveOperationMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11396,7 +11217,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EffectiveControlMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11409,7 +11229,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Capacity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11424,7 +11243,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Speed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11437,7 +11255,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LifetimeRunningHours(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11452,7 +11269,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Power(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11465,7 +11281,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LifetimeEnergyConsumed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11480,7 +11295,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OperationMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11493,7 +11307,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ControlMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11508,7 +11321,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11522,7 +11334,6 @@ class PumpConfigurationAndControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11535,7 +11346,6 @@ class PumpConfigurationAndControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11551,8 +11361,6 @@ class PumpConfigurationAndControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Thermostat:
     id: typing.ClassVar[int] = 0x0201
@@ -11563,8 +11371,6 @@ class Thermostat:
             kCoolSetpoint = 0x01
             kHeatAndCoolSetpoints = 0x02
 
-
-
     class Commands:
         @dataclass
         class SetpointRaiseLower(ClusterCommand):
@@ -11574,9 +11380,11 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Mode", Tag=0, Type=Thermostat.Enums.SetpointAdjustMode),
-                            ClusterObjectFieldDescriptor(Label="Amount", Tag=1, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Mode", Tag=0, Type=Thermostat.Enums.SetpointAdjustMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Amount", Tag=1, Type=int),
                     ])
 
             Mode: 'Thermostat.Enums.SetpointAdjustMode' = None
@@ -11590,11 +11398,15 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NumberOfTransitionsForSequence", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DayOfWeekForSequence", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="ModeForSequence", Tag=2, Type=int),
-                            ClusterObjectFieldDescriptor(Label="Payload", Tag=3, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfTransitionsForSequence", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DayOfWeekForSequence", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="ModeForSequence", Tag=2, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="Payload", Tag=3, Type=uint, IsArray=True),
                     ])
 
             NumberOfTransitionsForSequence: 'uint' = None
@@ -11610,11 +11422,15 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NumberOfTransitionsForSequence", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DayOfWeekForSequence", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="ModeForSequence", Tag=2, Type=int),
-                            ClusterObjectFieldDescriptor(Label="Payload", Tag=3, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfTransitionsForSequence", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DayOfWeekForSequence", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="ModeForSequence", Tag=2, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="Payload", Tag=3, Type=uint, IsArray=True),
                     ])
 
             NumberOfTransitionsForSequence: 'uint' = None
@@ -11630,13 +11446,19 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TimeOfDay", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="RelayStatus", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LocalTemperature", Tag=2, Type=int),
-                            ClusterObjectFieldDescriptor(Label="HumidityInPercentage", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Setpoint", Tag=4, Type=int),
-                            ClusterObjectFieldDescriptor(Label="UnreadEntries", Tag=5, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeOfDay", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="RelayStatus", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LocalTemperature", Tag=2, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="HumidityInPercentage", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Setpoint", Tag=4, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="UnreadEntries", Tag=5, Type=uint),
                     ])
 
             TimeOfDay: 'uint' = None
@@ -11654,9 +11476,11 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="DaysToReturn", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="ModeToReturn", Tag=1, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="DaysToReturn", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="ModeToReturn", Tag=1, Type=int),
                     ])
 
             DaysToReturn: 'int' = None
@@ -11670,9 +11494,8 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetRelayStatusLog(ClusterCommand):
@@ -11682,10 +11505,8 @@ class Thermostat:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class LocalTemperature(ClusterAttributeDescriptor):
@@ -11701,7 +11522,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class OutdoorTemperature(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11714,7 +11534,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class Occupancy(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11729,7 +11548,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AbsMinHeatSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11742,7 +11560,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class AbsMaxHeatSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11757,7 +11574,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AbsMinCoolSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11770,7 +11586,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class AbsMaxCoolSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11785,7 +11600,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class PiCoolingDemand(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11798,7 +11612,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PiHeatingDemand(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11813,7 +11626,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class HvacSystemTypeConfiguration(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11826,7 +11638,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LocalTemperatureCalibration(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11841,7 +11652,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class OccupiedCoolingSetpoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11854,7 +11664,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class OccupiedHeatingSetpoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11869,7 +11678,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class UnoccupiedCoolingSetpoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11882,7 +11690,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class UnoccupiedHeatingSetpoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11897,7 +11704,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinHeatSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11910,7 +11716,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxHeatSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11925,7 +11730,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinCoolSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11938,7 +11742,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxCoolSetpointLimit(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11953,7 +11756,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinSetpointDeadBand(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11966,7 +11768,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class RemoteSensing(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -11981,7 +11782,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ControlSequenceOfOperation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -11994,7 +11794,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SystemMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12009,7 +11808,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AlarmMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12022,7 +11820,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ThermostatRunningMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12037,7 +11834,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class StartOfWeek(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12050,7 +11846,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NumberOfWeeklyTransitions(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12065,7 +11860,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumberOfDailyTransitions(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12078,7 +11872,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TemperatureSetpointHold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12093,7 +11886,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class TemperatureSetpointHoldDuration(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12106,7 +11898,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ThermostatProgrammingOperationMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12121,7 +11912,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class HvacRelayState(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12134,7 +11924,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SetpointChangeSource(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12149,7 +11938,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SetpointChangeAmount(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12162,7 +11950,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class SetpointChangeSourceTimestamp(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12177,7 +11964,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12190,7 +11976,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcCapacity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12205,7 +11990,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcRefrigerantType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12218,7 +12002,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcCompressor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12233,7 +12016,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcErrorCode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12246,7 +12028,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcLouverPosition(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12261,7 +12042,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcCoilTemperature(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12274,7 +12054,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class AcCapacityFormat(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12289,7 +12068,6 @@ class Thermostat:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12302,7 +12080,6 @@ class Thermostat:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12318,14 +12095,9 @@ class Thermostat:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class FanControl:
     id: typing.ClassVar[int] = 0x0202
-
-
-
 
     class Attributes:
         class FanMode(ClusterAttributeDescriptor):
@@ -12341,7 +12113,6 @@ class FanControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FanModeSequence(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12355,7 +12126,6 @@ class FanControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12368,7 +12138,6 @@ class FanControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12384,14 +12153,9 @@ class FanControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class DehumidificationControl:
     id: typing.ClassVar[int] = 0x0203
-
-
-
 
     class Attributes:
         class RelativeHumidity(ClusterAttributeDescriptor):
@@ -12407,7 +12171,6 @@ class DehumidificationControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DehumidificationCooling(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12420,7 +12183,6 @@ class DehumidificationControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RhDehumidificationSetpoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12435,7 +12197,6 @@ class DehumidificationControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RelativeHumidityMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12448,7 +12209,6 @@ class DehumidificationControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DehumidificationLockout(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12463,7 +12223,6 @@ class DehumidificationControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DehumidificationHysteresis(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12476,7 +12235,6 @@ class DehumidificationControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DehumidificationMaxCool(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12491,7 +12249,6 @@ class DehumidificationControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RelativeHumidityDisplay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12505,7 +12262,6 @@ class DehumidificationControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12518,7 +12274,6 @@ class DehumidificationControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12534,14 +12289,9 @@ class DehumidificationControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ThermostatUserInterfaceConfiguration:
     id: typing.ClassVar[int] = 0x0204
-
-
-
 
     class Attributes:
         class TemperatureDisplayMode(ClusterAttributeDescriptor):
@@ -12557,7 +12307,6 @@ class ThermostatUserInterfaceConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class KeypadLockout(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12570,7 +12319,6 @@ class ThermostatUserInterfaceConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ScheduleProgrammingVisibility(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -12585,7 +12333,6 @@ class ThermostatUserInterfaceConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12599,7 +12346,6 @@ class ThermostatUserInterfaceConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -12612,8 +12358,6 @@ class ThermostatUserInterfaceConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -12659,8 +12403,6 @@ class ColorControl:
             kUp = 0x01
             kDown = 0x03
 
-
-
     class Commands:
         @dataclass
         class MoveToHue(ClusterCommand):
@@ -12670,12 +12412,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Hue", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Direction", Tag=1, Type=ColorControl.Enums.HueDirection),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Hue", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Direction", Tag=1, Type=ColorControl.Enums.HueDirection),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             Hue: 'uint' = None
@@ -12692,11 +12439,15 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MoveMode", Tag=0, Type=ColorControl.Enums.HueMoveMode),
-                            ClusterObjectFieldDescriptor(Label="Rate", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MoveMode", Tag=0, Type=ColorControl.Enums.HueMoveMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rate", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=3, Type=uint),
                     ])
 
             MoveMode: 'ColorControl.Enums.HueMoveMode' = None
@@ -12712,12 +12463,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepMode", Tag=0, Type=ColorControl.Enums.HueStepMode),
-                            ClusterObjectFieldDescriptor(Label="StepSize", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepMode", Tag=0, Type=ColorControl.Enums.HueStepMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepSize", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             StepMode: 'ColorControl.Enums.HueStepMode' = None
@@ -12734,11 +12490,15 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Saturation", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Saturation", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=3, Type=uint),
                     ])
 
             Saturation: 'uint' = None
@@ -12754,11 +12514,15 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MoveMode", Tag=0, Type=ColorControl.Enums.SaturationMoveMode),
-                            ClusterObjectFieldDescriptor(Label="Rate", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MoveMode", Tag=0, Type=ColorControl.Enums.SaturationMoveMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rate", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=3, Type=uint),
                     ])
 
             MoveMode: 'ColorControl.Enums.SaturationMoveMode' = None
@@ -12774,12 +12538,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepMode", Tag=0, Type=ColorControl.Enums.SaturationStepMode),
-                            ClusterObjectFieldDescriptor(Label="StepSize", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepMode", Tag=0, Type=ColorControl.Enums.SaturationStepMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepSize", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             StepMode: 'ColorControl.Enums.SaturationStepMode' = None
@@ -12796,12 +12565,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Hue", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Saturation", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Hue", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Saturation", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             Hue: 'uint' = None
@@ -12818,12 +12592,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ColorX", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ColorY", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorX", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorY", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             ColorX: 'uint' = None
@@ -12840,11 +12619,15 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="RateX", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="RateY", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="RateX", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="RateY", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=3, Type=uint),
                     ])
 
             RateX: 'int' = None
@@ -12860,12 +12643,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepX", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="StepY", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepX", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepY", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             StepX: 'int' = None
@@ -12882,11 +12670,15 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ColorTemperature", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorTemperature", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=3, Type=uint),
                     ])
 
             ColorTemperature: 'uint' = None
@@ -12902,12 +12694,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EnhancedHue", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Direction", Tag=1, Type=ColorControl.Enums.HueDirection),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EnhancedHue", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Direction", Tag=1, Type=ColorControl.Enums.HueDirection),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             EnhancedHue: 'uint' = None
@@ -12924,11 +12721,15 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MoveMode", Tag=0, Type=ColorControl.Enums.HueMoveMode),
-                            ClusterObjectFieldDescriptor(Label="Rate", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MoveMode", Tag=0, Type=ColorControl.Enums.HueMoveMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rate", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=3, Type=uint),
                     ])
 
             MoveMode: 'ColorControl.Enums.HueMoveMode' = None
@@ -12944,12 +12745,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepMode", Tag=0, Type=ColorControl.Enums.HueStepMode),
-                            ClusterObjectFieldDescriptor(Label="StepSize", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepMode", Tag=0, Type=ColorControl.Enums.HueStepMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepSize", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             StepMode: 'ColorControl.Enums.HueStepMode' = None
@@ -12966,12 +12772,17 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EnhancedHue", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Saturation", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=4, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EnhancedHue", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Saturation", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=4, Type=uint),
                     ])
 
             EnhancedHue: 'uint' = None
@@ -12988,14 +12799,21 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UpdateFlags", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="Action", Tag=1, Type=ColorControl.Enums.ColorLoopAction),
-                            ClusterObjectFieldDescriptor(Label="Direction", Tag=2, Type=ColorControl.Enums.ColorLoopDirection),
-                            ClusterObjectFieldDescriptor(Label="Time", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartHue", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=6, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UpdateFlags", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="Action", Tag=1, Type=ColorControl.Enums.ColorLoopAction),
+                        ClusterObjectFieldDescriptor(
+                            Label="Direction", Tag=2, Type=ColorControl.Enums.ColorLoopDirection),
+                        ClusterObjectFieldDescriptor(
+                            Label="Time", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartHue", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=6, Type=uint),
                     ])
 
             UpdateFlags: 'int' = None
@@ -13014,9 +12832,11 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=1, Type=uint),
                     ])
 
             OptionsMask: 'uint' = None
@@ -13030,13 +12850,19 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MoveMode", Tag=0, Type=ColorControl.Enums.HueMoveMode),
-                            ClusterObjectFieldDescriptor(Label="Rate", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ColorTemperatureMinimum", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ColorTemperatureMaximum", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=5, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MoveMode", Tag=0, Type=ColorControl.Enums.HueMoveMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="Rate", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorTemperatureMinimum", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorTemperatureMaximum", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=5, Type=uint),
                     ])
 
             MoveMode: 'ColorControl.Enums.HueMoveMode' = None
@@ -13054,14 +12880,21 @@ class ColorControl:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StepMode", Tag=0, Type=ColorControl.Enums.HueStepMode),
-                            ClusterObjectFieldDescriptor(Label="StepSize", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="TransitionTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ColorTemperatureMinimum", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ColorTemperatureMaximum", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsMask", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionsOverride", Tag=6, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StepMode", Tag=0, Type=ColorControl.Enums.HueStepMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="StepSize", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="TransitionTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorTemperatureMinimum", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ColorTemperatureMaximum", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsMask", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionsOverride", Tag=6, Type=uint),
                     ])
 
             StepMode: 'ColorControl.Enums.HueStepMode' = None
@@ -13071,7 +12904,6 @@ class ColorControl:
             ColorTemperatureMaximum: 'uint' = None
             OptionsMask: 'uint' = None
             OptionsOverride: 'uint' = None
-
 
     class Attributes:
         class CurrentHue(ClusterAttributeDescriptor):
@@ -13087,7 +12919,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentSaturation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13100,7 +12931,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RemainingTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13115,7 +12945,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CurrentX(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13128,7 +12957,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentY(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13143,7 +12971,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DriftCompensation(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13156,7 +12983,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CompensationText(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13171,7 +12997,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class ColorTemperature(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13184,7 +13009,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13199,7 +13023,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorControlOptions(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13212,7 +13035,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class NumberOfPrimaries(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13227,7 +13049,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary1X(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13240,7 +13061,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary1Y(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13255,7 +13075,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary1Intensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13268,7 +13087,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary2X(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13283,7 +13101,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary2Y(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13296,7 +13113,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary2Intensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13311,7 +13127,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary3X(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13324,7 +13139,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary3Y(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13339,7 +13153,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary3Intensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13352,7 +13165,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary4X(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13367,7 +13179,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary4Y(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13380,7 +13191,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary4Intensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13395,7 +13205,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary5X(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13408,7 +13217,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary5Y(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13423,7 +13231,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary5Intensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13436,7 +13243,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary6X(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13451,7 +13257,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Primary6Y(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13464,7 +13269,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Primary6Intensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13479,7 +13283,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class WhitePointX(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13492,7 +13295,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class WhitePointY(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13507,7 +13309,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorPointRX(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13520,7 +13321,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorPointRY(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13535,7 +13335,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorPointRIntensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13548,7 +13347,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorPointGX(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13563,7 +13361,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorPointGY(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13576,7 +13373,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorPointGIntensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13591,7 +13387,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorPointBX(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13604,7 +13399,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorPointBY(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13619,7 +13413,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorPointBIntensity(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13632,7 +13425,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class EnhancedCurrentHue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13647,7 +13439,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EnhancedColorMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13660,7 +13451,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorLoopActive(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13675,7 +13465,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorLoopDirection(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13688,7 +13477,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorLoopTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13703,7 +13491,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorLoopStartEnhancedHue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13716,7 +13503,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorLoopStoredEnhancedHue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13731,7 +13517,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorCapabilities(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13744,7 +13529,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ColorTempPhysicalMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13759,7 +13543,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ColorTempPhysicalMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13772,7 +13555,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CoupleColorTempToLevelMinMireds(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13787,7 +13569,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class StartUpColorTemperatureMireds(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13801,7 +13582,6 @@ class ColorControl:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13814,7 +13594,6 @@ class ColorControl:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13830,14 +13609,9 @@ class ColorControl:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class BallastConfiguration:
     id: typing.ClassVar[int] = 0x0301
-
-
-
 
     class Attributes:
         class PhysicalMinLevel(ClusterAttributeDescriptor):
@@ -13853,7 +13627,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PhysicalMaxLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13866,7 +13639,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BallastStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13881,7 +13653,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13894,7 +13665,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13909,7 +13679,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PowerOnLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13922,7 +13691,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PowerOnFadeTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13937,7 +13705,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class IntrinsicBallastFactor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13950,7 +13717,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class BallastFactorAdjustment(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13965,7 +13731,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LampQuality(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -13978,7 +13743,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LampType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -13993,7 +13757,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class LampManufacturer(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14006,7 +13769,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class LampRatedHours(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14021,7 +13783,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LampBurnHours(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14034,7 +13795,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LampAlarmMode(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14049,7 +13809,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LampBurnHoursTripPoint(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14063,7 +13822,6 @@ class BallastConfiguration:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14076,7 +13834,6 @@ class BallastConfiguration:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14092,8 +13849,6 @@ class BallastConfiguration:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class IlluminanceMeasurement:
     id: typing.ClassVar[int] = 0x0400
@@ -14102,9 +13857,6 @@ class IlluminanceMeasurement:
         class LightSensorType(IntEnum):
             kPhotodiode = 0x00
             kCmos = 0x01
-
-
-
 
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
@@ -14120,7 +13872,6 @@ class IlluminanceMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14133,7 +13884,6 @@ class IlluminanceMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14148,7 +13898,6 @@ class IlluminanceMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14161,7 +13910,6 @@ class IlluminanceMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LightSensorType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14176,7 +13924,6 @@ class IlluminanceMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14190,7 +13937,6 @@ class IlluminanceMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14203,17 +13949,12 @@ class IlluminanceMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class TemperatureMeasurement:
     id: typing.ClassVar[int] = 0x0402
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14228,7 +13969,6 @@ class TemperatureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14241,7 +13981,6 @@ class TemperatureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14256,7 +13995,6 @@ class TemperatureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14270,7 +14008,6 @@ class TemperatureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14283,7 +14020,6 @@ class TemperatureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14299,14 +14035,9 @@ class TemperatureMeasurement:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class PressureMeasurement:
     id: typing.ClassVar[int] = 0x0403
-
-
-
 
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
@@ -14322,7 +14053,6 @@ class PressureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14335,7 +14065,6 @@ class PressureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14350,7 +14079,6 @@ class PressureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14363,7 +14091,6 @@ class PressureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ScaledValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14378,7 +14105,6 @@ class PressureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinScaledValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14391,7 +14117,6 @@ class PressureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxScaledValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14406,7 +14131,6 @@ class PressureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ScaledTolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14419,7 +14143,6 @@ class PressureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Scale(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14434,7 +14157,6 @@ class PressureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14448,7 +14170,6 @@ class PressureMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14461,17 +14182,12 @@ class PressureMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class FlowMeasurement:
     id: typing.ClassVar[int] = 0x0404
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14486,7 +14202,6 @@ class FlowMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14499,7 +14214,6 @@ class FlowMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14514,7 +14228,6 @@ class FlowMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14527,7 +14240,6 @@ class FlowMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14542,7 +14254,6 @@ class FlowMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14555,17 +14266,12 @@ class FlowMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class RelativeHumidityMeasurement:
     id: typing.ClassVar[int] = 0x0405
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14580,7 +14286,6 @@ class RelativeHumidityMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14593,7 +14298,6 @@ class RelativeHumidityMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14608,7 +14312,6 @@ class RelativeHumidityMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14622,7 +14325,6 @@ class RelativeHumidityMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14635,7 +14337,6 @@ class RelativeHumidityMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14651,14 +14352,9 @@ class RelativeHumidityMeasurement:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class OccupancySensing:
     id: typing.ClassVar[int] = 0x0406
-
-
-
 
     class Attributes:
         class Occupancy(ClusterAttributeDescriptor):
@@ -14674,7 +14370,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OccupancySensorType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14687,7 +14382,6 @@ class OccupancySensing:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OccupancySensorTypeBitmap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14702,7 +14396,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PirOccupiedToUnoccupiedDelay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14715,7 +14408,6 @@ class OccupancySensing:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PirUnoccupiedToOccupiedDelay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14730,7 +14422,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PirUnoccupiedToOccupiedThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14743,7 +14434,6 @@ class OccupancySensing:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class UltrasonicOccupiedToUnoccupiedDelay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14758,7 +14448,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class UltrasonicUnoccupiedToOccupiedDelay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14771,7 +14460,6 @@ class OccupancySensing:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class UltrasonicUnoccupiedToOccupiedThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14786,7 +14474,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PhysicalContactOccupiedToUnoccupiedDelay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14799,7 +14486,6 @@ class OccupancySensing:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PhysicalContactUnoccupiedToOccupiedDelay(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14814,7 +14500,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PhysicalContactUnoccupiedToOccupiedThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14828,7 +14513,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14842,7 +14526,6 @@ class OccupancySensing:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14855,17 +14538,12 @@ class OccupancySensing:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class CarbonMonoxideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x040C
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14880,7 +14558,6 @@ class CarbonMonoxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14893,7 +14570,6 @@ class CarbonMonoxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14908,7 +14584,6 @@ class CarbonMonoxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14921,7 +14596,6 @@ class CarbonMonoxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14936,7 +14610,6 @@ class CarbonMonoxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14949,17 +14622,12 @@ class CarbonMonoxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class CarbonDioxideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x040D
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -14974,7 +14642,6 @@ class CarbonDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -14987,7 +14654,6 @@ class CarbonDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15002,7 +14668,6 @@ class CarbonDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15015,7 +14680,6 @@ class CarbonDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15030,7 +14694,6 @@ class CarbonDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15043,17 +14706,12 @@ class CarbonDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class EthyleneConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x040E
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15068,7 +14726,6 @@ class EthyleneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15081,7 +14738,6 @@ class EthyleneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15096,7 +14752,6 @@ class EthyleneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15109,7 +14764,6 @@ class EthyleneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15124,7 +14778,6 @@ class EthyleneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15137,17 +14790,12 @@ class EthyleneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class EthyleneOxideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x040F
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15162,7 +14810,6 @@ class EthyleneOxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15175,7 +14822,6 @@ class EthyleneOxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15190,7 +14836,6 @@ class EthyleneOxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15203,7 +14848,6 @@ class EthyleneOxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15218,7 +14862,6 @@ class EthyleneOxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15231,17 +14874,12 @@ class EthyleneOxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class HydrogenConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0410
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15256,7 +14894,6 @@ class HydrogenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15269,7 +14906,6 @@ class HydrogenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15284,7 +14920,6 @@ class HydrogenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15297,7 +14932,6 @@ class HydrogenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15312,7 +14946,6 @@ class HydrogenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15325,17 +14958,12 @@ class HydrogenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class HydrogenSulphideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0411
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15350,7 +14978,6 @@ class HydrogenSulphideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15363,7 +14990,6 @@ class HydrogenSulphideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15378,7 +15004,6 @@ class HydrogenSulphideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15391,7 +15016,6 @@ class HydrogenSulphideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15406,7 +15030,6 @@ class HydrogenSulphideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15419,17 +15042,12 @@ class HydrogenSulphideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class NitricOxideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0412
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15444,7 +15062,6 @@ class NitricOxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15457,7 +15074,6 @@ class NitricOxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15472,7 +15088,6 @@ class NitricOxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15485,7 +15100,6 @@ class NitricOxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15500,7 +15114,6 @@ class NitricOxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15513,17 +15126,12 @@ class NitricOxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class NitrogenDioxideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0413
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15538,7 +15146,6 @@ class NitrogenDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15551,7 +15158,6 @@ class NitrogenDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15566,7 +15172,6 @@ class NitrogenDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15579,7 +15184,6 @@ class NitrogenDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15594,7 +15198,6 @@ class NitrogenDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15607,17 +15210,12 @@ class NitrogenDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class OxygenConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0414
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15632,7 +15230,6 @@ class OxygenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15645,7 +15242,6 @@ class OxygenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15660,7 +15256,6 @@ class OxygenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15673,7 +15268,6 @@ class OxygenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15688,7 +15282,6 @@ class OxygenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15701,17 +15294,12 @@ class OxygenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class OzoneConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0415
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15726,7 +15314,6 @@ class OzoneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15739,7 +15326,6 @@ class OzoneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15754,7 +15340,6 @@ class OzoneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15767,7 +15352,6 @@ class OzoneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15782,7 +15366,6 @@ class OzoneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15795,17 +15378,12 @@ class OzoneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class SulfurDioxideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0416
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15820,7 +15398,6 @@ class SulfurDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15833,7 +15410,6 @@ class SulfurDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15848,7 +15424,6 @@ class SulfurDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15861,7 +15436,6 @@ class SulfurDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15876,7 +15450,6 @@ class SulfurDioxideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15889,17 +15462,12 @@ class SulfurDioxideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class DissolvedOxygenConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0417
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15914,7 +15482,6 @@ class DissolvedOxygenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15927,7 +15494,6 @@ class DissolvedOxygenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15942,7 +15508,6 @@ class DissolvedOxygenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15955,7 +15520,6 @@ class DissolvedOxygenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -15970,7 +15534,6 @@ class DissolvedOxygenConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -15983,17 +15546,12 @@ class DissolvedOxygenConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class BromateConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0418
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16008,7 +15566,6 @@ class BromateConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16021,7 +15578,6 @@ class BromateConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16036,7 +15592,6 @@ class BromateConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16049,7 +15604,6 @@ class BromateConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16064,7 +15618,6 @@ class BromateConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16077,17 +15630,12 @@ class BromateConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class ChloraminesConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0419
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16102,7 +15650,6 @@ class ChloraminesConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16115,7 +15662,6 @@ class ChloraminesConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16130,7 +15676,6 @@ class ChloraminesConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16143,7 +15688,6 @@ class ChloraminesConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16158,7 +15702,6 @@ class ChloraminesConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16171,17 +15714,12 @@ class ChloraminesConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class ChlorineConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x041A
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16196,7 +15734,6 @@ class ChlorineConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16209,7 +15746,6 @@ class ChlorineConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16224,7 +15760,6 @@ class ChlorineConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16237,7 +15772,6 @@ class ChlorineConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16252,7 +15786,6 @@ class ChlorineConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16265,17 +15798,12 @@ class ChlorineConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class FecalColiformAndEColiConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x041B
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16290,7 +15818,6 @@ class FecalColiformAndEColiConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16303,7 +15830,6 @@ class FecalColiformAndEColiConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16318,7 +15844,6 @@ class FecalColiformAndEColiConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16331,7 +15856,6 @@ class FecalColiformAndEColiConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16346,7 +15870,6 @@ class FecalColiformAndEColiConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16359,17 +15882,12 @@ class FecalColiformAndEColiConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class FluorideConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x041C
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16384,7 +15902,6 @@ class FluorideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16397,7 +15914,6 @@ class FluorideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16412,7 +15928,6 @@ class FluorideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16425,7 +15940,6 @@ class FluorideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16440,7 +15954,6 @@ class FluorideConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16453,17 +15966,12 @@ class FluorideConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class HaloaceticAcidsConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x041D
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16478,7 +15986,6 @@ class HaloaceticAcidsConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16491,7 +15998,6 @@ class HaloaceticAcidsConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16506,7 +16012,6 @@ class HaloaceticAcidsConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16519,7 +16024,6 @@ class HaloaceticAcidsConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16534,7 +16038,6 @@ class HaloaceticAcidsConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16547,17 +16050,12 @@ class HaloaceticAcidsConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class TotalTrihalomethanesConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x041E
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16572,7 +16070,6 @@ class TotalTrihalomethanesConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16585,7 +16082,6 @@ class TotalTrihalomethanesConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16600,7 +16096,6 @@ class TotalTrihalomethanesConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16613,7 +16108,6 @@ class TotalTrihalomethanesConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16628,7 +16122,6 @@ class TotalTrihalomethanesConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16641,17 +16134,12 @@ class TotalTrihalomethanesConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class TotalColiformBacteriaConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x041F
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16666,7 +16154,6 @@ class TotalColiformBacteriaConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16679,7 +16166,6 @@ class TotalColiformBacteriaConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16694,7 +16180,6 @@ class TotalColiformBacteriaConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16707,7 +16192,6 @@ class TotalColiformBacteriaConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16722,7 +16206,6 @@ class TotalColiformBacteriaConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16735,17 +16218,12 @@ class TotalColiformBacteriaConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class TurbidityConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0420
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16760,7 +16238,6 @@ class TurbidityConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16773,7 +16250,6 @@ class TurbidityConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16788,7 +16264,6 @@ class TurbidityConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16801,7 +16276,6 @@ class TurbidityConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16816,7 +16290,6 @@ class TurbidityConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16829,17 +16302,12 @@ class TurbidityConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class CopperConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0421
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16854,7 +16322,6 @@ class CopperConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16867,7 +16334,6 @@ class CopperConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16882,7 +16348,6 @@ class CopperConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16895,7 +16360,6 @@ class CopperConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16910,7 +16374,6 @@ class CopperConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16923,17 +16386,12 @@ class CopperConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class LeadConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0422
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16948,7 +16406,6 @@ class LeadConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16961,7 +16418,6 @@ class LeadConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -16976,7 +16432,6 @@ class LeadConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -16989,7 +16444,6 @@ class LeadConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17004,7 +16458,6 @@ class LeadConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17017,17 +16470,12 @@ class LeadConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class ManganeseConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0423
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17042,7 +16490,6 @@ class ManganeseConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17055,7 +16502,6 @@ class ManganeseConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17070,7 +16516,6 @@ class ManganeseConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17083,7 +16528,6 @@ class ManganeseConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17098,7 +16542,6 @@ class ManganeseConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17111,17 +16554,12 @@ class ManganeseConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class SulfateConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0424
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17136,7 +16574,6 @@ class SulfateConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17149,7 +16586,6 @@ class SulfateConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17164,7 +16600,6 @@ class SulfateConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17177,7 +16612,6 @@ class SulfateConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17192,7 +16626,6 @@ class SulfateConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17205,17 +16638,12 @@ class SulfateConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class BromodichloromethaneConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0425
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17230,7 +16658,6 @@ class BromodichloromethaneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17243,7 +16670,6 @@ class BromodichloromethaneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17258,7 +16684,6 @@ class BromodichloromethaneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17271,7 +16696,6 @@ class BromodichloromethaneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17286,7 +16710,6 @@ class BromodichloromethaneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17299,17 +16722,12 @@ class BromodichloromethaneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class BromoformConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0426
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17324,7 +16742,6 @@ class BromoformConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17337,7 +16754,6 @@ class BromoformConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17352,7 +16768,6 @@ class BromoformConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17365,7 +16780,6 @@ class BromoformConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17380,7 +16794,6 @@ class BromoformConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17393,17 +16806,12 @@ class BromoformConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class ChlorodibromomethaneConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0427
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17418,7 +16826,6 @@ class ChlorodibromomethaneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17431,7 +16838,6 @@ class ChlorodibromomethaneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17446,7 +16852,6 @@ class ChlorodibromomethaneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17459,7 +16864,6 @@ class ChlorodibromomethaneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17474,7 +16878,6 @@ class ChlorodibromomethaneConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17487,17 +16890,12 @@ class ChlorodibromomethaneConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class ChloroformConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0428
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17512,7 +16910,6 @@ class ChloroformConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17525,7 +16922,6 @@ class ChloroformConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17540,7 +16936,6 @@ class ChloroformConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17553,7 +16948,6 @@ class ChloroformConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17568,7 +16962,6 @@ class ChloroformConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17581,17 +16974,12 @@ class ChloroformConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
 class SodiumConcentrationMeasurement:
     id: typing.ClassVar[int] = 0x0429
 
-
-
-
     class Attributes:
         class MeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17606,7 +16994,6 @@ class SodiumConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class MinMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17619,7 +17006,6 @@ class SodiumConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class MaxMeasuredValue(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17634,7 +17020,6 @@ class SodiumConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
 
-
         class Tolerance(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17647,7 +17032,6 @@ class SodiumConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=float)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17662,7 +17046,6 @@ class SodiumConcentrationMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17675,8 +17058,6 @@ class SodiumConcentrationMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -17708,8 +17089,6 @@ class IasZone:
             kSecurityRepeater = 0x229
             kInvalidZoneType = 0xFFFF
 
-
-
     class Commands:
         @dataclass
         class ZoneEnrollResponse(ClusterCommand):
@@ -17719,9 +17098,11 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EnrollResponseCode", Tag=0, Type=IasZone.Enums.IasEnrollResponseCode),
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EnrollResponseCode", Tag=0, Type=IasZone.Enums.IasEnrollResponseCode),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=1, Type=uint),
                     ])
 
             EnrollResponseCode: 'IasZone.Enums.IasEnrollResponseCode' = None
@@ -17735,11 +17116,15 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneStatus", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="ExtendedStatus", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Delay", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatus", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExtendedStatus", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Delay", Tag=3, Type=uint),
                     ])
 
             ZoneStatus: 'int' = None
@@ -17755,9 +17140,8 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ZoneEnrollRequest(ClusterCommand):
@@ -17767,9 +17151,11 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneType", Tag=0, Type=IasZone.Enums.IasZoneType),
-                            ClusterObjectFieldDescriptor(Label="ManufacturerCode", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneType", Tag=0, Type=IasZone.Enums.IasZoneType),
+                        ClusterObjectFieldDescriptor(
+                            Label="ManufacturerCode", Tag=1, Type=uint),
                     ])
 
             ZoneType: 'IasZone.Enums.IasZoneType' = None
@@ -17783,9 +17169,11 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TestModeDuration", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="CurrentZoneSensitivityLevel", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TestModeDuration", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="CurrentZoneSensitivityLevel", Tag=1, Type=uint),
                     ])
 
             TestModeDuration: 'uint' = None
@@ -17799,9 +17187,8 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class InitiateTestModeResponse(ClusterCommand):
@@ -17811,10 +17198,8 @@ class IasZone:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class ZoneState(ClusterAttributeDescriptor):
@@ -17830,7 +17215,6 @@ class IasZone:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ZoneType(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17843,7 +17227,6 @@ class IasZone:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ZoneStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17858,7 +17241,6 @@ class IasZone:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class IasCieAddress(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17871,7 +17253,6 @@ class IasZone:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ZoneId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17886,7 +17267,6 @@ class IasZone:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NumberOfZoneSensitivityLevelsSupported(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17899,7 +17279,6 @@ class IasZone:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class CurrentZoneSensitivityLevel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -17914,7 +17293,6 @@ class IasZone:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17928,7 +17306,6 @@ class IasZone:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -17941,8 +17318,6 @@ class IasZone:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -18017,22 +17392,21 @@ class IasAce:
             kSecurityRepeater = 0x229
             kInvalidZoneType = 0xFFFF
 
-
     class Structs:
         @dataclass
         class IasAceZoneStatusResult(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneStatus", Tag=1, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatus", Tag=1, Type=int),
                     ])
 
             ZoneId: 'uint' = None
             ZoneStatus: 'int' = None
-
-
 
     class Commands:
         @dataclass
@@ -18043,10 +17417,13 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ArmMode", Tag=0, Type=IasAce.Enums.IasAceArmMode),
-                            ClusterObjectFieldDescriptor(Label="ArmDisarmCode", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ArmMode", Tag=0, Type=IasAce.Enums.IasAceArmMode),
+                        ClusterObjectFieldDescriptor(
+                            Label="ArmDisarmCode", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=2, Type=uint),
                     ])
 
             ArmMode: 'IasAce.Enums.IasAceArmMode' = None
@@ -18061,8 +17438,9 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ArmNotification", Tag=0, Type=IasAce.Enums.IasAceArmNotification),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ArmNotification", Tag=0, Type=IasAce.Enums.IasAceArmNotification),
                     ])
 
             ArmNotification: 'IasAce.Enums.IasAceArmNotification' = None
@@ -18075,10 +17453,13 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NumberOfZones", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneIds", Tag=1, Type=uint, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="ArmDisarmCode", Tag=2, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfZones", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneIds", Tag=1, Type=uint, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="ArmDisarmCode", Tag=2, Type=str),
                     ])
 
             NumberOfZones: 'uint' = None
@@ -18093,23 +17474,39 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Section0", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section1", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section2", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section3", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section4", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section5", Tag=5, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section6", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section7", Tag=7, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section8", Tag=8, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section9", Tag=9, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section10", Tag=10, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section11", Tag=11, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section12", Tag=12, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section13", Tag=13, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section14", Tag=14, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Section15", Tag=15, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Section0", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section1", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section2", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section3", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section4", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section5", Tag=5, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section6", Tag=6, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section7", Tag=7, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section8", Tag=8, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section9", Tag=9, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section10", Tag=10, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section11", Tag=11, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section12", Tag=12, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section13", Tag=13, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section14", Tag=14, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Section15", Tag=15, Type=uint),
                     ])
 
             Section0: 'uint' = None
@@ -18137,9 +17534,8 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetZoneInformationResponse(ClusterCommand):
@@ -18149,11 +17545,15 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneType", Tag=1, Type=IasAce.Enums.IasZoneType),
-                            ClusterObjectFieldDescriptor(Label="IeeeAddress", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneLabel", Tag=3, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneType", Tag=1, Type=IasAce.Enums.IasZoneType),
+                        ClusterObjectFieldDescriptor(
+                            Label="IeeeAddress", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneLabel", Tag=3, Type=str),
                     ])
 
             ZoneId: 'uint' = None
@@ -18169,9 +17569,8 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class ZoneStatusChanged(ClusterCommand):
@@ -18181,11 +17580,15 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneStatus", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AudibleNotification", Tag=2, Type=IasAce.Enums.IasAceAudibleNotification),
-                            ClusterObjectFieldDescriptor(Label="ZoneLabel", Tag=3, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatus", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AudibleNotification", Tag=2, Type=IasAce.Enums.IasAceAudibleNotification),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneLabel", Tag=3, Type=str),
                     ])
 
             ZoneId: 'uint' = None
@@ -18201,9 +17604,8 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class PanelStatusChanged(ClusterCommand):
@@ -18213,11 +17615,15 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PanelStatus", Tag=0, Type=IasAce.Enums.IasAcePanelStatus),
-                            ClusterObjectFieldDescriptor(Label="SecondsRemaining", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AudibleNotification", Tag=2, Type=IasAce.Enums.IasAceAudibleNotification),
-                            ClusterObjectFieldDescriptor(Label="AlarmStatus", Tag=3, Type=IasAce.Enums.IasAceAlarmStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PanelStatus", Tag=0, Type=IasAce.Enums.IasAcePanelStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="SecondsRemaining", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AudibleNotification", Tag=2, Type=IasAce.Enums.IasAceAudibleNotification),
+                        ClusterObjectFieldDescriptor(
+                            Label="AlarmStatus", Tag=3, Type=IasAce.Enums.IasAceAlarmStatus),
                     ])
 
             PanelStatus: 'IasAce.Enums.IasAcePanelStatus' = None
@@ -18233,9 +17639,8 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetPanelStatusResponse(ClusterCommand):
@@ -18245,11 +17650,15 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="PanelStatus", Tag=0, Type=IasAce.Enums.IasAcePanelStatus),
-                            ClusterObjectFieldDescriptor(Label="SecondsRemaining", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AudibleNotification", Tag=2, Type=IasAce.Enums.IasAceAudibleNotification),
-                            ClusterObjectFieldDescriptor(Label="AlarmStatus", Tag=3, Type=IasAce.Enums.IasAceAlarmStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="PanelStatus", Tag=0, Type=IasAce.Enums.IasAcePanelStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="SecondsRemaining", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AudibleNotification", Tag=2, Type=IasAce.Enums.IasAceAudibleNotification),
+                        ClusterObjectFieldDescriptor(
+                            Label="AlarmStatus", Tag=3, Type=IasAce.Enums.IasAceAlarmStatus),
                     ])
 
             PanelStatus: 'IasAce.Enums.IasAcePanelStatus' = None
@@ -18265,8 +17674,9 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneId", Tag=0, Type=uint),
                     ])
 
             ZoneId: 'uint' = None
@@ -18279,9 +17689,11 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NumberOfZones", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneIds", Tag=1, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfZones", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneIds", Tag=1, Type=uint, IsArray=True),
                     ])
 
             NumberOfZones: 'uint' = None
@@ -18295,9 +17707,8 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class BypassResponse(ClusterCommand):
@@ -18307,9 +17718,11 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NumberOfZones", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="BypassResult", Tag=1, Type=IasAce.Enums.IasAceBypassResult, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfZones", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="BypassResult", Tag=1, Type=IasAce.Enums.IasAceBypassResult, IsArray=True),
                     ])
 
             NumberOfZones: 'uint' = None
@@ -18323,9 +17736,8 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetZoneStatusResponse(ClusterCommand):
@@ -18335,10 +17747,13 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ZoneStatusComplete", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NumberOfZones", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneStatusResult", Tag=2, Type=IasAce.Structs.IasAceZoneStatusResult, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatusComplete", Tag=0, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfZones", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatusResult", Tag=2, Type=IasAce.Structs.IasAceZoneStatusResult, IsArray=True),
                     ])
 
             ZoneStatusComplete: 'bool' = None
@@ -18353,18 +17768,21 @@ class IasAce:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StartingZoneId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MaxNumberOfZoneIds", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ZoneStatusMaskFlag", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="ZoneStatusMask", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StartingZoneId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MaxNumberOfZoneIds", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatusMaskFlag", Tag=2, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="ZoneStatusMask", Tag=3, Type=uint),
                     ])
 
             StartingZoneId: 'uint' = None
             MaxNumberOfZoneIds: 'uint' = None
             ZoneStatusMaskFlag: 'bool' = None
             ZoneStatusMask: 'uint' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -18380,7 +17798,6 @@ class IasAce:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18395,13 +17812,9 @@ class IasAce:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class IasWd:
     id: typing.ClassVar[int] = 0x0502
-
-
 
     class Commands:
         @dataclass
@@ -18412,11 +17825,15 @@ class IasWd:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="WarningInfo", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="WarningDuration", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StrobeDutyCycle", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StrobeLevel", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="WarningInfo", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="WarningDuration", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StrobeDutyCycle", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StrobeLevel", Tag=3, Type=uint),
                     ])
 
             WarningInfo: 'int' = None
@@ -18432,12 +17849,12 @@ class IasWd:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="SquawkInfo", Tag=0, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="SquawkInfo", Tag=0, Type=int),
                     ])
 
             SquawkInfo: 'int' = None
-
 
     class Attributes:
         class MaxDuration(ClusterAttributeDescriptor):
@@ -18453,7 +17870,6 @@ class IasWd:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18466,7 +17882,6 @@ class IasWd:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -18482,14 +17897,9 @@ class IasWd:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class WakeOnLan:
     id: typing.ClassVar[int] = 0x0503
-
-
-
 
     class Attributes:
         class WakeOnLanMacAddress(ClusterAttributeDescriptor):
@@ -18505,7 +17915,6 @@ class WakeOnLan:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18518,7 +17927,6 @@ class WakeOnLan:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -18534,8 +17942,6 @@ class WakeOnLan:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class TvChannel:
     id: typing.ClassVar[int] = 0x0504
@@ -18548,19 +17954,23 @@ class TvChannel:
         class TvChannelLineupInfoType(IntEnum):
             kMso = 0x00
 
-
     class Structs:
         @dataclass
         class TvChannelInfo(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MajorNumber", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MinorNumber", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="CallSign", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="AffiliateCallSign", Tag=4, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MajorNumber", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MinorNumber", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=2, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="CallSign", Tag=3, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="AffiliateCallSign", Tag=4, Type=str),
                     ])
 
             MajorNumber: 'uint' = None
@@ -18574,19 +17984,21 @@ class TvChannel:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="OperatorName", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="LineupName", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="PostalCode", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="LineupInfoType", Tag=3, Type=TvChannel.Enums.TvChannelLineupInfoType),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="OperatorName", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="LineupName", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="PostalCode", Tag=2, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="LineupInfoType", Tag=3, Type=TvChannel.Enums.TvChannelLineupInfoType),
                     ])
 
             OperatorName: 'str' = None
             LineupName: 'str' = None
             PostalCode: 'str' = None
             LineupInfoType: 'TvChannel.Enums.TvChannelLineupInfoType' = None
-
-
 
     class Commands:
         @dataclass
@@ -18597,8 +18009,9 @@ class TvChannel:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Match", Tag=0, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Match", Tag=0, Type=str),
                     ])
 
             Match: 'str' = None
@@ -18611,9 +18024,11 @@ class TvChannel:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ChannelMatch", Tag=0, Type=TvChannel.Structs.TvChannelInfo, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="ErrorType", Tag=1, Type=TvChannel.Enums.TvChannelErrorType),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ChannelMatch", Tag=0, Type=TvChannel.Structs.TvChannelInfo, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="ErrorType", Tag=1, Type=TvChannel.Enums.TvChannelErrorType),
                     ])
 
             ChannelMatch: typing.List['TvChannel.Structs.TvChannelInfo'] = None
@@ -18627,9 +18042,11 @@ class TvChannel:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MajorNumber", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MinorNumber", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MajorNumber", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MinorNumber", Tag=1, Type=uint),
                     ])
 
             MajorNumber: 'uint' = None
@@ -18643,12 +18060,12 @@ class TvChannel:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Count", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Count", Tag=0, Type=uint),
                     ])
 
             Count: 'uint' = None
-
 
     class Attributes:
         class TvChannelList(ClusterAttributeDescriptor):
@@ -18664,7 +18081,6 @@ class TvChannel:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=TvChannel.Structs.TvChannelInfo, IsArray=True)
 
-
         class TvChannelLineup(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18677,7 +18093,6 @@ class TvChannel:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class CurrentTvChannel(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -18692,7 +18107,6 @@ class TvChannel:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18705,7 +18119,6 @@ class TvChannel:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -18721,8 +18134,6 @@ class TvChannel:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class TargetNavigator:
     id: typing.ClassVar[int] = 0x0505
@@ -18733,22 +18144,21 @@ class TargetNavigator:
             kAppNotAvailable = 0x01
             kSystemBusy = 0x02
 
-
     class Structs:
         @dataclass
         class NavigateTargetTargetInfo(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Identifier", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Identifier", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=1, Type=str),
                     ])
 
             Identifier: 'uint' = None
             Name: 'str' = None
-
-
 
     class Commands:
         @dataclass
@@ -18759,9 +18169,11 @@ class TargetNavigator:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Target", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Target", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=1, Type=str),
                     ])
 
             Target: 'uint' = None
@@ -18775,14 +18187,15 @@ class TargetNavigator:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=TargetNavigator.Enums.NavigateTargetStatus),
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=TargetNavigator.Enums.NavigateTargetStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=1, Type=str),
                     ])
 
             Status: 'TargetNavigator.Enums.NavigateTargetStatus' = None
             Data: 'str' = None
-
 
     class Attributes:
         class TargetNavigatorList(ClusterAttributeDescriptor):
@@ -18798,7 +18211,6 @@ class TargetNavigator:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=TargetNavigator.Structs.NavigateTargetTargetInfo, IsArray=True)
 
-
         class CurrentNavigatorTarget(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18811,7 +18223,6 @@ class TargetNavigator:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -18826,7 +18237,6 @@ class TargetNavigator:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -18839,8 +18249,6 @@ class TargetNavigator:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -18862,22 +18270,21 @@ class MediaPlayback:
             kSpeedOutOfRange = 0x04
             kSeekOutOfRange = 0x05
 
-
     class Structs:
         @dataclass
         class MediaPlaybackPosition(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="UpdatedAt", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Position", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="UpdatedAt", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Position", Tag=1, Type=uint),
                     ])
 
             UpdatedAt: 'uint' = None
             Position: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -18888,9 +18295,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaPlayResponse(ClusterCommand):
@@ -18900,8 +18306,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -18914,9 +18321,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaPauseResponse(ClusterCommand):
@@ -18926,8 +18332,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -18940,9 +18347,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaStopResponse(ClusterCommand):
@@ -18952,8 +18358,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -18966,9 +18373,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaStartOverResponse(ClusterCommand):
@@ -18978,8 +18384,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -18992,9 +18399,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaPreviousResponse(ClusterCommand):
@@ -19004,8 +18410,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -19018,9 +18425,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaNextResponse(ClusterCommand):
@@ -19030,8 +18436,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -19044,9 +18451,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaRewindResponse(ClusterCommand):
@@ -19056,8 +18462,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -19070,9 +18477,8 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class MediaFastForwardResponse(ClusterCommand):
@@ -19082,8 +18488,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -19096,8 +18503,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="DeltaPositionMilliseconds", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="DeltaPositionMilliseconds", Tag=0, Type=uint),
                     ])
 
             DeltaPositionMilliseconds: 'uint' = None
@@ -19110,8 +18518,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -19124,8 +18533,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="DeltaPositionMilliseconds", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="DeltaPositionMilliseconds", Tag=0, Type=uint),
                     ])
 
             DeltaPositionMilliseconds: 'uint' = None
@@ -19138,8 +18548,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
@@ -19152,8 +18563,9 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Position", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Position", Tag=0, Type=uint),
                     ])
 
             Position: 'uint' = None
@@ -19166,12 +18578,12 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MediaPlaybackStatus", Tag=0, Type=MediaPlayback.Enums.MediaPlaybackStatus),
                     ])
 
             MediaPlaybackStatus: 'MediaPlayback.Enums.MediaPlaybackStatus' = None
-
 
     class Attributes:
         class PlaybackState(ClusterAttributeDescriptor):
@@ -19187,7 +18599,6 @@ class MediaPlayback:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class StartTime(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19200,7 +18611,6 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Duration(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -19215,7 +18625,6 @@ class MediaPlayback:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PositionUpdatedAt(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19228,7 +18637,6 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Position(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -19243,7 +18651,6 @@ class MediaPlayback:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PlaybackSpeed(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19256,7 +18663,6 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class SeekRangeEnd(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -19271,7 +18677,6 @@ class MediaPlayback:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class SeekRangeStart(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19284,7 +18689,6 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -19299,7 +18703,6 @@ class MediaPlayback:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19312,8 +18715,6 @@ class MediaPlayback:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -19335,26 +18736,27 @@ class MediaInput:
             kUsb = 0x0A
             kOther = 0x0B
 
-
     class Structs:
         @dataclass
         class MediaInputInfo(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Index", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="InputType", Tag=1, Type=MediaInput.Enums.MediaInputType),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=2, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Description", Tag=3, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Index", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="InputType", Tag=1, Type=MediaInput.Enums.MediaInputType),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=2, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Description", Tag=3, Type=str),
                     ])
 
             Index: 'uint' = None
             InputType: 'MediaInput.Enums.MediaInputType' = None
             Name: 'str' = None
             Description: 'str' = None
-
-
 
     class Commands:
         @dataclass
@@ -19365,8 +18767,9 @@ class MediaInput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Index", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Index", Tag=0, Type=uint),
                     ])
 
             Index: 'uint' = None
@@ -19379,9 +18782,8 @@ class MediaInput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class HideInputStatus(ClusterCommand):
@@ -19391,9 +18793,8 @@ class MediaInput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class RenameInput(ClusterCommand):
@@ -19403,14 +18804,15 @@ class MediaInput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Index", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Index", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=1, Type=str),
                     ])
 
             Index: 'uint' = None
             Name: 'str' = None
-
 
     class Attributes:
         class MediaInputList(ClusterAttributeDescriptor):
@@ -19426,7 +18828,6 @@ class MediaInput:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=MediaInput.Structs.MediaInputInfo, IsArray=True)
 
-
         class CurrentMediaInput(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19440,7 +18841,6 @@ class MediaInput:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19453,7 +18853,6 @@ class MediaInput:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -19469,13 +18868,9 @@ class MediaInput:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class LowPower:
     id: typing.ClassVar[int] = 0x0508
-
-
 
     class Commands:
         @dataclass
@@ -19486,10 +18881,8 @@ class LowPower:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -19505,7 +18898,6 @@ class LowPower:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19518,8 +18910,6 @@ class LowPower:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -19620,8 +19010,6 @@ class KeypadInput:
             kUnsupportedKey = 0x01
             kInvalidKeyInCurrentState = 0x02
 
-
-
     class Commands:
         @dataclass
         class SendKey(ClusterCommand):
@@ -19631,8 +19019,9 @@ class KeypadInput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="KeyCode", Tag=0, Type=KeypadInput.Enums.KeypadInputCecKeyCode),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="KeyCode", Tag=0, Type=KeypadInput.Enums.KeypadInputCecKeyCode),
                     ])
 
             KeyCode: 'KeypadInput.Enums.KeypadInputCecKeyCode' = None
@@ -19645,12 +19034,12 @@ class KeypadInput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=KeypadInput.Enums.KeypadInputStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=KeypadInput.Enums.KeypadInputStatus),
                     ])
 
             Status: 'KeypadInput.Enums.KeypadInputStatus' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -19666,7 +19055,6 @@ class KeypadInput:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19679,8 +19067,6 @@ class KeypadInput:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -19714,16 +19100,17 @@ class ContentLauncher:
             kDash = 0x00
             kHls = 0x01
 
-
     class Structs:
         @dataclass
         class ContentLaunchAdditionalInfo(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Value", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Value", Tag=1, Type=str),
                     ])
 
             Name: 'str' = None
@@ -19734,10 +19121,13 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Type", Tag=0, Type=ContentLauncher.Enums.ContentLaunchParameterEnum),
-                            ClusterObjectFieldDescriptor(Label="Value", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ExternalIDList", Tag=2, Type=ContentLauncher.Structs.ContentLaunchAdditionalInfo, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Type", Tag=0, Type=ContentLauncher.Enums.ContentLaunchParameterEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="Value", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ExternalIDList", Tag=2, Type=ContentLauncher.Structs.ContentLaunchAdditionalInfo, IsArray=True),
                     ])
 
             Type: 'ContentLauncher.Enums.ContentLaunchParameterEnum' = None
@@ -19749,13 +19139,19 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ProviderName", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Background", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Logo", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ProgressBar", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Splash", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="WaterMark", Tag=5, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ProviderName", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Background", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Logo", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ProgressBar", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Splash", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="WaterMark", Tag=5, Type=uint),
                     ])
 
             ProviderName: 'str' = None
@@ -19770,10 +19166,13 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Width", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Height", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Metric", Tag=2, Type=ContentLauncher.Enums.ContentLaunchMetricType),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Width", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Height", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Metric", Tag=2, Type=ContentLauncher.Enums.ContentLaunchMetricType),
                     ])
 
             Width: 'str' = None
@@ -19785,17 +19184,18 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ImageUrl", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Color", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="Size", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ImageUrl", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Color", Tag=1, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="Size", Tag=2, Type=uint),
                     ])
 
             ImageUrl: 'str' = None
             Color: 'str' = None
             Size: 'uint' = None
-
-
 
     class Commands:
         @dataclass
@@ -19806,9 +19206,11 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AutoPlay", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AutoPlay", Tag=0, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=1, Type=str),
                     ])
 
             AutoPlay: 'bool' = None
@@ -19822,9 +19224,11 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ContentLaunchStatus", Tag=1, Type=ContentLauncher.Enums.ContentLaunchStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ContentLaunchStatus", Tag=1, Type=ContentLauncher.Enums.ContentLaunchStatus),
                     ])
 
             Data: 'str' = None
@@ -19838,9 +19242,11 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ContentURL", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="DisplayString", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ContentURL", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="DisplayString", Tag=1, Type=str),
                     ])
 
             ContentURL: 'str' = None
@@ -19854,14 +19260,15 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="ContentLaunchStatus", Tag=1, Type=ContentLauncher.Enums.ContentLaunchStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="ContentLaunchStatus", Tag=1, Type=ContentLauncher.Enums.ContentLaunchStatus),
                     ])
 
             Data: 'str' = None
             ContentLaunchStatus: 'ContentLauncher.Enums.ContentLaunchStatus' = None
-
 
     class Attributes:
         class AcceptsHeaderList(ClusterAttributeDescriptor):
@@ -19877,7 +19284,6 @@ class ContentLauncher:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes, IsArray=True)
 
-
         class SupportedStreamingTypes(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19890,7 +19296,6 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=ContentLauncher.Enums.ContentLaunchStreamingType, IsArray=True)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -19905,7 +19310,6 @@ class ContentLauncher:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -19918,8 +19322,6 @@ class ContentLauncher:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -19935,24 +19337,24 @@ class AudioOutput:
             kInternal = 0x04
             kOther = 0x05
 
-
     class Structs:
         @dataclass
         class AudioOutputInfo(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Index", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OutputType", Tag=1, Type=AudioOutput.Enums.AudioOutputType),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=2, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Index", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OutputType", Tag=1, Type=AudioOutput.Enums.AudioOutputType),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=2, Type=str),
                     ])
 
             Index: 'uint' = None
             OutputType: 'AudioOutput.Enums.AudioOutputType' = None
             Name: 'str' = None
-
-
 
     class Commands:
         @dataclass
@@ -19963,8 +19365,9 @@ class AudioOutput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Index", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Index", Tag=0, Type=uint),
                     ])
 
             Index: 'uint' = None
@@ -19977,14 +19380,15 @@ class AudioOutput:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Index", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Name", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Index", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Name", Tag=1, Type=str),
                     ])
 
             Index: 'uint' = None
             Name: 'str' = None
-
 
     class Attributes:
         class AudioOutputList(ClusterAttributeDescriptor):
@@ -20000,7 +19404,6 @@ class AudioOutput:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=AudioOutput.Structs.AudioOutputInfo, IsArray=True)
 
-
         class CurrentAudioOutput(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20014,7 +19417,6 @@ class AudioOutput:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20027,7 +19429,6 @@ class AudioOutput:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20043,8 +19444,6 @@ class AudioOutput:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ApplicationLauncher:
     id: typing.ClassVar[int] = 0x050C
@@ -20055,22 +19454,21 @@ class ApplicationLauncher:
             kAppNotAvailable = 0x01
             kSystemBusy = 0x02
 
-
     class Structs:
         @dataclass
         class ApplicationLauncherApp(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="CatalogVendorId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ApplicationId", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="CatalogVendorId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ApplicationId", Tag=1, Type=str),
                     ])
 
             CatalogVendorId: 'uint' = None
             ApplicationId: 'str' = None
-
-
 
     class Commands:
         @dataclass
@@ -20081,10 +19479,13 @@ class ApplicationLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="CatalogVendorId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ApplicationId", Tag=2, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="CatalogVendorId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ApplicationId", Tag=2, Type=str),
                     ])
 
             Data: 'str' = None
@@ -20099,14 +19500,15 @@ class ApplicationLauncher:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=ApplicationLauncher.Enums.ApplicationLauncherStatus),
-                            ClusterObjectFieldDescriptor(Label="Data", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=ApplicationLauncher.Enums.ApplicationLauncherStatus),
+                        ClusterObjectFieldDescriptor(
+                            Label="Data", Tag=1, Type=str),
                     ])
 
             Status: 'ApplicationLauncher.Enums.ApplicationLauncherStatus' = None
             Data: 'str' = None
-
 
     class Attributes:
         class ApplicationLauncherList(ClusterAttributeDescriptor):
@@ -20122,7 +19524,6 @@ class ApplicationLauncher:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class CatalogVendorId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20135,7 +19536,6 @@ class ApplicationLauncher:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ApplicationId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20150,7 +19550,6 @@ class ApplicationLauncher:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20163,7 +19562,6 @@ class ApplicationLauncher:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20179,8 +19577,6 @@ class ApplicationLauncher:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ApplicationBasic:
     id: typing.ClassVar[int] = 0x050D
@@ -20192,8 +19588,6 @@ class ApplicationBasic:
             kActiveHidden = 0x02
             kActiveVisibleNotFocus = 0x03
 
-
-
     class Commands:
         @dataclass
         class ChangeStatus(ClusterCommand):
@@ -20203,12 +19597,12 @@ class ApplicationBasic:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=0, Type=ApplicationBasic.Enums.ApplicationBasicStatus),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=0, Type=ApplicationBasic.Enums.ApplicationBasicStatus),
                     ])
 
             Status: 'ApplicationBasic.Enums.ApplicationBasicStatus' = None
-
 
     class Attributes:
         class VendorName(ClusterAttributeDescriptor):
@@ -20224,7 +19618,6 @@ class ApplicationBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class VendorId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20237,7 +19630,6 @@ class ApplicationBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ApplicationName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20252,7 +19644,6 @@ class ApplicationBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class ProductId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20265,7 +19656,6 @@ class ApplicationBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ApplicationId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20280,7 +19670,6 @@ class ApplicationBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class CatalogVendorId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20293,7 +19682,6 @@ class ApplicationBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ApplicationStatus(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20308,7 +19696,6 @@ class ApplicationBasic:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20321,7 +19708,6 @@ class ApplicationBasic:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -20337,13 +19723,9 @@ class ApplicationBasic:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class AccountLogin:
     id: typing.ClassVar[int] = 0x050E
-
-
 
     class Commands:
         @dataclass
@@ -20354,8 +19736,9 @@ class AccountLogin:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TempAccountIdentifier", Tag=0, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TempAccountIdentifier", Tag=0, Type=str),
                     ])
 
             TempAccountIdentifier: 'str' = None
@@ -20368,8 +19751,9 @@ class AccountLogin:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="SetupPIN", Tag=0, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="SetupPIN", Tag=0, Type=str),
                     ])
 
             SetupPIN: 'str' = None
@@ -20382,14 +19766,15 @@ class AccountLogin:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TempAccountIdentifier", Tag=0, Type=str),
-                            ClusterObjectFieldDescriptor(Label="SetupPIN", Tag=1, Type=str),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TempAccountIdentifier", Tag=0, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="SetupPIN", Tag=1, Type=str),
                     ])
 
             TempAccountIdentifier: 'str' = None
             SetupPIN: 'str' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -20405,7 +19790,6 @@ class AccountLogin:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -20420,8 +19804,6 @@ class AccountLogin:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class TestCluster:
     id: typing.ClassVar[int] = 0x050F
@@ -20433,20 +19815,25 @@ class TestCluster:
             kValueB = 0x02
             kValueC = 0x03
 
-
     class Structs:
         @dataclass
         class SimpleStruct(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="A", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="B", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="C", Tag=2, Type=TestCluster.Enums.SimpleEnum),
-                            ClusterObjectFieldDescriptor(Label="D", Tag=3, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="E", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="F", Tag=5, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="A", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="B", Tag=1, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="C", Tag=2, Type=TestCluster.Enums.SimpleEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="D", Tag=3, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="E", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="F", Tag=5, Type=int),
                     ])
 
             A: 'uint' = None
@@ -20461,19 +19848,31 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NullableInt", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionalInt", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalInt", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NullableString", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="OptionalString", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalString", Tag=5, Type=str),
-                            ClusterObjectFieldDescriptor(Label="NullableStruct", Tag=6, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="OptionalStruct", Tag=7, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStruct", Tag=8, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="NullableList", Tag=9, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="OptionalList", Tag=10, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalList", Tag=11, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableInt", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalInt", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalInt", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableString", Tag=3, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalString", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalString", Tag=5, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableStruct", Tag=6, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalStruct", Tag=7, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStruct", Tag=8, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableList", Tag=9, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalList", Tag=10, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalList", Tag=11, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
                     ])
 
             NullableInt: 'uint' = None
@@ -20494,10 +19893,13 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="A", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="B", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="C", Tag=2, Type=TestCluster.Structs.SimpleStruct),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="A", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="B", Tag=1, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="C", Tag=2, Type=TestCluster.Structs.SimpleStruct),
                     ])
 
             A: 'uint' = None
@@ -20509,14 +19911,21 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="A", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="B", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="C", Tag=2, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="D", Tag=3, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="E", Tag=4, Type=uint, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="F", Tag=5, Type=bytes, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="G", Tag=6, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="A", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="B", Tag=1, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="C", Tag=2, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="D", Tag=3, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="E", Tag=4, Type=uint, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="F", Tag=5, Type=bytes, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="G", Tag=6, Type=uint, IsArray=True),
                     ])
 
             A: 'uint' = None
@@ -20532,8 +19941,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="A", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="A", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
                     ])
 
             A: typing.List['TestCluster.Structs.NestedStructList'] = None
@@ -20543,15 +19953,15 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="FabricIndex", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OperationalCert", Tag=1, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="FabricIndex", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OperationalCert", Tag=1, Type=bytes),
                     ])
 
             FabricIndex: 'uint' = None
             OperationalCert: 'bytes' = None
-
-
 
     class Commands:
         @dataclass
@@ -20562,9 +19972,8 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class TestSpecificResponse(ClusterCommand):
@@ -20574,8 +19983,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ReturnValue", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ReturnValue", Tag=0, Type=uint),
                     ])
 
             ReturnValue: 'uint' = None
@@ -20588,9 +19998,8 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class TestAddArgumentsResponse(ClusterCommand):
@@ -20600,8 +20009,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ReturnValue", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ReturnValue", Tag=0, Type=uint),
                     ])
 
             ReturnValue: 'uint' = None
@@ -20614,9 +20024,8 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class TestSimpleArgumentResponse(ClusterCommand):
@@ -20626,8 +20035,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ReturnValue", Tag=0, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ReturnValue", Tag=0, Type=bool),
                     ])
 
             ReturnValue: 'bool' = None
@@ -20640,9 +20050,8 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class TestStructArrayArgumentResponse(ClusterCommand):
@@ -20652,13 +20061,19 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg2", Tag=1, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg3", Tag=2, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg4", Tag=3, Type=bool, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg5", Tag=4, Type=TestCluster.Enums.SimpleEnum),
-                            ClusterObjectFieldDescriptor(Label="Arg6", Tag=5, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg2", Tag=1, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg3", Tag=2, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg4", Tag=3, Type=bool, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg5", Tag=4, Type=TestCluster.Enums.SimpleEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg6", Tag=5, Type=bool),
                     ])
 
             Arg1: typing.List['TestCluster.Structs.NestedStructList'] = None
@@ -20676,9 +20091,11 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Arg2", Tag=1, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg2", Tag=1, Type=uint),
                     ])
 
             Arg1: 'uint' = None
@@ -20692,8 +20109,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint, IsArray=True),
                     ])
 
             Arg1: typing.List['uint'] = None
@@ -20706,8 +20124,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=bool),
                     ])
 
             Arg1: 'bool' = None
@@ -20720,9 +20139,11 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Arg2", Tag=1, Type=TestCluster.Enums.SimpleEnum),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg2", Tag=1, Type=TestCluster.Enums.SimpleEnum),
                     ])
 
             Arg1: 'uint' = None
@@ -20736,13 +20157,19 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg2", Tag=1, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg3", Tag=2, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg4", Tag=3, Type=bool, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="Arg5", Tag=4, Type=TestCluster.Enums.SimpleEnum),
-                            ClusterObjectFieldDescriptor(Label="Arg6", Tag=5, Type=bool),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg2", Tag=1, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg3", Tag=2, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg4", Tag=3, Type=bool, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg5", Tag=4, Type=TestCluster.Enums.SimpleEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg6", Tag=5, Type=bool),
                     ])
 
             Arg1: typing.List['TestCluster.Structs.NestedStructList'] = None
@@ -20760,10 +20187,13 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="WasPresent", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="WasNull", Tag=1, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="Value", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="WasPresent", Tag=0, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="WasNull", Tag=1, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="Value", Tag=2, Type=uint),
                     ])
 
             WasPresent: 'bool' = None
@@ -20778,8 +20208,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.SimpleStruct),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.SimpleStruct),
                     ])
 
             Arg1: 'TestCluster.Structs.SimpleStruct' = None
@@ -20792,35 +20223,63 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NullableIntWasNull", Tag=0, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableIntValue", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionalIntWasPresent", Tag=2, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="OptionalIntValue", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalIntWasPresent", Tag=4, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalIntWasNull", Tag=5, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalIntValue", Tag=6, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NullableStringWasNull", Tag=7, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableStringValue", Tag=8, Type=str),
-                            ClusterObjectFieldDescriptor(Label="OptionalStringWasPresent", Tag=9, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="OptionalStringValue", Tag=10, Type=str),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStringWasPresent", Tag=11, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStringWasNull", Tag=12, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStringValue", Tag=13, Type=str),
-                            ClusterObjectFieldDescriptor(Label="NullableStructWasNull", Tag=14, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableStructValue", Tag=15, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="OptionalStructWasPresent", Tag=16, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="OptionalStructValue", Tag=17, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStructWasPresent", Tag=18, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStructWasNull", Tag=19, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStructValue", Tag=20, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="NullableListWasNull", Tag=21, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableListValue", Tag=22, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="OptionalListWasPresent", Tag=23, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="OptionalListValue", Tag=24, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalListWasPresent", Tag=25, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalListWasNull", Tag=26, Type=bool),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalListValue", Tag=27, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableIntWasNull", Tag=0, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableIntValue", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalIntWasPresent", Tag=2, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalIntValue", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalIntWasPresent", Tag=4, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalIntWasNull", Tag=5, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalIntValue", Tag=6, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableStringWasNull", Tag=7, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableStringValue", Tag=8, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalStringWasPresent", Tag=9, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalStringValue", Tag=10, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStringWasPresent", Tag=11, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStringWasNull", Tag=12, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStringValue", Tag=13, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableStructWasNull", Tag=14, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableStructValue", Tag=15, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalStructWasPresent", Tag=16, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalStructValue", Tag=17, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStructWasPresent", Tag=18, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStructWasNull", Tag=19, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStructValue", Tag=20, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableListWasNull", Tag=21, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableListValue", Tag=22, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalListWasPresent", Tag=23, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalListValue", Tag=24, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalListWasPresent", Tag=25, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalListWasNull", Tag=26, Type=bool),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalListValue", Tag=27, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
                     ])
 
             NullableIntWasNull: 'bool' = None
@@ -20860,8 +20319,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStruct),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStruct),
                     ])
 
             Arg1: 'TestCluster.Structs.NestedStruct' = None
@@ -20874,8 +20334,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.SimpleStruct, IsArray=True),
                     ])
 
             Arg1: typing.List['TestCluster.Structs.SimpleStruct'] = None
@@ -20888,8 +20349,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint, IsArray=True),
                     ])
 
             Arg1: typing.List['uint'] = None
@@ -20902,8 +20364,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList),
                     ])
 
             Arg1: 'TestCluster.Structs.NestedStructList' = None
@@ -20916,8 +20379,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=TestCluster.Structs.NestedStructList, IsArray=True),
                     ])
 
             Arg1: typing.List['TestCluster.Structs.NestedStructList'] = None
@@ -20930,8 +20394,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint, IsArray=True),
                     ])
 
             Arg1: typing.List['uint'] = None
@@ -20944,9 +20409,11 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Arg2", Tag=1, Type=TestCluster.Enums.SimpleEnum),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg2", Tag=1, Type=TestCluster.Enums.SimpleEnum),
                     ])
 
             Arg1: 'uint' = None
@@ -20960,8 +20427,9 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="Arg1", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="Arg1", Tag=0, Type=uint),
                     ])
 
             Arg1: 'uint' = None
@@ -20974,19 +20442,31 @@ class TestCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NullableInt", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="OptionalInt", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalInt", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NullableString", Tag=3, Type=str),
-                            ClusterObjectFieldDescriptor(Label="OptionalString", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalString", Tag=5, Type=str),
-                            ClusterObjectFieldDescriptor(Label="NullableStruct", Tag=6, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="OptionalStruct", Tag=7, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalStruct", Tag=8, Type=TestCluster.Structs.SimpleStruct),
-                            ClusterObjectFieldDescriptor(Label="NullableList", Tag=9, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="OptionalList", Tag=10, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
-                            ClusterObjectFieldDescriptor(Label="NullableOptionalList", Tag=11, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableInt", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalInt", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalInt", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableString", Tag=3, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalString", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalString", Tag=5, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableStruct", Tag=6, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalStruct", Tag=7, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalStruct", Tag=8, Type=TestCluster.Structs.SimpleStruct),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableList", Tag=9, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalList", Tag=10, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
+                        ClusterObjectFieldDescriptor(
+                            Label="NullableOptionalList", Tag=11, Type=TestCluster.Enums.SimpleEnum, IsArray=True),
                     ])
 
             NullableInt: 'uint' = None
@@ -21002,7 +20482,6 @@ class TestCluster:
             OptionalList: typing.List['TestCluster.Enums.SimpleEnum'] = None
             NullableOptionalList: typing.List['TestCluster.Enums.SimpleEnum'] = None
 
-
     class Attributes:
         class Boolean(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21017,7 +20496,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
 
-
         class Bitmap8(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21030,7 +20508,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Bitmap16(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21045,7 +20522,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Bitmap32(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21058,7 +20534,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Bitmap64(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21073,7 +20548,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Int8u(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21086,7 +20560,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Int16u(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21101,7 +20574,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Int32u(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21114,7 +20586,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Int64u(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21129,7 +20600,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Int8s(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21142,7 +20612,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class Int16s(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21157,7 +20626,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Int32s(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21170,7 +20638,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class Int64s(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21185,7 +20652,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Enum8(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21198,7 +20664,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class Enum16(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21213,7 +20678,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class OctetString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21226,7 +20690,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class ListInt8u(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21241,7 +20704,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint, IsArray=True)
 
-
         class ListOctetString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21254,7 +20716,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes, IsArray=True)
-
 
         class ListStructOctetString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21269,7 +20730,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=TestCluster.Structs.TestListStructOctet, IsArray=True)
 
-
         class LongOctetString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21282,7 +20742,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class CharString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21297,7 +20756,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class LongCharString(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21310,7 +20768,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class EpochUs(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21325,7 +20782,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EpochS(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21338,7 +20794,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class VendorId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21353,7 +20808,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Unsupported(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21366,7 +20820,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bool)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21381,7 +20834,6 @@ class TestCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21394,8 +20846,6 @@ class TestCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
 
 
 @dataclass
@@ -21506,8 +20956,6 @@ class Messaging:
             kAnonymous = 0x02
             kReserved = 0x03
 
-
-
     class Commands:
         @dataclass
         class DisplayMessage(ClusterCommand):
@@ -21517,13 +20965,19 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MessageId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MessageControl", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="StartTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DurationInMinutes", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Message", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="OptionalExtendedMessageControl", Tag=5, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageControl", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DurationInMinutes", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Message", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalExtendedMessageControl", Tag=5, Type=int),
                     ])
 
             MessageId: 'uint' = None
@@ -21541,9 +20995,8 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class CancelMessage(ClusterCommand):
@@ -21553,9 +21006,11 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MessageId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MessageControl", Tag=1, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageControl", Tag=1, Type=int),
                     ])
 
             MessageId: 'uint' = None
@@ -21569,11 +21024,15 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MessageId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ConfirmationTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MessageConfirmationControl", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MessageResponse", Tag=3, Type=bytes),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ConfirmationTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageConfirmationControl", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageResponse", Tag=3, Type=bytes),
                     ])
 
             MessageId: 'uint' = None
@@ -21589,13 +21048,19 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="MessageId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MessageControl", Tag=1, Type=int),
-                            ClusterObjectFieldDescriptor(Label="StartTime", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="DurationInMinutes", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Message", Tag=4, Type=str),
-                            ClusterObjectFieldDescriptor(Label="OptionalExtendedMessageControl", Tag=5, Type=int),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MessageControl", Tag=1, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartTime", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="DurationInMinutes", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Message", Tag=4, Type=str),
+                        ClusterObjectFieldDescriptor(
+                            Label="OptionalExtendedMessageControl", Tag=5, Type=int),
                     ])
 
             MessageId: 'uint' = None
@@ -21613,8 +21078,9 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EarliestImplementationTime", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EarliestImplementationTime", Tag=0, Type=uint),
                     ])
 
             EarliestImplementationTime: 'uint' = None
@@ -21627,12 +21093,12 @@ class Messaging:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ImplementationDateTime", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ImplementationDateTime", Tag=0, Type=uint),
                     ])
 
             ImplementationDateTime: 'uint' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -21648,7 +21114,6 @@ class Messaging:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21663,14 +21128,9 @@ class Messaging:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ApplianceIdentification:
     id: typing.ClassVar[int] = 0x0B00
-
-
-
 
     class Attributes:
         class BasicIdentification(ClusterAttributeDescriptor):
@@ -21686,7 +21146,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CompanyName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21699,7 +21158,6 @@ class ApplianceIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class CompanyId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21714,7 +21172,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class BrandName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21727,7 +21184,6 @@ class ApplianceIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class BrandId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21742,7 +21198,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Model(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21755,7 +21210,6 @@ class ApplianceIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class PartNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21770,7 +21224,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class ProductRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21783,7 +21236,6 @@ class ApplianceIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class SoftwareRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21798,7 +21250,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class ProductTypeName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21811,7 +21262,6 @@ class ApplianceIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class ProductTypeId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21826,7 +21276,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CecedSpecificationVersion(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21840,7 +21289,6 @@ class ApplianceIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21853,7 +21301,6 @@ class ApplianceIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21869,14 +21316,9 @@ class ApplianceIdentification:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class MeterIdentification:
     id: typing.ClassVar[int] = 0x0B01
-
-
-
 
     class Attributes:
         class CompanyName(ClusterAttributeDescriptor):
@@ -21892,7 +21334,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class MeterTypeId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21905,7 +21346,6 @@ class MeterIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DataQualityId(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21920,7 +21360,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class CustomerName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21933,7 +21372,6 @@ class MeterIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class Model(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21948,7 +21386,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class PartNumber(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21961,7 +21398,6 @@ class MeterIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class ProductRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -21976,7 +21412,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
 
-
         class SoftwareRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -21989,7 +21424,6 @@ class MeterIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=bytes)
-
 
         class UtilityName(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22004,7 +21438,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
 
-
         class Pod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22017,7 +21450,6 @@ class MeterIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=str)
-
 
         class AvailablePower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22032,7 +21464,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class PowerThreshold(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22046,7 +21477,6 @@ class MeterIdentification:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22059,7 +21489,6 @@ class MeterIdentification:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22075,8 +21504,6 @@ class MeterIdentification:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ApplianceEventsAndAlert:
     id: typing.ClassVar[int] = 0x0B02
@@ -22089,8 +21516,6 @@ class ApplianceEventsAndAlert:
             kSwitchingOff = 0x06
             kWrongData = 0x07
 
-
-
     class Commands:
         @dataclass
         class GetAlerts(ClusterCommand):
@@ -22100,9 +21525,8 @@ class ApplianceEventsAndAlert:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetAlertsResponse(ClusterCommand):
@@ -22112,9 +21536,11 @@ class ApplianceEventsAndAlert:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AlertsCount", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="AlertStructures", Tag=1, Type=int, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AlertsCount", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="AlertStructures", Tag=1, Type=int, IsArray=True),
                     ])
 
             AlertsCount: 'int' = None
@@ -22128,9 +21554,11 @@ class ApplianceEventsAndAlert:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AlertsCount", Tag=0, Type=int),
-                            ClusterObjectFieldDescriptor(Label="AlertStructures", Tag=1, Type=int, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AlertsCount", Tag=0, Type=int),
+                        ClusterObjectFieldDescriptor(
+                            Label="AlertStructures", Tag=1, Type=int, IsArray=True),
                     ])
 
             AlertsCount: 'int' = None
@@ -22144,14 +21572,15 @@ class ApplianceEventsAndAlert:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="EventHeader", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EventId", Tag=1, Type=ApplianceEventsAndAlert.Enums.EventIdentification),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="EventHeader", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EventId", Tag=1, Type=ApplianceEventsAndAlert.Enums.EventIdentification),
                     ])
 
             EventHeader: 'uint' = None
             EventId: 'ApplianceEventsAndAlert.Enums.EventIdentification' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -22167,7 +21596,6 @@ class ApplianceEventsAndAlert:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22182,13 +21610,9 @@ class ApplianceEventsAndAlert:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ApplianceStatistics:
     id: typing.ClassVar[int] = 0x0B03
-
-
 
     class Commands:
         @dataclass
@@ -22199,11 +21623,15 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TimeStamp", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogLength", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogPayload", Tag=3, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeStamp", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogLength", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogPayload", Tag=3, Type=uint, IsArray=True),
                     ])
 
             TimeStamp: 'uint' = None
@@ -22219,8 +21647,9 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LogId", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LogId", Tag=0, Type=uint),
                     ])
 
             LogId: 'uint' = None
@@ -22233,11 +21662,15 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="TimeStamp", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogLength", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogPayload", Tag=3, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="TimeStamp", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogLength", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogPayload", Tag=3, Type=uint, IsArray=True),
                     ])
 
             TimeStamp: 'uint' = None
@@ -22253,9 +21686,8 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class LogQueueResponse(ClusterCommand):
@@ -22265,9 +21697,11 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LogQueueSize", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogIds", Tag=1, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LogQueueSize", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogIds", Tag=1, Type=uint, IsArray=True),
                     ])
 
             LogQueueSize: 'uint' = None
@@ -22281,14 +21715,15 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="LogQueueSize", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="LogIds", Tag=1, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="LogQueueSize", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="LogIds", Tag=1, Type=uint, IsArray=True),
                     ])
 
             LogQueueSize: 'uint' = None
             LogIds: typing.List['uint'] = None
-
 
     class Attributes:
         class LogMaxSize(ClusterAttributeDescriptor):
@@ -22304,7 +21739,6 @@ class ApplianceStatistics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class LogQueueMaxSize(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22318,7 +21752,6 @@ class ApplianceStatistics:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22331,7 +21764,6 @@ class ApplianceStatistics:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22347,13 +21779,9 @@ class ApplianceStatistics:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class ElectricalMeasurement:
     id: typing.ClassVar[int] = 0x0B04
-
-
 
     class Commands:
         @dataclass
@@ -22364,11 +21792,15 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ProfileCount", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ProfileIntervalPeriod", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="MaxNumberOfIntervals", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ListOfAttributes", Tag=3, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ProfileCount", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ProfileIntervalPeriod", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="MaxNumberOfIntervals", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ListOfAttributes", Tag=3, Type=uint, IsArray=True),
                     ])
 
             ProfileCount: 'uint' = None
@@ -22384,9 +21816,8 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
+                    Fields=[
                     ])
-
 
         @dataclass
         class GetMeasurementProfileResponseCommand(ClusterCommand):
@@ -22396,13 +21827,19 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="StartTime", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Status", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ProfileIntervalPeriod", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumberOfIntervalsDelivered", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="AttributeId", Tag=4, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="Intervals", Tag=5, Type=uint, IsArray=True),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="StartTime", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Status", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ProfileIntervalPeriod", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfIntervalsDelivered", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="AttributeId", Tag=4, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="Intervals", Tag=5, Type=uint, IsArray=True),
                     ])
 
             StartTime: 'uint' = None
@@ -22420,16 +21857,18 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="AttributeId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="StartTime", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="NumberOfIntervals", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="AttributeId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="StartTime", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="NumberOfIntervals", Tag=2, Type=uint),
                     ])
 
             AttributeId: 'uint' = None
             StartTime: 'uint' = None
             NumberOfIntervals: 'uint' = None
-
 
     class Attributes:
         class MeasurementType(ClusterAttributeDescriptor):
@@ -22445,7 +21884,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DcVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22458,7 +21896,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class DcVoltageMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22473,7 +21910,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class DcVoltageMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22486,7 +21922,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class DcCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22501,7 +21936,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class DcCurrentMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22514,7 +21948,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class DcCurrentMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22529,7 +21962,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class DcPower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22542,7 +21974,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class DcPowerMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22557,7 +21988,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class DcPowerMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22570,7 +22000,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class DcVoltageMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22585,7 +22014,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DcVoltageDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22598,7 +22026,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DcCurrentMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22613,7 +22040,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DcCurrentDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22626,7 +22052,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class DcPowerMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22641,7 +22066,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class DcPowerDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22654,7 +22078,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcFrequency(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22669,7 +22092,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcFrequencyMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22682,7 +22104,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcFrequencyMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22697,7 +22118,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class NeutralCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22710,7 +22130,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class TotalActivePower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22725,7 +22144,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class TotalReactivePower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22738,7 +22156,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class TotalApparentPower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22753,7 +22170,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class Measured1stHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22766,7 +22182,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class Measured3rdHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22781,7 +22196,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Measured5thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22794,7 +22208,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class Measured7thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22809,7 +22222,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class Measured9thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22822,7 +22234,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class Measured11thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22837,7 +22248,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MeasuredPhase1stHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22850,7 +22260,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MeasuredPhase3rdHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22865,7 +22274,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MeasuredPhase5thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22878,7 +22286,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MeasuredPhase7thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22893,7 +22300,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class MeasuredPhase9thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22906,7 +22312,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class MeasuredPhase11thHarmonicCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22921,7 +22326,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AcFrequencyMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22934,7 +22338,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcFrequencyDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22949,7 +22352,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PowerMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22962,7 +22364,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PowerDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -22977,7 +22378,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class HarmonicCurrentMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -22990,7 +22390,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class PhaseHarmonicCurrentMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23005,7 +22404,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class InstantaneousVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23018,7 +22416,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class InstantaneousLineCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23033,7 +22430,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class InstantaneousActiveCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23046,7 +22442,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class InstantaneousReactiveCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23061,7 +22456,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class InstantaneousPower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23074,7 +22468,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class RmsVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23089,7 +22482,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsVoltageMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23102,7 +22494,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsVoltageMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23117,7 +22508,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsCurrent(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23130,7 +22520,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsCurrentMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23145,7 +22534,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsCurrentMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23158,7 +22546,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ActivePower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23173,7 +22560,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ActivePowerMin(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23186,7 +22572,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ActivePowerMax(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23201,7 +22586,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ReactivePower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23214,7 +22598,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ApparentPower(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23229,7 +22612,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class PowerFactor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23242,7 +22624,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class AverageRmsVoltageMeasurementPeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23257,7 +22638,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AverageRmsUnderVoltageCounter(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23270,7 +22650,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsExtremeOverVoltagePeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23285,7 +22664,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsExtremeUnderVoltagePeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23298,7 +22676,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsVoltageSagPeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23313,7 +22690,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsVoltageSwellPeriod(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23326,7 +22702,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcVoltageMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23341,7 +22716,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcVoltageDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23354,7 +22728,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcCurrentMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23369,7 +22742,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcCurrentDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23382,7 +22754,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcPowerMultiplier(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23397,7 +22768,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AcPowerDivisor(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23410,7 +22780,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class OverloadAlarmsMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23425,7 +22794,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class VoltageOverload(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23438,7 +22806,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class CurrentOverload(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23453,7 +22820,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AcOverloadAlarmsMask(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23466,7 +22832,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AcVoltageOverload(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23481,7 +22846,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AcCurrentOverload(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23494,7 +22858,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class AcActivePowerOverload(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23509,7 +22872,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AcReactivePowerOverload(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23522,7 +22884,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class AverageRmsOverVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23537,7 +22898,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AverageRmsUnderVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23550,7 +22910,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class RmsExtremeOverVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23565,7 +22924,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class RmsExtremeUnderVoltage(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23578,7 +22936,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class RmsVoltageSag(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23593,7 +22950,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class RmsVoltageSwell(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23606,7 +22962,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class LineCurrentPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23621,7 +22976,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ActiveCurrentPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23634,7 +22988,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ReactiveCurrentPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23649,7 +23002,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class RmsVoltagePhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23662,7 +23014,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsVoltageMinPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23677,7 +23028,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsVoltageMaxPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23690,7 +23040,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsCurrentPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23705,7 +23054,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsCurrentMinPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23718,7 +23066,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsCurrentMaxPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23733,7 +23080,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ActivePowerPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23746,7 +23092,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ActivePowerMinPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23761,7 +23106,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ActivePowerMaxPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23774,7 +23118,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ReactivePowerPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23789,7 +23132,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ApparentPowerPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23802,7 +23144,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PowerFactorPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23817,7 +23158,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AverageRmsVoltageMeasurementPeriodPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23830,7 +23170,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AverageRmsOverVoltageCounterPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23845,7 +23184,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AverageRmsUnderVoltageCounterPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23858,7 +23196,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsExtremeOverVoltagePeriodPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23873,7 +23210,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsExtremeUnderVoltagePeriodPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23886,7 +23222,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsVoltageSagPeriodPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23901,7 +23236,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsVoltageSwellPeriodPhaseB(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23914,7 +23248,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class LineCurrentPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23929,7 +23262,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ActiveCurrentPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23942,7 +23274,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ReactiveCurrentPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23957,7 +23288,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class RmsVoltagePhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23970,7 +23300,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsVoltageMinPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -23985,7 +23314,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsVoltageMaxPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -23998,7 +23326,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsCurrentPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24013,7 +23340,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsCurrentMinPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24026,7 +23352,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsCurrentMaxPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24041,7 +23366,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ActivePowerPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24054,7 +23378,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ActivePowerMinPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24069,7 +23392,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ActivePowerMaxPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24082,7 +23404,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
-
 
         class ReactivePowerPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24097,7 +23418,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class ApparentPowerPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24110,7 +23430,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class PowerFactorPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24125,7 +23444,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=int)
 
-
         class AverageRmsVoltageMeasurementPeriodPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24138,7 +23456,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class AverageRmsOverVoltageCounterPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24153,7 +23470,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class AverageRmsUnderVoltageCounterPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24166,7 +23482,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsExtremeOverVoltagePeriodPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24181,7 +23496,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsExtremeUnderVoltagePeriodPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24194,7 +23508,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class RmsVoltageSagPeriodPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24209,7 +23522,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class RmsVoltageSwellPeriodPhaseC(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24223,7 +23535,6 @@ class ElectricalMeasurement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24236,7 +23547,6 @@ class ElectricalMeasurement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24252,13 +23562,9 @@ class ElectricalMeasurement:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class Binding:
     id: typing.ClassVar[int] = 0xF000
-
-
 
     class Commands:
         @dataclass
@@ -24269,11 +23575,15 @@ class Binding:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NodeId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EndpointId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ClusterId", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NodeId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EndpointId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ClusterId", Tag=3, Type=uint),
                     ])
 
             NodeId: 'uint' = None
@@ -24289,18 +23599,21 @@ class Binding:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="NodeId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="EndpointId", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="ClusterId", Tag=3, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="NodeId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="EndpointId", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="ClusterId", Tag=3, Type=uint),
                     ])
 
             NodeId: 'uint' = None
             GroupId: 'uint' = None
             EndpointId: 'uint' = None
             ClusterId: 'uint' = None
-
 
     class Attributes:
         class FeatureMap(ClusterAttributeDescriptor):
@@ -24316,7 +23629,6 @@ class Binding:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24331,8 +23643,6 @@ class Binding:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class GroupKeyManagement:
     id: typing.ClassVar[int] = 0xF004
@@ -24342,19 +23652,23 @@ class GroupKeyManagement:
             kStandard = 0x00
             kLowLatency = 0x01
 
-
     class Structs:
         @dataclass
         class GroupKey(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="VendorId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupKeyIndex", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupKeyRoot", Tag=2, Type=bytes),
-                            ClusterObjectFieldDescriptor(Label="GroupKeyEpochStartTime", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupKeySecurityPolicy", Tag=4, Type=GroupKeyManagement.Enums.GroupKeySecurityPolicy),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="VendorId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupKeyIndex", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupKeyRoot", Tag=2, Type=bytes),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupKeyEpochStartTime", Tag=3, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupKeySecurityPolicy", Tag=4, Type=GroupKeyManagement.Enums.GroupKeySecurityPolicy),
                     ])
 
             VendorId: 'uint' = None
@@ -24368,18 +23682,18 @@ class GroupKeyManagement:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="VendorId", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="VendorGroupId", Tag=1, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="GroupKeySetIndex", Tag=2, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="VendorId", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="VendorGroupId", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="GroupKeySetIndex", Tag=2, Type=uint),
                     ])
 
             VendorId: 'uint' = None
             VendorGroupId: 'uint' = None
             GroupKeySetIndex: 'uint' = None
-
-
-
 
     class Attributes:
         class Groups(ClusterAttributeDescriptor):
@@ -24395,7 +23709,6 @@ class GroupKeyManagement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=GroupKeyManagement.Structs.GroupState, IsArray=True)
 
-
         class GroupKeys(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24409,7 +23722,6 @@ class GroupKeyManagement:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=GroupKeyManagement.Structs.GroupKey, IsArray=True)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24422,7 +23734,6 @@ class GroupKeyManagement:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24438,13 +23749,9 @@ class GroupKeyManagement:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class SampleMfgSpecificCluster:
     id: typing.ClassVar[int] = 0xFC00
-
-
 
     class Commands:
         @dataclass
@@ -24455,12 +23762,12 @@ class SampleMfgSpecificCluster:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ArgOne", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ArgOne", Tag=0, Type=uint),
                     ])
 
             ArgOne: 'uint' = None
-
 
     class Attributes:
         class EmberSampleAttribute(ClusterAttributeDescriptor):
@@ -24476,7 +23783,6 @@ class SampleMfgSpecificCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EmberSampleAttribute2(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24490,7 +23796,6 @@ class SampleMfgSpecificCluster:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24503,7 +23808,6 @@ class SampleMfgSpecificCluster:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24519,13 +23823,9 @@ class SampleMfgSpecificCluster:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
 
-
-
 @dataclass
 class SampleMfgSpecificCluster2:
     id: typing.ClassVar[int] = 0xFC00
-
-
 
     class Commands:
         @dataclass
@@ -24536,12 +23836,12 @@ class SampleMfgSpecificCluster2:
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="ArgOne", Tag=0, Type=uint),
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="ArgOne", Tag=0, Type=uint),
                     ])
 
             ArgOne: 'uint' = None
-
 
     class Attributes:
         class EmberSampleAttribute3(ClusterAttributeDescriptor):
@@ -24557,7 +23857,6 @@ class SampleMfgSpecificCluster2:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class EmberSampleAttribute4(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24570,7 +23869,6 @@ class SampleMfgSpecificCluster2:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
 
         class FeatureMap(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
@@ -24585,7 +23883,6 @@ class SampleMfgSpecificCluster2:
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
 
-
         class ClusterRevision(ClusterAttributeDescriptor):
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -24598,7 +23895,3 @@ class SampleMfgSpecificCluster2:
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=uint)
-
-
-
-

--- a/src/darwin/Framework/CHIP/templates/tests.js
+++ b/src/darwin/Framework/CHIP/templates/tests.js
@@ -116,6 +116,7 @@ function getTests()
     'TestDelayCommands',
     'TestDescriptorCluster',
     'TestBasicInformation',
+    'TestIdentifyCluster',
     'TestOperationalCredentialsCluster',
   ];
 

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -12154,6 +12154,28 @@ CHIPDevice * GetConnectedDevice()
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+- (void)testSendClusterTestIdentifyCluster_000000_Identify
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Send Identify command and expect success response"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestIdentify * cluster = [[CHIPTestIdentify alloc] initWithDevice:device endpoint:0 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t identifyTimeArgument = 0U;
+    [cluster identify:identifyTimeArgument
+        responseHandler:^(NSError * err, NSDictionary * values) {
+            NSLog(@"Send Identify command and expect success response Error: %@", err);
+
+            XCTAssertEqual(err.code, 0);
+
+            [expectation fulfill];
+        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
 - (void)testSendClusterTestOperationalCredentialsCluster_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read number of supported fabrics"];

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -802,8 +802,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Identify::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Identify::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     uint16_t identifyTime;
 
@@ -813,8 +813,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Identify::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Identify::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     uint16_t identifyTime;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -830,8 +830,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return IdentifyQueryResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQueryResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     uint16_t timeout;
 
@@ -841,8 +841,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return IdentifyQueryResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQueryResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     uint16_t timeout;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -857,8 +857,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return IdentifyQuery::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQuery::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -866,8 +866,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return IdentifyQuery::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::IdentifyQuery::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -883,8 +883,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TriggerEffect::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TriggerEffect::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     IdentifyEffectIdentifier effectIdentifier;
     IdentifyEffectVariant effectVariant;
@@ -895,8 +895,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TriggerEffect::Id; }
-    static constexpr ClusterId GetClusterId() { return Identify::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TriggerEffect::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     IdentifyEffectIdentifier effectIdentifier;
     IdentifyEffectVariant effectVariant;
@@ -962,8 +962,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddGroup::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddGroup::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
     chip::CharSpan groupName;
@@ -974,8 +974,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddGroup::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddGroup::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
     chip::CharSpan groupName;
@@ -993,8 +993,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddGroupResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddGroupResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1005,8 +1005,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddGroupResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddGroupResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1023,8 +1023,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ViewGroup::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewGroup::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
 
@@ -1034,8 +1034,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ViewGroup::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewGroup::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -1053,8 +1053,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ViewGroupResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewGroupResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1066,8 +1066,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ViewGroupResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewGroupResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1086,8 +1086,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetGroupMembership::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetGroupMembership::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t groupCount;
     DataModel::List<uint16_t> groupList;
@@ -1098,8 +1098,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetGroupMembership::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetGroupMembership::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t groupCount;
     DataModel::DecodableList<uint16_t> groupList;
@@ -1118,8 +1118,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetGroupMembershipResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t capacity;
     uint8_t groupCount;
@@ -1131,8 +1131,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetGroupMembershipResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetGroupMembershipResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t capacity;
     uint8_t groupCount;
@@ -1150,8 +1150,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveGroup::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveGroup::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
 
@@ -1161,8 +1161,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveGroup::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveGroup::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -1179,8 +1179,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveGroupResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveGroupResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1191,8 +1191,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveGroupResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveGroupResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1208,8 +1208,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveAllGroups::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveAllGroups::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -1217,8 +1217,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveAllGroups::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveAllGroups::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -1234,8 +1234,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddGroupIfIdentifying::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddGroupIfIdentifying::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
     chip::CharSpan groupName;
@@ -1246,8 +1246,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddGroupIfIdentifying::Id; }
-    static constexpr ClusterId GetClusterId() { return Groups::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddGroupIfIdentifying::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     uint16_t groupId;
     chip::CharSpan groupName;
@@ -1337,8 +1337,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1352,8 +1352,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1375,8 +1375,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1388,8 +1388,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1408,8 +1408,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ViewScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1420,8 +1420,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ViewScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1443,8 +1443,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ViewSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1459,8 +1459,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ViewSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ViewSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1482,8 +1482,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1494,8 +1494,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1514,8 +1514,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1527,8 +1527,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1546,8 +1546,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveAllScenes::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenes::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
 
@@ -1557,8 +1557,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveAllScenes::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenes::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -1575,8 +1575,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveAllScenesResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenesResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1587,8 +1587,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveAllScenesResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveAllScenesResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1606,8 +1606,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StoreScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StoreScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1618,8 +1618,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StoreScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StoreScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1638,8 +1638,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StoreSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StoreSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1651,8 +1651,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StoreSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StoreSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1672,8 +1672,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RecallScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RecallScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1685,8 +1685,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RecallScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RecallScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1704,8 +1704,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetSceneMembership::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSceneMembership::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
 
@@ -1715,8 +1715,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetSceneMembership::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSceneMembership::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -1736,8 +1736,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetSceneMembershipResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSceneMembershipResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint8_t capacity;
@@ -1751,8 +1751,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetSceneMembershipResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSceneMembershipResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint8_t capacity;
@@ -1776,8 +1776,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedAddScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedAddScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1791,8 +1791,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedAddScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedAddScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1814,8 +1814,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedAddSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedAddSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1827,8 +1827,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedAddSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedAddSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1847,8 +1847,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedViewScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedViewScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1859,8 +1859,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedViewScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedViewScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint16_t groupId;
     uint8_t sceneId;
@@ -1882,8 +1882,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedViewSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedViewSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1898,8 +1898,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedViewSceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedViewSceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupId;
@@ -1924,8 +1924,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CopyScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CopyScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     chip::BitFlags<ScenesCopyMode> mode;
     uint16_t groupIdFrom;
@@ -1939,8 +1939,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CopyScene::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CopyScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     chip::BitFlags<ScenesCopyMode> mode;
     uint16_t groupIdFrom;
@@ -1962,8 +1962,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CopySceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CopySceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupIdFrom;
@@ -1975,8 +1975,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CopySceneResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Scenes::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CopySceneResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
 
     uint8_t status;
     uint16_t groupIdFrom;
@@ -2123,8 +2123,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Off::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Off::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2132,8 +2132,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Off::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Off::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2147,8 +2147,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificOffWithTransition::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificOffWithTransition::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2156,8 +2156,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificOffWithTransition::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificOffWithTransition::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2171,8 +2171,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return On::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::On::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2180,8 +2180,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return On::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::On::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2195,8 +2195,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificOnWithTransition::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificOnWithTransition::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2204,8 +2204,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificOnWithTransition::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificOnWithTransition::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2219,8 +2219,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificOnWithTransition2::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificOnWithTransition2::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2228,8 +2228,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificOnWithTransition2::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificOnWithTransition2::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2243,8 +2243,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Toggle::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Toggle::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2252,8 +2252,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Toggle::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Toggle::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2267,8 +2267,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificToggleWithTransition::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificToggleWithTransition::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2276,8 +2276,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificToggleWithTransition::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificToggleWithTransition::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2291,8 +2291,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificToggleWithTransition2::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificToggleWithTransition2::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2300,8 +2300,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SampleMfgSpecificToggleWithTransition2::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SampleMfgSpecificToggleWithTransition2::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2317,8 +2317,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OffWithEffect::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OffWithEffect::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     OnOffEffectIdentifier effectId;
     OnOffDelayedAllOffEffectVariant effectVariant;
@@ -2329,8 +2329,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OffWithEffect::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OffWithEffect::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     OnOffEffectIdentifier effectId;
     OnOffDelayedAllOffEffectVariant effectVariant;
@@ -2346,8 +2346,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OnWithRecallGlobalScene::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OnWithRecallGlobalScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2355,8 +2355,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OnWithRecallGlobalScene::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OnWithRecallGlobalScene::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -2373,8 +2373,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OnWithTimedOff::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OnWithTimedOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     chip::BitFlags<OnOffControl> onOffControl;
     uint16_t onTime;
@@ -2386,8 +2386,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OnWithTimedOff::Id; }
-    static constexpr ClusterId GetClusterId() { return OnOff::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OnWithTimedOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     chip::BitFlags<OnOffControl> onOffControl;
     uint16_t onTime;
@@ -2595,8 +2595,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToLevel::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToLevel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     uint8_t level;
     uint16_t transitionTime;
@@ -2609,8 +2609,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToLevel::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToLevel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     uint8_t level;
     uint16_t transitionTime;
@@ -2632,8 +2632,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Move::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Move::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     MoveMode moveMode;
     uint8_t rate;
@@ -2646,8 +2646,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Move::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Move::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     MoveMode moveMode;
     uint8_t rate;
@@ -2670,8 +2670,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Step::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Step::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     StepMode stepMode;
     uint8_t stepSize;
@@ -2685,8 +2685,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Step::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Step::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     StepMode stepMode;
     uint8_t stepSize;
@@ -2707,8 +2707,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Stop::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Stop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     uint8_t optionMask;
     uint8_t optionOverride;
@@ -2719,8 +2719,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Stop::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Stop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     uint8_t optionMask;
     uint8_t optionOverride;
@@ -2738,8 +2738,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToLevelWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToLevelWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     uint8_t level;
     uint16_t transitionTime;
@@ -2750,8 +2750,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToLevelWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToLevelWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     uint8_t level;
     uint16_t transitionTime;
@@ -2769,8 +2769,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     MoveMode moveMode;
     uint8_t rate;
@@ -2781,8 +2781,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     MoveMode moveMode;
     uint8_t rate;
@@ -2801,8 +2801,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StepWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     StepMode stepMode;
     uint8_t stepSize;
@@ -2814,8 +2814,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StepWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     StepMode stepMode;
     uint8_t stepSize;
@@ -2832,8 +2832,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StopWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StopWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -2841,8 +2841,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StopWithOnOff::Id; }
-    static constexpr ClusterId GetClusterId() { return LevelControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StopWithOnOff::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3026,8 +3026,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetAlarm::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetAlarm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     uint8_t alarmCode;
     chip::ClusterId clusterId;
@@ -3038,8 +3038,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetAlarm::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetAlarm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     uint8_t alarmCode;
     chip::ClusterId clusterId;
@@ -3057,8 +3057,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Alarm::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Alarm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     uint8_t alarmCode;
     chip::ClusterId clusterId;
@@ -3069,8 +3069,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Alarm::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Alarm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     uint8_t alarmCode;
     chip::ClusterId clusterId;
@@ -3086,8 +3086,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetAllAlarms::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetAllAlarms::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3095,8 +3095,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetAllAlarms::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetAllAlarms::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3114,8 +3114,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetAlarmResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlarmResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     uint8_t status;
     uint8_t alarmCode;
@@ -3128,8 +3128,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetAlarmResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlarmResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     uint8_t status;
     uint8_t alarmCode;
@@ -3147,8 +3147,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetAlarm::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlarm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3156,8 +3156,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetAlarm::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlarm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3171,8 +3171,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetAlarmLog::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetAlarmLog::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3180,8 +3180,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetAlarmLog::Id; }
-    static constexpr ClusterId GetClusterId() { return Alarms::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetAlarmLog::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3549,8 +3549,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
 
@@ -3560,8 +3560,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -3580,8 +3580,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t totalProfileNum;
     uint8_t powerProfileId;
@@ -3594,8 +3594,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t totalProfileNum;
     uint8_t powerProfileId;
@@ -3613,8 +3613,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileStateRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileStateRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3622,8 +3622,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileStateRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileStateRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3641,8 +3641,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t totalProfileNum;
     uint8_t powerProfileId;
@@ -3655,8 +3655,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t totalProfileNum;
     uint8_t powerProfileId;
@@ -3678,8 +3678,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePriceResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t currency;
@@ -3692,8 +3692,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePriceResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t currency;
@@ -3713,8 +3713,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileStateResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileStateResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileCount;
     DataModel::List<Structs::PowerProfileRecord::Type> powerProfileRecords;
@@ -3725,8 +3725,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileStateResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileStateResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileCount;
     DataModel::DecodableList<Structs::PowerProfileRecord::DecodableType> powerProfileRecords;
@@ -3745,8 +3745,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetOverallSchedulePriceResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetOverallSchedulePriceResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint16_t currency;
     uint32_t price;
@@ -3758,8 +3758,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetOverallSchedulePriceResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetOverallSchedulePriceResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint16_t currency;
     uint32_t price;
@@ -3777,8 +3777,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePrice::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePrice::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
 
@@ -3788,8 +3788,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePrice::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePrice::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -3807,8 +3807,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -3820,8 +3820,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -3840,8 +3840,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfilesStateNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfilesStateNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileCount;
     DataModel::List<Structs::PowerProfileRecord::Type> powerProfileRecords;
@@ -3852,8 +3852,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfilesStateNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfilesStateNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileCount;
     DataModel::DecodableList<Structs::PowerProfileRecord::DecodableType> powerProfileRecords;
@@ -3872,8 +3872,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -3885,8 +3885,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -3903,8 +3903,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetOverallSchedulePrice::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetOverallSchedulePrice::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3912,8 +3912,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetOverallSchedulePrice::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetOverallSchedulePrice::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3928,8 +3928,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileScheduleConstraintsRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
 
@@ -3939,8 +3939,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileScheduleConstraintsRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -3956,8 +3956,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
 
@@ -3967,8 +3967,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -3984,8 +3984,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleStateRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
 
@@ -3995,8 +3995,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleStateRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -4014,8 +4014,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleStateResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -4027,8 +4027,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleStateResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -4049,8 +4049,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePriceExtendedResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtendedResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t currency;
@@ -4063,8 +4063,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePriceExtendedResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtendedResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t currency;
@@ -4085,8 +4085,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleStateNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -4098,8 +4098,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnergyPhasesScheduleStateNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnergyPhasesScheduleStateNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint8_t numOfScheduledPhases;
@@ -4119,8 +4119,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileScheduleConstraintsNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t startAfter;
@@ -4132,8 +4132,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileScheduleConstraintsNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t startAfter;
@@ -4153,8 +4153,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PowerProfileScheduleConstraintsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t startAfter;
@@ -4166,8 +4166,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PowerProfileScheduleConstraintsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PowerProfileScheduleConstraintsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t powerProfileId;
     uint16_t startAfter;
@@ -4187,8 +4187,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePriceExtended::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtended::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t options;
     uint8_t powerProfileId;
@@ -4200,8 +4200,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPowerProfilePriceExtended::Id; }
-    static constexpr ClusterId GetClusterId() { return PowerProfile::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPowerProfilePriceExtended::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     uint8_t options;
     uint8_t powerProfileId;
@@ -4365,8 +4365,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ExecutionOfACommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ExecutionOfACommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CommandIdentification commandId;
 
@@ -4376,8 +4376,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ExecutionOfACommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ExecutionOfACommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CommandIdentification commandId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -4395,8 +4395,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SignalStateResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SignalStateResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
     chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
@@ -4408,8 +4408,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SignalStateResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SignalStateResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
     chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
@@ -4426,8 +4426,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SignalState::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SignalState::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4435,8 +4435,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SignalState::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SignalState::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4453,8 +4453,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SignalStateNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SignalStateNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
     chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
@@ -4466,8 +4466,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SignalStateNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SignalStateNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     ApplianceStatus applianceStatus;
     chip::BitFlags<RemoteEnableFlagsAndDeviceStatus2> remoteEnableFlagsAndDeviceStatus2;
@@ -4487,8 +4487,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return WriteFunctions::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::WriteFunctions::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     uint16_t functionId;
     uint8_t functionDataType;
@@ -4500,8 +4500,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return WriteFunctions::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::WriteFunctions::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     uint16_t functionId;
     uint8_t functionDataType;
@@ -4518,8 +4518,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OverloadPauseResume::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OverloadPauseResume::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4527,8 +4527,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OverloadPauseResume::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OverloadPauseResume::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4542,8 +4542,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OverloadPause::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OverloadPause::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4551,8 +4551,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OverloadPause::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OverloadPause::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4567,8 +4567,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OverloadWarning::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OverloadWarning::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     WarningEvent warningEvent;
 
@@ -4578,8 +4578,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OverloadWarning::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OverloadWarning::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     WarningEvent warningEvent;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -4740,8 +4740,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CheckIn::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CheckIn::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4749,8 +4749,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CheckIn::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CheckIn::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4766,8 +4766,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CheckInResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CheckInResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     bool startFastPolling;
     uint16_t fastPollTimeout;
@@ -4778,8 +4778,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CheckInResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CheckInResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     bool startFastPolling;
     uint16_t fastPollTimeout;
@@ -4795,8 +4795,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return FastPollStop::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::FastPollStop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4804,8 +4804,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return FastPollStop::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::FastPollStop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4820,8 +4820,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetLongPollInterval::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetLongPollInterval::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     uint32_t newLongPollInterval;
 
@@ -4831,8 +4831,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetLongPollInterval::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetLongPollInterval::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     uint32_t newLongPollInterval;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -4848,8 +4848,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetShortPollInterval::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetShortPollInterval::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     uint16_t newShortPollInterval;
 
@@ -4859,8 +4859,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetShortPollInterval::Id; }
-    static constexpr ClusterId GetClusterId() { return PollControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetShortPollInterval::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     uint16_t newShortPollInterval;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -4973,8 +4973,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StartUp::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StartUp::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -4982,8 +4982,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StartUp::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StartUp::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -4997,8 +4997,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MfgSpecificPing::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MfgSpecificPing::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -5006,8 +5006,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MfgSpecificPing::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MfgSpecificPing::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5021,8 +5021,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ShutDown::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ShutDown::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -5030,8 +5030,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ShutDown::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ShutDown::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5045,8 +5045,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Leave::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Leave::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -5054,8 +5054,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Leave::Id; }
-    static constexpr ClusterId GetClusterId() { return Basic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Leave::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -5325,8 +5325,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return QueryImage::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::QueryImage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     uint16_t vendorId;
     uint16_t productId;
@@ -5343,8 +5343,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return QueryImage::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::QueryImage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     uint16_t vendorId;
     uint16_t productId;
@@ -5368,8 +5368,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ApplyUpdateRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ApplyUpdateRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
     uint32_t newVersion;
@@ -5380,8 +5380,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ApplyUpdateRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ApplyUpdateRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
     uint32_t newVersion;
@@ -5399,8 +5399,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return NotifyUpdateApplied::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NotifyUpdateApplied::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
     uint32_t softwareVersion;
@@ -5411,8 +5411,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return NotifyUpdateApplied::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NotifyUpdateApplied::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     chip::ByteSpan updateToken;
     uint32_t softwareVersion;
@@ -5436,8 +5436,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return QueryImageResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::QueryImageResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     OTAQueryStatus status;
     uint32_t delayedActionTime;
@@ -5454,8 +5454,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return QueryImageResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::QueryImageResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     OTAQueryStatus status;
     uint32_t delayedActionTime;
@@ -5479,8 +5479,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ApplyUpdateRequestResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ApplyUpdateRequestResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     OTAApplyUpdateAction action;
     uint32_t delayedActionTime;
@@ -5491,8 +5491,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ApplyUpdateRequestResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateProvider::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ApplyUpdateRequestResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     OTAApplyUpdateAction action;
     uint32_t delayedActionTime;
@@ -5553,8 +5553,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AnnounceOtaProvider::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateRequestor::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AnnounceOtaProvider::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
     chip::NodeId providerLocation;
     chip::VendorId vendorId;
@@ -5567,8 +5567,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AnnounceOtaProvider::Id; }
-    static constexpr ClusterId GetClusterId() { return OtaSoftwareUpdateRequestor::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AnnounceOtaProvider::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
 
     chip::NodeId providerLocation;
     chip::VendorId vendorId;
@@ -6019,8 +6019,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ArmFailSafe::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ArmFailSafe::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     uint16_t expiryLengthSeconds;
     uint64_t breadcrumb;
@@ -6032,8 +6032,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ArmFailSafe::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ArmFailSafe::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     uint16_t expiryLengthSeconds;
     uint64_t breadcrumb;
@@ -6052,8 +6052,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ArmFailSafeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ArmFailSafeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
     chip::CharSpan debugText;
@@ -6064,8 +6064,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ArmFailSafeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ArmFailSafeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
     chip::CharSpan debugText;
@@ -6085,8 +6085,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetRegulatoryConfig::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfig::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     RegulatoryLocationType location;
     chip::CharSpan countryCode;
@@ -6099,8 +6099,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetRegulatoryConfig::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfig::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     RegulatoryLocationType location;
     chip::CharSpan countryCode;
@@ -6120,8 +6120,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetRegulatoryConfigResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfigResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
     chip::CharSpan debugText;
@@ -6132,8 +6132,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetRegulatoryConfigResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRegulatoryConfigResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
     chip::CharSpan debugText;
@@ -6149,8 +6149,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CommissioningComplete::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommissioningComplete::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6158,8 +6158,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CommissioningComplete::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommissioningComplete::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -6175,8 +6175,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CommissioningCompleteResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommissioningCompleteResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
     chip::CharSpan debugText;
@@ -6187,8 +6187,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CommissioningCompleteResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return GeneralCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommissioningCompleteResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     GeneralCommissioningError errorCode;
     chip::CharSpan debugText;
@@ -6352,8 +6352,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ScanNetworks::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ScanNetworks::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
     uint64_t breadcrumb;
@@ -6365,8 +6365,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ScanNetworks::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ScanNetworks::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
     uint64_t breadcrumb;
@@ -6387,8 +6387,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ScanNetworksResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ScanNetworksResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6401,8 +6401,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ScanNetworksResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ScanNetworksResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6424,8 +6424,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddWiFiNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddWiFiNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
@@ -6438,8 +6438,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddWiFiNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddWiFiNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
@@ -6459,8 +6459,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddWiFiNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddWiFiNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6471,8 +6471,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddWiFiNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddWiFiNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6492,8 +6492,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpdateWiFiNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateWiFiNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
@@ -6506,8 +6506,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpdateWiFiNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateWiFiNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan ssid;
     chip::ByteSpan credentials;
@@ -6527,8 +6527,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpdateWiFiNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateWiFiNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6539,8 +6539,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpdateWiFiNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateWiFiNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6559,8 +6559,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddThreadNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddThreadNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
     uint64_t breadcrumb;
@@ -6572,8 +6572,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddThreadNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddThreadNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
     uint64_t breadcrumb;
@@ -6592,8 +6592,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddThreadNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddThreadNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6604,8 +6604,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddThreadNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddThreadNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6624,8 +6624,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpdateThreadNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateThreadNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
     uint64_t breadcrumb;
@@ -6637,8 +6637,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpdateThreadNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateThreadNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan operationalDataset;
     uint64_t breadcrumb;
@@ -6657,8 +6657,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpdateThreadNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateThreadNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6669,8 +6669,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpdateThreadNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateThreadNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6689,8 +6689,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
     uint64_t breadcrumb;
@@ -6702,8 +6702,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
     uint64_t breadcrumb;
@@ -6722,8 +6722,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6734,8 +6734,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6754,8 +6754,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnableNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnableNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
     uint64_t breadcrumb;
@@ -6767,8 +6767,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnableNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnableNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
     uint64_t breadcrumb;
@@ -6787,8 +6787,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnableNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnableNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6799,8 +6799,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnableNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnableNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6819,8 +6819,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return DisableNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisableNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
     uint64_t breadcrumb;
@@ -6832,8 +6832,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return DisableNetwork::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisableNetwork::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     chip::ByteSpan networkID;
     uint64_t breadcrumb;
@@ -6852,8 +6852,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return DisableNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisableNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6864,8 +6864,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return DisableNetworkResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisableNetworkResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint8_t errorCode;
     chip::CharSpan debugText;
@@ -6882,8 +6882,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetLastNetworkCommissioningResult::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLastNetworkCommissioningResult::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint32_t timeoutMs;
 
@@ -6893,8 +6893,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetLastNetworkCommissioningResult::Id; }
-    static constexpr ClusterId GetClusterId() { return NetworkCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLastNetworkCommissioningResult::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
 
     uint32_t timeoutMs;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -6980,8 +6980,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RetrieveLogsRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return DiagnosticLogs::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
     LogsIntent intent;
     LogsTransferProtocol requestedProtocol;
@@ -6993,8 +6993,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RetrieveLogsRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return DiagnosticLogs::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
     LogsIntent intent;
     LogsTransferProtocol requestedProtocol;
@@ -7015,8 +7015,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RetrieveLogsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DiagnosticLogs::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
     LogsStatus status;
     chip::ByteSpan content;
@@ -7029,8 +7029,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RetrieveLogsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DiagnosticLogs::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RetrieveLogsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
 
     LogsStatus status;
     chip::ByteSpan content;
@@ -7325,8 +7325,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetWatermarks::Id; }
-    static constexpr ClusterId GetClusterId() { return SoftwareDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetWatermarks::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -7334,8 +7334,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetWatermarks::Id; }
-    static constexpr ClusterId GetClusterId() { return SoftwareDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetWatermarks::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -7591,8 +7591,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
-    static constexpr ClusterId GetClusterId() { return ThreadNetworkDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetCounts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -7600,8 +7600,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
-    static constexpr ClusterId GetClusterId() { return ThreadNetworkDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetCounts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8305,8 +8305,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
-    static constexpr ClusterId GetClusterId() { return WiFiNetworkDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetCounts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8314,8 +8314,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
-    static constexpr ClusterId GetClusterId() { return WiFiNetworkDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetCounts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8507,8 +8507,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
-    static constexpr ClusterId GetClusterId() { return EthernetNetworkDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetCounts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8516,8 +8516,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ResetCounts::Id; }
-    static constexpr ClusterId GetClusterId() { return EthernetNetworkDiagnostics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ResetCounts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8649,8 +8649,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StartUp::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StartUp::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8658,8 +8658,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StartUp::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StartUp::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8673,8 +8673,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ShutDown::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ShutDown::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8682,8 +8682,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ShutDown::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ShutDown::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8697,8 +8697,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Leave::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Leave::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8706,8 +8706,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Leave::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Leave::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8721,8 +8721,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ReachableChanged::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ReachableChanged::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -8730,8 +8730,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ReachableChanged::Id; }
-    static constexpr ClusterId GetClusterId() { return BridgedDeviceBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ReachableChanged::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -8987,8 +8987,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OpenCommissioningWindow::Id; }
-    static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpenCommissioningWindow::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     uint16_t commissioningTimeout;
     chip::ByteSpan PAKEVerifier;
@@ -9003,8 +9003,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OpenCommissioningWindow::Id; }
-    static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpenCommissioningWindow::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     uint16_t commissioningTimeout;
     chip::ByteSpan PAKEVerifier;
@@ -9025,8 +9025,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OpenBasicCommissioningWindow::Id; }
-    static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpenBasicCommissioningWindow::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     uint16_t commissioningTimeout;
 
@@ -9036,8 +9036,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OpenBasicCommissioningWindow::Id; }
-    static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpenBasicCommissioningWindow::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     uint16_t commissioningTimeout;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9052,8 +9052,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RevokeCommissioning::Id; }
-    static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RevokeCommissioning::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -9061,8 +9061,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RevokeCommissioning::Id; }
-    static constexpr ClusterId GetClusterId() { return AdministratorCommissioning::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RevokeCommissioning::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -9176,8 +9176,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AttestationRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AttestationRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan attestationNonce;
 
@@ -9187,8 +9187,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AttestationRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AttestationRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan attestationNonce;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9205,8 +9205,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AttestationResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AttestationResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan attestationElements;
     chip::ByteSpan signature;
@@ -9217,8 +9217,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AttestationResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AttestationResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan attestationElements;
     chip::ByteSpan signature;
@@ -9235,8 +9235,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CertificateChainRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CertificateChainRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     uint8_t certificateType;
 
@@ -9246,8 +9246,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CertificateChainRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CertificateChainRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     uint8_t certificateType;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9263,8 +9263,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CertificateChainResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CertificateChainResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan certificate;
 
@@ -9274,8 +9274,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CertificateChainResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CertificateChainResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan certificate;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9291,8 +9291,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OpCSRRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpCSRRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan CSRNonce;
 
@@ -9302,8 +9302,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OpCSRRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpCSRRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan CSRNonce;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9320,8 +9320,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OpCSRResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpCSRResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan NOCSRElements;
     chip::ByteSpan attestationSignature;
@@ -9332,8 +9332,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OpCSRResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OpCSRResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan NOCSRElements;
     chip::ByteSpan attestationSignature;
@@ -9354,8 +9354,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddNOC::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddNOC::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan NOCValue;
     Optional<chip::ByteSpan> ICACValue;
@@ -9369,8 +9369,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddNOC::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddNOC::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan NOCValue;
     Optional<chip::ByteSpan> ICACValue;
@@ -9391,8 +9391,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpdateNOC::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateNOC::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan NOCValue;
     Optional<chip::ByteSpan> ICACValue;
@@ -9403,8 +9403,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpdateNOC::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateNOC::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan NOCValue;
     Optional<chip::ByteSpan> ICACValue;
@@ -9423,8 +9423,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return NOCResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NOCResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     uint8_t statusCode;
     uint8_t fabricIndex;
@@ -9436,8 +9436,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return NOCResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NOCResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     uint8_t statusCode;
     uint8_t fabricIndex;
@@ -9455,8 +9455,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpdateFabricLabel::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateFabricLabel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::CharSpan label;
 
@@ -9466,8 +9466,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpdateFabricLabel::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpdateFabricLabel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::CharSpan label;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9483,8 +9483,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveFabric::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveFabric::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     uint8_t fabricIndex;
 
@@ -9494,8 +9494,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveFabric::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveFabric::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     uint8_t fabricIndex;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9511,8 +9511,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AddTrustedRootCertificate::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddTrustedRootCertificate::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan rootCertificate;
 
@@ -9522,8 +9522,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AddTrustedRootCertificate::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AddTrustedRootCertificate::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan rootCertificate;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9539,8 +9539,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RemoveTrustedRootCertificate::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveTrustedRootCertificate::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan trustedRootIdentifier;
 
@@ -9550,8 +9550,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RemoveTrustedRootCertificate::Id; }
-    static constexpr ClusterId GetClusterId() { return OperationalCredentials::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RemoveTrustedRootCertificate::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
 
     chip::ByteSpan trustedRootIdentifier;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9729,7 +9729,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000000;
-    static constexpr ClusterId GetClusterId() { return BooleanState::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
 
     bool stateValue;
 
@@ -9741,7 +9741,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return BooleanState::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
 
     bool stateValue;
 
@@ -9936,8 +9936,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LockDoor::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LockDoor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     chip::ByteSpan pin;
 
@@ -9947,8 +9947,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LockDoor::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LockDoor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9964,8 +9964,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LockDoorResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LockDoorResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -9975,8 +9975,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LockDoorResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LockDoorResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -9992,8 +9992,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UnlockDoor::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockDoor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     chip::ByteSpan pin;
 
@@ -10003,8 +10003,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UnlockDoor::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockDoor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     chip::ByteSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10020,8 +10020,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UnlockDoorResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockDoorResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10031,8 +10031,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UnlockDoorResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockDoorResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10048,8 +10048,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Toggle::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Toggle::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     chip::CharSpan pin;
 
@@ -10059,8 +10059,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Toggle::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Toggle::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     chip::CharSpan pin;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10076,8 +10076,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ToggleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ToggleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10087,8 +10087,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ToggleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ToggleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10105,8 +10105,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UnlockWithTimeout::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockWithTimeout::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t timeoutInSeconds;
     chip::ByteSpan pin;
@@ -10117,8 +10117,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UnlockWithTimeout::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockWithTimeout::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t timeoutInSeconds;
     chip::ByteSpan pin;
@@ -10135,8 +10135,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UnlockWithTimeoutResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockWithTimeoutResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10146,8 +10146,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UnlockWithTimeoutResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UnlockWithTimeoutResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10163,8 +10163,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetLogRecord::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLogRecord::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t logIndex;
 
@@ -10174,8 +10174,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetLogRecord::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLogRecord::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t logIndex;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10197,8 +10197,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetLogRecordResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLogRecordResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t logEntryId;
     uint32_t timestamp;
@@ -10214,8 +10214,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetLogRecordResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLogRecordResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t logEntryId;
     uint32_t timestamp;
@@ -10240,8 +10240,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetPin::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetPin::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -10254,8 +10254,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetPin::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetPin::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -10274,8 +10274,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetPinResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetPinResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     DoorLockSetPinOrIdStatus status;
 
@@ -10285,8 +10285,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetPinResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetPinResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     DoorLockSetPinOrIdStatus status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10302,8 +10302,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPin::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPin::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
 
@@ -10313,8 +10313,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPin::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPin::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10333,8 +10333,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPinResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPinResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -10347,8 +10347,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPinResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPinResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -10367,8 +10367,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearPin::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearPin::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
 
@@ -10378,8 +10378,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearPin::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearPin::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10395,8 +10395,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearPinResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearPinResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10406,8 +10406,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearPinResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearPinResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10422,8 +10422,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearAllPins::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllPins::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -10431,8 +10431,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearAllPins::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllPins::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -10447,8 +10447,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearAllPinsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllPinsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10458,8 +10458,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearAllPinsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllPinsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10476,8 +10476,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetUserStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     uint8_t userStatus;
@@ -10488,8 +10488,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetUserStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     uint8_t userStatus;
@@ -10506,8 +10506,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetUserStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10517,8 +10517,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetUserStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10534,8 +10534,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetUserStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
 
@@ -10545,8 +10545,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetUserStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10563,8 +10563,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetUserStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     uint8_t status;
@@ -10575,8 +10575,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetUserStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     uint8_t status;
@@ -10599,8 +10599,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetWeekdaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetWeekdaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10616,8 +10616,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetWeekdaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetWeekdaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10639,8 +10639,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetWeekdayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetWeekdayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10650,8 +10650,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetWeekdayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetWeekdayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10668,8 +10668,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetWeekdaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetWeekdaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10680,8 +10680,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetWeekdaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetWeekdaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10705,8 +10705,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetWeekdayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetWeekdayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10723,8 +10723,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetWeekdayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetWeekdayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10748,8 +10748,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearWeekdaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearWeekdaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10760,8 +10760,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearWeekdaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearWeekdaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10778,8 +10778,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearWeekdayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearWeekdayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10789,8 +10789,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearWeekdayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearWeekdayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10809,8 +10809,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetYeardaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetYeardaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10823,8 +10823,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetYeardaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetYeardaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10843,8 +10843,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetYeardayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetYeardayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10854,8 +10854,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetYeardayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetYeardayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -10872,8 +10872,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetYeardaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetYeardaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10884,8 +10884,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetYeardaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetYeardaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10906,8 +10906,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetYeardayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetYeardayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10921,8 +10921,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetYeardayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetYeardayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10943,8 +10943,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearYeardaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearYeardaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10955,8 +10955,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearYeardaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearYeardaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint16_t userId;
@@ -10973,8 +10973,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearYeardayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearYeardayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -10984,8 +10984,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearYeardayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearYeardayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11004,8 +11004,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetHolidaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetHolidaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint32_t localStartTime;
@@ -11018,8 +11018,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetHolidaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetHolidaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint32_t localStartTime;
@@ -11038,8 +11038,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetHolidayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetHolidayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -11049,8 +11049,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetHolidayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetHolidayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11066,8 +11066,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetHolidaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetHolidaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
 
@@ -11077,8 +11077,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetHolidaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetHolidaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11098,8 +11098,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetHolidayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetHolidayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint8_t status;
@@ -11113,8 +11113,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetHolidayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetHolidayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     uint8_t status;
@@ -11134,8 +11134,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearHolidaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearHolidaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
 
@@ -11145,8 +11145,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearHolidaySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearHolidaySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t scheduleId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11162,8 +11162,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearHolidayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearHolidayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -11173,8 +11173,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearHolidayScheduleResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearHolidayScheduleResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11191,8 +11191,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetUserType::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserType::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserType userType;
@@ -11203,8 +11203,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetUserType::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserType::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserType userType;
@@ -11221,8 +11221,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetUserTypeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserTypeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -11232,8 +11232,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetUserTypeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetUserTypeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11249,8 +11249,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetUserType::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserType::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
 
@@ -11260,8 +11260,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetUserType::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserType::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11278,8 +11278,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetUserTypeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserTypeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserType userType;
@@ -11290,8 +11290,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetUserTypeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetUserTypeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserType userType;
@@ -11311,8 +11311,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetRfid::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRfid::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -11325,8 +11325,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetRfid::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRfid::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -11345,8 +11345,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetRfidResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRfidResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     DoorLockSetPinOrIdStatus status;
 
@@ -11356,8 +11356,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetRfidResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetRfidResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     DoorLockSetPinOrIdStatus status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11373,8 +11373,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetRfid::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetRfid::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
 
@@ -11384,8 +11384,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetRfid::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetRfid::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11404,8 +11404,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetRfidResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetRfidResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -11418,8 +11418,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetRfidResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetRfidResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     DoorLockUserStatus userStatus;
@@ -11438,8 +11438,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearRfid::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearRfid::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
 
@@ -11449,8 +11449,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearRfid::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearRfid::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint16_t userId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11466,8 +11466,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearRfidResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearRfidResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -11477,8 +11477,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearRfidResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearRfidResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11493,8 +11493,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearAllRfids::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllRfids::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -11502,8 +11502,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearAllRfids::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllRfids::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -11518,8 +11518,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearAllRfidsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllRfidsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
 
@@ -11529,8 +11529,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearAllRfidsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearAllRfidsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -11551,8 +11551,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return OperationEventNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OperationEventNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t source;
     DoorLockOperationEventCode eventCode;
@@ -11567,8 +11567,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return OperationEventNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::OperationEventNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t source;
     DoorLockOperationEventCode eventCode;
@@ -11596,8 +11596,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ProgrammingEventNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ProgrammingEventNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t source;
     DoorLockProgrammingEventCode eventCode;
@@ -11614,8 +11614,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ProgrammingEventNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return DoorLock::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ProgrammingEventNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     uint8_t source;
     DoorLockProgrammingEventCode eventCode;
@@ -12197,8 +12197,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return UpOrOpen::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpOrOpen::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12206,8 +12206,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return UpOrOpen::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::UpOrOpen::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12221,8 +12221,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return DownOrClose::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DownOrClose::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12230,8 +12230,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return DownOrClose::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DownOrClose::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12245,8 +12245,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StopMotion::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StopMotion::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12254,8 +12254,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StopMotion::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StopMotion::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -12270,8 +12270,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GoToLiftValue::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToLiftValue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint16_t liftValue;
 
@@ -12281,8 +12281,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GoToLiftValue::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToLiftValue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint16_t liftValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -12299,8 +12299,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GoToLiftPercentage::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToLiftPercentage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint8_t liftPercentageValue;
     uint16_t liftPercent100thsValue;
@@ -12311,8 +12311,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GoToLiftPercentage::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToLiftPercentage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint8_t liftPercentageValue;
     uint16_t liftPercent100thsValue;
@@ -12329,8 +12329,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GoToTiltValue::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToTiltValue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint16_t tiltValue;
 
@@ -12340,8 +12340,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GoToTiltValue::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToTiltValue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint16_t tiltValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -12358,8 +12358,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GoToTiltPercentage::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToTiltPercentage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint8_t tiltPercentageValue;
     uint16_t tiltPercent100thsValue;
@@ -12370,8 +12370,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GoToTiltPercentage::Id; }
-    static constexpr ClusterId GetClusterId() { return WindowCovering::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GoToTiltPercentage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     uint8_t tiltPercentageValue;
     uint16_t tiltPercent100thsValue;
@@ -12686,8 +12686,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return BarrierControlGoToPercent::Id; }
-    static constexpr ClusterId GetClusterId() { return BarrierControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::BarrierControlGoToPercent::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
     uint8_t percentOpen;
 
@@ -12697,8 +12697,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return BarrierControlGoToPercent::Id; }
-    static constexpr ClusterId GetClusterId() { return BarrierControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::BarrierControlGoToPercent::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
     uint8_t percentOpen;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -12713,8 +12713,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return BarrierControlStop::Id; }
-    static constexpr ClusterId GetClusterId() { return BarrierControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::BarrierControlStop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -12722,8 +12722,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return BarrierControlStop::Id; }
-    static constexpr ClusterId GetClusterId() { return BarrierControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::BarrierControlStop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13175,7 +13175,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000000;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13185,7 +13185,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13203,7 +13203,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000001;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13213,7 +13213,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13231,7 +13231,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000002;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13241,7 +13241,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13259,7 +13259,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000003;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13269,7 +13269,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13287,7 +13287,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000004;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13297,7 +13297,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13315,7 +13315,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Critical;
     static constexpr EventId eventId             = 0x00000005;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13325,7 +13325,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13343,7 +13343,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000006;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13353,7 +13353,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13371,7 +13371,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Critical;
     static constexpr EventId eventId             = 0x00000007;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13381,7 +13381,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13399,7 +13399,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000008;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13409,7 +13409,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13427,7 +13427,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Critical;
     static constexpr EventId eventId             = 0x00000009;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13437,7 +13437,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13455,7 +13455,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x0000000A;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13465,7 +13465,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13483,7 +13483,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x0000000B;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13493,7 +13493,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13511,7 +13511,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Critical;
     static constexpr EventId eventId             = 0x0000000C;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13521,7 +13521,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13539,7 +13539,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x0000000D;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13549,7 +13549,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13567,7 +13567,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x0000000E;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13577,7 +13577,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13595,7 +13595,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x0000000F;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13605,7 +13605,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13623,7 +13623,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000010;
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13633,7 +13633,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return PumpConfigurationAndControl::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13687,8 +13687,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetpointRaiseLower::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetpointRaiseLower::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     SetpointAdjustMode mode;
     int8_t amount;
@@ -13699,8 +13699,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetpointRaiseLower::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetpointRaiseLower::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     SetpointAdjustMode mode;
     int8_t amount;
@@ -13720,8 +13720,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CurrentWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CurrentWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
     chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
@@ -13734,8 +13734,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CurrentWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CurrentWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
     chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
@@ -13757,8 +13757,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
     chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
@@ -13771,8 +13771,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     uint8_t numberOfTransitionsForSequence;
     chip::BitFlags<DayOfWeek> dayOfWeekForSequence;
@@ -13796,8 +13796,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RelayStatusLog::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RelayStatusLog::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     uint16_t timeOfDay;
     uint16_t relayStatus;
@@ -13812,8 +13812,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RelayStatusLog::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RelayStatusLog::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     uint16_t timeOfDay;
     uint16_t relayStatus;
@@ -13835,8 +13835,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     chip::BitFlags<DayOfWeek> daysToReturn;
     chip::BitFlags<ModeForSequence> modeToReturn;
@@ -13847,8 +13847,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     chip::BitFlags<DayOfWeek> daysToReturn;
     chip::BitFlags<ModeForSequence> modeToReturn;
@@ -13864,8 +13864,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ClearWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13873,8 +13873,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ClearWeeklySchedule::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ClearWeeklySchedule::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -13888,8 +13888,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetRelayStatusLog::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetRelayStatusLog::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -13897,8 +13897,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetRelayStatusLog::Id; }
-    static constexpr ClusterId GetClusterId() { return Thermostat::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetRelayStatusLog::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -14701,8 +14701,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t hue;
     HueDirection direction;
@@ -14716,8 +14716,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t hue;
     HueDirection direction;
@@ -14740,8 +14740,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueMoveMode moveMode;
     uint8_t rate;
@@ -14754,8 +14754,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueMoveMode moveMode;
     uint8_t rate;
@@ -14778,8 +14778,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StepHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueStepMode stepMode;
     uint8_t stepSize;
@@ -14793,8 +14793,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StepHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueStepMode stepMode;
     uint8_t stepSize;
@@ -14817,8 +14817,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t saturation;
     uint16_t transitionTime;
@@ -14831,8 +14831,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t saturation;
     uint16_t transitionTime;
@@ -14854,8 +14854,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     SaturationMoveMode moveMode;
     uint8_t rate;
@@ -14868,8 +14868,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     SaturationMoveMode moveMode;
     uint8_t rate;
@@ -14892,8 +14892,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StepSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     SaturationStepMode stepMode;
     uint8_t stepSize;
@@ -14907,8 +14907,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StepSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     SaturationStepMode stepMode;
     uint8_t stepSize;
@@ -14932,8 +14932,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToHueAndSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToHueAndSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t hue;
     uint8_t saturation;
@@ -14947,8 +14947,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToHueAndSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToHueAndSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t hue;
     uint8_t saturation;
@@ -14972,8 +14972,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToColor::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToColor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t colorX;
     uint16_t colorY;
@@ -14987,8 +14987,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToColor::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToColor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t colorX;
     uint16_t colorY;
@@ -15011,8 +15011,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveColor::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveColor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     int16_t rateX;
     int16_t rateY;
@@ -15025,8 +15025,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveColor::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveColor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     int16_t rateX;
     int16_t rateY;
@@ -15049,8 +15049,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StepColor::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepColor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     int16_t stepX;
     int16_t stepY;
@@ -15064,8 +15064,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StepColor::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepColor::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     int16_t stepX;
     int16_t stepY;
@@ -15088,8 +15088,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveToColorTemperature::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToColorTemperature::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t colorTemperature;
     uint16_t transitionTime;
@@ -15102,8 +15102,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveToColorTemperature::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveToColorTemperature::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t colorTemperature;
     uint16_t transitionTime;
@@ -15126,8 +15126,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedMoveToHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t enhancedHue;
     HueDirection direction;
@@ -15141,8 +15141,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedMoveToHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t enhancedHue;
     HueDirection direction;
@@ -15165,8 +15165,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedMoveHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueMoveMode moveMode;
     uint16_t rate;
@@ -15179,8 +15179,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedMoveHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueMoveMode moveMode;
     uint16_t rate;
@@ -15203,8 +15203,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedStepHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedStepHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueStepMode stepMode;
     uint16_t stepSize;
@@ -15218,8 +15218,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedStepHue::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedStepHue::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueStepMode stepMode;
     uint16_t stepSize;
@@ -15243,8 +15243,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EnhancedMoveToHueAndSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHueAndSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t enhancedHue;
     uint8_t saturation;
@@ -15258,8 +15258,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EnhancedMoveToHueAndSaturation::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EnhancedMoveToHueAndSaturation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint16_t enhancedHue;
     uint8_t saturation;
@@ -15285,8 +15285,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ColorLoopSet::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ColorLoopSet::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     chip::BitFlags<ColorLoopUpdateFlags> updateFlags;
     ColorLoopAction action;
@@ -15302,8 +15302,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ColorLoopSet::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ColorLoopSet::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     chip::BitFlags<ColorLoopUpdateFlags> updateFlags;
     ColorLoopAction action;
@@ -15326,8 +15326,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StopMoveStep::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StopMoveStep::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t optionsMask;
     uint8_t optionsOverride;
@@ -15338,8 +15338,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StopMoveStep::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StopMoveStep::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     uint8_t optionsMask;
     uint8_t optionsOverride;
@@ -15361,8 +15361,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MoveColorTemperature::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveColorTemperature::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueMoveMode moveMode;
     uint16_t rate;
@@ -15377,8 +15377,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MoveColorTemperature::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MoveColorTemperature::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueMoveMode moveMode;
     uint16_t rate;
@@ -15405,8 +15405,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StepColorTemperature::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepColorTemperature::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueStepMode stepMode;
     uint16_t stepSize;
@@ -15422,8 +15422,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StepColorTemperature::Id; }
-    static constexpr ClusterId GetClusterId() { return ColorControl::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StepColorTemperature::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
 
     HueStepMode stepMode;
     uint16_t stepSize;
@@ -18726,8 +18726,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ZoneEnrollResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     IasEnrollResponseCode enrollResponseCode;
     uint8_t zoneId;
@@ -18738,8 +18738,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ZoneEnrollResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     IasEnrollResponseCode enrollResponseCode;
     uint8_t zoneId;
@@ -18759,8 +18759,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ZoneStatusChangeNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChangeNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     chip::BitFlags<IasZoneStatus> zoneStatus;
     uint8_t extendedStatus;
@@ -18773,8 +18773,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ZoneStatusChangeNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChangeNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     chip::BitFlags<IasZoneStatus> zoneStatus;
     uint8_t extendedStatus;
@@ -18792,8 +18792,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return InitiateNormalOperationMode::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateNormalOperationMode::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -18801,8 +18801,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return InitiateNormalOperationMode::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateNormalOperationMode::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -18818,8 +18818,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ZoneEnrollRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     IasZoneType zoneType;
     uint16_t manufacturerCode;
@@ -18830,8 +18830,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ZoneEnrollRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneEnrollRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     IasZoneType zoneType;
     uint16_t manufacturerCode;
@@ -18849,8 +18849,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return InitiateTestMode::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateTestMode::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     uint8_t testModeDuration;
     uint8_t currentZoneSensitivityLevel;
@@ -18861,8 +18861,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return InitiateTestMode::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateTestMode::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     uint8_t testModeDuration;
     uint8_t currentZoneSensitivityLevel;
@@ -18878,8 +18878,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return InitiateNormalOperationModeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateNormalOperationModeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -18887,8 +18887,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return InitiateNormalOperationModeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateNormalOperationModeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -18902,8 +18902,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return InitiateTestModeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateTestModeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -18911,8 +18911,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return InitiateTestModeResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasZone::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::InitiateTestModeResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19188,8 +19188,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Arm::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Arm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAceArmMode armMode;
     chip::CharSpan armDisarmCode;
@@ -19201,8 +19201,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Arm::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Arm::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAceArmMode armMode;
     chip::CharSpan armDisarmCode;
@@ -19220,8 +19220,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ArmResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ArmResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAceArmNotification armNotification;
 
@@ -19231,8 +19231,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ArmResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ArmResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAceArmNotification armNotification;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -19250,8 +19250,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Bypass::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Bypass::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t numberOfZones;
     DataModel::List<uint8_t> zoneIds;
@@ -19263,8 +19263,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Bypass::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Bypass::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t numberOfZones;
     DataModel::DecodableList<uint8_t> zoneIds;
@@ -19297,8 +19297,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetZoneIdMapResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneIdMapResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint16_t section0;
     uint16_t section1;
@@ -19323,8 +19323,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetZoneIdMapResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneIdMapResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint16_t section0;
     uint16_t section1;
@@ -19354,8 +19354,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Emergency::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Emergency::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19363,8 +19363,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Emergency::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Emergency::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19382,8 +19382,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetZoneInformationResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneInformationResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t zoneId;
     IasZoneType zoneType;
@@ -19396,8 +19396,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetZoneInformationResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneInformationResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t zoneId;
     IasZoneType zoneType;
@@ -19415,8 +19415,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Fire::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Fire::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19424,8 +19424,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Fire::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Fire::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19443,8 +19443,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ZoneStatusChanged::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChanged::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t zoneId;
     uint16_t zoneStatus;
@@ -19457,8 +19457,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ZoneStatusChanged::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ZoneStatusChanged::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t zoneId;
     uint16_t zoneStatus;
@@ -19476,8 +19476,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Panic::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Panic::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19485,8 +19485,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Panic::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Panic::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19504,8 +19504,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return PanelStatusChanged::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PanelStatusChanged::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAcePanelStatus panelStatus;
     uint8_t secondsRemaining;
@@ -19518,8 +19518,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return PanelStatusChanged::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::PanelStatusChanged::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAcePanelStatus panelStatus;
     uint8_t secondsRemaining;
@@ -19537,8 +19537,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetZoneIdMap::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneIdMap::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19546,8 +19546,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetZoneIdMap::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneIdMap::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19565,8 +19565,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPanelStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPanelStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAcePanelStatus panelStatus;
     uint8_t secondsRemaining;
@@ -19579,8 +19579,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPanelStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPanelStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     IasAcePanelStatus panelStatus;
     uint8_t secondsRemaining;
@@ -19599,8 +19599,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetZoneInformation::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneInformation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t zoneId;
 
@@ -19610,8 +19610,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetZoneInformation::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneInformation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t zoneId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -19628,8 +19628,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SetBypassedZoneList::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetBypassedZoneList::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t numberOfZones;
     DataModel::List<uint8_t> zoneIds;
@@ -19640,8 +19640,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SetBypassedZoneList::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SetBypassedZoneList::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t numberOfZones;
     DataModel::DecodableList<uint8_t> zoneIds;
@@ -19657,8 +19657,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetPanelStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPanelStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19666,8 +19666,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetPanelStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetPanelStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19683,8 +19683,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return BypassResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::BypassResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t numberOfZones;
     DataModel::List<IasAceBypassResult> bypassResult;
@@ -19695,8 +19695,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return BypassResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::BypassResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t numberOfZones;
     DataModel::DecodableList<IasAceBypassResult> bypassResult;
@@ -19712,8 +19712,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetBypassedZoneList::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetBypassedZoneList::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -19721,8 +19721,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetBypassedZoneList::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetBypassedZoneList::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -19739,8 +19739,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetZoneStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     bool zoneStatusComplete;
     uint8_t numberOfZones;
@@ -19752,8 +19752,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetZoneStatusResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneStatusResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     bool zoneStatusComplete;
     uint8_t numberOfZones;
@@ -19774,8 +19774,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetZoneStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t startingZoneId;
     uint8_t maxNumberOfZoneIds;
@@ -19788,8 +19788,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetZoneStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return IasAce::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetZoneStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     uint8_t startingZoneId;
     uint8_t maxNumberOfZoneIds;
@@ -19855,8 +19855,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StartWarning::Id; }
-    static constexpr ClusterId GetClusterId() { return IasWd::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StartWarning::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
     chip::BitFlags<WarningInfo> warningInfo;
     uint16_t warningDuration;
@@ -19869,8 +19869,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StartWarning::Id; }
-    static constexpr ClusterId GetClusterId() { return IasWd::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StartWarning::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
     chip::BitFlags<WarningInfo> warningInfo;
     uint16_t warningDuration;
@@ -19889,8 +19889,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Squawk::Id; }
-    static constexpr ClusterId GetClusterId() { return IasWd::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Squawk::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
     chip::BitFlags<SquawkInfo> squawkInfo;
 
@@ -19900,8 +19900,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Squawk::Id; }
-    static constexpr ClusterId GetClusterId() { return IasWd::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Squawk::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
 
     chip::BitFlags<SquawkInfo> squawkInfo;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20066,8 +20066,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ChangeChannel::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeChannel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     chip::CharSpan match;
 
@@ -20077,8 +20077,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ChangeChannel::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeChannel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     chip::CharSpan match;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20095,8 +20095,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ChangeChannelResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeChannelResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     DataModel::List<Structs::TvChannelInfo::Type> channelMatch;
     TvChannelErrorType errorType;
@@ -20107,8 +20107,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ChangeChannelResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeChannelResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     DataModel::DecodableList<Structs::TvChannelInfo::DecodableType> channelMatch;
     TvChannelErrorType errorType;
@@ -20126,8 +20126,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ChangeChannelByNumber::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeChannelByNumber::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     uint16_t majorNumber;
     uint16_t minorNumber;
@@ -20138,8 +20138,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ChangeChannelByNumber::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeChannelByNumber::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     uint16_t majorNumber;
     uint16_t minorNumber;
@@ -20156,8 +20156,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SkipChannel::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SkipChannel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     uint16_t count;
 
@@ -20167,8 +20167,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SkipChannel::Id; }
-    static constexpr ClusterId GetClusterId() { return TvChannel::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SkipChannel::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
 
     uint16_t count;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20279,8 +20279,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return NavigateTarget::Id; }
-    static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NavigateTarget::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     uint8_t target;
     chip::CharSpan data;
@@ -20291,8 +20291,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return NavigateTarget::Id; }
-    static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NavigateTarget::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     uint8_t target;
     chip::CharSpan data;
@@ -20310,8 +20310,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return NavigateTargetResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NavigateTargetResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     NavigateTargetStatus status;
     chip::CharSpan data;
@@ -20322,8 +20322,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return NavigateTargetResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TargetNavigator::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::NavigateTargetResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
 
     NavigateTargetStatus status;
     chip::CharSpan data;
@@ -20440,8 +20440,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaPlay::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPlay::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20449,8 +20449,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaPlay::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPlay::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20465,8 +20465,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaPlayResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPlayResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20476,8 +20476,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaPlayResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPlayResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20492,8 +20492,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaPause::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPause::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20501,8 +20501,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaPause::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPause::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20517,8 +20517,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaPauseResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPauseResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20528,8 +20528,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaPauseResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPauseResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20544,8 +20544,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaStop::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20553,8 +20553,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaStop::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStop::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20569,8 +20569,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaStopResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStopResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20580,8 +20580,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaStopResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStopResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20596,8 +20596,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaStartOver::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStartOver::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20605,8 +20605,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaStartOver::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStartOver::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20621,8 +20621,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaStartOverResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStartOverResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20632,8 +20632,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaStartOverResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaStartOverResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20648,8 +20648,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaPrevious::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPrevious::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20657,8 +20657,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaPrevious::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPrevious::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20673,8 +20673,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaPreviousResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPreviousResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20684,8 +20684,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaPreviousResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaPreviousResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20700,8 +20700,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaNext::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaNext::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20709,8 +20709,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaNext::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaNext::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20725,8 +20725,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaNextResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaNextResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20736,8 +20736,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaNextResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaNextResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20752,8 +20752,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaRewind::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaRewind::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20761,8 +20761,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaRewind::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaRewind::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20777,8 +20777,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaRewindResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaRewindResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20788,8 +20788,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaRewindResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaRewindResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20804,8 +20804,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaFastForward::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaFastForward::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -20813,8 +20813,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaFastForward::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaFastForward::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -20829,8 +20829,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaFastForwardResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaFastForwardResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20840,8 +20840,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaFastForwardResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaFastForwardResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20857,8 +20857,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaSkipForward::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipForward::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     uint64_t deltaPositionMilliseconds;
 
@@ -20868,8 +20868,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaSkipForward::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipForward::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     uint64_t deltaPositionMilliseconds;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20885,8 +20885,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaSkipForwardResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipForwardResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20896,8 +20896,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaSkipForwardResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipForwardResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20913,8 +20913,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaSkipBackward::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipBackward::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     uint64_t deltaPositionMilliseconds;
 
@@ -20924,8 +20924,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaSkipBackward::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipBackward::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     uint64_t deltaPositionMilliseconds;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20941,8 +20941,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaSkipBackwardResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipBackwardResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -20952,8 +20952,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaSkipBackwardResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSkipBackwardResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20969,8 +20969,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaSeek::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSeek::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     uint64_t position;
 
@@ -20980,8 +20980,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaSeek::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSeek::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     uint64_t position;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -20997,8 +20997,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MediaSeekResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSeekResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
 
@@ -21008,8 +21008,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MediaSeekResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaPlayback::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MediaSeekResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     MediaPlaybackStatus mediaPlaybackStatus;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -21182,8 +21182,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SelectInput::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SelectInput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     uint8_t index;
 
@@ -21193,8 +21193,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SelectInput::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SelectInput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     uint8_t index;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -21209,8 +21209,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ShowInputStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ShowInputStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21218,8 +21218,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ShowInputStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ShowInputStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21233,8 +21233,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return HideInputStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::HideInputStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21242,8 +21242,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return HideInputStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::HideInputStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21259,8 +21259,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RenameInput::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RenameInput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     uint8_t index;
     chip::CharSpan name;
@@ -21271,8 +21271,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RenameInput::Id; }
-    static constexpr ClusterId GetClusterId() { return MediaInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RenameInput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     uint8_t index;
     chip::CharSpan name;
@@ -21336,8 +21336,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Sleep::Id; }
-    static constexpr ClusterId GetClusterId() { return LowPower::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Sleep::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LowPower::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -21345,8 +21345,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Sleep::Id; }
-    static constexpr ClusterId GetClusterId() { return LowPower::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Sleep::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::LowPower::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -21498,8 +21498,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SendKey::Id; }
-    static constexpr ClusterId GetClusterId() { return KeypadInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SendKey::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
     KeypadInputCecKeyCode keyCode;
 
@@ -21509,8 +21509,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SendKey::Id; }
-    static constexpr ClusterId GetClusterId() { return KeypadInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SendKey::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
     KeypadInputCecKeyCode keyCode;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -21526,8 +21526,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SendKeyResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return KeypadInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
     KeypadInputStatus status;
 
@@ -21537,8 +21537,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SendKeyResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return KeypadInput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SendKeyResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
 
     KeypadInputStatus status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -21764,8 +21764,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LaunchContent::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchContent::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     bool autoPlay;
     chip::CharSpan data;
@@ -21776,8 +21776,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LaunchContent::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchContent::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     bool autoPlay;
     chip::CharSpan data;
@@ -21795,8 +21795,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LaunchContentResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchContentResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
@@ -21807,8 +21807,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LaunchContentResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchContentResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
@@ -21826,8 +21826,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LaunchURL::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchURL::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan contentURL;
     chip::CharSpan displayString;
@@ -21838,8 +21838,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LaunchURL::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchURL::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan contentURL;
     chip::CharSpan displayString;
@@ -21857,8 +21857,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LaunchURLResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchURLResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
@@ -21869,8 +21869,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LaunchURLResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ContentLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchURLResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
 
     chip::CharSpan data;
     ContentLaunchStatus contentLaunchStatus;
@@ -21976,8 +21976,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return SelectOutput::Id; }
-    static constexpr ClusterId GetClusterId() { return AudioOutput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SelectOutput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
     uint8_t index;
 
@@ -21987,8 +21987,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return SelectOutput::Id; }
-    static constexpr ClusterId GetClusterId() { return AudioOutput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::SelectOutput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
     uint8_t index;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22005,8 +22005,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return RenameOutput::Id; }
-    static constexpr ClusterId GetClusterId() { return AudioOutput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RenameOutput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
     uint8_t index;
     chip::CharSpan name;
@@ -22017,8 +22017,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return RenameOutput::Id; }
-    static constexpr ClusterId GetClusterId() { return AudioOutput::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::RenameOutput::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
 
     uint8_t index;
     chip::CharSpan name;
@@ -22121,8 +22121,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LaunchApp::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchApp::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     chip::CharSpan data;
     uint16_t catalogVendorId;
@@ -22134,8 +22134,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LaunchApp::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchApp::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     chip::CharSpan data;
     uint16_t catalogVendorId;
@@ -22154,8 +22154,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LaunchAppResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchAppResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     ApplicationLauncherStatus status;
     chip::CharSpan data;
@@ -22166,8 +22166,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LaunchAppResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplicationLauncher::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LaunchAppResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
 
     ApplicationLauncherStatus status;
     chip::CharSpan data;
@@ -22256,8 +22256,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return ChangeStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplicationBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
 
     ApplicationBasicStatus status;
 
@@ -22267,8 +22267,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return ChangeStatus::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplicationBasic::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::ChangeStatus::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
 
     ApplicationBasicStatus status;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22382,8 +22382,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetSetupPIN::Id; }
-    static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSetupPIN::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
 
     chip::CharSpan tempAccountIdentifier;
 
@@ -22393,8 +22393,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetSetupPIN::Id; }
-    static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSetupPIN::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
 
     chip::CharSpan tempAccountIdentifier;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22410,8 +22410,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetSetupPINResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSetupPINResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
 
     chip::CharSpan setupPIN;
 
@@ -22421,8 +22421,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetSetupPINResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetSetupPINResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
 
     chip::CharSpan setupPIN;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22439,8 +22439,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Login::Id; }
-    static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Login::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
 
     chip::CharSpan tempAccountIdentifier;
     chip::CharSpan setupPIN;
@@ -22451,8 +22451,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Login::Id; }
-    static constexpr ClusterId GetClusterId() { return AccountLogin::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Login::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
 
     chip::CharSpan tempAccountIdentifier;
     chip::CharSpan setupPIN;
@@ -22708,8 +22708,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Test::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Test::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -22717,8 +22717,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Test::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Test::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -22733,8 +22733,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestSpecificResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSpecificResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t returnValue;
 
@@ -22744,8 +22744,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestSpecificResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSpecificResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t returnValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22760,8 +22760,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestNotHandled::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNotHandled::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -22769,8 +22769,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestNotHandled::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNotHandled::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -22785,8 +22785,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestAddArgumentsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestAddArgumentsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t returnValue;
 
@@ -22796,8 +22796,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestAddArgumentsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestAddArgumentsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t returnValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22812,8 +22812,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestSpecific::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSpecific::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -22821,8 +22821,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestSpecific::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSpecific::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -22837,8 +22837,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestSimpleArgumentResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool returnValue;
 
@@ -22848,8 +22848,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestSimpleArgumentResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool returnValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22864,8 +22864,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestUnknownCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestUnknownCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -22873,8 +22873,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestUnknownCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestUnknownCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -22894,8 +22894,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestStructArrayArgumentResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestStructArrayArgumentResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<Structs::NestedStructList::Type> arg1;
     DataModel::List<Structs::SimpleStruct::Type> arg2;
@@ -22910,8 +22910,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestStructArrayArgumentResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestStructArrayArgumentResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<Structs::NestedStructList::DecodableType> arg1;
     DataModel::DecodableList<Structs::SimpleStruct::DecodableType> arg2;
@@ -22933,8 +22933,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestAddArguments::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestAddArguments::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t arg1;
     uint8_t arg2;
@@ -22945,8 +22945,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestAddArguments::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestAddArguments::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t arg1;
     uint8_t arg2;
@@ -22963,8 +22963,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestListInt8UReverseResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListInt8UReverseResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<uint8_t> arg1;
 
@@ -22974,8 +22974,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestListInt8UReverseResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListInt8UReverseResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<uint8_t> arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -22991,8 +22991,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestSimpleArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool arg1;
 
@@ -23002,8 +23002,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestSimpleArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestSimpleArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23020,8 +23020,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestEnumsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestEnumsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     chip::VendorId arg1;
     SimpleEnum arg2;
@@ -23032,8 +23032,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestEnumsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestEnumsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     chip::VendorId arg1;
     SimpleEnum arg2;
@@ -23055,8 +23055,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestStructArrayArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestStructArrayArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<Structs::NestedStructList::Type> arg1;
     DataModel::List<Structs::SimpleStruct::Type> arg2;
@@ -23071,8 +23071,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestStructArrayArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestStructArrayArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<Structs::NestedStructList::DecodableType> arg1;
     DataModel::DecodableList<Structs::SimpleStruct::DecodableType> arg2;
@@ -23095,8 +23095,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestNullableOptionalResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNullableOptionalResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool wasPresent;
     Optional<bool> wasNull;
@@ -23108,8 +23108,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestNullableOptionalResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNullableOptionalResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool wasPresent;
     Optional<bool> wasNull;
@@ -23127,8 +23127,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestStructArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestStructArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Structs::SimpleStruct::Type arg1;
 
@@ -23138,8 +23138,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestStructArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestStructArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Structs::SimpleStruct::DecodableType arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23182,8 +23182,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestComplexNullableOptionalResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestComplexNullableOptionalResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool nullableIntWasNull;
     Optional<uint16_t> nullableIntValue;
@@ -23220,8 +23220,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestComplexNullableOptionalResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestComplexNullableOptionalResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     bool nullableIntWasNull;
     Optional<uint16_t> nullableIntValue;
@@ -23264,8 +23264,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestNestedStructArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNestedStructArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Structs::NestedStruct::Type arg1;
 
@@ -23275,8 +23275,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestNestedStructArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNestedStructArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Structs::NestedStruct::DecodableType arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23292,8 +23292,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestListStructArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListStructArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<Structs::SimpleStruct::Type> arg1;
 
@@ -23303,8 +23303,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestListStructArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListStructArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<Structs::SimpleStruct::DecodableType> arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23320,8 +23320,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestListInt8UArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListInt8UArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<uint8_t> arg1;
 
@@ -23331,8 +23331,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestListInt8UArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListInt8UArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<uint8_t> arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23348,8 +23348,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestNestedStructListArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNestedStructListArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Structs::NestedStructList::Type arg1;
 
@@ -23359,8 +23359,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestNestedStructListArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNestedStructListArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Structs::NestedStructList::DecodableType arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23376,8 +23376,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestListNestedStructListArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListNestedStructListArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<Structs::NestedStructList::Type> arg1;
 
@@ -23387,8 +23387,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestListNestedStructListArgumentRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListNestedStructListArgumentRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<Structs::NestedStructList::DecodableType> arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23404,8 +23404,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestListInt8UReverseRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListInt8UReverseRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::List<uint8_t> arg1;
 
@@ -23415,8 +23415,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestListInt8UReverseRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestListInt8UReverseRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::DecodableList<uint8_t> arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23433,8 +23433,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestEnumsRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestEnumsRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     chip::VendorId arg1;
     SimpleEnum arg2;
@@ -23445,8 +23445,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestEnumsRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestEnumsRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     chip::VendorId arg1;
     SimpleEnum arg2;
@@ -23463,8 +23463,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestNullableOptionalRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNullableOptionalRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Optional<DataModel::Nullable<uint8_t>> arg1;
 
@@ -23474,8 +23474,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestNullableOptionalRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestNullableOptionalRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     Optional<DataModel::Nullable<uint8_t>> arg1;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -23502,8 +23502,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return TestComplexNullableOptionalRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestComplexNullableOptionalRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::Nullable<uint16_t> nullableInt;
     Optional<uint16_t> optionalInt;
@@ -23524,8 +23524,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return TestComplexNullableOptionalRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::TestComplexNullableOptionalRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     DataModel::Nullable<uint16_t> nullableInt;
     Optional<uint16_t> optionalInt;
@@ -23846,7 +23846,7 @@ struct Type
 public:
     static constexpr PriorityLevel priorityLevel = PriorityLevel::Info;
     static constexpr EventId eventId             = 0x00000001;
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t arg1;
     SimpleEnum arg2;
@@ -23863,7 +23863,7 @@ struct DecodableType
 public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return kEventId; }
-    static constexpr ClusterId GetClusterId() { return TestCluster::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     uint8_t arg1;
     SimpleEnum arg2;
@@ -24060,8 +24060,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return DisplayMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisplayMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     chip::BitFlags<MessagingControlMask> messageControl;
@@ -24076,8 +24076,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return DisplayMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisplayMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     chip::BitFlags<MessagingControlMask> messageControl;
@@ -24097,8 +24097,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetLastMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLastMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24106,8 +24106,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetLastMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetLastMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -24123,8 +24123,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CancelMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CancelMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     chip::BitFlags<MessagingControlMask> messageControl;
@@ -24135,8 +24135,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CancelMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CancelMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     chip::BitFlags<MessagingControlMask> messageControl;
@@ -24156,8 +24156,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return MessageConfirmation::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MessageConfirmation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     uint32_t confirmationTime;
@@ -24170,8 +24170,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return MessageConfirmation::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::MessageConfirmation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     uint32_t confirmationTime;
@@ -24195,8 +24195,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return DisplayProtectedMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisplayProtectedMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     chip::BitFlags<MessagingControlMask> messageControl;
@@ -24211,8 +24211,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return DisplayProtectedMessage::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::DisplayProtectedMessage::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t messageId;
     chip::BitFlags<MessagingControlMask> messageControl;
@@ -24233,8 +24233,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetMessageCancellation::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetMessageCancellation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t earliestImplementationTime;
 
@@ -24244,8 +24244,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetMessageCancellation::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetMessageCancellation::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t earliestImplementationTime;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -24261,8 +24261,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CancelAllMessages::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CancelAllMessages::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t implementationDateTime;
 
@@ -24272,8 +24272,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CancelAllMessages::Id; }
-    static constexpr ClusterId GetClusterId() { return Messaging::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CancelAllMessages::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     uint32_t implementationDateTime;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -24636,8 +24636,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetAlerts::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlerts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24645,8 +24645,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetAlerts::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlerts::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -24662,8 +24662,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetAlertsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlertsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     chip::BitFlags<AlertCount> alertsCount;
     DataModel::List<chip::BitFlags<AlertStructure>> alertStructures;
@@ -24674,8 +24674,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetAlertsResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetAlertsResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     chip::BitFlags<AlertCount> alertsCount;
     DataModel::DecodableList<chip::BitFlags<AlertStructure>> alertStructures;
@@ -24693,8 +24693,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return AlertsNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AlertsNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     chip::BitFlags<AlertCount> alertsCount;
     DataModel::List<chip::BitFlags<AlertStructure>> alertStructures;
@@ -24705,8 +24705,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return AlertsNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::AlertsNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     chip::BitFlags<AlertCount> alertsCount;
     DataModel::DecodableList<chip::BitFlags<AlertStructure>> alertStructures;
@@ -24724,8 +24724,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return EventsNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EventsNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     uint8_t eventHeader;
     EventIdentification eventId;
@@ -24736,8 +24736,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return EventsNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceEventsAndAlert::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::EventsNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     uint8_t eventHeader;
     EventIdentification eventId;
@@ -24785,8 +24785,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LogNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint32_t timeStamp;
     uint32_t logId;
@@ -24799,8 +24799,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LogNotification::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogNotification::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint32_t timeStamp;
     uint32_t logId;
@@ -24819,8 +24819,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LogRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint32_t logId;
 
@@ -24830,8 +24830,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LogRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint32_t logId;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -24850,8 +24850,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LogResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint32_t timeStamp;
     uint32_t logId;
@@ -24864,8 +24864,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LogResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint32_t timeStamp;
     uint32_t logId;
@@ -24883,8 +24883,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LogQueueRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogQueueRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -24892,8 +24892,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LogQueueRequest::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogQueueRequest::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -24909,8 +24909,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return LogQueueResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogQueueResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint8_t logQueueSize;
     DataModel::List<uint32_t> logIds;
@@ -24921,8 +24921,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return LogQueueResponse::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::LogQueueResponse::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint8_t logQueueSize;
     DataModel::DecodableList<uint32_t> logIds;
@@ -24940,8 +24940,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return StatisticsAvailable::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StatisticsAvailable::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint8_t logQueueSize;
     DataModel::List<uint32_t> logIds;
@@ -24952,8 +24952,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return StatisticsAvailable::Id; }
-    static constexpr ClusterId GetClusterId() { return ApplianceStatistics::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::StatisticsAvailable::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     uint8_t logQueueSize;
     DataModel::DecodableList<uint32_t> logIds;
@@ -25021,8 +25021,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetProfileInfoResponseCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetProfileInfoResponseCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     uint8_t profileCount;
     uint8_t profileIntervalPeriod;
@@ -25035,8 +25035,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetProfileInfoResponseCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetProfileInfoResponseCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     uint8_t profileCount;
     uint8_t profileIntervalPeriod;
@@ -25054,8 +25054,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetProfileInfoCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetProfileInfoCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -25063,8 +25063,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetProfileInfoCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetProfileInfoCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -25084,8 +25084,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetMeasurementProfileResponseCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileResponseCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     uint32_t startTime;
     uint8_t status;
@@ -25100,8 +25100,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetMeasurementProfileResponseCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileResponseCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     uint32_t startTime;
     uint8_t status;
@@ -25124,8 +25124,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return GetMeasurementProfileCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     uint16_t attributeId;
     uint32_t startTime;
@@ -25137,8 +25137,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return GetMeasurementProfileCommand::Id; }
-    static constexpr ClusterId GetClusterId() { return ElectricalMeasurement::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::GetMeasurementProfileCommand::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     uint16_t attributeId;
     uint32_t startTime;
@@ -26467,8 +26467,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Bind::Id; }
-    static constexpr ClusterId GetClusterId() { return Binding::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Bind::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
     chip::NodeId nodeId;
     chip::GroupId groupId;
@@ -26481,8 +26481,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Bind::Id; }
-    static constexpr ClusterId GetClusterId() { return Binding::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Bind::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
     chip::NodeId nodeId;
     chip::GroupId groupId;
@@ -26504,8 +26504,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return Unbind::Id; }
-    static constexpr ClusterId GetClusterId() { return Binding::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Unbind::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
     chip::NodeId nodeId;
     chip::GroupId groupId;
@@ -26518,8 +26518,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return Unbind::Id; }
-    static constexpr ClusterId GetClusterId() { return Binding::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::Unbind::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
 
     chip::NodeId nodeId;
     chip::GroupId groupId;
@@ -26674,8 +26674,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CommandOne::Id; }
-    static constexpr ClusterId GetClusterId() { return SampleMfgSpecificCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommandOne::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster::Id; }
 
     uint8_t argOne;
 
@@ -26685,8 +26685,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CommandOne::Id; }
-    static constexpr ClusterId GetClusterId() { return SampleMfgSpecificCluster::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommandOne::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster::Id; }
 
     uint8_t argOne;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
@@ -26750,8 +26750,8 @@ struct Type
 {
 public:
     // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
-    static constexpr CommandId GetCommandId() { return CommandTwo::Id; }
-    static constexpr ClusterId GetClusterId() { return SampleMfgSpecificCluster2::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommandTwo::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster2::Id; }
 
     uint8_t argOne;
 
@@ -26761,8 +26761,8 @@ public:
 struct DecodableType
 {
 public:
-    static constexpr CommandId GetCommandId() { return CommandTwo::Id; }
-    static constexpr ClusterId GetClusterId() { return SampleMfgSpecificCluster2::Id; }
+    static constexpr CommandId GetCommandId() { return Commands::CommandTwo::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster2::Id; }
 
     uint8_t argOne;
     CHIP_ERROR Decode(TLV::TLVReader & reader);


### PR DESCRIPTION
If the name of a cluster happens to overlap with the name of some
other construct (e.g. a command), we can get the wrong ids like so:

    static constexpr CommandId GetCommandId() { return Identify::Id; }
    static constexpr ClusterId GetClusterId() { return Identify::Id; }

The solution, for now, is to prefix with Cluster:: and Command:: as needed.

#### Problem
See above

#### Change overview
See above

#### Testing
End-to-end test that catches this problem added.