### PR TITLE
Initialize chip-tool vendor ID with Test Vendor1

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -23,6 +23,7 @@
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 
@@ -74,10 +75,7 @@ CHIP_ERROR CHIPCommand::Run()
     commissionerParams.controllerRCAC                 = rcacSpan;
     commissionerParams.controllerICAC                 = icacSpan;
     commissionerParams.controllerNOC                  = nocSpan;
-
-    // Set controller vendor ID to Test Vendor #1
-    // As per specifications (section 2.5.2 Vendor Identifier)
-    commissionerParams.controllerVendorId = 0xFFF1;
+    commissionerParams.controllerVendorId             = chip::VendorId::TestVendor1;
 
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().SetupCommissioner(commissionerParams, mController));

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -75,6 +75,10 @@ CHIP_ERROR CHIPCommand::Run()
     commissionerParams.controllerICAC                 = icacSpan;
     commissionerParams.controllerNOC                  = nocSpan;
 
+    // Set controller vendor ID to Test Vendor #1
+    // As per specifications (section 2.5.2 Vendor Identifier)
+    commissionerParams.controllerVendorId = 0xFFF1;
+
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().SetupCommissioner(commissionerParams, mController));
 

--- a/src/lib/core/CHIPVendorIdentifiers.hpp
+++ b/src/lib/core/CHIPVendorIdentifiers.hpp
@@ -34,10 +34,15 @@ namespace chip {
 // CHIP Vendor Identifiers (16 bits max)
 //
 
+// As per specifications (section 2.5.2 Vendor Identifier)
 enum VendorId : uint16_t
 {
     Common       = 0x0000u,
     NestLabs     = 0x235Au,
+    TestVendor1  = 0xFFF1u,
+    TestVendor2  = 0xFFF2u,
+    TestVendor3  = 0xFFF3u,
+    TestVendor4  = 0xFFF4u,
     NotSpecified = 0xFFFFu
 };
 

--- a/src/lib/core/CHIPVendorIdentifiers.hpp
+++ b/src/lib/core/CHIPVendorIdentifiers.hpp
@@ -38,7 +38,7 @@ namespace chip {
 enum VendorId : uint16_t
 {
     Common       = 0x0000u,
-    NestLabs     = 0x235Au,
+    GoogleNest   = 0x235Au,
     TestVendor1  = 0xFFF1u,
     TestVendor2  = 0xFFF2u,
     TestVendor3  = 0xFFF3u,


### PR DESCRIPTION
#### Problem
* Fixes #11159 

#### Change overview
The chip-tool was not setting the vendor ID in the controller params. This PR sets the vendor ID to Test Vendor1.

#### Testing
Commissioned all-cluster-app using chip-tool, and read the fabrics list. The list shows the initialized vendor ID now.