### PR TITLE
Use BitMapPool for SecureSessionTable

### DIFF
--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -49,42 +49,30 @@ static constexpr uint32_t kUndefinedMessageIndex = UINT32_MAX;
 class SecureSession
 {
 public:
-    SecureSession() : mPeerAddress(PeerAddress::Uninitialized()) {}
-    SecureSession(const PeerAddress & addr) : mPeerAddress(addr) {}
-    SecureSession(PeerAddress && addr) : mPeerAddress(addr) {}
+    SecureSession(uint16_t localSessionId, NodeId peerNodeId, uint16_t peerSessionId, FabricIndex fabric, uint64_t currentTime) :
+        mPeerNodeId(peerNodeId), mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId), mFabric(fabric)
+    {
+        SetLastActivityTimeMs(currentTime);
+    }
 
-    SecureSession(SecureSession &&)      = default;
-    SecureSession(const SecureSession &) = default;
-    SecureSession & operator=(const SecureSession &) = default;
-    SecureSession & operator=(SecureSession &&) = default;
+    SecureSession(SecureSession &&)      = delete;
+    SecureSession(const SecureSession &) = delete;
+    SecureSession & operator=(const SecureSession &) = delete;
+    SecureSession & operator=(SecureSession &&) = delete;
 
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     PeerAddress & GetPeerAddress() { return mPeerAddress; }
     void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
-    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
-
-    uint16_t GetPeerSessionId() const { return mPeerSessionId; }
-    void SetPeerSessionId(uint16_t id) { mPeerSessionId = id; }
-
-    // TODO: Rename KeyID to SessionID
     uint16_t GetLocalSessionId() const { return mLocalSessionId; }
-    void SetLocalSessionId(uint16_t id) { mLocalSessionId = id; }
+    uint16_t GetPeerSessionId() const { return mPeerSessionId; }
+    FabricIndex GetFabricIndex() const { return mFabric; }
 
     uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
 
     CryptoContext & GetCryptoContext() { return mCryptoContext; }
-
-    FabricIndex GetFabricIndex() const { return mFabric; }
-    void SetFabricIndex(FabricIndex fabricIndex) { mFabric = fabricIndex; }
-
-    bool IsInitialized()
-    {
-        return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerSessionId != UINT16_MAX ||
-                mLocalSessionId != UINT16_MAX);
-    }
 
     CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
                                  MessageAuthenticationCode & mac) const
@@ -101,14 +89,15 @@ public:
     SessionMessageCounter & GetSessionMessageCounter() { return mSessionMessageCounter; }
 
 private:
+    const NodeId mPeerNodeId;
+    const uint16_t mLocalSessionId;
+    const uint16_t mPeerSessionId;
+    const FabricIndex mFabric;
+
     PeerAddress mPeerAddress;
-    NodeId mPeerNodeId           = kUndefinedNodeId;
-    uint16_t mPeerSessionId      = UINT16_MAX;
-    uint16_t mLocalSessionId     = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;
-    FabricIndex mFabric = kUndefinedFabricIndex;
 };
 
 } // namespace Transport

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -103,7 +103,7 @@ void SessionManager::Shutdown()
     mCB           = nullptr;
 }
 
