### PR TITLE
Add support for null in yaml tests.

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -206,6 +206,30 @@ protected:
         return false;
     }
 
+    template <typename T>
+    bool CheckValueNull(const char * itemName, const chip::app::DataModel::Nullable<T> & value)
+    {
+        if (value.IsNull())
+        {
+            return true;
+        }
+
+        Exit(std::string(itemName) + " expected to be null but isn't");
+        return false;
+    }
+
+    template <typename T>
+    bool CheckValueNonNull(const char * itemName, const chip::app::DataModel::Nullable<T> & value)
+    {
+        if (!value.IsNull())
+        {
+            return true;
+        }
+
+        Exit(std::string(itemName) + " expected to not be null but is");
+        return false;
+    }
+
     chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -172,18 +172,26 @@ class {{filename}}: public TestCommand
           {{/if}}
           {{#chip_tests_item_response_parameters}}
             {{~#*inline "item"}}{{asLowerCamelCase name}}{{#if isOptional}}.Value(){{/if}}{{/inline}}
+            {{~#*inline "itemValue"}}{{>item}}{{#if isNullable}}.Value(){{/if}}{{/inline}}
             {{#if hasExpectedValue}}
               {{#if isOptional}}
                 {{~#*inline "item"}}{{asLowerCamelCase name}}{{/inline}}
                 VerifyOrReturn(CheckValuePresent("{{> item}}", {{> item}}));
               {{/if}}
-              VerifyOrReturn(CheckValue
-                {{~#if isList}}AsListLength("{{>item}}", {{>item}}, {{expectedValue.length}})
-                {{else if isArray}}AsList("{{>item}}", {{>item}}, {{expectedValue}})
-                {{else if (isString type)}}AsString("{{>item}}", {{>item}}, "{{expectedValue}}")
-                {{else}}<{{chipType}}>("{{>item}}", {{>item}}, {{expectedValue}}{{asTypeLiteralSuffix type}})
+              {{#if (isLiteralNull expectedValue)}}
+                VerifyOrReturn(CheckValueNull("{{> item}}", {{> item}}));
+              {{else}}
+                {{#if isNullable}}
+                VerifyOrReturn(CheckValueNonNull("{{> item}}", {{> item}}));
                 {{/if}}
-              );
+                VerifyOrReturn(CheckValue
+                  {{~#if isList}}AsListLength("{{>itemValue}}", {{>itemValue}}, {{expectedValue.length}})
+                  {{else if isArray}}AsList("{{>itemValue}}", {{>itemValue}}, {{expectedValue}})
+                  {{else if (isString type)}}AsString("{{>itemValue}}", {{>itemValue}}, "{{expectedValue}}")
+                  {{else}}<{{chipType}}>("{{>itemValue}}", {{>itemValue}}, {{expectedValue}}{{asTypeLiteralSuffix type}})
+                  {{/if}}
+                );
+              {{/if}}
             {{/if}}
             {{#if hasExpectedConstraints}}
               {{#if isOptional}}

--- a/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
@@ -2,13 +2,17 @@
   {{#if ignore}}
     {{>commandValue ns=ns container=(concat container ".Emplace()") definedValue=definedValue type=type isOptional=false ignore=true}}
   {{else}}
-    {{>commandValue ns=ns container=(concat container "." label ".Emplace()") definedValue=definedValue type=type isOptional=false ignore=true}}
+    {{>commandValue ns=ns container=(concat container "." (asLowerCamelCase label) ".Emplace()") definedValue=definedValue type=type isOptional=false ignore=true}}
   {{/if}}
 {{else if isNullable}}
-  {{#if ignore}}
-    {{>commandValue ns=ns container=(concat container ".SetNonNull()") definedValue=definedValue type=type isNullable=false ignore=true}}
+  {{#if (isLiteralNull definedValue)}}
+    {{container}}{{#unless ignore}}.{{asLowerCamelCase label}}{{/unless}}.SetNull();
   {{else}}
-    {{>commandValue ns=ns container=(concat container "." label ".SetNonNull()") definedValue=definedValue type=type isNullable=false ignore=true}}
+    {{#if ignore}}
+      {{>commandValue ns=ns container=(concat container ".SetNonNull()") definedValue=definedValue type=type isNullable=false ignore=true}}
+    {{else}}
+      {{>commandValue ns=ns container=(concat container "." (asLowerCamelCase label) ".SetNonNull()") definedValue=definedValue type=type isNullable=false ignore=true}}
+    {{/if}}
   {{/if}}
 {{else if isArray}}
 
@@ -26,9 +30,9 @@
 
     {{#zcl_struct_items_by_struct_name type}}
       {{#if ../ignore}}
-      {{>commandValue ns=parent.ns container=(concat parent.container "." label) definedValue=(lookup parent.definedValue name) ignore=../ignore}}
+      {{>commandValue ns=parent.ns container=(concat parent.container "." (asLowerCamelCase label)) definedValue=(lookup parent.definedValue name) ignore=../ignore}}
       {{else}}
-      {{>commandValue ns=parent.ns container=(concat parent.container "." parent.label) definedValue=(lookup parent.definedValue name) ignore=../ignore}}
+      {{>commandValue ns=parent.ns container=(concat parent.container "." (asLowerCamelCase parent.label)) definedValue=(lookup parent.definedValue name) ignore=../ignore}}
       {{/if}}
     {{/zcl_struct_items_by_struct_name}}
 

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -444,6 +444,8 @@ bool emberAfTestClusterClusterTestNullableOptionalRequestCallback(
         {
             response.value.SetValue(commandData.arg1.Value().Value());
         }
+
+        response.originalValue.Emplace(commandData.arg1.Value());
     }
 
     CHIP_ERROR err = commandObj->AddResponseData(commandPath, response);

--- a/src/app/tests/suites/TestClusterComplexTypes.yaml
+++ b/src/app/tests/suites/TestClusterComplexTypes.yaml
@@ -407,6 +407,8 @@ tests:
                 value: false
               - name: "value"
                 value: 5
+              - name: "originalValue"
+                value: 5
 
     - label: "Send Test Command without its optional arg."
       command: "testNullableOptionalRequest"
@@ -416,7 +418,6 @@ tests:
                 value: false
 
     - label: "Send Test Command with optional arg set to null."
-      disabled: true
       command: "testNullableOptionalRequest"
       arguments:
           values:
@@ -427,4 +428,6 @@ tests:
               - name: "wasPresent"
                 value: true
               - name: "wasNull"
-                value: false
+                value: true
+              - name: "originalValue"
+                value: null

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -42,6 +42,13 @@ const kResponseName      = 'response';
 const kDisabledName      = 'disabled';
 const kResponseErrorName = 'error';
 
+class NullObject {
+  toString()
+  {
+    return "YOU SHOULD HAVE CHECKED (isLiteralNull definedValue)"
+  }
+};
+
 function throwError(test, errorStr)
 {
   console.error('Error in: ' + test.filename + '.yaml for test with label: "' + test.label + '"\n');
@@ -417,6 +424,8 @@ function chip_tests_item_parameters(options)
             }
             value[key] = attachGlobal(global, value[key]);
           }
+        } else if (value === null) {
+          value = new NullObject();
         } else {
           switch (typeof value) {
           case 'number':
@@ -487,6 +496,13 @@ function chip_tests_item_response_parameters(options)
   return asBlocks.call(this, promise, options);
 }
 
+function isLiteralNull(value, options)
+{
+  // Literal null might look different depending on whether it went through
+  // attachGlobal or not.
+  return (value === null) || (value instanceof NullObject);
+}
+
 //
 // Module exports
 //
@@ -496,3 +512,4 @@ exports.chip_tests_item_parameters          = chip_tests_item_parameters;
 exports.chip_tests_item_response_type       = chip_tests_item_response_type;
 exports.chip_tests_item_response_parameters = chip_tests_item_response_parameters;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
+exports.isLiteralNull                       = isLiteralNull;

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -367,11 +367,13 @@ limitations under the License.
 
     <command source="server" code="0x06" name="TestNullableOptionalResponse" optional="false" disableDefaultResponse="true">
       <description>
-        Delivers information about the argument TestNullableOptionalRequest had.
+        Delivers information about the argument TestNullableOptionalRequest had,
+        and the original value if there was one.
       </description>
       <arg name="wasPresent" type="BOOLEAN"/>
       <arg name="wasNull" type="BOOLEAN" optional="true"/>
       <arg name="value" type="INT8U" optional="true"/>
+      <arg name="originalValue" type="INT8U" optional="true" isNullable="true"/>
     </command>
 
     <command source="server" code="0x07" name="TestComplexNullableOptionalResponse" optional="false" disableDefaultResponse="true">

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -6070,7 +6070,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, bool wasPresent, bool wasNull, uint8_t value)
+    static void CallbackFn(void * context, bool wasPresent, bool wasNull, uint8_t value, uint8_t originalValue)
     {
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -6087,11 +6087,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ZZI)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ZZII)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jboolean>(wasPresent), static_cast<jboolean>(wasNull),
-                            static_cast<jint>(value));
+                            static_cast<jint>(value), static_cast<jint>(originalValue));
 
     exit:
         if (err != CHIP_NO_ERROR)

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -6042,7 +6042,7 @@ public class ChipClusters {
     }
 
     public interface TestNullableOptionalResponseCallback {
-      void onSuccess(boolean wasPresent, boolean wasNull, int value);
+      void onSuccess(boolean wasPresent, boolean wasNull, int value, int originalValue);
 
       void onError(Exception error);
     }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -1870,11 +1870,12 @@ public class ClusterInfoMapping {
     }
 
     @Override
-    public void onSuccess(boolean wasPresent, boolean wasNull, int value) {
+    public void onSuccess(boolean wasPresent, boolean wasNull, int value, int originalValue) {
       List<Object> responseValues = new ArrayList<>();
       responseValues.add(wasPresent);
       responseValues.add(wasNull);
       responseValues.add(value);
+      responseValues.add(originalValue);
       callback.onSuccess(responseValues);
     }
 

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -20871,11 +20871,14 @@ class TestCluster:
                             Label="wasNull", Tag=1, Type=bool),
                         ClusterObjectFieldDescriptor(
                             Label="value", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="originalValue", Tag=3, Type=uint),
                     ])
 
             wasPresent: 'bool' = None
             wasNull: 'bool' = None
             value: 'uint' = None
+            originalValue: 'uint' = None
 
         @dataclass
         class TestStructArgumentRequest(ClusterCommand):

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -1336,12 +1336,13 @@ void CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge::OnSuccess
 };
 
 void CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge::OnSuccessFn(
-    void * context, bool wasPresent, bool wasNull, uint8_t value)
+    void * context, bool wasPresent, bool wasNull, uint8_t value, uint8_t originalValue)
 {
     DispatchSuccess(context, @ {
         @"wasPresent" : [NSNumber numberWithBool:wasPresent],
         @"wasNull" : [NSNumber numberWithBool:wasNull],
         @"value" : [NSNumber numberWithUnsignedChar:value],
+        @"originalValue" : [NSNumber numberWithUnsignedChar:originalValue],
     });
 };
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -1335,7 +1335,7 @@ public:
         CHIPCallbackBridge<TestClusterClusterTestNullableOptionalResponseCallback>(queue, handler, action, OnSuccessFn,
                                                                                    keepAlive){};
 
-    static void OnSuccessFn(void * context, bool wasPresent, bool wasNull, uint8_t value);
+    static void OnSuccessFn(void * context, bool wasPresent, bool wasNull, uint8_t value, uint8_t originalValue);
 };
 
 class CHIPTestClusterClusterTestSpecificResponseCallbackBridge

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -14093,7 +14093,8 @@ bool emberAfTestClusterClusterTestStructArrayArgumentRequestCallback(
  * @brief Test Cluster Cluster TestNullableOptionalResponse Command callback (from server)
  */
 bool emberAfTestClusterClusterTestNullableOptionalResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                   bool wasPresent, bool wasNull, uint8_t value);
+                                                                   bool wasPresent, bool wasNull, uint8_t value,
+                                                                   uint8_t originalValue);
 /**
  * @brief Test Cluster Cluster TestStructArgumentRequest Command callback (from client)
  */

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -16461,6 +16461,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kWasPresent)), wasPresent));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kWasNull)), wasNull));
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kValue)), value));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kOriginalValue)), originalValue));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -16484,6 +16485,9 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
             break;
         case to_underlying(Fields::kValue):
             ReturnErrorOnFailure(DataModel::Decode(reader, value));
+            break;
+        case to_underlying(Fields::kOriginalValue):
+            ReturnErrorOnFailure(DataModel::Decode(reader, originalValue));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -23603,9 +23603,10 @@ public:
 namespace TestNullableOptionalResponse {
 enum class Fields
 {
-    kWasPresent = 0,
-    kWasNull    = 1,
-    kValue      = 2,
+    kWasPresent    = 0,
+    kWasNull       = 1,
+    kValue         = 2,
+    kOriginalValue = 3,
 };
 
 struct Type
@@ -23618,6 +23619,7 @@ public:
     bool wasPresent;
     Optional<bool> wasNull;
     Optional<uint8_t> value;
+    Optional<DataModel::Nullable<uint8_t>> originalValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -23631,6 +23633,7 @@ public:
     bool wasPresent;
     Optional<bool> wasNull;
     Optional<uint8_t> value;
+    Optional<DataModel::Nullable<uint8_t>> originalValue;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace TestNullableOptionalResponse

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -1924,6 +1924,7 @@ static void OnTestClusterTestNullableOptionalResponseSuccess(
     ChipLogProgress(Zcl, "  wasPresent: %d", data.wasPresent);
     ChipLogProgress(Zcl, "  wasNull: Optional printing is not implemented yet.");
     ChipLogProgress(Zcl, "  value: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  originalValue: Optional printing is not implemented yet.");
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
     command->SetCommandExitStatus(CHIP_NO_ERROR);

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -1959,18 +1959,20 @@ bool emberAfTestClusterClusterTestListInt8UReverseResponseCallback(EndpointId en
 }
 
 bool emberAfTestClusterClusterTestNullableOptionalResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                   bool wasPresent, bool wasNull, uint8_t value)
+                                                                   bool wasPresent, bool wasNull, uint8_t value,
+                                                                   uint8_t originalValue)
 {
     ChipLogProgress(Zcl, "TestNullableOptionalResponse:");
     ChipLogProgress(Zcl, "  wasPresent: %d", wasPresent);
     ChipLogProgress(Zcl, "  wasNull: %d", wasNull);
     ChipLogProgress(Zcl, "  value: %" PRIu8 "", value);
+    ChipLogProgress(Zcl, "  originalValue: %" PRIu8 "", originalValue);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("TestClusterClusterTestNullableOptionalResponseCallback");
 
     Callback::Callback<TestClusterClusterTestNullableOptionalResponseCallback> * cb =
         Callback::Callback<TestClusterClusterTestNullableOptionalResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, wasPresent, wasNull, value);
+    cb->mCall(cb->mContext, wasPresent, wasNull, value, originalValue);
     return true;
 }
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.h
@@ -146,8 +146,8 @@ typedef void (*TestClusterClusterTestAddArgumentsResponseCallback)(void * contex
 typedef void (*TestClusterClusterTestEnumsResponseCallback)(void * context, chip::VendorId arg1, uint8_t arg2);
 typedef void (*TestClusterClusterTestListInt8UReverseResponseCallback)(void * context,
                                                                        /* TYPE WARNING: array array defaults to */ uint8_t * arg1);
-typedef void (*TestClusterClusterTestNullableOptionalResponseCallback)(void * context, bool wasPresent, bool wasNull,
-                                                                       uint8_t value);
+typedef void (*TestClusterClusterTestNullableOptionalResponseCallback)(void * context, bool wasPresent, bool wasNull, uint8_t value,
+                                                                       uint8_t originalValue);
 typedef void (*TestClusterClusterTestSpecificResponseCallback)(void * context, uint8_t returnValue);
 
 // List specific responses

--- a/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/IMClusterCommandHandler.cpp
@@ -5364,11 +5364,12 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
             break;
         }
         case Commands::TestNullableOptionalResponse::Id: {
-            expectArgumentCount = 3;
+            expectArgumentCount = 4;
             bool wasPresent;
             bool wasNull;
             uint8_t value;
-            bool argExists[3];
+            uint8_t originalValue;
+            bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
 
@@ -5381,7 +5382,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                     continue;
                 }
                 currentDecodeTagId = TLV::TagNumFromTag(aDataTlv.GetTag());
-                if (currentDecodeTagId < 3)
+                if (currentDecodeTagId < 4)
                 {
                     if (argExists[currentDecodeTagId])
                     {
@@ -5406,6 +5407,9 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                 case 2:
                     TLVUnpackError = aDataTlv.Get(value);
                     break;
+                case 3:
+                    TLVUnpackError = aDataTlv.Get(originalValue);
+                    break;
                 default:
                     // Unsupported tag, ignore it.
                     ChipLogProgress(Zcl, "Unknown TLV tag during processing.");
@@ -5423,10 +5427,10 @@ void DispatchClientCommand(CommandSender * apCommandObj, const ConcreteCommandPa
                 TLVError = CHIP_NO_ERROR;
             }
 
-            if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 3 == validArgumentCount)
+            if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfTestClusterClusterTestNullableOptionalResponseCallback(aCommandPath.mEndpointId, apCommandObj,
-                                                                                           wasPresent, wasNull, value);
+                wasHandled = emberAfTestClusterClusterTestNullableOptionalResponseCallback(
+                    aCommandPath.mEndpointId, apCommandObj, wasPresent, wasNull, value, originalValue);
             }
             break;
         }


### PR DESCRIPTION
Adds support for sending null as a command argument and for null in
the expected value.

#### Problem
Can't test things involving null values in yaml.

#### Change overview
Add support for it.

#### Testing
Tests are modified to exercise this functionality in a simple case.