### PR TITLE
Add pw_trace functionality to esp32 all cluster app

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -45,6 +45,7 @@ include(third_party/connectedhomeip/third_party/pigweed/repo/pw_build/pigweed.cm
 pw_set_backend(pw_log pw_log_basic)
 pw_set_backend(pw_assert pw_assert_log)
 pw_set_backend(pw_sys_io pw_sys_io.esp32)
+pw_set_backend(pw_trace pw_trace_tokenized)
 
 add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -187,6 +187,10 @@ target_link_libraries(${COMPONENT_LIB} PUBLIC
   pw_hdlc
   pw_log
   pw_rpc.server
+  pw_trace_tokenized
+  pw_trace_tokenized.trace_buffer
+  pw_trace_tokenized.rpc_service
+  pw_trace_tokenized.protos.nanopb_rpc
 )
 
 set_property(TARGET ${chip_lib} APPEND PROPERTY LINK_LIBRARIES ${COMPONENT_LIB})

--- a/examples/all-clusters-app/esp32/main/Rpc.cpp
+++ b/examples/all-clusters-app/esp32/main/Rpc.cpp
@@ -44,13 +44,26 @@
 #include "pw_containers/flat_map.h"
 #include "pw_status/status.h"
 #include "pw_status/try.h"
+#include "pw_trace_tokenized/trace_rpc_service_nanopb.h"
 #include "wifi_service/wifi_service.rpc.pb.h"
+#include <pw_trace/trace.h>
 
 #include "WiFiProvisioning.h"
 
 #include "ESP32Utils.h"
 
 static const char * TAG = "RPC";
+
+// Define trace time for pw_trace
+PW_TRACE_TIME_TYPE pw_trace_GetTraceTime()
+{
+    return (PW_TRACE_TIME_TYPE) chip::System::SystemClock().GetMonotonicMicroseconds64().count();
+}
+// Microsecond time source
+size_t pw_trace_GetTraceTimeTicksPerSecond()
+{
+    return 1000000;
+}
 
 namespace chip {
 namespace rpc {
@@ -291,6 +304,7 @@ Esp32Button button_service;
 Esp32Device device_service;
 Lighting lighting_service;
 Wifi wifi_service;
+pw::trace::TraceService trace_service;
 
 void RegisterServices(pw::rpc::Server & server)
 {
@@ -298,6 +312,8 @@ void RegisterServices(pw::rpc::Server & server)
     server.RegisterService(device_service);
     server.RegisterService(lighting_service);
     server.RegisterService(wifi_service);
+    server.RegisterService(trace_service);
+    PW_TRACE_SET_ENABLED(true);
 }
 
 void RunRpcService(void *)


### PR DESCRIPTION
Add pw_trace rpc service to Rpc.cpp.

#### Problem
Integrate pw_trace module into esp32 all-cluster-app

#### Change overview
Add pw::trace::TraceService to Rpc.cc

#### Testing
build esp32 all cluster app with RPC on and off.
