### PR TITLE
Fix boot crash in all-clusters-app on esp32

### DIFF
--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -106,7 +106,11 @@ static inline void unreg(Identify * inst)
 
 void emberAfIdentifyClusterServerInitCallback(EndpointId endpoint)
 {
-    (void) Clusters::Identify::Attributes::IdentifyType::Set(endpoint, inst(endpoint)->mIdentifyType);
+    Identify * identify = inst(endpoint);
+    if (identify != nullptr)
+    {
+        (void) Clusters::Identify::Attributes::IdentifyType::Set(endpoint, identify->mIdentifyType);
+    }
 }
 
 static void onIdentifyClusterTick(chip::System::Layer * systemLayer, void * appState)


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/10907 added some
identify bits on Linux only but changed the core cluster impl to
assume that those bits are always there.

This change stops assuming that identify is actually configured on
every endpoint that supports it, since nothing enforces that.

#### Problem
Crash on startup.

#### Change overview
Add the needed null-check.

#### Testing
Booted m5stack with all-clusters-app, made sure it boots properly.