### PR TITLE
Unblacklist nrf52840 for RPC builds

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -170,9 +170,10 @@ def NrfTargets():
 
         rpc = target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True)
 
-        if '-nrf5340-' in  rpc.name:
-           rpc = rpc.GlobBlacklist('Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760')
-        
+        if '-nrf5340-' in rpc.name:
+            rpc = rpc.GlobBlacklist(
+                'Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760')
+
         yield rpc
 
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -170,7 +170,7 @@ def NrfTargets():
 
         rpc = target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True)
 
-        if '-nrf5340-' in  rpc.name
+        if '-nrf5340-' in  rpc.name:
            rpc = rpc.GlobBlacklist('Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760')
         
         yield rpc

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -164,10 +164,16 @@ def NrfTargets():
     for target in targets:
         yield target.Extend('lock', app=NrfApp.LOCK)
         yield target.Extend('light', app=NrfApp.LIGHT)
-        yield target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True).GlobBlacklist('Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760')
         yield target.Extend('shell', app=NrfApp.SHELL)
         yield target.Extend('pump', app=NrfApp.PUMP)
         yield target.Extend('pump-controller', app=NrfApp.PUMP_CONTROLLER)
+
+        rpc = target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True)
+
+        if '-nrf5340-' in  rpc.name
+           rpc = rpc.GlobBlacklist('Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760')
+        
+        yield rpc
 
 
 def AndroidTargets():

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -25,7 +25,7 @@ esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
 infineon-p6-lock
 nrf-nrf52840-light
-nrf-nrf52840-light-rpc (NOGLOB: Compile failure due to pw_build args not forwarded to proto compiler. https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/66760)
+nrf-nrf52840-light-rpc
 nrf-nrf52840-lock
 nrf-nrf52840-pump
 nrf-nrf52840-pump-controller

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -25,6 +25,7 @@ esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
 infineon-p6-lock
 nrf-nrf52840-light
+nrf-nrf52840-light-rpc
 nrf-nrf52840-lock
 nrf-nrf52840-pump
 nrf-nrf52840-pump-controller


### PR DESCRIPTION
#### Problem
NRF5340 fails to compile the rpc version, however nrf52840 seems ok. Remove the blacklist for it.

#### Change overview
Keeps the glob blacklist only for NRF5340