-CHIP_ERROR SessionManager::PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR SessionManager::PrepareMessage(SessionHandle sessionHandle, PayloadHeader & payloadHeader,
                                           System::PacketBufferHandle && message, EncryptedPacketBufferHandle & preparedMessage)
 {
     PacketHeader packetHeader;
@@ -115,26 +115,26 @@ CHIP_ERROR SessionManager::PrepareMessage(SessionHandle session, PayloadHeader &
 #if CHIP_PROGRESS_LOGGING
     NodeId destination;
 #endif // CHIP_PROGRESS_LOGGING
-    if (session.IsSecure())
+    if (sessionHandle.IsSecure())
     {
-        SecureSession * state = GetSecureSession(session);
-        if (state == nullptr)
+        SecureSession * session = GetSecureSession(sessionHandle);
+        if (session == nullptr)
         {
             return CHIP_ERROR_NOT_CONNECTED;
         }
 
-        MessageCounter & counter = GetSendCounterForPacket(payloadHeader, *state);
-        ReturnErrorOnFailure(SecureMessageCodec::Encrypt(state, payloadHeader, packetHeader, message, counter));
+        MessageCounter & counter = GetSendCounterForPacket(payloadHeader, *session);
+        ReturnErrorOnFailure(SecureMessageCodec::Encrypt(session, payloadHeader, packetHeader, message, counter));
 
 #if CHIP_PROGRESS_LOGGING
-        destination = state->GetPeerNodeId();
+        destination = session->GetPeerNodeId();
 #endif // CHIP_PROGRESS_LOGGING
     }
     else
     {
         ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(message));
 
-        MessageCounter & counter = session.GetUnauthenticatedSession()->GetLocalMessageCounter();
+        MessageCounter & counter = sessionHandle.GetUnauthenticatedSession()->GetLocalMessageCounter();
         uint32_t messageCounter  = counter.Value();
         ReturnErrorOnFailure(counter.Advance());
 
@@ -149,7 +149,7 @@ CHIP_ERROR SessionManager::PrepareMessage(SessionHandle session, PayloadHeader &
                     "Prepared %s message %p to 0x" ChipLogFormatX64 " of type " ChipLogFormatMessageType
                     " and protocolId " ChipLogFormatProtocolId " on exchange " ChipLogFormatExchangeId
                     " with MessageCounter:" ChipLogFormatMessageCounter ".",
-                    session.IsSecure() ? "encrypted" : "plaintext", &preparedMessage, ChipLogValueX64(destination),
+                    sessionHandle.IsSecure() ? "encrypted" : "plaintext", &preparedMessage, ChipLogValueX64(destination),
                     payloadHeader.GetMessageType(), ChipLogValueProtocolId(payloadHeader.GetProtocolID()),
                     ChipLogValueExchangeIdFromSentHeader(payloadHeader), packetHeader.GetMessageCounter());
 
@@ -159,37 +159,37 @@ CHIP_ERROR SessionManager::PrepareMessage(SessionHandle session, PayloadHeader &
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SessionManager::SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage)
+CHIP_ERROR SessionManager::SendPreparedMessage(SessionHandle sessionHandle, const EncryptedPacketBufferHandle & preparedMessage)
 {
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(!preparedMessage.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
     const Transport::PeerAddress * destination;
 
-    if (session.IsSecure())
+    if (sessionHandle.IsSecure())
     {
         // Find an active connection to the specified peer node
-        SecureSession * state = GetSecureSession(session);
-        if (state == nullptr)
+        SecureSession * session = GetSecureSession(sessionHandle);
+        if (session == nullptr)
         {
             ChipLogError(Inet, "Secure transport could not find a valid PeerConnection");
             return CHIP_ERROR_NOT_CONNECTED;
         }
 
         // This marks any connection where we send data to as 'active'
-        mPeerConnections.MarkSessionActive(state);
+        mSecureSessions.MarkSessionActive(session);
 
-        destination = &state->GetPeerAddress();
+        destination = &session->GetPeerAddress();
 
         ChipLogProgress(Inet,
                         "Sending %s msg %p with MessageCounter:" ChipLogFormatMessageCounter " to 0x" ChipLogFormatX64
                         " at monotonic time: %" PRId64 " msec",
-                        "encrypted", &preparedMessage, preparedMessage.GetMessageCounter(), ChipLogValueX64(state->GetPeerNodeId()),
-                        System::SystemClock().GetMonotonicMilliseconds64().count());
+                        "encrypted", &preparedMessage, preparedMessage.GetMessageCounter(),
+                        ChipLogValueX64(session->GetPeerNodeId()), System::SystemClock().GetMonotonicMilliseconds64().count());
     }
     else
     {
-        auto unauthenticated = session.GetUnauthenticatedSession();
+        auto unauthenticated = sessionHandle.GetUnauthenticatedSession();
         mUnauthenticatedSessions.MarkSessionActive(unauthenticated);
         destination = &unauthenticated->GetPeerAddress();
 
@@ -215,44 +215,39 @@ CHIP_ERROR SessionManager::SendPreparedMessage(SessionHandle session, const Encr
     }
 }
 
-void SessionManager::ExpirePairing(SessionHandle session)
+void SessionManager::ExpirePairing(SessionHandle sessionHandle)
 {
-    SecureSession * state = GetSecureSession(session);
-    if (state != nullptr)
+    SecureSession * session = GetSecureSession(sessionHandle);
+    if (session != nullptr)
     {
-        mPeerConnections.MarkSessionExpired(state,
-                                            [this](const Transport::SecureSession & state1) { HandleConnectionExpired(state1); });
+        HandleConnectionExpired(*session);
+        mSecureSessions.ReleaseSession(session);
     }
 }
 
 void SessionManager::ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric)
 {
-    SecureSession * state = mPeerConnections.FindSecureSession(peerNodeId, nullptr);
-    while (state != nullptr)
-    {
-        if (fabric == state->GetFabricIndex())
+    mSecureSessions.ForEachSession([&](auto session) {
+        if (session->GetPeerNodeId() == peerNodeId && session->GetFabricIndex() == fabric)
         {
-            mPeerConnections.MarkSessionExpired(
-                state, [this](const Transport::SecureSession & state1) { HandleConnectionExpired(state1); });
-            state = mPeerConnections.FindSecureSession(peerNodeId, nullptr);
+            HandleConnectionExpired(*session);
+            mSecureSessions.ReleaseSession(session);
         }
-        else
-        {
-            state = mPeerConnections.FindSecureSession(peerNodeId, state);
-        }
-    }
+        return true;
+    });
 }
 
 void SessionManager::ExpireAllPairingsForFabric(FabricIndex fabric)
 {
     ChipLogDetail(Inet, "Expiring all connections for fabric %d!!", fabric);
-    SecureSession * state = mPeerConnections.FindSecureSessionByFabric(fabric);
-    while (state != nullptr)
-    {
-        mPeerConnections.MarkSessionExpired(state,
-                                            [this](const Transport::SecureSession & state1) { HandleConnectionExpired(state1); });
-        state = mPeerConnections.FindSecureSessionByFabric(fabric);
-    }
+    mSecureSessions.ForEachSession([&](auto session) {
+        if (session->GetFabricIndex() == fabric)
+        {
+            HandleConnectionExpired(*session);
+            mSecureSessions.ReleaseSession(session);
+        }
+        return true;
+    });
 }
 
 CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
@@ -260,30 +255,27 @@ CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & p
 {
     uint16_t peerSessionId  = pairing->GetPeerSessionId();
     uint16_t localSessionId = pairing->GetLocalSessionId();
-    SecureSession * state   = mPeerConnections.FindSecureSessionByLocalKey(localSessionId, nullptr);
+    SecureSession * session = mSecureSessions.FindSecureSessionByLocalKey(localSessionId);
 
     // Find any existing connection with the same local key ID
-    if (state)
+    if (session)
     {
-        mPeerConnections.MarkSessionExpired(state,
-                                            [this](const Transport::SecureSession & state1) { HandleConnectionExpired(state1); });
+        HandleConnectionExpired(*session);
+        mSecureSessions.ReleaseSession(session);
     }
 
     ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
                   peerSessionId);
-    state = nullptr;
-    ReturnErrorOnFailure(mPeerConnections.CreateNewSecureSession(peerNodeId, peerSessionId, localSessionId, &state));
-    ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
-
-    state->SetFabricIndex(fabric);
+    session = mSecureSessions.CreateNewSecureSession(localSessionId, peerNodeId, peerSessionId, fabric);
+    ReturnErrorCodeIf(session == nullptr, CHIP_ERROR_NO_MEMORY);
 
     if (peerAddr.HasValue() && peerAddr.Value().GetIPAddress() != Inet::IPAddress::Any)
     {
-        state->SetPeerAddress(peerAddr.Value());
+        session->SetPeerAddress(peerAddr.Value());
     }
     else if (peerAddr.HasValue() && peerAddr.Value().GetTransportType() == Transport::Type::kBle)
     {
-        state->SetPeerAddress(peerAddr.Value());
+        session->SetPeerAddress(peerAddr.Value());
     }
     else if (peerAddr.HasValue() &&
              (peerAddr.Value().GetTransportType() == Transport::Type::kTcp ||
@@ -292,12 +284,13 @@ CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & p
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ReturnErrorOnFailure(pairing->DeriveSecureSession(state->GetCryptoContext(), direction));
+    ReturnErrorOnFailure(pairing->DeriveSecureSession(session->GetCryptoContext(), direction));
 
     if (mCB != nullptr)
     {
-        state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
-        mCB->OnNewConnection(SessionHandle(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(), fabric));
+        session->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
+        mCB->OnNewConnection(
+            SessionHandle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(), fabric));
     }
 
     return CHIP_NO_ERROR;
@@ -390,7 +383,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    SecureSession * state = mPeerConnections.FindSecureSessionByLocalKey(packetHeader.GetSessionId(), nullptr);
+    SecureSession * session = mSecureSessions.FindSecureSessionByLocalKey(packetHeader.GetSessionId());
 
     PayloadHeader payloadHeader;
 
@@ -398,14 +391,14 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
 
     VerifyOrExit(!msg.IsNull(), ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
 
-    if (state == nullptr)
+    if (session == nullptr)
     {
         ChipLogError(Inet, "Data received on an unknown connection (%d). Dropping it!!", packetHeader.GetSessionId());
         ExitNow(err = CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
     }
 
     // Decrypt and verify the message before message counter verification or any further processing.
-    VerifyOrExit(CHIP_NO_ERROR == SecureMessageCodec::Decrypt(state, payloadHeader, packetHeader, msg),
+    VerifyOrExit(CHIP_NO_ERROR == SecureMessageCodec::Decrypt(session, payloadHeader, packetHeader, msg),
                  ChipLogError(Inet, "Secure transport received message, but failed to decode/authenticate it, discarding"));
 
     // Verify message counter
@@ -415,14 +408,14 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
     }
     else
     {
-        if (!state->GetSessionMessageCounter().GetPeerMessageCounter().IsSynchronized())
+        if (!session->GetSessionMessageCounter().GetPeerMessageCounter().IsSynchronized())
         {
             // Queue and start message sync procedure
             err = mMessageCounterManager->QueueReceivedMessageAndStartSync(
                 packetHeader,
-                SessionHandle(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(),
-                              state->GetFabricIndex()),
-                state, peerAddress, std::move(msg));
+                SessionHandle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(),
+                              session->GetFabricIndex()),
+                session, peerAddress, std::move(msg));
 
             if (err != CHIP_NO_ERROR)
             {
@@ -439,7 +432,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
             return;
         }
 
-        err = state->GetSessionMessageCounter().GetPeerMessageCounter().Verify(packetHeader.GetMessageCounter());
+        err = session->GetSessionMessageCounter().GetPeerMessageCounter().Verify(packetHeader.GetMessageCounter());
         if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED)
         {
             isDuplicate = SessionManagerDelegate::DuplicateMessage::Yes;
@@ -452,7 +445,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
         SuccessOrExit(err);
     }
 
-    mPeerConnections.MarkSessionActive(state);
+    mSecureSessions.MarkSessionActive(session);
 
     if (isDuplicate == SessionManagerDelegate::DuplicateMessage::Yes && !payloadHeader.NeedsAck())
     {
@@ -474,22 +467,22 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & packetHea
     }
     else
     {
-        state->GetSessionMessageCounter().GetPeerMessageCounter().Commit(packetHeader.GetMessageCounter());
+        session->GetSessionMessageCounter().GetPeerMessageCounter().Commit(packetHeader.GetMessageCounter());
     }
 
     // TODO: once mDNS address resolution is available reconsider if this is required
     // This updates the peer address once a packet is received from a new address
     // and serves as a way to auto-detect peer changing IPs.
-    if (state->GetPeerAddress() != peerAddress)
+    if (session->GetPeerAddress() != peerAddress)
     {
-        state->SetPeerAddress(peerAddress);
+        session->SetPeerAddress(peerAddress);
     }
 
     if (mCB != nullptr)
     {
-        SessionHandle session(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(),
-                              state->GetFabricIndex());
-        mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
+        SessionHandle sessionHandle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(),
+                                    session->GetFabricIndex());
+        mCB->OnMessageReceived(packetHeader, payloadHeader, sessionHandle, peerAddress, isDuplicate, std::move(msg));
     }
 
 exit:
@@ -542,8 +535,8 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
     if (mCB != nullptr)
     {
         // TODO: Update Session Handle for Group messages.
-        // SessionHandle session(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(),
-        //                       state->GetFabricIndex());
+        // SessionHandle session(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(),
+        //                       session->GetFabricIndex());
         // mCB->OnMessageReceived(packetHeader, payloadHeader, nullptr, peerAddress, isDuplicate, std::move(msg));
     }
 
@@ -554,18 +547,18 @@ exit:
     }
 }
 
-void SessionManager::HandleConnectionExpired(const Transport::SecureSession & state)
+void SessionManager::HandleConnectionExpired(const Transport::SecureSession & session)
 {
     ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired",
-                  ChipLogValueX64(state.GetPeerNodeId()));
+                  ChipLogValueX64(session.GetPeerNodeId()));
 
     if (mCB != nullptr)
     {
-        mCB->OnConnectionExpired(
-            SessionHandle(state.GetPeerNodeId(), state.GetLocalSessionId(), state.GetPeerSessionId(), state.GetFabricIndex()));
+        mCB->OnConnectionExpired(SessionHandle(session.GetPeerNodeId(), session.GetLocalSessionId(), session.GetPeerSessionId(),
+                                               session.GetFabricIndex()));
     }
 
