### PR TITLE
Do not compile x64 android in cloudbuild smoke test

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -86,7 +86,7 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob 'android-{arm64,x64}-chip-tool' build
+              --target-glob 'android-arm64-chip-tool' build
               --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap


### PR DESCRIPTION
 LLVM currently cannot properly compiler x64 (out of resources it seems)

