### PR TITLE
Use safer System::Clock types in dnssd

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -513,14 +513,14 @@ CHIP_ERROR MinMdnsResolver::ScheduleResolveRetries()
     ReturnErrorCodeIf(mSystemLayer == nullptr, CHIP_ERROR_INCORRECT_STATE);
     mSystemLayer->CancelTimer(&ResolveRetryCallback, this);
 
-    Optional<uint32_t> delayMs = mActiveResolves.GetMsUntilNextExpectedResponse();
+    Optional<System::Clock::Timeout> delay = mActiveResolves.GetTimeUntilNextExpectedResponse();
 
-    if (!delayMs.HasValue())
+    if (!delay.HasValue())
     {
         return CHIP_NO_ERROR;
     }
 
-    return mSystemLayer->StartTimer(System::Clock::Milliseconds32(delayMs.Value()), &ResolveRetryCallback, this);
+    return mSystemLayer->StartTimer(delay.Value(), &ResolveRetryCallback, this);
 }
 
 void MinMdnsResolver::ResolveRetryCallback(System::Layer *, void * self)

--- a/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.cpp
@@ -26,6 +26,8 @@ using namespace chip;
 namespace mdns {
 namespace Minimal {
 
+constexpr chip::System::Clock::Timeout ActiveResolveAttempts::kMaxRetryDelay;
+
 void ActiveResolveAttempts::Reset()
 
 {
@@ -56,9 +58,9 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
     // Strategy when picking the peer id to use:
     //   1 if a matching peer id is already found, use that one
     //   2 if an 'unused' entry is found, use that
-    //   3 otherwise expire the one with the largest nextRetryDelaySec
-    //     or if equal nextRetryDelaySec, pick the one with the oldest
-    //     queryDueTimeMs
+    //   3 otherwise expire the one with the largest nextRetryDelay
+    //     or if equal nextRetryDelay, pick the one with the oldest
+    //     queryDueTime
 
     RetryEntry * entryToUse = &mRetryQueue[0];
 
@@ -94,12 +96,12 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
         //    - on same delay, use queryDueTime to determine the oldest request
         //      (the one with the smallest  due time was issued the longest time
         //       ago)
-        if (entry->nextRetryDelaySec > entryToUse->nextRetryDelaySec)
+        if (entry->nextRetryDelay > entryToUse->nextRetryDelay)
         {
             entryToUse = entry;
         }
-        else if ((entry->nextRetryDelaySec == entryToUse->nextRetryDelaySec) &&
-                 (entry->queryDueTimeMs < entryToUse->queryDueTimeMs))
+        else if ((entry->nextRetryDelay == entryToUse->nextRetryDelay) &&
+                 (entry->queryDueTime < entryToUse->queryDueTime))
         {
             entryToUse = entry;
         }
@@ -118,15 +120,15 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
     }
 
     entryToUse->peerId            = peerId;
-    entryToUse->queryDueTimeMs    = mClock->GetMonotonicMilliseconds();
-    entryToUse->nextRetryDelaySec = 1;
+    entryToUse->queryDueTime    = mClock->GetMonotonicTimestamp();
+    entryToUse->nextRetryDelay = System::Clock::Seconds16(1);
 }
 
-Optional<uint32_t> ActiveResolveAttempts::GetMsUntilNextExpectedResponse() const
+Optional<System::Clock::Timeout> ActiveResolveAttempts::GetTimeUntilNextExpectedResponse() const
 {
-    Optional<uint32_t> minDelay = Optional<uint32_t>::Missing();
+    Optional<System::Clock::Timeout> minDelay = Optional<System::Clock::Timeout>::Missing();
 
-    chip::System::Clock::MonotonicMilliseconds nowMs = mClock->GetMonotonicMilliseconds();
+    chip::System::Clock::Timestamp now = mClock->GetMonotonicTimestamp();
 
     for (auto & entry : mRetryQueue)
     {
@@ -135,13 +137,13 @@ Optional<uint32_t> ActiveResolveAttempts::GetMsUntilNextExpectedResponse() const
             continue;
         }
 
-        if (nowMs >= entry.queryDueTimeMs)
+        if (now >= entry.queryDueTime)
         {
             // found an entry that needs processing right now
-            return Optional<uint32_t>::Value(0);
+            return Optional<System::Clock::Timeout>::Value(0);
         }
 
-        uint32_t entryDelay = static_cast<int>(entry.queryDueTimeMs - nowMs);
+        System::Clock::Timeout entryDelay = entry.queryDueTime - now;
         if (!minDelay.HasValue() || (minDelay.Value() > entryDelay))
         {
             minDelay.SetValue(entryDelay);
@@ -153,7 +155,7 @@ Optional<uint32_t> ActiveResolveAttempts::GetMsUntilNextExpectedResponse() const
 
 Optional<PeerId> ActiveResolveAttempts::NextScheduledPeer()
 {
-    chip::System::Clock::MonotonicMilliseconds nowMs = mClock->GetMonotonicMilliseconds();
+    chip::System::Clock::Timestamp now = mClock->GetMonotonicTimestamp();
 
     for (auto & entry : mRetryQueue)
     {
@@ -162,20 +164,20 @@ Optional<PeerId> ActiveResolveAttempts::NextScheduledPeer()
             continue; // not a pending item
         }
 
-        if (entry.queryDueTimeMs > nowMs)
+        if (entry.queryDueTime > now)
         {
             continue; // not yet due
         }
 
-        if (entry.nextRetryDelaySec > kMaxRetryDelaySec)
+        if (entry.nextRetryDelay > kMaxRetryDelay)
         {
             ChipLogError(Discovery, "Timeout waiting for mDNS resolution.");
             entry.peerId.SetNodeId(kUndefinedNodeId);
             continue;
         }
 
-        entry.queryDueTimeMs = nowMs + entry.nextRetryDelaySec * 1000L;
-        entry.nextRetryDelaySec *= 2;
+        entry.queryDueTime = now + entry.nextRetryDelay;
+        entry.nextRetryDelay *= 2;
 
         return Optional<PeerId>::Value(entry.peerId);
     }

--- a/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.cpp
@@ -100,8 +100,7 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
         {
             entryToUse = entry;
         }
-        else if ((entry->nextRetryDelay == entryToUse->nextRetryDelay) &&
-                 (entry->queryDueTime < entryToUse->queryDueTime))
+        else if ((entry->nextRetryDelay == entryToUse->nextRetryDelay) && (entry->queryDueTime < entryToUse->queryDueTime))
         {
             entryToUse = entry;
         }
@@ -119,8 +118,8 @@ void ActiveResolveAttempts::MarkPending(const PeerId & peerId)
         ChipLogError(Discovery, "Re-using pending resolve entry before reply was received.");
     }
 
-    entryToUse->peerId            = peerId;
-    entryToUse->queryDueTime    = mClock->GetMonotonicTimestamp();
+    entryToUse->peerId         = peerId;
+    entryToUse->queryDueTime   = mClock->GetMonotonicTimestamp();
     entryToUse->nextRetryDelay = System::Clock::Seconds16(1);
 }
 

--- a/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.h
@@ -39,7 +39,7 @@ class ActiveResolveAttempts
 {
 public:
     static constexpr size_t kRetryQueueSize     = 4;
-    static constexpr uint32_t kMaxRetryDelaySec = 16;
+    static constexpr chip::System::Clock::Timeout kMaxRetryDelay = chip::System::Clock::Seconds16(16);
 
     ActiveResolveAttempts(chip::System::Clock::ClockBase * clock) : mClock(clock) { Reset(); }
 
@@ -55,10 +55,10 @@ public:
     /// by NextScheduledPeer (potentially with others as well)
     void MarkPending(const chip::PeerId & peerId);
 
-    // Get minimum milliseconds until the next pending reply is required.
+    // Get minimum time until the next pending reply is required.
     //
     // Returns missing if no actively tracked elements exist.
-    chip::Optional<uint32_t> GetMsUntilNextExpectedResponse() const;
+    chip::Optional<chip::System::Clock::Timeout> GetTimeUntilNextExpectedResponse() const;
 
     // Get the peer Id that needs scheduling for a query
     //
@@ -79,7 +79,7 @@ private:
         chip::PeerId peerId;
 
         // When a reply is expected for this item
-        chip::System::Clock::MonotonicMilliseconds queryDueTimeMs;
+        chip::System::Clock::Timestamp queryDueTime;
 
         // Next expected delay for sending if reply is not reached by
         // 'queryDueTimeMs'
@@ -89,7 +89,7 @@ private:
         //      one second
         //    - the intervals between successive queries MUST increase by at
         //      least a factor of two
-        uint32_t nextRetryDelaySec = 1;
+        chip::System::Clock::Timeout nextRetryDelay = chip::System::Clock::Seconds16(1);
     };
 
     chip::System::Clock::ClockBase * mClock;

--- a/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/minimal_mdns/ActiveResolveAttempts.h
@@ -38,7 +38,7 @@ namespace Minimal {
 class ActiveResolveAttempts
 {
 public:
-    static constexpr size_t kRetryQueueSize     = 4;
+    static constexpr size_t kRetryQueueSize                      = 4;
     static constexpr chip::System::Clock::Timeout kMaxRetryDelay = chip::System::Clock::Seconds16(16);
 
     ActiveResolveAttempts(chip::System::Clock::ClockBase * clock) : mClock(clock) { Reset(); }

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
 
     // send all 'Answer' replies
     {
-        const uint64_t kTimeNowMs = chip::System::SystemClock().GetMonotonicMilliseconds();
+        const chip::System::Clock::Timestamp kTimeNow = chip::System::SystemClock().GetMonotonicTimestamp();
 
         QueryReplyFilter queryReplyFilter(query);
         QueryResponderRecordFilter responseFilter;
@@ -102,8 +102,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
             //
             // TODO: the 'last sent' value does NOT track the interface we used to send, so this may cause
             //       broadcasts on one interface to throttle broadcasts on another interface.
-            constexpr uint64_t kOneSecondMs = 1000;
-            responseFilter.SetIncludeOnlyMulticastBeforeMS(kTimeNowMs - kOneSecondMs);
+            responseFilter.SetIncludeOnlyMulticastBeforeMS(kTimeNow - chip::System::Clock::Seconds32(1));
         }
         for (size_t i = 0; i < kMaxQueryResponders; ++i)
         {
@@ -120,7 +119,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
 
                 if (!mSendState.SendUnicast())
                 {
-                    it->lastMulticastTime = kTimeNowMs;
+                    it->lastMulticastTime = kTimeNow;
                 }
             }
         }

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
@@ -160,7 +160,7 @@ void QueryResponderBase::ClearBroadcastThrottle()
 {
     for (size_t i = 0; i < mResponderInfoSize; i++)
     {
-        mResponderInfos[i].lastMulticastTime = 0;
+        mResponderInfos[i].lastMulticastTime = chip::System::Clock::Zero;
     }
 }
 

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -31,7 +31,7 @@ struct QueryResponderRecord
 {
     Responder * responder      = nullptr; // what response/data is available
     bool reportService         = false;   // report as a service when listing dnssd services
-    uint64_t lastMulticastTime = 0;       // last time this record was multicast
+    chip::System::Clock::Timestamp lastMulticastTime { 0 };       // last time this record was multicast
 };
 
 namespace Internal {
@@ -122,9 +122,9 @@ public:
 
     /// Filter out anything that was multicast past ms.
     /// If ms is 0, no filtering is done
-    QueryResponderRecordFilter & SetIncludeOnlyMulticastBeforeMS(uint64_t ms)
+    QueryResponderRecordFilter & SetIncludeOnlyMulticastBeforeMS(chip::System::Clock::Timestamp time)
     {
-        mIncludeOnlyMulticastBeforeMS = ms;
+        mIncludeOnlyMulticastBefore = time;
         return *this;
     }
 
@@ -140,7 +140,7 @@ public:
             return false;
         }
 
-        if ((mIncludeOnlyMulticastBeforeMS > 0) && (record->lastMulticastTime >= mIncludeOnlyMulticastBeforeMS))
+        if ((mIncludeOnlyMulticastBefore > chip::System::Clock::Zero) && (record->lastMulticastTime >= mIncludeOnlyMulticastBefore))
         {
             return false;
         }
@@ -156,7 +156,7 @@ public:
 private:
     bool mIncludeAdditionalRepliesOnly     = false;
     ReplyFilter * mReplyFilter             = nullptr;
-    uint64_t mIncludeOnlyMulticastBeforeMS = 0;
+    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore { 0 };
 };
 
 /// Iterates over an array of QueryResponderRecord items, providing only 'valid' ones, where

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -29,9 +29,9 @@ namespace Minimal {
 /// Represents available data (replies) for mDNS queries.
 struct QueryResponderRecord
 {
-    Responder * responder      = nullptr; // what response/data is available
-    bool reportService         = false;   // report as a service when listing dnssd services
-    chip::System::Clock::Timestamp lastMulticastTime { 0 };       // last time this record was multicast
+    Responder * responder = nullptr;                       // what response/data is available
+    bool reportService    = false;                         // report as a service when listing dnssd services
+    chip::System::Clock::Timestamp lastMulticastTime{ 0 }; // last time this record was multicast
 };
 
 namespace Internal {
@@ -154,9 +154,9 @@ public:
     }
 
 private:
-    bool mIncludeAdditionalRepliesOnly     = false;
-    ReplyFilter * mReplyFilter             = nullptr;
-    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore { 0 };
+    bool mIncludeAdditionalRepliesOnly = false;
+    ReplyFilter * mReplyFilter         = nullptr;
+    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore{ 0 };
 };
 
 /// Iterates over an array of QueryResponderRecord items, providing only 'valid' ones, where

--- a/src/lib/dnssd/minimal_mdns/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestActiveResolveAttempts.cpp
@@ -152,10 +152,10 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
     }
 
     // +2 because: 1 element skipped, one element is the "current" that has a delay of 1000ms
