### PR TITLE
InetLayer/SystemLayer use C++11 singleton patter instead of global variable

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -365,7 +365,7 @@ public:
 private:
     void DoReinit()
     {
-        CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(&DeviceLayer::InetLayer);
+        CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(&DeviceLayer::InetLayer());
         if (err != CHIP_NO_ERROR)
         {
             ESP_LOGE(TAG, "Error initializing: %s", err.AsString());

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -32,7 +32,7 @@ public:
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(&chip::DeviceLayer::InetLayer));
+        ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(&chip::DeviceLayer::InetLayer()));
         chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),

--- a/examples/minimal-mdns/advertiser.cpp
+++ b/examples/minimal-mdns/advertiser.cpp
@@ -255,7 +255,7 @@ int main(int argc, char ** args)
         return 1;
     }
 
-    if (chip::Dnssd::ServiceAdvertiser::Instance().Init(&DeviceLayer::InetLayer) != CHIP_NO_ERROR)
+    if (chip::Dnssd::ServiceAdvertiser::Instance().Init(&DeviceLayer::InetLayer()) != CHIP_NO_ERROR)
     {
         fprintf(stderr, "FAILED to start MDNS advertisement\n");
         return 1;

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -317,7 +317,7 @@ int main(int argc, char ** args)
 
         MdnsExample::AllInterfaces allInterfaces(gOptions.enableIpV4);
 
-        err = mdnsServer.Listen(&chip::DeviceLayer::InetLayer, &allInterfaces, gOptions.listenPort);
+        err = mdnsServer.Listen(&chip::DeviceLayer::InetLayer(), &allInterfaces, gOptions.listenPort);
         if (err != CHIP_NO_ERROR)
         {
             printf("Server failed to listen on all interfaces: %s\n", chip::ErrorStr(err));

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -252,7 +252,7 @@ int main(int argc, char ** args)
     {
         MdnsExample::AllInterfaces allInterfaces(gOptions.enableIpV4);
 
-        if (mdnsServer.Listen(&DeviceLayer::InetLayer, &allInterfaces, gOptions.listenPort) != CHIP_NO_ERROR)
+        if (mdnsServer.Listen(&DeviceLayer::InetLayer(), &allInterfaces, gOptions.listenPort) != CHIP_NO_ERROR)
         {
             printf("Server failed to listen on all interfaces\n");
             return 1;

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -292,13 +292,13 @@ void StartPinging(streamer_t * stream, char * destination)
     }
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer)
+    err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer())
                                .SetAddressType(gDestAddr.Type())
                                .SetListenPort(gPingArguments.GetEchoPort() + 1));
     VerifyOrExit(err == CHIP_NO_ERROR, streamer_printf(stream, "Failed to init TCP manager error: %s\n", ErrorStr(err)));
 #endif
 
-    err = gUDPManager.Init(Transport::UdpListenParameters(&DeviceLayer::InetLayer)
+    err = gUDPManager.Init(Transport::UdpListenParameters(&DeviceLayer::InetLayer())
                                .SetAddressType(gDestAddr.Type())
                                .SetListenPort(gPingArguments.GetEchoPort() + 1));
     VerifyOrExit(err == CHIP_NO_ERROR, streamer_printf(stream, "Failed to init UDP manager error: %s\n", ErrorStr(err)));

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -210,13 +210,13 @@ void ProcessCommand(streamer_t * stream, char * destination)
     }
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer)
+    err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer())
                                .SetAddressType(gDestAddr.Type())
                                .SetListenPort(gSendArguments.GetPort() + 1));
     VerifyOrExit(err == CHIP_NO_ERROR, streamer_printf(stream, "Failed to init TCP manager error: %s\n", ErrorStr(err)));
 #endif
 
-    err = gUDPManager.Init(Transport::UdpListenParameters(&DeviceLayer::InetLayer)
+    err = gUDPManager.Init(Transport::UdpListenParameters(&DeviceLayer::InetLayer())
                                .SetAddressType(gDestAddr.Type())
                                .SetListenPort(gSendArguments.GetPort() + 1));
     VerifyOrExit(err == CHIP_NO_ERROR, streamer_printf(stream, "Failed to init UDP manager error: %s\n", ErrorStr(err)));

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -140,7 +140,7 @@ bool DnssdServer::OnExpiration(uint64_t expirationMs)
 
     ChipLogDetail(Discovery, "OnExpiration - valid time out");
 
-    CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer);
+    CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to initialize advertiser: %s", chip::ErrorStr(err));
@@ -410,7 +410,7 @@ void DnssdServer::StartServer(chip::Dnssd::CommissioningMode mode)
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, 0);
 