-    mTransportMgr->Disconnect(state.GetPeerAddress());
+    mTransportMgr->Disconnect(session.GetPeerAddress());
 }
 
 void SessionManager::ExpiryTimerCallback(System::Layer * layer, void * param)
@@ -574,7 +567,7 @@ void SessionManager::ExpiryTimerCallback(System::Layer * layer, void * param)
 #if CHIP_CONFIG_SESSION_REKEYING
     // TODO(#2279): session expiration is currently disabled until rekeying is supported
     // the #ifdef should be removed after that.
-    mgr->mPeerConnections.ExpireInactiveSessions(
+    mgr->mSecureSessions.ExpireInactiveSessions(
         CHIP_PEER_CONNECTION_TIMEOUT_MS, [this](const Transport::SecureSession & state1) { HandleConnectionExpired(state1); });
 #endif
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
@@ -584,7 +577,7 @@ SecureSession * SessionManager::GetSecureSession(SessionHandle session)
 {
     if (session.mLocalSessionId.HasValue())
     {
-        return mPeerConnections.FindSecureSessionByLocalKey(session.mLocalSessionId.Value(), nullptr);
+        return mSecureSessions.FindSecureSessionByLocalKey(session.mLocalSessionId.Value());
     }
     else
     {
@@ -594,10 +587,18 @@ SecureSession * SessionManager::GetSecureSession(SessionHandle session)
 
 SessionHandle SessionManager::FindSecureSessionForNode(NodeId peerNodeId)
 {
-    SecureSession * session = mPeerConnections.FindSecureSession(peerNodeId, nullptr);
-    VerifyOrDie(session != nullptr);
-    return SessionHandle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(),
-                         session->GetFabricIndex());
+    SecureSession * found = nullptr;
+    mSecureSessions.ForEachSession([&](auto session) {
+        if (session->GetPeerNodeId() == peerNodeId)
+        {
+            found = session;
+            return false;
+        }
+        return true;
+    });
+
+    VerifyOrDie(found != nullptr);
+    return SessionHandle(found->GetPeerNodeId(), found->GetLocalSessionId(), found->GetPeerSessionId(), found->GetFabricIndex());
 }
 
 } // namespace chip

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -289,8 +289,8 @@ private:
 
     System::Layer * mSystemLayer = nullptr;
     Transport::UnauthenticatedSessionTable<CHIP_CONFIG_UNAUTHENTICATED_CONNECTION_POOL_SIZE> mUnauthenticatedSessions;
-    Transport::SecureSessionTable<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mPeerConnections; // < Active connections to other peers
-    State mState;                                                                          // < Initialization state of the object
+    Transport::SecureSessionTable<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mSecureSessions; // < Active connections to other peers
+    State mState;                                                                         // < Initialization state of the object
 
     SessionManagerDelegate * mCB                                       = nullptr;
     TransportMgrBase * mTransportMgr                                   = nullptr;


### PR DESCRIPTION
#### Problem
Use BitMapPool for SecureSessionTable

`BitMapPool` provides a more robust API than a array. constructors and destructors are called according to the lifecycle of the secure session object, so we can make some of its field to const.

`BitMapPool` will also have a POSIX implementation w/o capacity limitation using dynamic malloc.

#### Change overview
Change sessions in `SecureSessionTable` into a BitMapPool

#### Testing
Verified by unit-tests