-    NL_TEST_ASSERT(
-        inSuite,
-        attempts.GetTimeUntilNextExpectedResponse() ==
-            Optional<System::Clock::Timeout>::Value(System::Clock::Milliseconds32(1000 - mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize + 2)));
+    NL_TEST_ASSERT(inSuite,
+                   attempts.GetTimeUntilNextExpectedResponse() ==
+                       Optional<System::Clock::Timeout>::Value(
+                           System::Clock::Milliseconds32(1000 - mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize + 2)));
 
     // add another element - this should overwrite peer 9999
     attempts.MarkPending(MakePeerId(mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize));

--- a/src/lib/dnssd/minimal_mdns/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestActiveResolveAttempts.cpp
@@ -23,21 +23,19 @@
 namespace {
 
 using namespace chip;
+using namespace chip::System::Clock::Literals;
+using chip::System::Clock::Timeout;
 
 class MockClock : public System::Clock::ClockBase
 {
 public:
-    System::Clock::Microseconds64 GetMonotonicMicroseconds64() override { return mUsec; }
-    System::Clock::Milliseconds64 GetMonotonicMilliseconds64() override
-    {
-        return std::chrono::duration_cast<System::Clock::Milliseconds64>(mUsec);
-    }
+    System::Clock::Microseconds64 GetMonotonicMicroseconds64() override { return mMsec; }
+    System::Clock::Milliseconds64 GetMonotonicMilliseconds64() override { return mMsec; }
 
-    void AdvanceMs(uint32_t ms) { mUsec += System::Clock::Milliseconds32(ms); }
-    void AdvanceSec(uint32_t s) { mUsec += System::Clock::Seconds32(s); }
+    void Advance(System::Clock::Milliseconds32 ms) { mMsec += ms; }
 
 private:
-    System::Clock::Microseconds64 mUsec;
+    System::Clock::Milliseconds64 mMsec;
 };
 
 PeerId MakePeerId(NodeId nodeId)
@@ -51,41 +49,41 @@ void TestSinglePeerAddRemove(nlTestSuite * inSuite, void * inContext)
     MockClock mockClock;
     mdns::Minimal::ActiveResolveAttempts attempts(&mockClock);
 
-    mockClock.AdvanceMs(1234);
+    mockClock.Advance(1234_ms32);
 
     // Starting up, no scheduled peers are expected
-    NL_TEST_ASSERT(inSuite, !attempts.GetMsUntilNextExpectedResponse().HasValue());
+    NL_TEST_ASSERT(inSuite, !attempts.GetTimeUntilNextExpectedResponse().HasValue());
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
     // Adding a single peer should result in it being scheduled
 
     attempts.MarkPending(MakePeerId(1));
 
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(0u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(0_ms32));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(1)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
     // one Next schedule is called, expect to have a delay of 1000 ms
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(1000u));
-    mockClock.AdvanceMs(500);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(500u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(1000_ms32));
+    mockClock.Advance(500_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(500_ms32));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
     // past due date: timeout should be 0
