### PR TITLE
[nrfconnect] Add low-power configuration to lock-app

### DIFF
--- a/examples/lock-app/nrfconnect/Kconfig
+++ b/examples/lock-app/nrfconnect/Kconfig
@@ -1,0 +1,26 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+mainmenu "Matter nRF Connect Lock Example Application"
+
+config STATE_LEDS
+	bool "Use LEDs to indicate the device state"
+	default y
+	help
+	  Use LEDs to render the current state of the device such as the progress of commissioning of
+	  the device into a network or the factory reset initiation. Note that setting this option to
+	  'n' does not disable the LED indicating the state of the simulated bolt.
+
+source "Kconfig.zephyr"

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -378,7 +378,6 @@ For example, use the following command for `nrf52840dk_nrf52840`:
 
     $ west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=overlay-low_power.conf
 
-
 ### Building with Device Firmware Upgrade support
 
 To build the example with configuration that enables DFU, run the following

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -33,6 +33,7 @@ into an existing Matter network and can be controlled by this network.
 -   [Building](#building)
     -   [Removing build artifacts](#removing-build-artifacts)
     -   [Building with release configuration](#building-with-release-configuration)
+    -   [Building with low-power configuration](#building-with-low-power-configuration)
     -   [Building with Device Firmware Upgrade support](#building-with-device-firmware-upgrade-support)
 -   [Configuring the example](#configuring-the-example)
 -   [Flashing and debugging](#flashing-and-debugging)
@@ -360,6 +361,23 @@ features like logs and command-line interface, run the following command:
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
+
+### Building with low-power configuration
+
+You can build the example using the low-power configuration, which enables
+Thread's Sleepy End Device mode and disables debug features, such as the UART
+console or the **LED 1** usage.
+
+To build for the low-power configuration, run the following command with
+_build-target_ replaced with the build target name of the Nordic Semiconductor's
+kit you own (for example `nrf52840dk_nrf52840`):
+
+    $ west build -b build-target -- -DOVERLAY_CONFIG=overlay-low_power.conf
+
+For example, use the following command for `nrf52840dk_nrf52840`:
+
+    $ west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=overlay-low_power.conf
+
 
 ### Building with Device Firmware Upgrade support
 

--- a/examples/lock-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
@@ -25,3 +25,29 @@
 		zephyr,entropy = &rng;
 	};
 };
+
+/* Disable unused peripherals to reduce power consumption */
+&adc {
+	status = "disabled";
+};
+&uart1 {
+	status = "disabled";
+};
+&gpio1 {
+	status = "disabled";
+};
+&i2c0 {
+	status = "disabled";
+};
+&pwm0 {
+	status = "disabled";
+};
+&spi1 {
+	status = "disabled";
+};
+&spi3 {
+	status = "disabled";
+};
+&usbd {
+	status = "disabled";
+};

--- a/examples/lock-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -60,3 +60,23 @@
 	};
 
 };
+
+/* Disable unused peripherals to reduce power consumption */
+&adc {
+	status = "disabled";
+};
+&gpio1 {
+	status = "disabled";
+};
+&i2c1 {
+	status = "disabled";
+};
+&pwm0 {
+	status = "disabled";
+};
+&spi2 {
+	status = "disabled";
+};
+&usbd {
+	status = "disabled";
+};

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -212,6 +212,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
         sAppTask.StartTimer(FACTORY_RESET_CANCEL_WINDOW_TIMEOUT);
         sAppTask.mFunction = kFunction_FactoryReset;
 
+#ifdef CONFIG_STATE_LEDS
         // Turn off all LEDs before starting blink to make sure blink is co-ordinated.
         sStatusLED.Set(false);
         sLockLED.Set(false);
@@ -222,6 +223,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
         sLockLED.Blink(500);
         sUnusedLED.Blink(500);
         sUnusedLED_1.Blink(500);
+#endif
     }
     else if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_FactoryReset)
     {
@@ -357,6 +359,7 @@ void AppTask::LEDStateUpdateHandler(LEDWidget & ledWidget)
 
 void AppTask::UpdateStatusLED()
 {
+#ifdef CONFIG_STATE_LEDS
     /* Update the status LED.
      *
      * If thread and service provisioned, keep the LED On constantly.
@@ -377,6 +380,7 @@ void AppTask::UpdateStatusLED()
     {
         sStatusLED.Blink(50, 950);
     }
+#endif
 }
 
 void AppTask::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */)

--- a/examples/lock-app/nrfconnect/main/main.cpp
+++ b/examples/lock-app/nrfconnect/main/main.cpp
@@ -66,12 +66,33 @@ int main()
         goto exit;
     }
 
+#ifdef CONFIG_OPENTHREAD_MTD_SED
+    err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
+    if (err != CHIP_NO_ERROR)
+    {
+        LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
+        goto exit;
+    }
+
+    ConnectivityManager::ThreadPollingConfig pollingConfig;
+    pollingConfig.Clear();
+    pollingConfig.ActivePollingIntervalMS   = CONFIG_OPENTHREAD_POLL_PERIOD;
+    pollingConfig.InactivePollingIntervalMS = CONFIG_OPENTHREAD_POLL_PERIOD;
+
+    err = ConnectivityMgr().SetThreadPollingConfig(pollingConfig);
+    if (err != CHIP_NO_ERROR)
+    {
+        LOG_ERR("ConnectivityMgr().SetThreadPollingConfig() failed");
+        goto exit;
+    }
+#else
     err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
     if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         goto exit;
     }
+#endif
 
     ret = GetAppTask().StartApp();
     if (ret != 0)

--- a/examples/lock-app/nrfconnect/overlay-low_power.conf
+++ b/examples/lock-app/nrfconnect/overlay-low_power.conf
@@ -1,0 +1,31 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Enable MTD Sleepy End Device
+CONFIG_OPENTHREAD_MTD_SED=y
+CONFIG_OPENTHREAD_POLL_PERIOD=2000
+
+# Disable UART console
+CONFIG_SHELL=n
+CONFIG_LOG=n
+CONFIG_UART_CONSOLE=n
+CONFIG_SERIAL=n
+
+# Suspend devices when the CPU goes to sleep
+CONFIG_PM_DEVICE=y
+
+# Disable auxiliary state LEDs
+CONFIG_STATE_LEDS=n


### PR DESCRIPTION
#### Problem
There's currently no nRF Connect example for testing OpenThread's Sleepy End Device mode.

#### Change overview
Provide configuration overlay to build nRF Connect lock-app with reduced power consumption. The overlay enables
OpenThread's SED mode and disables debug features such as the UART console.

#### Testing
Built and commissioned nRF Connect lock-app with the low-power configuration.
