### PR TITLE
[android] Fix deadlock in DNS-SD callback

### DIFF
--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -17,18 +17,18 @@
 
 #include "DnssdImpl.h"
 
-#include <cstddef>
-#include <jni.h>
-#include <lib/support/CHIPJNIError.h>
-#include <lib/support/JniReferences.h>
-#include <lib/support/JniTypeWrappers.h>
-
 #include <lib/dnssd/platform/Dnssd.h>
+#include <lib/support/CHIPJNIError.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <cstddef>
+#include <jni.h>
 #include <string>
 
 namespace chip {
@@ -65,7 +65,10 @@ CHIP_ERROR ChipDnssdRemoveServices()
     VerifyOrReturnError(sResolverObject != nullptr && sRemoveServicesMethod != nullptr, CHIP_ERROR_INCORRECT_STATE);
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
 
-    env->CallVoidMethod(sResolverObject, sRemoveServicesMethod);
+    {
+        DeviceLayer::StackUnlock unlock;
+        env->CallVoidMethod(sResolverObject, sRemoveServicesMethod);
+    }
 
     if (env->ExceptionCheck())
     {
@@ -114,8 +117,11 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service)
         env->SetObjectArrayElement(subTypes, i, jniSubType.jniValue());
     }
 
-    env->CallVoidMethod(sResolverObject, sPublishMethod, jniName.jniValue(), jniHostName.jniValue(), jniServiceType.jniValue(),
-                        service->mPort, keys, datas, subTypes);
+    {
+        DeviceLayer::StackUnlock unlock;
+        env->CallVoidMethod(sResolverObject, sPublishMethod, jniName.jniValue(), jniHostName.jniValue(), jniServiceType.jniValue(),
+                            service->mPort, keys, datas, subTypes);
+    }
 
     if (env->ExceptionCheck())
     {
@@ -154,8 +160,11 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, Inet::InterfaceId interface,
     UtfString jniInstanceName(env, service->mName);
     UtfString jniServiceType(env, serviceType.c_str());
 
-    env->CallVoidMethod(sResolverObject, sResolveMethod, jniInstanceName.jniValue(), jniServiceType.jniValue(),
-                        reinterpret_cast<jlong>(callback), reinterpret_cast<jlong>(context), sMdnsCallbackObject);
+    {
+        DeviceLayer::StackUnlock unlock;
+        env->CallVoidMethod(sResolverObject, sResolveMethod, jniInstanceName.jniValue(), jniServiceType.jniValue(),
+                            reinterpret_cast<jlong>(callback), reinterpret_cast<jlong>(context), sMdnsCallbackObject);
+    }
 
     if (env->ExceptionCheck())
     {
@@ -209,6 +218,7 @@ void HandleResolve(jstring instanceName, jstring serviceType, jstring address, j
     VerifyOrReturn(callbackHandle != 0, ChipLogError(Discovery, "HandleResolve called with callback equal to nullptr"));
 
     const auto dispatch = [callbackHandle, contextHandle](CHIP_ERROR error, DnssdService * service = nullptr) {
+        DeviceLayer::StackLock lock;
         DnssdResolveCallback callback = reinterpret_cast<DnssdResolveCallback>(callbackHandle);
         callback(reinterpret_cast<void *>(contextHandle), service, error);
     };


### PR DESCRIPTION
#### Problem
Android CHIPTool may deadlock after the second DNS-SD query due to `StackLock`/`StackUnlock` missing in the Android's DNS-SD implementation which switches between Java and native code.

#### Change overview
Add missing `StackLock`/`StackUnlock` guards.

#### Testing
Tested updating a device address and sending ZCL messages several times in a random order.