-    mockClock.AdvanceMs(800);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(0u));
+    mockClock.Advance(800_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(0_ms32));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(1)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
     // one Next schedule is called, expect to have a delay of 2000 ms
     // sincve the timeout doubles every time
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(2000u));
-    mockClock.AdvanceMs(100);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(1900u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(2000_ms32));
+    mockClock.Advance(100_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(1900_ms32));
 
     // once complete, nothing to schedule
     attempts.Complete(MakePeerId(1));
-    NL_TEST_ASSERT(inSuite, !attempts.GetMsUntilNextExpectedResponse().HasValue());
+    NL_TEST_ASSERT(inSuite, !attempts.GetTimeUntilNextExpectedResponse().HasValue());
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 }
 
@@ -94,31 +92,31 @@ void TestRescheduleSamePeerId(nlTestSuite * inSuite, void * inContext)
     MockClock mockClock;
     mdns::Minimal::ActiveResolveAttempts attempts(&mockClock);
 
-    mockClock.AdvanceMs(112233);
+    mockClock.Advance(112233_ms32);
 
     attempts.MarkPending(MakePeerId(1));
 
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(0u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(0_ms32));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(1)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
     // one Next schedule is called, expect to have a delay of 1000 ms
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(1000u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(1000_ms32));
 
     // 2nd try goes to 2 seconds (once at least 1 second passes)
