### PR TITLE
Fix kMaxIfNameLength constant scoping after #10979

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -55,7 +55,7 @@ constexpr size_t kMaxHardwareAddrSize = 8;
 
 struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::Type
 {
-    char Name[Inet::InterfaceIterator::kMaxIfNameLength];
+    char Name[Inet::InterfaceId::kMaxIfNameLength];
     uint8_t MacAddress[kMaxHardwareAddrSize];
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1068,8 +1068,8 @@ CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(NetworkInterface ** ne
             {
                 NetworkInterface * ifp = new NetworkInterface();
 
-                strncpy(ifp->Name, ifa->ifa_name, Inet::InterfaceIterator::kMaxIfNameLength);
-                ifp->Name[Inet::InterfaceIterator::kMaxIfNameLength - 1] = '\0';
+                strncpy(ifp->Name, ifa->ifa_name, Inet::InterfaceId::kMaxIfNameLength);
+                ifp->Name[Inet::InterfaceId::kMaxIfNameLength - 1] = '\0';
 
                 ifp->name                            = CharSpan(ifp->Name, strlen(ifp->Name));
                 ifp->fabricConnected                 = ifa->ifa_flags & IFF_RUNNING;


### PR DESCRIPTION
#### Problem
ToT build broken

#### Change overview
Update name from `Inet::InterfaceIterator::kMaxIfNameLength` to `Inet::InterfaceId::kMaxIfNameLength`

#### Testing
Compled chip-tool on linux: used to fail after the patch it passes.
