### PR TITLE
[core] Add MEI Type and utility functions

### DIFF
--- a/src/lib/core/MEI.h
+++ b/src/lib/core/MEI.h
@@ -18,29 +18,33 @@
 #pragma once
 
 #include <cstdint>
-#include <lib/core/MEI.h>
 
 namespace chip {
 
-typedef uint8_t ActionId;
+namespace MEI {
+typedef uint16_t PrefixType;
+typedef uint16_t SuffixType;
+typedef uint32_t Type;
 
-typedef MEI::Type DeviceTypeId; // 7.17.2.13
-typedef MEI::Type ClusterId;    // 7.17.2.14
-typedef MEI::Type AttributeId;  // 7.17.2.15
-typedef MEI::Type FieldId;      // 7.17.2.16
-typedef MEI::Type EventId;      // 7.17.2.17
-typedef MEI::Type CommandId;    // 7.17.2.18
+/**
+ * 7.18.2.1 MEI Encoding
+ * Suffix 0x0000 - 0xFFFE : Item 0 to 65534
+ * Suffix 0xFFFF          : Wildcard
+ */
+constexpr Type kSuffixMask           = 0x0000'FFFF;
+constexpr Type kPrefixMask           = 0xFFFF'0000;
+constexpr Type kWildcard             = 0xFFFF'FFFF;
 
-typedef uint8_t ClusterStatus;
-typedef uint32_t DataVersion;
-typedef uint16_t EndpointId;
-typedef uint64_t EventNumber;
-typedef uint64_t FabricId;
-typedef uint8_t FabricIndex;
-typedef uint16_t ListIndex;
-typedef uint32_t TransactionId;
+constexpr SuffixType GetSuffix(Type id)
+{
+    return static_cast<SuffixType>(id & kSuffixMask);
+}
 
-static constexpr FabricIndex kUndefinedFabricIndex = 0;
+constexpr PrefixType GetPrefix(Type id)
+{
+    return static_cast<PrefixType>((id & kPrefixMask) >> 16);
+}
 
-constexpr EndpointId kWildcardEndpointId = 0xFFFF;
+} // namespace MEI
+
 } // namespace chip

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
     "TestCHIPCallback.cpp",
     "TestCHIPErrorStr.cpp",
     "TestCHIPTLV.cpp",
+    "TestMEI.cpp",
     "TestOptional.cpp",
     "TestReferenceCounted.cpp",
   ]

--- a/src/lib/core/tests/TestMEI.cpp
+++ b/src/lib/core/tests/TestMEI.cpp
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a test for  CHIP core library reference counted object.
+ *
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+static void TestMEI(nlTestSuite * inSuite, void * inContext)
+{
+    {
+        ClusterId clusterId = 0x1234'5678;
+        NL_TEST_ASSERT(inSuite, MEI::GetPrefix(clusterId) == 0x1234);
+        NL_TEST_ASSERT(inSuite, MEI::GetSuffix(clusterId) == 0x5678);
+    }
+}
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestMEI", TestMEI),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestMEI_Setup(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestMEI_Teardown(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestMEI(void)
+{
+    // clang-format off
+    nlTestSuite theSuite =
+    {
+        "MEI",
+        &sTests[0],
+        TestMEI_Setup,
+        TestMEI_Teardown
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestMEI)


### PR DESCRIPTION
#### Problem
We have seperate typedef-s for data model types.

#### Change overview
Create a chip::MEI::Type class.

By adding this type, we can avoid duplicate `*Wildcard`, `*PrefixMask` (since it will be reasonable to share the one under MEI namespace) and be type safe.

Added spec section number between the typedefs.

#### Testing
Build pass