### PR TITLE
[app] Forget exchange context when SubscribeResponse is received

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -295,6 +295,10 @@ CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchange
     {
         VerifyOrExit(apExchangeContext == mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
         err = ProcessSubscribeResponse(std::move(aPayload));
+        // Forget the context as SUBSCRIBE RESPONSE is the last message in SUBSCRIBE transaction and
+        // ExchangeContext::HandleMessage automatically closes a context if no other messages need to
+        // be sent or received.
+        mpExchangeCtx = nullptr;
         SuccessOrExit(err);
     }
     else


### PR DESCRIPTION
#### Problem
SubscribeResponse is the last action in the Subscribe transaction and ExchangeContext::HandleMessage
automatically closes exchanges that have no pending requests nor responses.

ReadClient still kept the pointer to the exchange after receiving SubscribeResponse, so it would attempt to abort
already closed exchange if the subscription was cancelled after receiving the SubscribeResponse and before receving
a subsequent Report message.

#### Change overview
Let ReadClient forget the exchange context when SubscribeResponse is received.

#### Testing
Tested on hardware using Android CHIPTool and trying to unsubscribe from an attribute in random moments.
Also, added UT.
