### PR TITLE
Only run arm64 AndroidStudio build in Android CI

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -550,6 +550,7 @@ matterc
 matterd
 MatterLock
 matterSdkSourceBuild
+matterSourceBuildAbiFilters
 matterUTestLib
 MaxInterval
 MaxIntervalCeilingSeconds

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -54,10 +54,14 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Build android examples
+            - name: Build Android CHIPTool and CHIPTest
               run: |
                 ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-*' build"
+                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-{arm,arm64,x64,x86}-chip-*' build"
+            - name: Build Android Studio build (arm64 only)
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-androidstudio-arm64-chip-tool' build"
             - name: Run Android build rule tests
               run: |
                 ./scripts/run_in_build_env.sh \

--- a/docs/guides/android_building.md
+++ b/docs/guides/android_building.md
@@ -116,9 +116,9 @@ which allows us to directly edit core Matter code in-IDE.
 
     See the table above for other values of `TARGET_CPU`.
 
-2. Modify the `matterSdkSourceBuild` variable to true and `matterBuildSrcDir`
-   point to the appropriate output directory (e.g.
-   `../../../../out/android_arm64`) in
+2. Modify the `matterSdkSourceBuild` variable to true, `matterBuildSrcDir` point
+   to the appropriate output directory (e.g. `../../../../out/android_arm64`),
+   and `matterSourceBuildAbiFilters` to the desired ABIs in
    [src/android/CHIPTool/gradle.properties](https://github.com/project-chip/connectedhomeip/blob/master/src/android/CHIPTool/gradle.properties)
 
 3) Open the project in Android Studio and run **Sync Project with Gradle

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -149,7 +149,10 @@ def AndroidTargets():
     yield target.Extend('x64-chip-tool', board=AndroidBoard.X64, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('x86-chip-tool', board=AndroidBoard.X86, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('arm64-chip-test', board=AndroidBoard.ARM64, app=AndroidApp.CHIP_TEST)
-    yield target.Extend('androidstudio-chip-tool', board=AndroidBoard.AndroidStudio, app=AndroidApp.CHIP_TOOL)
+    yield target.Extend('androidstudio-arm-chip-tool', board=AndroidBoard.AndroidStudio_ARM, app=AndroidApp.CHIP_TOOL)
+    yield target.Extend('androidstudio-arm64-chip-tool', board=AndroidBoard.AndroidStudio_ARM64, app=AndroidApp.CHIP_TOOL)
+    yield target.Extend('androidstudio-x86-chip-tool', board=AndroidBoard.AndroidStudio_X86, app=AndroidApp.CHIP_TOOL)
+    yield target.Extend('androidstudio-x64-chip-tool', board=AndroidBoard.AndroidStudio_X64, app=AndroidApp.CHIP_TOOL)
 
 
 ALL = []

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -25,36 +25,38 @@ class AndroidBoard(Enum):
     ARM64 = auto()
     X64 = auto()
     X86 = auto()
-    AndroidStudio = auto()
+    AndroidStudio_ARM = auto()
+    AndroidStudio_ARM64 = auto()
+    AndroidStudio_X64 = auto()
+    AndroidStudio_X86 = auto()
 
     def TargetCpuName(self):
-        if self == AndroidBoard.ARM:
+        if self == AndroidBoard.ARM or self == AndroidBoard.AndroidStudio_ARM:
             return 'arm'
-        elif self == AndroidBoard.ARM64:
+        elif self == AndroidBoard.ARM64 or self == AndroidBoard.AndroidStudio_ARM64:
             return 'arm64'
-        elif self == AndroidBoard.X64:
+        elif self == AndroidBoard.X64 or self == AndroidBoard.AndroidStudio_X64:
             return 'x64'
-        elif self == AndroidBoard.X86:
+        elif self == AndroidBoard.X86 or self == AndroidBoard.AndroidStudio_X86:
             return 'x86'
-        elif self == AndroidBoard.AndroidStudio:
-            return "arm64"
         else:
             raise Exception('Unknown board type: %r' % self)
 
     def AbiName(self):
-        if self == AndroidBoard.ARM:
+        if self.TargetCpuName() == 'arm':
             return 'armeabi-v7a'
-        elif self == AndroidBoard.ARM64:
+        elif self.TargetCpuName() == 'arm64':
             return 'arm64-v8a'
-        elif self == AndroidBoard.X64:
+        elif self.TargetCpuName() == 'x64':
             return 'x86_64'
-        elif self == AndroidBoard.X86:
+        elif self.TargetCpuName() == 'x86':
             return 'x86'
         else:
             raise Exception('Unknown board type: %r' % self)
 
     def IsIde(self):
-        if self == AndroidBoard.AndroidStudio:
+        if (self == AndroidBoard.AndroidStudio_ARM or self == AndroidBoard.AndroidStudio_ARM64
+                or self == AndroidBoard.AndroidStudio_X64 or self == AndroidBoard.AndroidStudio_X86):
             return True
         else:
             return False
@@ -161,6 +163,7 @@ class AndroidBuilder(Builder):
                 '%s/src/android/%s' % (self.root, self.app.AppName()),
                 '-PmatterBuildSrcDir=%s' % self.output_dir,
                 '-PmatterSdkSourceBuild=true',
+                '-PmatterSourceBuildAbiFilters=%s' % self.board.AbiName(),
                 'assembleDebug'
             ],
                 title='Building APP ' + self.identifier)

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -1,5 +1,8 @@
 ameba-amebad-all-clusters
