### PR TITLE
[im] Fix wildcard path support per spec

### DIFF
--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -34,6 +34,7 @@ namespace app {
 // Note: The change will happen after #11171 with a better linked list.
 struct ClusterInfo
 {
+private:
     // Endpoint Id is a uint16 number, and should between 0 and 0xFFFE
     static constexpr EndpointId kInvalidEndpointId = 0xFFFF;
     // The ClusterId, AttributeId and EventId are MEIs,
@@ -44,6 +45,7 @@ struct ClusterInfo
     // ListIndex is a uint16 number, thus 0xFFFF is not a valid list index.
     static constexpr ListIndex kInvalidListIndex = 0xFFFF;
 
+public:
     bool IsAttributePathSupersetOf(const ClusterInfo & other) const
     {
         VerifyOrReturnError(HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -27,8 +27,8 @@ namespace app {
 
 /**
  * ClusterInfo is the representation of an attribute path or an event path used by ReadHandler, ReadClient, WriteHandler,
- * Report::Engine etc, tt uses some invalid values for representing the wildcard value for its field and  contains a mpNext field so
- * it can be used as a linked list.
+ * Report::Engine etc, it uses some invalid values for representing the wildcard values for its fields and  contains a mpNext field
+ * so it can be used as a linked list.
  */
 // TODO: The cluster info should be separated into AttributeInfo and EventInfo.
 // Note: The change will happen after #11171 with a better linked list.
@@ -46,39 +46,39 @@ struct ClusterInfo
 
     bool IsAttributePathSupersetOf(const ClusterInfo & other) const
     {
-        VerifyOrReturnError(!HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);
-        VerifyOrReturnError(!HasWildcardClusterId() || mClusterId == other.mClusterId, false);
-        VerifyOrReturnError(!HasWildcardAttributeId() || mFieldId == other.mFieldId, false);
-        VerifyOrReturnError(!HasWildcardListIndex() || mListIndex == other.mListIndex, false);
+        VerifyOrReturnError(HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);
+        VerifyOrReturnError(HasWildcardClusterId() || mClusterId == other.mClusterId, false);
+        VerifyOrReturnError(HasWildcardAttributeId() || mFieldId == other.mFieldId, false);
+        VerifyOrReturnError(HasWildcardListIndex() || mListIndex == other.mListIndex, false);
 
         return true;
     }
 
-    bool HasWildcard() const { return !HasWildcardEndpointId() || !HasWildcardClusterId() || !HasWildcardAttributeId(); }
+    bool HasWildcard() const { return HasWildcardEndpointId() || HasWildcardClusterId() || HasWildcardAttributeId(); }
 
     /**
-     * Verify if it mets some basic constrants of a attribute path: If list index is valid, then field id must be valid too.
-     * There are other conditions that the path is not a valid path, e.g. the path does not exists, wildcard cluster id with
-     * non-wildcard attribute id and valid list index on a non-array attributes etc.
+     * Check that the path meets some basic constraints of an attribute path: If list index is not wildcard, then field id must not
+     * be wildcard. This does not verify that the attribute being targeted is actually of list type when the list index is not
+     * wildcard.
      */
-    bool IsValidAttributePath() const { return mListIndex == kInvalidListIndex || mFieldId != kInvalidAttributeId; }
+    bool IsValidAttributePath() const { return HasWildcardListIndex() || !HasWildcardAttributeId(); }
 
-    inline bool HasWildcardNodeId() const { return mNodeId != kUndefinedNodeId; }
-    inline bool HasWildcardEndpointId() const { return mEndpointId != kInvalidEndpointId; }
-    inline bool HasWildcardClusterId() const { return mClusterId != kInvalidClusterId; }
-    inline bool HasWildcardAttributeId() const { return mFieldId != kInvalidAttributeId; }
-    inline bool HasWildcardListIndex() const { return mListIndex != kInvalidListIndex; }
-    inline bool HasWildcardEventId() const { return mEventId != kInvalidEventId; }
+    inline bool HasWildcardNodeId() const { return mNodeId == kUndefinedNodeId; }
+    inline bool HasWildcardEndpointId() const { return mEndpointId == kInvalidEndpointId; }
+    inline bool HasWildcardClusterId() const { return mClusterId == kInvalidClusterId; }
+    inline bool HasWildcardAttributeId() const { return mFieldId == kInvalidAttributeId; }
+    inline bool HasWildcardListIndex() const { return mListIndex == kInvalidListIndex; }
+    inline bool HasWildcardEventId() const { return mEventId == kInvalidEventId; }
 
     ClusterInfo() {}
     /*
      * For better structure alignment
-     * Above ordering is by bit-size to ensure least amount of memory alignment padding.
+     * Below ordering is by bit-size to ensure least amount of memory alignment padding.
      * Changing order to something more natural (e.g. endpoint id before cluster id) will result
      * in extra memory alignment padding.
      */
-    ClusterInfo * mpNext   = nullptr;             // pointer width (32/64 bits)
     NodeId mNodeId         = kUndefinedNodeId;    // uint64
+    ClusterInfo * mpNext   = nullptr;             // pointer width (32/64 bits)
     ClusterId mClusterId   = kInvalidClusterId;   // uint32
     AttributeId mFieldId   = kInvalidAttributeId; // uint32
     EventId mEventId       = kInvalidEventId;     // uint32

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -18,103 +18,72 @@
 
 #pragma once
 
-#include <app/AttributePathParams.h>
 #include <app/util/basic-types.h>
 #include <assert.h>
 #include <lib/core/Optional.h>
 
 namespace chip {
 namespace app {
-static constexpr AttributeId kRootAttributeId = 0xFFFFFFFF;
 
+/**
+ * ClusterInfo is the representation of an attribute path or an event path used by ReadHandler, ReadClient, WriteHandler,
+ * Report::Engine etc, tt uses some invalid values for representing the wildcard value for its field and  contains a mpNext field so
+ * it can be used as a linked list.
+ */
+// TODO: The cluster info should be separated into AttributeInfo and EventInfo.
+// Note: The change will happen after #11171 with a better linked list.
 struct ClusterInfo
 {
-    enum class Flags : uint8_t
-    {
-        kFieldIdValid   = 0x01,
-        kListIndexValid = 0x02,
-        kEventIdValid   = 0x03,
-    };
+    // Endpoint Id is a uint16 number, and should between 0 and 0xFFFE
+    static constexpr EndpointId kInvalidEndpointId = 0xFFFF;
+    // The ClusterId, AttributeId and EventId are MEIs,
+    // 0xFFFF is not a valid manufacturer code, thus 0xFFFF'FFFF is not a valid MEI
+    static constexpr ClusterId kInvalidClusterId     = 0xFFFF'FFFF;
+    static constexpr AttributeId kInvalidAttributeId = 0xFFFF'FFFF;
+    static constexpr EventId kInvalidEventId         = 0xFFFF'FFFF;
+    // ListIndex is a uint16 number, thus 0xFFFF is not a valid list index.
+    static constexpr ListIndex kInvalidListIndex = 0xFFFF;
 
     bool IsAttributePathSupersetOf(const ClusterInfo & other) const
     {
-        if ((other.mEndpointId != mEndpointId) || (other.mClusterId != mClusterId))
-        {
-            return false;
-        }
+        VerifyOrReturnError(!HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);
+        VerifyOrReturnError(!HasWildcardClusterId() || mClusterId == other.mClusterId, false);
+        VerifyOrReturnError(!HasWildcardAttributeId() || mFieldId == other.mFieldId, false);
+        VerifyOrReturnError(!HasWildcardListIndex() || mListIndex == other.mListIndex, false);
 
-        Optional<AttributeId> myFieldId =
-            mFlags.Has(Flags::kFieldIdValid) ? Optional<AttributeId>::Value(mFieldId) : Optional<AttributeId>::Missing();
-
-        Optional<AttributeId> otherFieldId = other.mFlags.Has(Flags::kFieldIdValid) ? Optional<AttributeId>::Value(other.mFieldId)
-                                                                                    : Optional<AttributeId>::Missing();
-
-        Optional<ListIndex> myListIndex =
-            mFlags.Has(Flags::kListIndexValid) ? Optional<ListIndex>::Value(mListIndex) : Optional<ListIndex>::Missing();
-
-        Optional<ListIndex> otherListIndex = other.mFlags.Has(Flags::kListIndexValid) ? Optional<ListIndex>::Value(other.mListIndex)
-                                                                                      : Optional<ListIndex>::Missing();
-
-        // If list index exists, field index must exist
-        // Field 0xFFFFFFF (any) &  listindex set is invalid
-        assert(!(myListIndex.HasValue() && !myFieldId.HasValue()));
-        assert(!(otherListIndex.HasValue() && !otherFieldId.HasValue()));
-        assert(!(myFieldId == Optional<AttributeId>::Value(kRootAttributeId) && myListIndex.HasValue()));
-        assert(!(otherFieldId == Optional<AttributeId>::Value(kRootAttributeId) && otherListIndex.HasValue()));
-
-        if (myFieldId == Optional<AttributeId>::Value(kRootAttributeId))
-        {
-            return true;
-        }
-
-        if (myFieldId != otherFieldId)
-        {
-            return false;
-        }
-
-        // We only support top layer for attribute representation, either FieldId or FieldId + ListIndex
-        // Combination: if myFieldId == otherFieldId, ListIndex cannot exist without FieldId
-        // 1. myListIndex and otherListIndex both missing or both exactly the same, then current is superset of other
-        // 2. myListIndex is missing, no matter if otherListIndex is missing or not, then current is superset of other
-        if (myListIndex == otherListIndex)
-        {
-            // either both missing or both exactly the same
-            return true;
-        }
-
-        if (!myListIndex.HasValue())
-        {
-            // difference is ok only if myListIndex is missing
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
-    ClusterInfo() {}
-    NodeId mNodeId         = 0;
-    ClusterId mClusterId   = 0;
-    ListIndex mListIndex   = 0;
-    AttributeId mFieldId   = 0;
-    EndpointId mEndpointId = 0;
-    BitFlags<Flags> mFlags;
-    ClusterInfo * mpNext = nullptr;
-    EventId mEventId     = 0;
-    /* For better structure alignment
-     * Above ordering is by bit-size to ensure least amount of memory alignment padding.
-     * Changing order to something more natural (e.g. clusterid before nodeid) will result
-     * in extra memory alignment padding.
-     * uint64 mNodeId
-     * uint16_t mClusterId
-     * uint16_t mListIndex
-     * uint8_t FieldId
-     * uint8_t EndpointId
-     * uint8_t mDirty
-     * uint8_t mType
-     * uint32_t mpNext
-     * uint16_t EventId
-     * padding 2 bytes
+    bool HasWildcard() const { return !HasWildcardEndpointId() || !HasWildcardClusterId() || !HasWildcardAttributeId(); }
+
+    /**
+     * Verify if it mets some basic constrants of a attribute path: If list index is valid, then field id must be valid too.
+     * There are other conditions that the path is not a valid path, e.g. the path does not exists, wildcard cluster id with
+     * non-wildcard attribute id and valid list index on a non-array attributes etc.
      */
+    bool IsValidAttributePath() const { return mListIndex == kInvalidListIndex || mFieldId != kInvalidAttributeId; }
+
+    inline bool HasWildcardNodeId() const { return mNodeId != kUndefinedNodeId; }
+    inline bool HasWildcardEndpointId() const { return mEndpointId != kInvalidEndpointId; }
+    inline bool HasWildcardClusterId() const { return mClusterId != kInvalidClusterId; }
+    inline bool HasWildcardAttributeId() const { return mFieldId != kInvalidAttributeId; }
+    inline bool HasWildcardListIndex() const { return mListIndex != kInvalidListIndex; }
+    inline bool HasWildcardEventId() const { return mEventId != kInvalidEventId; }
+
+    ClusterInfo() {}
+    /*
+     * For better structure alignment
+     * Above ordering is by bit-size to ensure least amount of memory alignment padding.
+     * Changing order to something more natural (e.g. endpoint id before cluster id) will result
+     * in extra memory alignment padding.
+     */
+    ClusterInfo * mpNext   = nullptr;             // pointer width (32/64 bits)
+    NodeId mNodeId         = kUndefinedNodeId;    // uint64
+    ClusterId mClusterId   = kInvalidClusterId;   // uint32
+    AttributeId mFieldId   = kInvalidAttributeId; // uint32
+    EventId mEventId       = kInvalidEventId;     // uint32
+    ListIndex mListIndex   = kInvalidListIndex;   // uint16
+    EndpointId mEndpointId = kInvalidEndpointId;  // uint16
 };
 } // namespace app
 } // namespace chip

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -663,6 +663,7 @@ static bool IsInterestedEventPaths(EventLoadOutContext * eventLoadOutContext, co
     }
     while (interestedEventPaths != nullptr)
     {
+        // TODO: Support wildcard event path
         if (interestedEventPaths->mNodeId == event.mNodeId && interestedEventPaths->mEndpointId == event.mEndpointId &&
             interestedEventPaths->mClusterId == event.mClusterId && interestedEventPaths->mEventId == event.mEventId)
         {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -465,7 +465,6 @@ void InteractionModelEngine::ReleaseClusterInfoList(ClusterInfo *& aClusterInfo)
     {
         lastClusterInfo = lastClusterInfo->mpNext;
     }
-    lastClusterInfo->mFlags.ClearAll();
     lastClusterInfo->mpNext    = mpNextAvailableClusterInfo;
     mpNextAvailableClusterInfo = aClusterInfo;
     aClusterInfo               = nullptr;
@@ -502,7 +501,6 @@ bool InteractionModelEngine::MergeOverlappedAttributePath(ClusterInfo * apAttrib
         {
             runner->mListIndex = aAttributePath.mListIndex;
             runner->mFieldId   = aAttributePath.mFieldId;
-            runner->mFlags     = aAttributePath.mFlags;
             return true;
         }
         runner = runner->mpNext;

--- a/src/app/MessageDef/AttributePath.h
+++ b/src/app/MessageDef/AttributePath.h
@@ -74,7 +74,8 @@ public:
     CHIP_ERROR CheckSchemaValidity() const;
 #endif
     /**
-     *  @brief Get a TLVReader for the NodeId. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the NodeId. Next() must be called before accessing them. If the node id field does not exist, the
+     * nodeid will not be touched.
      *
      *  @param [in] apNodeId    A pointer to apNodeId
      *
@@ -85,7 +86,8 @@ public:
     CHIP_ERROR GetNodeId(chip::NodeId * const apNodeId) const;
 
     /**
-     *  @brief Get a TLVReader for the EndpointId. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the EndpointId. Next() must be called before accessing them. If the endpoint id field does not
+     * exist, the value will not be touched.
      *
      *  @param [in] apEndpointId    A pointer to apEndpointId
      *
@@ -96,7 +98,8 @@ public:
     CHIP_ERROR GetEndpointId(chip::EndpointId * const apEndpointId) const;
 
     /**
-     *  @brief Get a TLVReader for the ClusterId. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the ClusterId. Next() must be called before accessing them. If the cluster id field does not
+     * exist, the value will not be touched.
      *
      *  @param [in] apClusterId    A pointer to apClusterId
      *
@@ -107,7 +110,8 @@ public:
     CHIP_ERROR GetClusterId(chip::ClusterId * const apClusterId) const;
 
     /**
-     *  @brief Get a TLVReader for the FieldId. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the FieldId. Next() must be called before accessing them. If the field id field does not exist,
+     * the value will not be touched.
      *
      *  @param [in] apFieldId    A pointer to apFieldId
      *
@@ -118,7 +122,8 @@ public:
     CHIP_ERROR GetFieldId(chip::AttributeId * const apFieldId) const;
 
     /**
-     *  @brief Get a TLVReader for the ListIndex. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the ListIndex. Next() must be called before accessing them. If the list index field does not
+     * exist, the value will not be touched.
      *
      *  @param [in] apListIndex    A pointer to apListIndex
      *

--- a/src/app/MessageDef/Parser.h
+++ b/src/app/MessageDef/Parser.h
@@ -86,10 +86,10 @@ protected:
         CHIP_ERROR err = CHIP_NO_ERROR;
         chip::TLV::TLVReader reader;
 
-        *apLValue = 0;
-
         err = mReader.FindElementWithTag(chip::TLV::ContextTag(aContextTag), reader);
         SuccessOrExit(err);
+
+        *apLValue = 0;
 
         VerifyOrExit(aTLVType == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 

--- a/src/app/MessageDef/Parser.h
+++ b/src/app/MessageDef/Parser.h
@@ -88,7 +88,7 @@ protected:
     };
 
     /**
-     * Gets a scaler value with the given tag, the value is not touched when the tag is not found in the TLV.
+     * Gets a scalar value with the given tag, the value is not touched when the tag is not found in the TLV.
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types

--- a/src/app/MessageDef/Parser.h
+++ b/src/app/MessageDef/Parser.h
@@ -74,12 +74,26 @@ protected:
     chip::TLV::TLVType mOuterContainerType;
     Parser();
 
+    /**
+     * Gets a unsigned integer value with the given tag, the value is not touched when the tag is not found in the TLV.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
     template <typename T>
     CHIP_ERROR GetUnsignedInteger(const uint8_t aContextTag, T * const apLValue) const
     {
         return GetSimpleValue(aContextTag, chip::TLV::kTLVType_UnsignedInteger, apLValue);
     };
 
+    /**
+     * Gets a scaler value with the given tag, the value is not touched when the tag is not found in the TLV.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
     template <typename T>
     CHIP_ERROR GetSimpleValue(const uint8_t aContextTag, const chip::TLV::TLVType aTLVType, T * const apLValue) const
     {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -476,7 +476,13 @@ CHIP_ERROR ReadClient::ProcessAttributeDataList(TLV::TLVReader & aAttributeDataL
         SuccessOrExit(err);
 
         err = attributePathParser.GetNodeId(&(clusterInfo.mNodeId));
+        if (err == CHIP_END_OF_TLV)
+        {
+            err = CHIP_NO_ERROR;
+        }
         SuccessOrExit(err);
+
+        // The ReportData must contain a concrete attribute path
 
         err = attributePathParser.GetEndpointId(&(clusterInfo.mEndpointId));
         SuccessOrExit(err);
@@ -485,23 +491,10 @@ CHIP_ERROR ReadClient::ProcessAttributeDataList(TLV::TLVReader & aAttributeDataL
         SuccessOrExit(err);
 
         err = attributePathParser.GetFieldId(&(clusterInfo.mFieldId));
-        if (CHIP_NO_ERROR == err)
-        {
-            clusterInfo.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
-        }
-        else if (CHIP_END_OF_TLV == err)
-        {
-            err = CHIP_NO_ERROR;
-        }
         SuccessOrExit(err);
 
         err = attributePathParser.GetListIndex(&(clusterInfo.mListIndex));
-        if (CHIP_NO_ERROR == err)
-        {
-            VerifyOrExit(clusterInfo.mFlags.Has(ClusterInfo::Flags::kFieldIdValid), err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
-            clusterInfo.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
-        }
-        else if (CHIP_END_OF_TLV == err)
+        if (CHIP_END_OF_TLV == err)
         {
             err = CHIP_NO_ERROR;
         }
@@ -530,6 +523,10 @@ CHIP_ERROR ReadClient::ProcessAttributeDataList(TLV::TLVReader & aAttributeDataL
     }
 
 exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH;
+    }
     return err;
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -473,32 +473,37 @@ CHIP_ERROR ReadClient::ProcessAttributeDataList(TLV::TLVReader & aAttributeDataL
         SuccessOrExit(err);
 
         err = element.GetAttributePath(&attributePathParser);
-        SuccessOrExit(err);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
+
+        // We are using the feature that the parser won't touch the value if the field does not exist, since all fields in the
+        // cluster info will be invalid / wildcard, it is safe ignore CHIP_END_OF_TLV directly.
 
         err = attributePathParser.GetNodeId(&(clusterInfo.mNodeId));
         if (err == CHIP_END_OF_TLV)
         {
             err = CHIP_NO_ERROR;
         }
-        SuccessOrExit(err);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 
         // The ReportData must contain a concrete attribute path
 
         err = attributePathParser.GetEndpointId(&(clusterInfo.mEndpointId));
-        SuccessOrExit(err);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 
         err = attributePathParser.GetClusterId(&(clusterInfo.mClusterId));
-        SuccessOrExit(err);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 
         err = attributePathParser.GetFieldId(&(clusterInfo.mFieldId));
-        SuccessOrExit(err);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 
         err = attributePathParser.GetListIndex(&(clusterInfo.mListIndex));
         if (CHIP_END_OF_TLV == err)
         {
             err = CHIP_NO_ERROR;
         }
-        SuccessOrExit(err);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
+
+        VerifyOrExit(clusterInfo.IsValidAttributePath(), err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 
         err = element.GetData(&dataReader);
         if (err == CHIP_END_OF_TLV)
@@ -523,10 +528,6 @@ CHIP_ERROR ReadClient::ProcessAttributeDataList(TLV::TLVReader & aAttributeDataL
     }
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH;
-    }
     return err;
 }
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -341,13 +341,13 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathList::Parser & aAt
         err = path.GetEndpointId(&(clusterInfo.mEndpointId));
         if (err == CHIP_NO_ERROR)
         {
-            VerifyOrExit(clusterInfo.mEndpointId != ClusterInfo::kInvalidEndpointId, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
+            VerifyOrExit(!clusterInfo.HasWildcardEndpointId(), err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
         }
         SuccessOrExit(err);
         err = path.GetClusterId(&(clusterInfo.mClusterId));
         if (err == CHIP_NO_ERROR)
         {
-            VerifyOrExit(clusterInfo.mClusterId != ClusterInfo::kInvalidClusterId, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
+            VerifyOrExit(!clusterInfo.HasWildcardClusterId(), err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
         }
 
         SuccessOrExit(err);
@@ -358,14 +358,15 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathList::Parser & aAt
         }
         else if (err == CHIP_NO_ERROR)
         {
-            VerifyOrExit(clusterInfo.mFieldId != ClusterInfo::kInvalidAttributeId, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
+            VerifyOrExit(!clusterInfo.HasWildcardAttributeId(), err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
         }
         SuccessOrExit(err);
 
         err = path.GetListIndex(&(clusterInfo.mListIndex));
         if (CHIP_NO_ERROR == err)
         {
-            VerifyOrExit(clusterInfo.mFieldId != ClusterInfo::kInvalidAttributeId, err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
+            VerifyOrExit(!clusterInfo.HasWildcardAttributeId() && !clusterInfo.HasWildcardListIndex(),
+                         err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
         }
         else if (CHIP_END_OF_TLV == err)
         {

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -124,7 +124,10 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataList(TLV::TLVReader & aAttributeDat
         SuccessOrExit(err);
 
         err = attributePath.GetNodeId(&(clusterInfo.mNodeId));
-        SuccessOrExit(err);
+        if (CHIP_END_OF_TLV == err)
+        {
+            err = CHIP_NO_ERROR;
+        }
 
         err = attributePath.GetEndpointId(&(clusterInfo.mEndpointId));
         SuccessOrExit(err);
@@ -133,22 +136,16 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataList(TLV::TLVReader & aAttributeDat
         SuccessOrExit(err);
 
         err = attributePath.GetFieldId(&(clusterInfo.mFieldId));
-        if (CHIP_NO_ERROR == err)
-        {
-            clusterInfo.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
-        }
-        else if (CHIP_END_OF_TLV == err)
-        {
-            err = CHIP_NO_ERROR;
-        }
         SuccessOrExit(err);
 
         err = attributePath.GetListIndex(&(clusterInfo.mListIndex));
-        if (CHIP_NO_ERROR == err)
+        if (CHIP_END_OF_TLV == err)
         {
-            VerifyOrExit(clusterInfo.mFlags.Has(ClusterInfo::Flags::kFieldIdValid), err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
-            clusterInfo.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
+            err = CHIP_NO_ERROR;
         }
+
+        VerifyOrExit(clusterInfo.IsValidAttributePath() && !clusterInfo.HasWildcard(),
+                     err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 
         err = element.GetData(&dataReader);
         SuccessOrExit(err);

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -123,6 +123,9 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataList(TLV::TLVReader & aAttributeDat
         err = element.GetAttributePath(&attributePath);
         SuccessOrExit(err);
 
+        // We are using the feature that the parser won't touch the value if the field does not exist, since all fields in the
+        // cluster info will be invalid / wildcard, it is safe ignore CHIP_END_OF_TLV directly.
+
         err = attributePath.GetNodeId(&(clusterInfo.mNodeId));
         if (CHIP_END_OF_TLV == err)
         {
@@ -144,6 +147,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataList(TLV::TLVReader & aAttributeDat
             err = CHIP_NO_ERROR;
         }
 
+        // We do not support Wildcard writes for now, reject all wildcard write requests.
         VerifyOrExit(clusterInfo.IsValidAttributePath() && !clusterInfo.HasWildcard(),
                      err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -70,8 +70,7 @@ Engine::RetrieveClusterData(FabricIndex aAccessingFabricIndex, AttributeDataList
     ConcreteAttributePath path(aClusterInfo.mEndpointId, aClusterInfo.mClusterId, aClusterInfo.mFieldId);
     AttributeDataElement::Builder attributeDataElementBuilder = aAttributeDataList.CreateAttributeDataElementBuilder();
     AttributePath::Builder attributePathBuilder               = attributeDataElementBuilder.CreateAttributePathBuilder();
-    attributePathBuilder.NodeId(aClusterInfo.mNodeId)
-        .EndpointId(aClusterInfo.mEndpointId)
+    attributePathBuilder.EndpointId(aClusterInfo.mEndpointId)
         .ClusterId(aClusterInfo.mClusterId)
         .FieldId(aClusterInfo.mFieldId)
         .EndOfAttributePath();

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -50,20 +50,31 @@ void TestAttributePathIncludedSameFieldId(nlTestSuite * apSuite, void * apContex
 
 void TestAttributePathIncludedDifferentFieldId(nlTestSuite * apSuite, void * apContext)
 {
-    ClusterInfo clusterInfo1;
-    ClusterInfo clusterInfo2;
-    clusterInfo1.mFieldId = 1;
-    clusterInfo2.mFieldId = 2;
-    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo1.mFieldId = ClusterInfo::kInvalidAttributeId;
-    clusterInfo2.mFieldId = 2;
-    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo1.mFieldId = ClusterInfo::kInvalidAttributeId;
-    clusterInfo2.mFieldId = ClusterInfo::kInvalidAttributeId;
-    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo1.mFieldId = 1;
-    clusterInfo2.mFieldId = ClusterInfo::kInvalidAttributeId;
-    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    {
+        ClusterInfo clusterInfo1;
+        ClusterInfo clusterInfo2;
+        clusterInfo1.mFieldId = 1;
+        clusterInfo2.mFieldId = 2;
+        NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    }
+    {
+        ClusterInfo clusterInfo1;
+        ClusterInfo clusterInfo2;
+        clusterInfo2.mFieldId = 2;
+        NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    }
+    {
+        ClusterInfo clusterInfo1;
+        ClusterInfo clusterInfo2;
+        NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    }
+    {
+        ClusterInfo clusterInfo1;
+        ClusterInfo clusterInfo2;
+
+        clusterInfo1.mFieldId = 1;
+        NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    }
 }
 
 void TestAttributePathIncludedDifferentEndpointId(nlTestSuite * apSuite, void * apContext)

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -34,19 +34,15 @@ void TestAttributePathIncludedSameFieldId(nlTestSuite * apSuite, void * apContex
     ClusterInfo clusterInfo1;
     ClusterInfo clusterInfo2;
     ClusterInfo clusterInfo3;
-    clusterInfo1.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
-    clusterInfo2.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
-    clusterInfo3.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
     clusterInfo1.mFieldId = 1;
     clusterInfo2.mFieldId = 1;
     clusterInfo3.mFieldId = 1;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo2.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
     clusterInfo2.mListIndex = 1;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo1.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
+    clusterInfo1.mListIndex = 0;
     NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo3));
-    clusterInfo3.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
+    clusterInfo3.mListIndex = 0;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo3));
     clusterInfo3.mListIndex = 1;
     NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo3));
@@ -56,19 +52,17 @@ void TestAttributePathIncludedDifferentFieldId(nlTestSuite * apSuite, void * apC
 {
     ClusterInfo clusterInfo1;
     ClusterInfo clusterInfo2;
-    clusterInfo1.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
-    clusterInfo2.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
     clusterInfo1.mFieldId = 1;
     clusterInfo2.mFieldId = 2;
     NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo1.mFieldId = 0xFFFFFFFF;
+    clusterInfo1.mFieldId = ClusterInfo::kInvalidAttributeId;
     clusterInfo2.mFieldId = 2;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-    clusterInfo1.mFieldId = 0xFFFFFFFF;
-    clusterInfo2.mFieldId = 0xFFFFFFFF;
+    clusterInfo1.mFieldId = ClusterInfo::kInvalidAttributeId;
+    clusterInfo2.mFieldId = ClusterInfo::kInvalidAttributeId;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
     clusterInfo1.mFieldId = 1;
-    clusterInfo2.mFieldId = 0xFFFFFFFF;
+    clusterInfo2.mFieldId = ClusterInfo::kInvalidAttributeId;
     NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
 }
 

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -102,15 +102,24 @@ void TestInteractionModelEngine::TestMergeOverlappedAttributePath(nlTestSuite * 
     clusterInfoList[0].mFieldId = 1;
     clusterInfoList[1].mFieldId = 2;
 
-    chip::app::ClusterInfo testClusterInfo;
-    testClusterInfo.mFieldId = 3;
-
-    NL_TEST_ASSERT(apSuite, !InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    testClusterInfo.mFieldId = ClusterInfo::kInvalidAttributeId;
-    NL_TEST_ASSERT(apSuite, InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    testClusterInfo.mFieldId   = 1;
-    testClusterInfo.mListIndex = 2;
-    NL_TEST_ASSERT(apSuite, InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
+    {
+        chip::app::ClusterInfo testClusterInfo;
+        testClusterInfo.mFieldId = 3;
+        NL_TEST_ASSERT(apSuite,
+                       !InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
+    }
+    {
+        chip::app::ClusterInfo testClusterInfo;
+        NL_TEST_ASSERT(apSuite,
+                       InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
+    }
+    {
+        chip::app::ClusterInfo testClusterInfo;
+        testClusterInfo.mFieldId   = 1;
+        testClusterInfo.mListIndex = 2;
+        NL_TEST_ASSERT(apSuite,
+                       InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
+    }
 }
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -99,19 +99,15 @@ void TestInteractionModelEngine::TestMergeOverlappedAttributePath(nlTestSuite * 
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ClusterInfo clusterInfoList[2];
 
-    clusterInfoList[0].mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
     clusterInfoList[0].mFieldId = 1;
-    clusterInfoList[1].mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
     clusterInfoList[1].mFieldId = 2;
 
     chip::app::ClusterInfo testClusterInfo;
-    testClusterInfo.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
     testClusterInfo.mFieldId = 3;
 
     NL_TEST_ASSERT(apSuite, !InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    testClusterInfo.mFieldId = 0xFFFFFFFF;
+    testClusterInfo.mFieldId = ClusterInfo::kInvalidAttributeId;
     NL_TEST_ASSERT(apSuite, InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));
-    testClusterInfo.mFlags.Set(chip::app::ClusterInfo::Flags::kListIndexValid);
     testClusterInfo.mFieldId   = 1;
     testClusterInfo.mListIndex = 2;
     NL_TEST_ASSERT(apSuite, InteractionModelEngine::GetInstance()->MergeOverlappedAttributePath(clusterInfoList, testClusterInfo));

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -906,34 +906,28 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
     chip::app::ClusterInfo dirtyPath1;
     dirtyPath1.mClusterId  = kTestClusterId;
     dirtyPath1.mEndpointId = kTestEndpointId;
-    dirtyPath1.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
-    dirtyPath1.mFieldId = 1;
+    dirtyPath1.mFieldId    = 1;
 
     chip::app::ClusterInfo dirtyPath2;
     dirtyPath2.mClusterId  = kTestClusterId;
     dirtyPath2.mEndpointId = kTestEndpointId;
-    dirtyPath2.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
-    dirtyPath2.mFieldId = 2;
+    dirtyPath2.mFieldId    = 2;
 
     chip::app::ClusterInfo dirtyPath3;
-    dirtyPath2.mClusterId  = kTestClusterId;
-    dirtyPath2.mEndpointId = kTestEndpointId;
-    dirtyPath2.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
-    dirtyPath2.mFlags.Set(chip::app::ClusterInfo::Flags::kListIndexValid);
-    dirtyPath2.mFieldId   = 2;
-    dirtyPath2.mListIndex = 1;
+    dirtyPath3.mClusterId  = kTestClusterId;
+    dirtyPath3.mEndpointId = kTestEndpointId;
+    dirtyPath3.mFieldId    = 2;
+    dirtyPath3.mListIndex  = 1;
 
     chip::app::ClusterInfo dirtyPath4;
     dirtyPath4.mClusterId  = kTestClusterId;
     dirtyPath4.mEndpointId = kTestEndpointId;
-    dirtyPath4.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
-    dirtyPath4.mFieldId = 3;
+    dirtyPath4.mFieldId    = 3;
 
     chip::app::ClusterInfo dirtyPath5;
     dirtyPath5.mClusterId  = kTestClusterId;
     dirtyPath5.mEndpointId = kTestEndpointId;
-    dirtyPath5.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
-    dirtyPath5.mFieldId = 4;
+    dirtyPath5.mFieldId    = 4;
 
     // Test report with 2 different path
     delegate.mpReadHandler->mHoldReport = false;

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -171,7 +171,6 @@ void MutateClusterHandler(chip::System::Layer * systemLayer, void * appState)
     chip::app::ClusterInfo dirtyPath;
     dirtyPath.mClusterId  = kTestClusterId;
     dirtyPath.mEndpointId = kTestEndpointId;
-    dirtyPath.mFlags.Set(chip::app::ClusterInfo::Flags::kFieldIdValid);
     printf("MutateClusterHandler is triggered...");
     // send dirty change
     if (!testSyncReport)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -502,7 +502,6 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
     info.mClusterId  = clusterId;
     info.mFieldId    = attributeId;
     info.mEndpointId = endpoint;
-    info.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(info);
 


### PR DESCRIPTION
#### Problem
- The current implementation of ClusterInfo class is not handling wildcard paths correctly.
- Spec requirement: wildcard by omitting fields

#### Change overview
- Fix the logic for handling wildcard paths.
- Uses Optional<T> for missing values, and changes the usages to .Value()
- Assume ClusterInfo values are concrete path now, this will be changed in https://github.com/project-chip/connectedhomeip/issues/8364
- Update tests to use SetValue, ClearValue

#### Testing
Updtaes existing test, the logic is covered by existing `src/app/tests/TestClusterInfo.cpp`