-    mockClock.AdvanceMs(1234);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(0u));
+    mockClock.Advance(1234_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(0_ms32));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(1)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(2000u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(2000_ms32));
 
     // reschedule starts fresh
     attempts.MarkPending(MakePeerId(1));
 
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(0u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(0_ms32));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(1)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(1000u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(1000_ms32));
 }
 
 void TestLRU(nlTestSuite * inSuite, void * inContext)
@@ -127,18 +125,18 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
     MockClock mockClock;
     mdns::Minimal::ActiveResolveAttempts attempts(&mockClock);
 
-    mockClock.AdvanceMs(334455);
+    mockClock.Advance(334455_ms32);
 
     // add a single very old peer
     attempts.MarkPending(MakePeerId(9999));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(9999)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
-    mockClock.AdvanceMs(1000);
+    mockClock.Advance(1000_ms32);
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(9999)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
-    mockClock.AdvanceMs(2000);
+    mockClock.Advance(2000_ms32);
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(9999)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
@@ -147,7 +145,7 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
     for (uint32_t i = 1; i < mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize; i++)
     {
         attempts.MarkPending(MakePeerId(i));
-        mockClock.AdvanceMs(1);
+        mockClock.Advance(1_ms32);
 
         NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(i)));
         NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
@@ -156,12 +154,12 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
     // +2 because: 1 element skipped, one element is the "current" that has a delay of 1000ms
     NL_TEST_ASSERT(
         inSuite,
-        attempts.GetMsUntilNextExpectedResponse() ==
-            Optional<uint32_t>::Value(static_cast<uint32_t>(1000 - mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize + 2)));
+        attempts.GetTimeUntilNextExpectedResponse() ==
+            Optional<System::Clock::Timeout>::Value(System::Clock::Milliseconds32(1000 - mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize + 2)));
 
     // add another element - this should overwrite peer 9999
     attempts.MarkPending(MakePeerId(mdns::Minimal::ActiveResolveAttempts::kRetryQueueSize));
