### PR TITLE
Add a glob blacklist option for the build system 

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -17,8 +17,8 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
-              ./scripts/build/build_examples.py --enable-flashbundle build
-              --create-archives /workspace/artifacts/
+              ./scripts/build/build_examples.py --enable-flashbundle
+              --target-glob '*' build --create-archives /workspace/artifacts/
       id: CompileAll
       waitFor:
           - Bootstrap

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -86,8 +86,8 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob 'android-arm64-chip-tool' build
-              --create-archives /workspace/artifacts/
+              --target-glob 'android-arm64-chip-tool' build --create-archives
+              /workspace/artifacts/
       waitFor:
           - Bootstrap
           - Linux

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -37,7 +37,18 @@ class Target:
     def __init__(self, name, builder_class, **kwargs):
         self.name = name
         self.builder_class = builder_class
+        self.glob_blacklist_reason = None
+
         self.create_kw_args = kwargs
+
+    def Clone(self):
+        """Creates a clone of self."""
+
+        clone = Target(self.name, self.builder_class,
+                       **self.create_kw_args.copy())
+        clone.glob_blacklist_reason = self.glob_blacklist_reason
+
+        return clone
 
     def Extend(self, suffix, **kargs):
         """Creates a clone of the current object extending its build parameters.
@@ -46,8 +57,7 @@ class Target:
            suffix: appended with a "-" as separator to the clone name
            **kargs: arguments needed to produce the new build variant
         """
-        clone = Target(self.name, self.builder_class,
-                       **self.create_kw_args.copy())
+        clone = self.Clone()
         clone.name += "-" + suffix
         clone.create_kw_args.update(kargs)
         return clone
@@ -56,11 +66,30 @@ class Target:
         builder = self.builder_class(
             repository_path, runner=runner, **self.create_kw_args)
 
+        builder.target = self
         builder.identifier = self.name
         builder.output_dir = os.path.join(output_prefix, self.name)
         builder.enable_flashbundle(enable_flashbundle)
 
         return builder
+
+    def GlobBlacklist(self, reason):
+        clone = self.Clone()
+        if clone.glob_blacklist_reason:
+            clone.glob_blacklist_reason += ", "
+            clone.glob_blacklist_reason += reason
+        else:
+            clone.glob_blacklist_reason = reason
+
+        return clone
+
+    @property
+    def IsGlobBlacklisted(self):
+        return self.glob_blacklist_reason is not None
+
+    @property
+    def GlobBlacklistReason(self):
+        return self.glob_blacklist_reason
 
 
 def HostTargets():
@@ -135,7 +164,7 @@ def NrfTargets():
     for target in targets:
         yield target.Extend('lock', app=NrfApp.LOCK)
         yield target.Extend('light', app=NrfApp.LIGHT)
-        yield target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True)
+        yield target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True).GlobBlacklist('Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760')
         yield target.Extend('shell', app=NrfApp.SHELL)
         yield target.Extend('pump', app=NrfApp.PUMP)
         yield target.Extend('pump-controller', app=NrfApp.PUMP_CONTROLLER)

--- a/scripts/build/test.py
+++ b/scripts/build/test.py
@@ -106,6 +106,13 @@ class TestBuilder(unittest.TestCase):
             '--skip-target-glob {linux,darwin}-* targets'.split(' ')
         )
 
+    def test_glob_targets(self):
+        self.assertCommandOutput(
+            os.path.join('testdata', 'glob_star_targets_except_host.txt'),
+            '--target-glob * --skip-target-glob {linux,darwin}-* targets'.split(
+                ' ')
+        )
+
     @unittest.skipUnless(sys.platform == 'linux', 'Build on linux test')
     @unittest.skipUnless(os.uname().machine == 'x86_64', 'Validation x64 and crosscompile, requires linux x64')
     def test_linux_build(self):

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -25,13 +25,11 @@ esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
 infineon-p6-lock
 nrf-nrf52840-light
-nrf-nrf52840-light-rpc (NOGLOB: Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760)
 nrf-nrf52840-lock
 nrf-nrf52840-pump
 nrf-nrf52840-pump-controller
 nrf-nrf52840-shell
 nrf-nrf5340-light
-nrf-nrf5340-light-rpc (NOGLOB: Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760)
 nrf-nrf5340-lock
 nrf-nrf5340-pump
 nrf-nrf5340-pump-controller


### PR DESCRIPTION
#### Problem
NRF RPC variants are not compilable, which makes cloudbuild red
In the future, I expect variants to have the ability to explode exponentially (e.g. I see mbedos having release, reldebug and debug versions) and we probably want to limit what variants are being built by defult.

#### Change description

- added a tag on builds for 'blacklist for globbing' and whenever a `--target-glob` is used, these targets are automatically discarded. 
- changed the cloudbuild settings to use `--target-glob *` to only build things that are buy default globbable.