### PR TITLE
[OperationalCredentials]: Reporting change for the attributes not managed by the attribute store.

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -28,6 +28,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/reporting/reporting.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
@@ -262,6 +263,10 @@ CHIP_ERROR writeFabricsIntoFabricsListAttribute()
                        CHIP_CONFIG_MAX_DEVICE_ADMINS);
         err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
+
+    // Currently, we only manage FabricsList attribute in endpoint 0, OperationalCredentials cluster is always required to be on
+    // EP0.
+    MatterReportingAttributeChangeCallback(0, OperationalCredentials::Id, OperationalCredentials::Attributes::FabricsList::Id);
 
     return err;
 }
@@ -785,6 +790,11 @@ exit:
         gFabricBeingCommissioned.Reset();
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed AddTrustedRootCert request.");
     }
+    else
+    {
+        MatterReportingAttributeChangeCallback(commandPath.mEndpointId, OperationalCredentials::Id,
+                                               OperationalCredentials::Attributes::TrustedRootCertificates::Id);
+    }
 
     return true;
 }
@@ -795,5 +805,9 @@ bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
     emberAfSendImmediateDefaultResponse(status);
+
+    MatterReportingAttributeChangeCallback(commandPath.mEndpointId, OperationalCredentials::Id,
+                                           OperationalCredentials::Attributes::TrustedRootCertificates::Id);
+
     return true;
 }

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -334,8 +334,14 @@ void Engine::Run(System::Layer * aSystemLayer, void * apAppState)
 
 CHIP_ERROR Engine::ScheduleRun()
 {
+    if (mScheduleRunPending)
+    {
+        return CHIP_NO_ERROR;
+    }
+
     if (InteractionModelEngine::GetInstance()->GetExchangeManager() != nullptr)
     {
+        mScheduleRunPending = true;
         return InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionManager()->SystemLayer()->ScheduleWork(Run,
                                                                                                                              this);
     }
@@ -351,6 +357,8 @@ void Engine::Run()
 
     InteractionModelEngine * imEngine = InteractionModelEngine::GetInstance();
     ReadHandler * readHandler         = imEngine->mReadHandlers + mCurReadHandlerIdx;
+
+    mScheduleRunPending = false;
 
     while ((mNumReportsInFlight < CHIP_IM_MAX_REPORTS_IN_FLIGHT) && (numReadHandled < CHIP_IM_MAX_NUM_READ_HANDLER))
     {

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -334,14 +334,14 @@ void Engine::Run(System::Layer * aSystemLayer, void * apAppState)
 
 CHIP_ERROR Engine::ScheduleRun()
 {
-    if (mScheduleRunPending)
+    if (mRunScheduled)
     {
         return CHIP_NO_ERROR;
     }
 
     if (InteractionModelEngine::GetInstance()->GetExchangeManager() != nullptr)
     {
-        mScheduleRunPending = true;
+        mRunScheduled = true;
         return InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionManager()->SystemLayer()->ScheduleWork(Run,
                                                                                                                              this);
     }
@@ -358,7 +358,7 @@ void Engine::Run()
     InteractionModelEngine * imEngine = InteractionModelEngine::GetInstance();
     ReadHandler * readHandler         = imEngine->mReadHandlers + mCurReadHandlerIdx;
 
-    mScheduleRunPending = false;
+    mRunScheduled = false;
 
     while ((mNumReportsInFlight < CHIP_IM_MAX_REPORTS_IN_FLIGHT) && (numReadHandled < CHIP_IM_MAX_NUM_READ_HANDLER))
     {

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -122,6 +122,13 @@ private:
     bool mMoreChunkedMessages = false;
 
     /**
+     * Boolean to indicate if ScheduleRun is pending. This flag is used to prevent calling ScheduleRun multiple times
+     * within the same excution context.
+     *
+     */
+    bool mScheduleRunPending = false;
+
+    /**
      * The number of report date request in flight
      *
      */

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -126,7 +126,7 @@ private:
      * within the same execution context to avoid applying too much pressure on platforms that use small, fixed size event queues.
      *
      */
-    bool mScheduleRunPending = false;
+    bool mRunScheduled = false;
 
     /**
      * The number of report date request in flight

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -123,7 +123,7 @@ private:
 
     /**
      * Boolean to indicate if ScheduleRun is pending. This flag is used to prevent calling ScheduleRun multiple times
-     * within the same excution context.
+     * within the same execution context to avoid applying too much pressure on platforms that use small, fixed size event queues.
      *
      */
     bool mScheduleRunPending = false;

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -505,7 +505,7 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(info);
 
-    // Schedule a run work asynchronously on the CHIP thread, the scheduled work won't execute until the current execution context
+    // Schedule work to run asynchronously on the CHIP thread. The scheduled work won't execute until the current execution context
     // has completed. This ensures that we can 'gather up' multiple attribute changes that have occurred in the same execution
     // context without requiring any explicit 'start' or 'end' change calls into the engine to book-end the change.
     InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -504,4 +504,9 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
     info.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(info);
+
+    // Schedule a run work asynchronously on the CHIP thread, the scheduled work won't execute until the current execution context
+    // has completed. This ensures that we can 'gather up' multiple attribute changes that have occurred in the same execution
+    // context without requiring any explicit 'start' or 'end' change calls into the engine to book-end the change.
+    InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* For the attribute not managed by the attribute store, there is no logic to mark them dirty and notify the report engine when those attributes change. We need to call notify the report engine in such case with the affected paths. 

#### Change overview
Reporting change for the attributes not managed by the attribute store.

#### Testing
How was this tested? (at least one bullet point required)
* Remove fabriclist from client:  "./chip-tool operationalcredentials remove-fabric 0 12344321 0"
* Confirm the change is notified to the reporting engine from the server side log
```
[1635450586.589869][70791:70791] CHIP:ZCL: OpCreds: Fabric 0x1 was retrieved from storage. FabricId 0x0000000000000000, NodeId 0x0000000000BC5C01, VendorId 0x4C38
[1635450586.589872][70791:70791] CHIP:ZCL: OpCreds: Call to writeFabricsIntoFabricsListAttribute
[1635450586.589908][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.589933][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.589936][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.589978][70791:70791] CHIP:ZCL: OpCreds: Fabric 0x1 was retrieved from storage. FabricId 0x0000000000000000, NodeId 0x0000000000BC5C01, VendorId 0x4C38
[1635450586.589981][70791:70791] CHIP:ZCL: OpCreds: Call to writeFabricsIntoFabricsListAttribute
[1635450586.590028][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.590051][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.590054][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.590363][70791:70791] CHIP:DMG: Engine::Run
[1635450586.592092][70791:70791] CHIP:ZCL: OpCreds: RemoveFabric
[1635450586.623815][70791:70791] CHIP:ZCL: OpCreds: Call to writeFabricsIntoFabricsListAttribute
[1635450586.623877][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.623885][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.623902][70791:70791] CHIP:DMG: Engine::ScheduleRun
[1635450586.624016][70791:70791] CHIP:DMG: Engine::Run
```