-    mockClock.AdvanceSec(32);
+    mockClock.Advance(32_s16);
 
     for (Optional<PeerId> peerId = attempts.NextScheduledPeer(); peerId.HasValue(); peerId = attempts.NextScheduledPeer())
     {
@@ -169,7 +167,7 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
     }
 
     // Still have active pending items (queue is full)
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse().HasValue());
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse().HasValue());
 
     // expire all of them. Since we double timeout every expiry, we expect a
     // few iteratios to be able to expire the entire queue
@@ -178,13 +176,13 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
     int i = 0;
     for (; i < kMaxIterations; i++)
     {
-        Optional<uint32_t> ms = attempts.GetMsUntilNextExpectedResponse();
+        Optional<System::Clock::Timeout> ms = attempts.GetTimeUntilNextExpectedResponse();
         if (!ms.HasValue())
         {
             break;
         }
 
-        mockClock.AdvanceMs(ms.Value());
+        mockClock.Advance(ms.Value());
 
         Optional<PeerId> peerId = attempts.NextScheduledPeer();
         while (peerId.HasValue())
@@ -201,16 +199,16 @@ void TestNextPeerOrdering(nlTestSuite * inSuite, void * inContext)
     MockClock mockClock;
     mdns::Minimal::ActiveResolveAttempts attempts(&mockClock);
 
-    mockClock.AdvanceMs(123321);
+    mockClock.Advance(123321_ms32);
 
     // add a single peer that will be resolved quickly
     attempts.MarkPending(MakePeerId(1));
 
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(1)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(1000u));
-    mockClock.AdvanceMs(20);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(980u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(1000_ms32));
+    mockClock.Advance(20_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(980_ms32));
 
     // expect peerid to be resolve within 1 second from now
     attempts.MarkPending(MakePeerId(2));