-    CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer);
+    CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(&chip::DeviceLayer::InetLayer());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to initialize advertiser: %s", chip::ErrorStr(err));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -96,11 +96,11 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 
     // Init transport before operations with secure session mgr.
     err = mTransports.Init(
-        UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(IPAddressType::kIPv6).SetListenPort(mSecuredServicePort)
+        UdpListenParameters(&DeviceLayer::InetLayer()).SetAddressType(IPAddressType::kIPv6).SetListenPort(mSecuredServicePort)
 
 #if INET_CONFIG_ENABLE_IPV4
             ,
-        UdpListenParameters(&DeviceLayer::InetLayer).SetAddressType(IPAddressType::kIPv4).SetListenPort(mSecuredServicePort)
+        UdpListenParameters(&DeviceLayer::InetLayer()).SetAddressType(IPAddressType::kIPv4).SetListenPort(mSecuredServicePort)
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
             ,

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -685,7 +685,7 @@ int main(int argc, char * argv[])
 
     InitializeChip();
 
-    err = gTransportManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer)
+    err = gTransportManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer())
                                      .SetAddressType(chip::Inet::IPAddressType::kIPv6)
                                      .SetListenPort(IM_CLIENT_PORT));
     SuccessOrExit(err);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -212,7 +212,7 @@ int main(int argc, char * argv[])
     InitializeChip();
 
     err = gTransportManager.Init(
-        chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::IPAddressType::kIPv6));
+        chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer()).SetAddressType(chip::Inet::IPAddressType::kIPv6));
     SuccessOrExit(err);
 
     err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &gMessageCounterManager);

--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -67,7 +67,7 @@ void AbstractDnssdDiscoveryController::OnNodeDiscoveryComplete(const chip::Dnssd
 CHIP_ERROR AbstractDnssdDiscoveryController::SetUpNodeDiscovery()
 {
 #if CONFIG_DEVICE_LAYER
-    ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer));
+    ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer()));
 #endif
     mResolver->SetResolverDelegate(this);
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -91,7 +91,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().InitChipStack());
 
     stateParams.systemLayer = &DeviceLayer::SystemLayer();
-    stateParams.inetLayer   = &DeviceLayer::InetLayer;
+    stateParams.inetLayer   = &DeviceLayer::InetLayer();
 #else
     stateParams.systemLayer = params.systemLayer;
     stateParams.inetLayer   = params.inetLayer;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -153,7 +153,7 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self)
     SuccessOrExit(err);
 
     wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, kLocalDeviceId, &DeviceLayer::SystemLayer(),
