### PR TITLE
IM/ReadHandler: remove NodeId usage

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -295,9 +295,8 @@ CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeConte
 
     for (auto & readHandler : mReadHandlers)
     {
-        if (!readHandler.IsFree() && readHandler.IsSubscriptionType() &&
-            readHandler.GetInitiatorNodeId() == apExchangeContext->GetSessionHandle().GetPeerNodeId() &&
-            readHandler.GetFabricIndex() == apExchangeContext->GetSessionHandle().GetFabricIndex())
+        if (!readHandler.IsFree() && readHandler.IsSubscriptionType() && apExchangeContext->HasSessionHandle() &&
+            readHandler.MatchSession(apExchangeContext->GetSessionHandle()))
         {
             bool keepSubscriptions = true;
             System::PacketBufferTLVReader reader;

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -54,8 +54,6 @@ CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, Interac
     mDirty              = false;
     mActiveSubscription = false;
     mInteractionType    = aInteractionType;
-    mInitiatorNodeId    = apExchangeContext->GetSessionHandle().GetPeerNodeId();
-    mFabricIndex        = apExchangeContext->GetSessionHandle().GetFabricIndex();
 
     if (apExchangeContext != nullptr)
     {
@@ -106,7 +104,6 @@ void ReadHandler::Shutdown(ShutdownOptions aOptions)
     mHoldReport                = false;
     mDirty                     = false;
     mActiveSubscription        = false;
-    mInitiatorNodeId           = kUndefinedNodeId;
 }
 
 CHIP_ERROR ReadHandler::OnReadInitialRequest(System::PacketBufferHandle && aPayload)

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -133,8 +133,10 @@ public:
     void SetDirty() { mDirty = true; }
     void ClearDirty() { mDirty = false; }
     bool IsDirty() { return mDirty; }
-    NodeId GetInitiatorNodeId() const { return mInitiatorNodeId; }
-    FabricIndex GetFabricIndex() const { return mFabricIndex; }
+    bool MatchSession(const SessionHandle & session) const
+    {
+        return mSessionHandle.HasValue() && mSessionHandle.Value() == session;
+    }
 
 private:
     friend class TestReadInteraction;
@@ -192,8 +194,6 @@ private:
     bool mHoldReport         = false;
     bool mDirty              = false;
     bool mActiveSubscription = false;
-    NodeId mInitiatorNodeId  = kUndefinedNodeId;
-    FabricIndex mFabricIndex = 0;
 };
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
#### Problem
In IM ReadHandler, we match different reader by comparing their node id which is grabbed from session. But we should compare the session directly.

#### Change overview
Comparing session instead of node in IM ReadHandler

#### Testing
Verified by unit-tests.