@@ -218,14 +216,14 @@ void TestNextPeerOrdering(nlTestSuite * inSuite, void * inContext)
     // mock that we are querying 2 as well
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(2)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
-    mockClock.AdvanceMs(80);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(900u));
+    mockClock.Advance(80_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(900_ms32));
 
     // Peer 1 is done, now peer2 should be pending (in 980ms)
     attempts.Complete(MakePeerId(1));
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(920u));
-    mockClock.AdvanceMs(20);
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(900u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(920_ms32));
+    mockClock.Advance(20_ms32);
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(900_ms32));
 
     // Once peer 3 is added, queue should be
     //  - 900 ms until peer id 2 is pending
@@ -233,19 +231,19 @@ void TestNextPeerOrdering(nlTestSuite * inSuite, void * inContext)
     attempts.MarkPending(MakePeerId(3));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(3)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(900u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(900_ms32));
 
     // After the clock advance
     //  - 400 ms until peer id 2 is pending
     //  - 500 ms until peer id 3 is pending
-    mockClock.AdvanceMs(500);
+    mockClock.Advance(500_ms32);
 
-    NL_TEST_ASSERT(inSuite, attempts.GetMsUntilNextExpectedResponse() == Optional<uint32_t>::Value(400u));
+    NL_TEST_ASSERT(inSuite, attempts.GetTimeUntilNextExpectedResponse() == Optional<Timeout>(400_ms32));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());
 
     // advancing the clock 'too long' will return both other entries, in  reverse order due to how
     // the internal cache is built
-    mockClock.AdvanceMs(500);
+    mockClock.Advance(500_ms32);
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(3)));
     NL_TEST_ASSERT(inSuite, attempts.NextScheduledPeer() == Optional<PeerId>::Value(MakePeerId(2)));
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduledPeer().HasValue());


### PR DESCRIPTION
#### Problem

Code uses plain integers to represent time values and relies on
users to get the unit scale correct.

Part of #10062 _Some operations on System::Clock types are not safe_

#### Change overview

Convert `src/lib/dnssd` to use the safer `Clock` types.

#### Testing

CI; no change to functionality intended.

Conversion includes `TestActiveResolveAttempts.cpp`.
