### PR TITLE
Move the lib/core type includes from basic_types.h to DataModelTypes.h.

### DIFF
--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -25,11 +25,7 @@
 
 #include <cstdint>
 
-#include <lib/core/GroupId.h>
-#include <lib/core/NodeId.h>
-
-// Pull in other core types
-#include <lib/core/CHIPVendorIdentifiers.hpp>
+// Pull in core types
 #include <lib/core/DataModelTypes.h>
 
 namespace chip {

--- a/src/lib/core/DataModelTypes.h
+++ b/src/lib/core/DataModelTypes.h
@@ -19,6 +19,10 @@
 
 #include <cstdint>
 
+#include <lib/core/CHIPVendorIdentifiers.hpp> // For VendorId
+#include <lib/core/GroupId.h>
+#include <lib/core/NodeId.h>
+
 namespace chip {
 
 typedef uint8_t ActionId;

--- a/src/lib/core/DataModelTypes.h
+++ b/src/lib/core/DataModelTypes.h
@@ -22,6 +22,7 @@
 #include <lib/core/CHIPVendorIdentifiers.hpp> // For VendorId
 #include <lib/core/GroupId.h>
 #include <lib/core/NodeId.h>
+#include <lib/core/PasscodeId.h>
 
 namespace chip {
 


### PR DESCRIPTION
NodeId, GroupId, and VendorId declarations should come along when
including a header called DataModelTypes.h.

#### Problem
Not all data model types are declared if you include DataModelTypes.h

#### Change overview
Move some includes around to fix that.

#### Testing
Tree compiles.