-                                                          &DeviceLayer::InetLayer, &err);
+                                                          &DeviceLayer::InetLayer(), &err);
     SuccessOrExit(err);
 
     // Create and start the IO thread. Must be called after Controller()->Init

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -93,7 +93,7 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
     CHIP_ERROR result = CHIP_NO_ERROR;
 
     chip::python::ChipMainThreadScheduleAndWait([&] {
-        result = Resolver::Instance().Init(&chip::DeviceLayer::InetLayer);
+        result = Resolver::Instance().Init(&chip::DeviceLayer::InetLayer());
         ReturnOnFailure(result);
         Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
 

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -42,29 +42,13 @@
 namespace chip {
 namespace DeviceLayer {
 
-namespace Internal {
-extern chip::System::Layer * gSystemLayer;
-} // namespace Internal
-
-struct ChipDeviceEvent;
-extern Inet::InetLayer InetLayer;
-
-inline chip::System::Layer & SystemLayer()
-{
-    return *Internal::gSystemLayer;
-}
+// These functions are defined in src/platform/Globals.cpp
+chip::Inet::InetLayer & InetLayer();
+chip::System::Layer & SystemLayer();
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-inline chip::System::LayerSockets & SystemLayerSockets()
-{
-    return *static_cast<chip::System::LayerSockets *>(Internal::gSystemLayer);
-}
+chip::System::LayerSockets & SystemLayerSockets();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-inline void SetSystemLayerForTesting(System::Layer * layer)
-{
-    Internal::gSystemLayer = layer;
-}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -43,9 +43,7 @@
 namespace chip {
 namespace DeviceLayer {
 
-#ifndef NDEBUG
 void SetSystemLayerForTesting(System::LayerImpl * layer);
-#endif
 
 // These functions are defined in src/platform/Globals.cpp
 chip::Inet::InetLayer & InetLayer();

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -23,6 +23,7 @@
 #if !CHIP_DEVICE_LAYER_NONE
 
 #include <ble/BleLayer.h>
+#include <inet/InetLayer.h>
 #include <lib/core/CHIPCore.h>
 #include <platform/CHIPDeviceError.h>
 #include <platform/ConfigurationManager.h>
@@ -41,6 +42,10 @@
 
 namespace chip {
 namespace DeviceLayer {
+
+#ifndef NDEBUG
+void SetSystemLayerForTesting(System::LayerImpl * layer);
+#endif
 
 // These functions are defined in src/platform/Globals.cpp
 chip::Inet::InetLayer & InetLayer();

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -42,9 +42,6 @@ namespace DeviceLayer {
 
 namespace Internal {
 
-extern chip::System::Layer * gSystemLayer;
-extern chip::System::LayerImpl gSystemLayerImpl;
-
 extern CHIP_ERROR InitEntropy();
 
 template <class ImplClass>
@@ -75,11 +72,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     SuccessOrExit(err);
 
     // Initialize the CHIP system layer.
-    if (gSystemLayer == nullptr)
-    {
-        gSystemLayer = &gSystemLayerImpl;
-    }
-    err = gSystemLayer->Init();
+    err = SystemLayer().Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));
@@ -87,7 +80,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     SuccessOrExit(err);
 
     // Initialize the CHIP Inet layer.
-    err = InetLayer.Init(*gSystemLayer, nullptr);
+    err = InetLayer().Init(SystemLayer(), nullptr);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "InetLayer initialization failed: %s", ErrorStr(err));
@@ -137,7 +130,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 {
     CHIP_ERROR err;
     ChipLogError(DeviceLayer, "Inet Layer shutdown");
-    err = InetLayer.Shutdown();
+    err = InetLayer().Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     ChipLogError(DeviceLayer, "BLE layer shutdown");
@@ -145,7 +138,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 #endif
 
     ChipLogError(DeviceLayer, "System Layer shutdown");
-    err = gSystemLayer->Shutdown();
+    err = SystemLayer().Shutdown();
 
     return err;
 }

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -157,7 +157,7 @@ void TestStub(nlTestSuite * inSuite, void * inContext)
     // without an expected event.
     ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
     OperationalAdvertisingParameters params;
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_UNEXPECTED_EVENT);
@@ -168,7 +168,7 @@ void TestOperational(nlTestSuite * inSuite, void * inContext)
     ChipLogError(Discovery, "Test operational");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
 
     operationalCall1.callType = test::CallType::kStart;
@@ -189,7 +189,7 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
     ChipLogError(Discovery, "Test commissionable");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(&DeviceLayer::InetLayer()) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
 
     commissionableSmall.callType = test::CallType::kStart;

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -218,7 +218,7 @@ CHIP_ERROR DnsHandler(int argc, char ** argv)
         return CHIP_NO_ERROR;
     }
 
-    Dnssd::Resolver::Instance().Init(&DeviceLayer::InetLayer);
+    Dnssd::Resolver::Instance().Init(&DeviceLayer::InetLayer());
     Dnssd::Resolver::Instance().SetResolverDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsSubcommands.ExecCommand(argc, argv);

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -228,7 +228,7 @@ int main(int argc, char * argv[])
 
     if (gUseTCP)
     {
-        err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer)
+        err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer())
                                    .SetAddressType(chip::Inet::IPAddressType::kIPv6)
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
@@ -238,7 +238,7 @@ int main(int argc, char * argv[])
     }
     else
     {
-        err = gUDPManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer)
+        err = gUDPManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer())
                                    .SetAddressType(chip::Inet::IPAddressType::kIPv6)
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -83,7 +83,7 @@ int main(int argc, char * argv[])
 
     if (useTCP)
     {
-        err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer)
+        err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer())
 #if INET_CONFIG_ENABLE_IPV4
                                    .SetAddressType(chip::Inet::IPAddressType::kIPv4)
 #else
@@ -98,7 +98,7 @@ int main(int argc, char * argv[])
     else
     {
         err = gUDPManager.Init(
-            chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::IPAddressType::kIPv6));
+            chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer()).SetAddressType(chip::Inet::IPAddressType::kIPv6));
         SuccessOrExit(err);
 
         err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &gMessageCounterManager);

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -31,8 +31,22 @@ chip::Inet::InetLayer & InetLayer()
     return gInetLayer;
 }
 