-android-androidstudio-chip-tool
+android-androidstudio-arm-chip-tool
+android-androidstudio-arm64-chip-tool
+android-androidstudio-x64-chip-tool
+android-androidstudio-x86-chip-tool
 android-arm-chip-tool
 android-arm64-chip-test
 android-arm64-chip-tool

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -10,8 +10,44 @@ python3 build/chip/java/tests/generate_jars_for_test.py
 # Setting up Android deps through Gradle
 python3 third_party/android_deps/set_up_android_deps.py
 
-# Generating android-androidstudio-chip-tool
-gn gen --check --fail-on-unused-args {out}/android-androidstudio-chip-tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
+# Generating android-androidstudio-arm-chip-tool
+gn gen --check --fail-on-unused-args {out}/android-androidstudio-arm-chip-tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
+
+# Accepting NDK licenses
+bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
+
+# Generating JARs for Java build rules test
+python3 build/chip/java/tests/generate_jars_for_test.py
+
+# Setting up Android deps through Gradle
+python3 third_party/android_deps/set_up_android_deps.py
+
+# Generating android-androidstudio-arm64-chip-tool
+gn gen --check --fail-on-unused-args {out}/android-androidstudio-arm64-chip-tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
+
+# Accepting NDK licenses
+bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
+
+# Generating JARs for Java build rules test
+python3 build/chip/java/tests/generate_jars_for_test.py
+
+# Setting up Android deps through Gradle
+python3 third_party/android_deps/set_up_android_deps.py
+
+# Generating android-androidstudio-x64-chip-tool
+gn gen --check --fail-on-unused-args {out}/android-androidstudio-x64-chip-tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
+
+# Accepting NDK licenses
+bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
+
+# Generating JARs for Java build rules test
+python3 build/chip/java/tests/generate_jars_for_test.py
+
+# Setting up Android deps through Gradle
+python3 third_party/android_deps/set_up_android_deps.py
+
+# Generating android-androidstudio-x86-chip-tool
+gn gen --check --fail-on-unused-args {out}/android-androidstudio-x86-chip-tool '--args=target_os="android" target_cpu="x86" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
@@ -294,8 +330,17 @@ gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/linux '
 # Building ameba-amebad-all-clusters
 ninja -C {out}/ameba-amebad-all-clusters
 
-# Building APP android-androidstudio-chip-tool
-{root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-androidstudio-chip-tool -PmatterSdkSourceBuild=true assembleDebug
+# Building APP android-androidstudio-arm-chip-tool
+{root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-androidstudio-arm-chip-tool -PmatterSdkSourceBuild=true -PmatterSourceBuildAbiFilters=armeabi-v7a assembleDebug
+
+# Building APP android-androidstudio-arm64-chip-tool
+{root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-androidstudio-arm64-chip-tool -PmatterSdkSourceBuild=true -PmatterSourceBuildAbiFilters=arm64-v8a assembleDebug
+
+# Building APP android-androidstudio-x64-chip-tool
+{root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-androidstudio-x64-chip-tool -PmatterSdkSourceBuild=true -PmatterSourceBuildAbiFilters=x86_64 assembleDebug
+
+# Building APP android-androidstudio-x86-chip-tool
+{root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-androidstudio-x86-chip-tool -PmatterSdkSourceBuild=true -PmatterSourceBuildAbiFilters=x86 assembleDebug
 
 # Building JNI android-arm-chip-tool
 ninja -C {out}/android-arm-chip-tool

--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -14,9 +14,12 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        // NOTE: This build assumes CHIP was configured and built for armeabi-v7a. Deal with
-        // other archs later when build is sane.
-        //  ndk {abiFilters 'armeabi-v7a'}
+        if (matterSdkSourceBuild.toBoolean() && !matterBuildSrcDir.isEmpty()) {
+            ndk {
+                abiFilters = []
+                abiFilters.addAll(matterSourceBuildAbiFilters.split(';').collect { it as String })
+            }
+        }
 
         externalNativeBuild {
             cmake {

--- a/src/android/CHIPTool/gradle.properties
+++ b/src/android/CHIPTool/gradle.properties
@@ -25,3 +25,7 @@ matterSdkSourceBuild=false
 # example) to build SDK from source code and debug in Android Studio.
 # Set to blank to use the SDK prebuilt by scripts/build/build_examples.py.
 matterBuildSrcDir=../../../../out/android_arm64
+# Semicolon-separated ABI filter list for building from source (aka IDE build).
+# Has no effect if matterSdkSourceBuild is false or matterBuildSrcDir is empty.
+# See https://developer.android.com/ndk/guides/abis#sa for a list of ABIs.
+matterSourceBuildAbiFilters=arm64-v8a


### PR DESCRIPTION
#### Problem
* Adding the AndroidStudio IDE build to Android CI significantly increased CI time, since the current `android-androidstudio-chip-tool` target will build arm, arm64, x86, and x64 targets.

#### Change overview
* Split singular androidstudio target into different targets per-ABI: `android-androidstudio-$ABI-chip-tool`
  * Add Gradle property which sets `ndk { abiFilters }`
* Exclusively build `android-androidstudio-arm64-chip-tool` in Android CI. In my fork, this cut CI time down to 40min.

#### Testing
* Ran all `android-androidstudio-*` targets locally
* CI verifies arm64 target and other android targets
