### PR TITLE
[Linux]:Enable additional dbus APIs for BSS management

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -510,6 +510,35 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
         g_error_free(err);
 }
 
+void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
+{
+    GError * err = nullptr;
+
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+
+    WpaFiW1Wpa_supplicant1BSS * bss = wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus_finish(res, &err);
+
+    if (mWpaSupplicant.bss)
+    {
+        g_object_unref(mWpaSupplicant.bss);
+        mWpaSupplicant.bss = nullptr;
+    }
+
+    if (bss != nullptr && err == nullptr)
+    {
+        mWpaSupplicant.bss = bss;
+        ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant bss proxy");
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create wpa_supplicant bss proxy %s: %s",
+                        mWpaSupplicant.interfacePath, err ? err->message : "unknown error");
+    }
+
+    if (err != nullptr)
+        g_error_free(err);
+}
+
 void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
 {
     GError * err = nullptr;
@@ -526,6 +555,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
                                                               mWpaSupplicant.interfacePath, nullptr, _OnWpaInterfaceProxyReady,
                                                               nullptr);
+
+        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
+                                                        mWpaSupplicant.interfacePath, nullptr, _OnWpaBssProxyReady, nullptr);
     }
     else
     {
@@ -556,6 +588,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
             wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
                                                                   kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
                                                                   _OnWpaInterfaceProxyReady, nullptr);
+
+            wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
+                                                            mWpaSupplicant.interfacePath, nullptr, _OnWpaBssProxyReady, nullptr);
         }
         else
         {
@@ -598,6 +633,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * prox
         wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
                                                               mWpaSupplicant.interfacePath, nullptr, _OnWpaInterfaceProxyReady,
                                                               nullptr);
+
+        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
+                                                        mWpaSupplicant.interfacePath, nullptr, _OnWpaBssProxyReady, nullptr);
     }
 }
 
@@ -627,6 +665,12 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
         {
             g_object_unref(mWpaSupplicant.iface);
             mWpaSupplicant.iface = nullptr;
+        }
+
+        if (mWpaSupplicant.bss)
+        {
+            g_object_unref(mWpaSupplicant.bss);
+            mWpaSupplicant.bss = nullptr;
         }
 
         mWpaSupplicant.scanState = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
@@ -669,6 +713,7 @@ void ConnectivityManagerImpl::StartWiFiManagement()
     mWpaSupplicant.scanState     = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
     mWpaSupplicant.proxy         = nullptr;
     mWpaSupplicant.iface         = nullptr;
+    mWpaSupplicant.bss           = nullptr;
     mWpaSupplicant.interfacePath = nullptr;
     mWpaSupplicant.networkPath   = nullptr;
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -38,6 +38,7 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 #include <platform/Linux/dbus/wpa/DBusWpa.h>
+#include <platform/Linux/dbus/wpa/DBusWpaBss.h>
 #include <platform/Linux/dbus/wpa/DBusWpaInterface.h>
 #include <platform/Linux/dbus/wpa/DBusWpaNetwork.h>
 #endif
@@ -73,6 +74,7 @@ struct GDBusWpaSupplicant
 
     WpaFiW1Wpa_supplicant1 * proxy;
     WpaFiW1Wpa_supplicant1Interface * iface;
+    WpaFiW1Wpa_supplicant1BSS * bss;
     gchar * interfacePath;
     gchar * networkPath;
 };
@@ -148,6 +150,7 @@ private:
     static void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties, gpointer user_data);
     static void _OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
     static void _OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
+    static void _OnWpaBssProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
 
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;

--- a/src/platform/Linux/dbus/wpa/BUILD.gn
+++ b/src/platform/Linux/dbus/wpa/BUILD.gn
@@ -19,6 +19,7 @@ import("${chip_root}/build/chip/linux/gdbus_library.gni")
 gdbus_library("wpa") {
   sources = [
     "DBusWpa.xml",
+    "DBusWpaBss.xml",
     "DBusWpaInterface.xml",
     "DBusWpaNetwork.xml",
   ]

--- a/src/platform/Linux/dbus/wpa/DBusWpaBss.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaBss.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<node>
+    <interface name="fi.w1.wpa_supplicant1.BSS">
+        <property name="SSID" type="ay" access="read" />
+        <property name="BSSID" type="ay" access="read" />
+        <property name="Signal" type="n" access="read" />
+        <property name="Frequency" type="q" access="read" />
+    </interface>
+</node>


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We are missing the dbus APIs for BSS management in Linux reference implementation. Those APIs are needed for diagnostic analysis in AP mode.


#### Change overview
Enable additional dbus APIs for BSS management

#### Testing
How was this tested? (at least one bullet point required)
* Confirm chip sdk can connect to wpa_supplicant bss proxy successfully via DBUS. 
[1635313608.287005][1753388:1753388] CHIP:SVR: Manual pairing code: [34970112332]
[1635313608.287014][1753388:1753388] CHIP:DL: wpa_supplicant: Start WiFi management
[1635313608.288823][1753388:1753391] CHIP:DL: wpa_supplicant: connected to wpa_supplicant proxy
[1635313608.289341][1753388:1753391] CHIP:DL: wpa_supplicant: WiFi interface: /fi/w1/wpa_supplicant1/Interfaces/15
[1635313608.292600][1753388:1753391] CHIP:DL: wpa_supplicant: connected to wpa_supplicant interface proxy
[1635313608.292934][1753388:1753391] CHIP:DL: wpa_supplicant: connected to wpa_supplicant bss proxy
