### PR TITLE
Decrease size for interaction model object pools (use 1/2 the current value)

### DIFF
--- a/examples/platform/qpg/project_include/CHIPProjectConfig.h
+++ b/examples/platform/qpg/project_include/CHIPProjectConfig.h
@@ -148,3 +148,77 @@
  *    their access control lists.
  */
 #define CHIP_CONFIG_MAX_DEVICE_ADMINS 4 // 3 fabrics + 1 for rotation slack
+
+/**
+ *  @name Interaction Model object pool configuration.
+ *
+ *  @brief
+ *    The following definitions sets the maximum number of corresponding interaction model object pool size.
+ *
+ *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *      * #CHIP_IM_MAX_NUM_COMMAND_SENDER
+ *      * #CHIP_IM_MAX_NUM_READ_HANDLER
+ *      * #CHIP_IM_MAX_NUM_READ_CLIENT
+ *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ *  @{
+ */
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *
+ * @brief Defines the maximum number of CommandHandler, limits the number of active commands transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_COMMAND_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_SENDER
+ *
+ * @brief Defines the maximum number of CommandSender, limits the number of active command transactions on client.
+ */
+#define CHIP_IM_MAX_NUM_COMMAND_SENDER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_HANDLER
+ *
+ * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_READ_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_CLIENT
+ *
+ * @brief Defines the maximum number of ReadClient, limits the number of active read transactions on client.
+ */
+#define CHIP_IM_MAX_NUM_READ_CLIENT 2
+
+/**
+ * @def CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *
+ * @brief Defines the maximum number of Reports, limits the traffic of read and subscription transactions.
+ */
+#define CHIP_IM_MAX_REPORTS_IN_FLIGHT 2
+
+/**
+ * @def CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *
+ * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
+ */
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 4
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *
+ * @brief Defines the maximum number of WriteHandler, limits the number of active write transactions on server.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_HANDLER 2
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ * @brief Defines the maximum number of WriteClient, limits the number of active write transactions on client.
+ */
+#define CHIP_IM_MAX_NUM_WRITE_CLIENT 2

--- a/examples/platform/qpg/project_include/CHIPProjectConfig.h
+++ b/examples/platform/qpg/project_include/CHIPProjectConfig.h
@@ -186,7 +186,7 @@
  *
  * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
  */
-#define CHIP_IM_MAX_NUM_READ_HANDLER 2
+#define CHIP_IM_MAX_NUM_READ_HANDLER 3
 
 /**
  * @def CHIP_IM_MAX_NUM_READ_CLIENT
@@ -207,7 +207,7 @@
  *
  * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
  */
-#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 4
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 9
 
 /**
  * @def CHIP_IM_MAX_NUM_WRITE_HANDLER


### PR DESCRIPTION
#### Problem
Interaction model pools occupy a lot of space and could be optimized for certain projects.

#### Change overview
This PR reduces the number of buffer pools allocated for each class by a factor of 2.

#### Testing
This was tested by establishing a BLE secure session, commissioning on Thread and running a series of zcl interactions with the device.
