### PR TITLE
Size reports: Stop running bloat_check.py

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -38,12 +38,6 @@ jobs:
 
             - name: Report
               run: |
-                  scripts/helpers/bloat_check.py                        \
-                       --github-repository project-chip/connectedhomeip \
-                       --github-api-token "${{ secrets.GITHUB_TOKEN }}"
-
-            - name: Report2
-              run: |
                   scripts/tools/memory/gh_report.py \
                     --verbose \
                     --report-increases 1 \

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -41,7 +41,6 @@ jobs:
             image: connectedhomeip/chip-build-efr32:latest
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -83,26 +82,6 @@ jobs:
                   scripts/examples/gn_efr32_example.sh examples/window-app/efr32/ out/window_app_debug BRD4161A
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A window-app \
                     out/window_app_debug/BRD4161A/chip-efr32-window-example.out /tmp/bloat_reports/
-            - name: Binary artifact suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-            - name: Uploading Binaries
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-example-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: |
-                      out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out
-                      out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out.map
-                      out/lighting_app_debug_rpc/BRD4161A/chip-efr32-lighting-example.out
-                      out/lighting_app_debug_rpc/BRD4161A/chip-efr32-lighting-example.out.map
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -41,7 +41,6 @@ jobs:
             image: connectedhomeip/chip-build-esp32:latest
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
 
         steps:
             - name: Checkout
@@ -104,25 +103,6 @@ jobs:
             - name: Build example IPv6 Only App
               timeout-minutes: 10
               run: scripts/examples/esp_example.sh ipv6only-app sdkconfig.defaults
-            - name: Binary artifact suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-            - name: Copy aside bloat report & binaries
-              run: |
-                  cp -r example_binaries/$BUILD_TYPE-build /tmp/output_binaries/
-            - name: Uploading Binaries
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-example-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -40,7 +40,6 @@ jobs:
             image: connectedhomeip/chip-build-k32w:latest
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -84,24 +83,6 @@ jobs:
                     k32w k32w061+se05x+release lighting-app \
                     out/lighting_app_se_release/chip-k32w061-light-example \
                     /tmp/bloat_reports/
-            - name: Binary artifact suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-            - name: Uploading Binaries
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-example-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: |
-                      out/lock_app_debug/chip-k32w061-lock-example.out
-                      out/lock_app_debug/chip-k32w061-lock-example.out.map
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -40,7 +40,6 @@ jobs:
             image: connectedhomeip/chip-build:0.5.22
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
 
         steps:
             - name: Checkout
@@ -124,24 +123,6 @@ jobs:
                     linux debug ota-requestor-app \
                     out/ota_requestor_debug/chip-ota-requestor-app \
                     /tmp/bloat_reports/
-            - name: Binary artifact suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-            - name: Uploading Binaries
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-example-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: |
-                      out/all_clusters_debug/all-clusters-server
-                      out/all_clusters_debug/all-clusters-server.map
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -43,7 +43,6 @@ jobs:
             image: connectedhomeip/chip-build-mbed-os:0.5.22
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
 
         steps:
             - name: Checkout
@@ -103,34 +102,6 @@ jobs:
             - name: Build unit tests
               timeout-minutes: 10
               run: scripts/tests/mbed/mbed_unit_tests.sh -b=$APP_TARGET -p=$APP_PROFILE
-
-            - name: Copy aside build products
-              run: |
-                  mkdir -p /tmp/output_binaries/$BUILD_TYPE-build
-                  cp examples/lock-app/mbed/build-$APP_TARGET/$APP_PROFILE/chip-mbed-lock-app-example.hex \
-                     /tmp/output_binaries/$BUILD_TYPE-build/lock-app-$APP_TARGET-$APP_PROFILE.hex
-                  cp examples/lighting-app/mbed/build-$APP_TARGET/$APP_PROFILE/chip-mbed-lighting-app-example.hex \
-                     /tmp/output_binaries/$BUILD_TYPE-build/lighting-app-$APP_TARGET-$APP_PROFILE.hex
-                  cp examples/all-clusters-app/mbed/build-$APP_TARGET/$APP_PROFILE/chip-mbed-all-clusters-app-example.hex \
-                     /tmp/output_binaries/$BUILD_TYPE-build/all-clusters-app-$APP_TARGET-$APP_PROFILE.hex
-
-            - name: Binary artifacts suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-
-            - name: Uploading binaries as artifacts
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-binaries-${{ env.APP_TARGET }}-${{ env.APP_PROFILE }}-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -40,7 +40,6 @@ jobs:
             image: connectedhomeip/chip-build-nrf-platform:0.5.22
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
 
         steps:
             - name: Checkout
@@ -145,29 +144,6 @@ jobs:
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh "scripts/tests/nrfconnect_native_posix_tests.sh native_posix_64"
-            - name: Copy aside build products
-              run: |
-                  mkdir -p /tmp/output_binaries/$BUILD_TYPE-build
-                  cp examples/lock-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
-                      /tmp/output_binaries/$BUILD_TYPE-build/chip-lock.elf
-                  cp examples/shell/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
-                      /tmp/output_binaries/$BUILD_TYPE-build/chip-shell.elf
-            - name: Binary artifact suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-            - name: Uploading Binaries
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-example-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -40,7 +40,6 @@ jobs:
             image: connectedhomeip/chip-build:0.5.22
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
-                - "/tmp/output_binaries:/tmp/output_binaries"
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -86,24 +85,6 @@ jobs:
               timeout-minutes: 5
               run: |
                   config/qpg/chip-gn/build.sh
-            - name: Binary artifact suffix
-              id: outsuffix
-              uses: haya14busa/action-cond@v1.0.0
-              if: ${{ !env.ACT }}
-              with:
-                  cond: ${{ github.event.pull_request.number == '' }}
-                  if_true: "${{ github.sha }}"
-                  if_false: "pull-${{ github.event.pull_request.number }}"
-            - name: Uploading Binaries
-              uses: actions/upload-artifact@v2
-              if: ${{ !env.ACT }}
-              with:
-                  name:
-                      ${{ env.BUILD_TYPE }}-example-build-${{
-                      steps.outsuffix.outputs.value }}
-                  path: |
-                      out/lighting_app_debug/chip-qpg6100-lighting-example.out
-                      out/lighting_app_debug/chip-qpg6100-lighting-example.out.map
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}


### PR DESCRIPTION
#### Problem

Size reports from `bloat_check.py` are now redundant.

#### Change overview

- Remove running `scripts/helpers/bloat_check.py` from the Bloat
  Check workflow.
- Stop uploading binary artifacts in build workflows.

#### Testing

None; can only be exercised on GitHub.