+#ifndef NDEBUG
+chip::System::LayerImpl * gMockedSystemLayer = nullptr;
+
+void SetSystemLayerForTesting(System::LayerImpl * layer)
+{
+    gMockedSystemLayer = layer;
+}
+#endif
+
 chip::System::LayerImpl & SystemLayerImpl()
 {
+#ifndef NDEBUG
+    if (gMockedSystemLayer != nullptr)
+        return *gMockedSystemLayer;
+#endif
+
     static chip::System::LayerImpl gSystemLayerImpl;
     return gSystemLayerImpl;
 }

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -25,14 +25,33 @@
 namespace chip {
 namespace DeviceLayer {
 
-chip::Inet::InetLayer InetLayer;
+chip::Inet::InetLayer & InetLayer()
+{
+    static chip::Inet::InetLayer gInetLayer;
+    return gInetLayer;
+}
+
+chip::System::LayerImpl & SystemLayerImpl()
+{
+    static chip::System::LayerImpl gSystemLayerImpl;
+    return gSystemLayerImpl;
+}
+
+chip::System::Layer & SystemLayer()
+{
+    return SystemLayerImpl();
+}
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+chip::System::LayerSockets & SystemLayerSockets()
+{
+    return SystemLayerImpl();
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 namespace Internal {
-
-chip::System::Layer * gSystemLayer = nullptr;
-chip::System::LayerImpl gSystemLayerImpl;
 const char * const TAG = "CHIP[DL]";
-
 } // namespace Internal
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -31,21 +31,17 @@ chip::Inet::InetLayer & InetLayer()
     return gInetLayer;
 }
 
-#ifndef NDEBUG
 chip::System::LayerImpl * gMockedSystemLayer = nullptr;
 
 void SetSystemLayerForTesting(System::LayerImpl * layer)
 {
     gMockedSystemLayer = layer;
 }
-#endif
 
 chip::System::LayerImpl & SystemLayerImpl()
 {
-#ifndef NDEBUG
     if (gMockedSystemLayer != nullptr)
         return *gMockedSystemLayer;
-#endif
 
     static chip::System::LayerImpl gSystemLayerImpl;
     return gSystemLayerImpl;

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -191,7 +191,6 @@ public:
     }
 };
 
-#ifndef NDEBUG
 static void TestPlatformMgr_MockSystemLayer(nlTestSuite * inSuite, void * inContext)
 {
     MockSystemLayer systemLayer;
@@ -212,7 +211,6 @@ static void TestPlatformMgr_MockSystemLayer(nlTestSuite * inSuite, void * inCont
 
     DeviceLayer::SetSystemLayerForTesting(nullptr);
 }
-#endif
 
 /**
  *   Test Suite. It lists all the test functions.
@@ -226,9 +224,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test PlatformMgr::RunEventLoop with stop before sleep", TestPlatformMgr_RunEventLoopStopBeforeSleep),
     NL_TEST_DEF("Test PlatformMgr::TryLockChipStack", TestPlatformMgr_TryLockChipStack),
     NL_TEST_DEF("Test PlatformMgr::AddEventHandler", TestPlatformMgr_AddEventHandler),
-#ifndef NDEBUG
     NL_TEST_DEF("Test mock System::Layer", TestPlatformMgr_MockSystemLayer),
-#endif
 
     NL_TEST_SENTINEL()
 };

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -178,40 +178,6 @@ static void TestPlatformMgr_AddEventHandler(nlTestSuite * inSuite, void * inCont
 #endif
 }
 
-class MockSystemLayer : public System::LayerImpl
-{
-public:
-    CHIP_ERROR StartTimer(System::Clock::Timeout aDelay, System::TimerCompleteCallback aComplete, void * aAppState) override
-    {
-        return CHIP_APPLICATION_ERROR(1);
-    }
-    CHIP_ERROR ScheduleWork(System::TimerCompleteCallback aComplete, void * aAppState) override
-    {
-        return CHIP_APPLICATION_ERROR(2);
-    }
-};
-
-static void TestPlatformMgr_MockSystemLayer(nlTestSuite * inSuite, void * inContext)
-{
-    MockSystemLayer systemLayer;
-
-    DeviceLayer::SetSystemLayerForTesting(&systemLayer);
-    NL_TEST_ASSERT(inSuite, &DeviceLayer::SystemLayer() == static_cast<chip::System::Layer *>(&systemLayer));
-
-    CHIP_ERROR err = PlatformMgr().InitChipStack();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, &DeviceLayer::SystemLayer() == static_cast<chip::System::Layer *>(&systemLayer));
-
-    NL_TEST_ASSERT(inSuite,
-                   DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Zero, nullptr, nullptr) == CHIP_APPLICATION_ERROR(1));
-    NL_TEST_ASSERT(inSuite, DeviceLayer::SystemLayer().ScheduleWork(nullptr, nullptr) == CHIP_APPLICATION_ERROR(2));
-
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    DeviceLayer::SetSystemLayerForTesting(nullptr);
-}
-
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -224,7 +190,6 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test PlatformMgr::RunEventLoop with stop before sleep", TestPlatformMgr_RunEventLoopStopBeforeSleep),
     NL_TEST_DEF("Test PlatformMgr::TryLockChipStack", TestPlatformMgr_TryLockChipStack),
     NL_TEST_DEF("Test PlatformMgr::AddEventHandler", TestPlatformMgr_AddEventHandler),
-    NL_TEST_DEF("Test mock System::Layer", TestPlatformMgr_MockSystemLayer),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
#### Problem
The constructor order of global variables are not controllable

#### Change overview
use C++11 singleton patter for InetLayer/SystemLayer

#### Testing
Verified by unit-tests