### PR TITLE
Size reports: Change the highlight threshold.

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -46,7 +46,7 @@ jobs:
               run: |
                   scripts/tools/memory/gh_report.py \
                     --verbose \
-                    --report-increases 1 \
+                    --report-increases 0.2 \
                     --report-pr \
                     --github-comment \
                     --github-limit-artifact-pages 50 \


### PR DESCRIPTION
#### Problem

Size report comments should highlight a reasonable number of size
increases — enough to flag significant changes, but no so many that
they cause fatigue.

#### Change overview

Changed the threshold to 0.2%, which, based on recent commits,
should trigger on about 20% of PRs (note: not 20% of builds).

#### Testing

Offline runs on past data.
