### PR TITLE
[K32W0][THREADIP-3663] Add Software Diagnosis Cluster

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w0/main/main.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/main.cpp
@@ -51,7 +51,7 @@ extern InitFunc __init_array_start;
 extern InitFunc __init_array_end;
 
 /* needed for FreeRtos Heap 4 */
-uint8_t __attribute__((section(".heap"))) ucHeap[0xF000];
+uint8_t __attribute__((section(".heap"))) ucHeap[HEAP_SIZE];
 
 extern "C" void main_task(void const * argument)
 {

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -74,5 +74,35 @@ exit:
     return err;
 }
 
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapFree(uint64_t & currentHeapFree)
+{
+    size_t freeHeapSize;
+
+    freeHeapSize = xPortGetFreeHeapSize();
+    currentHeapFree = static_cast<uint64_t>(freeHeapSize);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapUsed(uint64_t & currentHeapUsed)
+{
+    size_t freeHeapSize;
+    size_t usedHeapSize;
+
+    freeHeapSize = xPortGetFreeHeapSize();
+    usedHeapSize = HEAP_SIZE - freeHeapSize;
+
+    currentHeapUsed = static_cast<uint64_t>(usedHeapSize);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
+{
+    size_t highWatermarkHeapSize;
+
+    highWatermarkHeapSize = HEAP_SIZE - xPortGetMinimumEverFreeHeapSize();
+    currentHeapHighWatermark = static_cast<uint64_t>(highWatermarkHeapSize);
+    return CHIP_NO_ERROR;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -78,7 +78,7 @@ CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
     size_t freeHeapSize;
 
-    freeHeapSize = xPortGetFreeHeapSize();
+    freeHeapSize    = xPortGetFreeHeapSize();
     currentHeapFree = static_cast<uint64_t>(freeHeapSize);
     return CHIP_NO_ERROR;
 }
@@ -99,7 +99,7 @@ CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapHighWatermark(uint64_t & currentH
 {
     size_t highWatermarkHeapSize;
 
-    highWatermarkHeapSize = HEAP_SIZE - xPortGetMinimumEverFreeHeapSize();
+    highWatermarkHeapSize    = HEAP_SIZE - xPortGetMinimumEverFreeHeapSize();
     currentHeapHighWatermark = static_cast<uint64_t>(highWatermarkHeapSize);
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.h
@@ -54,6 +54,9 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _GetCurrentHeapFree(uint64_t & currentHeapFree);
+    CHIP_ERROR _GetCurrentHeapUsed(uint64_t & currentHeapUsed);
+    CHIP_ERROR _GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
 
     // ===== Members for internal use by the following friends.
 


### PR DESCRIPTION
Signed-off-by: Doru Gucea <doru-cristian.gucea@nxp.com>

#### Problem
Software Diagnosis Cluster was missing from K32W implementation.

#### Change overview
Add Add Software Diagnosis Cluster implementation.

#### Testing
Manual testing using chip-device-ctrl and TE6 branch.
