### PR TITLE
Update ot-efr32 submodule

### DIFF
--- a/third_party/openthread/platforms/BUILD.gn
+++ b/third_party/openthread/platforms/BUILD.gn
@@ -47,6 +47,7 @@ static_library("libopenthread-platform-utils") {
     "${openthread_root}/examples/platforms/utils/encoding.h",
     "${openthread_root}/examples/platforms/utils/logging_rtt.c",
     "${openthread_root}/examples/platforms/utils/logging_rtt.h",
+    "${openthread_root}/examples/platforms/utils/mac_frame.cpp",
     "${openthread_root}/examples/platforms/utils/mac_frame.h",
     "${openthread_root}/examples/platforms/utils/settings.h",
     "${openthread_root}/examples/platforms/utils/settings_ram.c",

--- a/third_party/openthread/platforms/efr32/BUILD.gn
+++ b/third_party/openthread/platforms/efr32/BUILD.gn
@@ -55,7 +55,6 @@ source_set("libopenthread-efr32") {
     "${openthread_efr32_root}/src/src/misc.c",
     "${openthread_efr32_root}/src/src/radio.c",
     "${openthread_efr32_root}/src/src/system.c",
-    "${openthread_efr32_root}/third_party/silabs/rail_config/rail_config.c",
     "${openthread_root}/examples/apps/cli/cli_uart.cpp",
   ]
 


### PR DESCRIPTION
#### Problem
openthread and ot-br-posix submodules were updated a few weeks ago but ot-efr32 submodule is 3 month old.

#### Change overview
Update ot-efr32 submodule to match openthread submodule commit used in matter.
update build.gn : `rail_config.c` doesn't exist anymore, `mac_frame.cpp` is now used by ot-efr32 platform code


#### Testing
Build lighting-app and complete full commissioning with chip-tool
