### PR TITLE
Add a complete diff of the changes to the ZAP job.

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -61,5 +61,9 @@ jobs:
             - name: Check for uncommited changes
               run: |
                 git add .
-                git diff-index HEAD --
-                git diff-index --quiet HEAD --
+                # Show the full diff
+                git diff-index -p HEAD --
+                # Also show just the files that are different, to make it easy
+                # to tell at a glance what might be going on.  And throw in
+                # --exit-code to make this job fail if there is a difference.
+                git diff-index --exit-code HEAD --


### PR DESCRIPTION
This makes it clearer why the job is failing, exactly.

#### Problem
ZAP job shows which files did not match a full regen, but it can be hard to tell why that happened.

#### Change overview
Show a full diff before the file list.

#### Testing
Tried this in CI in my fork.