### PR TITLE
[mcsp] Fix queued message processing to handle decrypted messages.

### DIFF
--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -165,8 +165,8 @@ void MessageCounterManager::ProcessPendingMessages(NodeId peerNodeId)
 
             if (packetHeader.GetSourceNodeId().HasValue() && packetHeader.GetSourceNodeId().Value() == peerNodeId)
             {
-                // Reprocess message.
-                sessionManager->OnMessageReceived(entry.peerAddress, std::move(entry.msgBuf));
+                // Reprocess message post-decryption.
+                sessionManager->SecureMessageCounterDispatch(packetHeader, entry.peerAddress, std::move(entry.msgBuf));
 
                 // Explicitly free any buffer owned by this handle.
                 entry.msgBuf = nullptr;

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -73,8 +73,7 @@ CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Decrypt(Transport::SecureSession * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
-                   System::PacketBufferHandle & msg)
+CHIP_ERROR Decrypt(Transport::SecureSession * state, const PacketHeader & packetHeader, System::PacketBufferHandle & msg)
 {
     ReturnErrorCodeIf(msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -105,7 +104,6 @@ CHIP_ERROR Decrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
     uint8_t * plainText = msg->Start();
     ReturnErrorOnFailure(state->DecryptOnReceive(data, len, plainText, packetHeader, mac));
 
-    ReturnErrorOnFailure(payloadHeader.DecodeAndConsume(msg));
     return CHIP_NO_ERROR;
 }
 

--- a/src/transport/SecureMessageCodec.h
+++ b/src/transport/SecureMessageCodec.h
@@ -66,8 +66,7 @@ CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHead
  *                      unencrypted message.
  * @ return CHIP_ERROR  The result of the decode operation
  */
-CHIP_ERROR Decrypt(Transport::SecureSession * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
-                   System::PacketBufferHandle & msgBuf);
+CHIP_ERROR Decrypt(Transport::SecureSession * state, const PacketHeader & packetHeader, System::PacketBufferHandle & msgBuf);
 } // namespace SecureMessageCodec
 
 } // namespace chip

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -419,7 +419,7 @@ void SessionManager::SecureMessageCounterDispatch(const PacketHeader & packetHea
     CHIP_ERROR err = CHIP_NO_ERROR;
     PayloadHeader payloadHeader;
     SessionManagerDelegate::DuplicateMessage isDuplicate = SessionManagerDelegate::DuplicateMessage::No;
-    SecureSession * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetSessionId(), nullptr);
+    SecureSession * state = mPeerConnections.FindSecureSessionByLocalKey(packetHeader.GetSessionId(), nullptr);
 
     SuccessOrExit(err = payloadHeader.DecodeAndConsume(msg));
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -45,6 +45,10 @@
 
 namespace chip {
 
+namespace secure_channel {
+class MessageCounterManager;
+}
+
 class PairingSession;
 
 /**
@@ -271,6 +275,15 @@ public:
 
     // TODO: this is a temporary solution for legacy tests which use nodeId to send packets
     SessionHandle FindSecureSessionForNode(NodeId peerNodeId);
+
+protected:
+    friend class secure_channel::MessageCounterManager;
+
+    /**
+     * Process a secure message after decryption, including all message counter replay checks.
+     */
+    void SecureMessageCounterDispatch(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
+                                      System::PacketBufferHandle && msg);
 
 private:
     /**


### PR DESCRIPTION
#### Problem
Fix #10643 - MCSP code path was broken by recent decrypt-first change.

#### Change overview
Split out message post-processing steps after decryption into a separate method.  
Update MCSP to call post-processing method on queued decrypted messages.

#### Testing
There isn't unit test coverage of MCSP right now, nor a well documented set of manual commands to test it.
We should spawn an issue for adding MCSP test coverage if such an issue does not exist already.
Primary message flows are validated with existing CI and are passing.