### PR TITLE
Replace and remove weakly-typed System::Clock code

### DIFF
--- a/examples/all-clusters-app/esp32/main/LEDWidget.cpp
+++ b/examples/all-clusters-app/esp32/main/LEDWidget.cpp
@@ -42,7 +42,7 @@ static led_strip_t * strip = NULL;
 #endif
 void LEDWidget::Init(gpio_num_t gpioNum)
 {
-    mLastChangeTimeUS = 0;
+    mLastChangeTimeMS = 0;
     mBlinkOnTimeMS    = 0;
     mBlinkOffTimeMS   = 0;
     mGPIONum          = gpioNum;
@@ -172,12 +172,12 @@ void LEDWidget::Animate()
     {
         int64_t nowUS            = ::esp_timer_get_time();
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
-        int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
+        int64_t nextChangeTimeUS = mLastChangeTimeMS + stateDurUS;
 
         if (nowUS > nextChangeTimeUS)
         {
             DoSet(!mState);
-            mLastChangeTimeUS = nowUS;
+            mLastChangeTimeMS = nowUS;
         }
     }
 }

--- a/examples/all-clusters-app/esp32/main/LEDWidget.cpp
+++ b/examples/all-clusters-app/esp32/main/LEDWidget.cpp
@@ -42,7 +42,7 @@ static led_strip_t * strip = NULL;
 #endif
 void LEDWidget::Init(gpio_num_t gpioNum)
 {
-    mLastChangeTimeMS = 0;
+    mLastChangeTimeUS = 0;
     mBlinkOnTimeMS    = 0;
     mBlinkOffTimeMS   = 0;
     mGPIONum          = gpioNum;
@@ -172,12 +172,12 @@ void LEDWidget::Animate()
     {
         int64_t nowUS            = ::esp_timer_get_time();
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
-        int64_t nextChangeTimeUS = mLastChangeTimeMS + stateDurUS;
+        int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
 
         if (nowUS > nextChangeTimeUS)
         {
             DoSet(!mState);
-            mLastChangeTimeMS = nowUS;
+            mLastChangeTimeUS = nowUS;
         }
     }
 }

--- a/examples/all-clusters-app/esp32/main/include/LEDWidget.h
+++ b/examples/all-clusters-app/esp32/main/include/LEDWidget.h
@@ -55,7 +55,7 @@ public:
 #endif
 
 private:
-    int64_t mLastChangeTimeUS;
+    int64_t mLastChangeTimeMS;
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
     uint8_t mDefaultOnBrightness;

--- a/examples/all-clusters-app/esp32/main/include/LEDWidget.h
+++ b/examples/all-clusters-app/esp32/main/include/LEDWidget.h
@@ -55,7 +55,7 @@ public:
 #endif
 
 private:
-    int64_t mLastChangeTimeMS;
+    int64_t mLastChangeTimeUS;
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
     uint8_t mDefaultOnBrightness;

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR AppTask::Init()
 void AppTask::AppTaskMain(void * pvParameter)
 {
     AppEvent event;
-    Clock::MonotonicMicroseconds mLastChangeTimeUS = 0;
+    Clock::Timestamp lastChangeTime { 0 };
 
     CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)
@@ -170,12 +170,12 @@ void AppTask::AppTaskMain(void * pvParameter)
         sStatusLED.Animate();
         sLockLED.Animate();
 
-        Clock::MonotonicMicroseconds nowUS            = SystemClock().GetMonotonicMicroseconds();
-        Clock::MonotonicMicroseconds nextChangeTimeUS = mLastChangeTimeUS + (5 * 1000 * 1000UL);
+        Clock::Timestamp now            = SystemClock().GetMonotonicTimestamp();
+        Clock::Timestamp nextChangeTime = lastChangeTimeUS + System::Clock::Seconds16(5);
 
-        if (nextChangeTimeUS < nowUS)
+        if (nextChangeTime < now)
         {
-            mLastChangeTimeUS = nowUS;
+            lastChangeTime = now;
         }
         if (lockButton.Poll())
         {

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR AppTask::Init()
 void AppTask::AppTaskMain(void * pvParameter)
 {
     AppEvent event;
-    Clock::Timestamp lastChangeTime{ 0 };
+    Clock::Timestamp lastChangeTime = Clock::Zero;
 
     CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR AppTask::Init()
 void AppTask::AppTaskMain(void * pvParameter)
 {
     AppEvent event;
-    Clock::Timestamp lastChangeTime { 0 };
+    Clock::Timestamp lastChangeTime{ 0 };
 
     CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)
@@ -171,7 +171,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         sLockLED.Animate();
 
         Clock::Timestamp now            = SystemClock().GetMonotonicTimestamp();
-        Clock::Timestamp nextChangeTime = lastChangeTimeUS + System::Clock::Seconds16(5);
+        Clock::Timestamp nextChangeTime = lastChangeTime + Clock::Seconds16(5);
 
         if (nextChangeTime < now)
         {

--- a/examples/lock-app/esp32/main/LEDWidget.cpp
+++ b/examples/lock-app/esp32/main/LEDWidget.cpp
@@ -22,7 +22,7 @@
 
 void LEDWidget::Init(gpio_num_t gpioNum)
 {
-    mLastChangeTimeUS = 0;
+    mLastChangeTimeMS = 0;
     mBlinkOnTimeMS    = 0;
     mBlinkOffTimeMS   = 0;
     mGPIONum          = gpioNum;
@@ -61,14 +61,14 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        chip::System::Clock::MonotonicMicroseconds nowUS            = chip::System::SystemClock().GetMonotonicMicroseconds();
-        chip::System::Clock::MonotonicMicroseconds stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
-        chip::System::Clock::MonotonicMicroseconds nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
+        uint64_t nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+        uint64_t stateDurMS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS);
+        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurMS;
 
-        if (nextChangeTimeUS < nowUS)
+        if (nextChangeTimeMS < nowMS)
         {
             DoSet(!mState);
-            mLastChangeTimeUS = nowUS;
+            mLastChangeTimeMS = nowMS;
         }
     }
 }

--- a/examples/lock-app/esp32/main/include/LEDWidget.h
+++ b/examples/lock-app/esp32/main/include/LEDWidget.h
@@ -33,7 +33,7 @@ public:
     void Animate();
 
 private:
-    uint64_t mLastChangeTimeUS;
+    uint64_t mLastChangeTimeMS;
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
     gpio_num_t mGPIONum;

--- a/examples/platform/efr32/LEDWidget.cpp
+++ b/examples/platform/efr32/LEDWidget.cpp
@@ -32,7 +32,7 @@ void LEDWidget::InitGpio(void)
 
 void LEDWidget::Init(const sl_led_t * led)
 {
-    mLastChangeTimeUS = 0;
+    mLastChangeTimeMS = 0;
     mBlinkOnTimeMS    = 0;
     mBlinkOffTimeMS   = 0;
     mLed              = led;
@@ -50,7 +50,7 @@ void LEDWidget::Invert(void)
 
 void LEDWidget::Set(bool state)
 {
-    mLastChangeTimeUS = mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
+    mLastChangeTimeMS = mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
     if (mLed)
     {
         state ? sl_led_turn_on(mLed) : sl_led_turn_off(mLed);
@@ -73,14 +73,14 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        Clock::MonotonicMicroseconds nowUS            = chip::System::SystemClock().GetMonotonicMicroseconds();
-        Clock::MonotonicMicroseconds stateDurUS       = ((sl_led_get_state(mLed)) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
-        Clock::MonotonicMicroseconds nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
+        uint64_t nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+        uint64_t stateDurMS       = sl_led_get_state(mLed) ? mBlinkOnTimeMS : mBlinkOffTimeMS;
+        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurMS;
 
-        if (nextChangeTimeUS < nowUS)
+        if (nextChangeTimeMS < nowMS)
         {
             Invert();
-            mLastChangeTimeUS = nowUS;
+            mLastChangeTimeMS = nowMS;
         }
     }
 }

--- a/examples/platform/efr32/LEDWidget.h
+++ b/examples/platform/efr32/LEDWidget.h
@@ -34,7 +34,7 @@ public:
     void Animate();
 
 private:
-    uint64_t mLastChangeTimeUS;
+    uint64_t mLastChangeTimeMS;
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
     const sl_led_t * mLed;

--- a/examples/platform/mbed/util/LEDWidget.cpp
+++ b/examples/platform/mbed/util/LEDWidget.cpp
@@ -57,9 +57,9 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        chip::System::Clock::MonotonicMilliseconds nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds();
-        chip::System::Clock::MonotonicMilliseconds stateDurMS       = (mLED == LED_ACTIVE_STATE) ? mBlinkOnTimeMS : mBlinkOffTimeMS;
-        chip::System::Clock::MonotonicMilliseconds nextChangeTimeMS = mLastChangeTimeMS + stateDurMS;
+        uint64_t nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+        uint64_t stateDurMS       = (mLED == LED_ACTIVE_STATE) ? mBlinkOnTimeMS : mBlinkOffTimeMS;
+        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurMS;
 
         if (nextChangeTimeMS < nowMS)
         {

--- a/examples/platform/nxp/k32w/k32w0/util/LEDWidget.cpp
+++ b/examples/platform/nxp/k32w/k32w0/util/LEDWidget.cpp
@@ -23,7 +23,7 @@
 
 void LEDWidget::Init(LED_t led)
 {
-    mLastChangeTimeUS = 0;
+    mLastChangeTimeMS = 0;
     mBlinkOnTimeMS    = 0;
     mBlinkOffTimeMS   = 0;
     mGPIONum          = led;
@@ -39,7 +39,7 @@ void LEDWidget::Invert(void)
 
 void LEDWidget::Set(bool state)
 {
-    mLastChangeTimeUS = mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
+    mLastChangeTimeMS = mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
     DoSet(state);
 }
 
@@ -59,14 +59,14 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        chip::System::Clock::MonotonicMicroseconds nowUS            = chip::System::SystemClock().GetMonotonicMicroseconds();
-        chip::System::Clock::MonotonicMicroseconds stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
-        chip::System::Clock::MonotonicMicroseconds nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
+        uint64_t nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+        uint64_t stateDurMS       = mState ? mBlinkOnTimeMS : mBlinkOffTimeMS;
+        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurUS;
 
-        if (nextChangeTimeUS < nowUS)
+        if (nextChangeTimeMS < nowUS)
         {
             DoSet(!mState);
-            mLastChangeTimeUS = nowUS;
+            mLastChangeTimeMS = nowMS;
         }
     }
 }

--- a/examples/platform/nxp/k32w/k32w0/util/LEDWidget.cpp
+++ b/examples/platform/nxp/k32w/k32w0/util/LEDWidget.cpp
@@ -61,9 +61,9 @@ void LEDWidget::Animate()
     {
         uint64_t nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
         uint64_t stateDurMS       = mState ? mBlinkOnTimeMS : mBlinkOffTimeMS;
-        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurUS;
+        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurMS;
 
-        if (nextChangeTimeMS < nowUS)
+        if (nextChangeTimeMS < nowMS)
         {
             DoSet(!mState);
             mLastChangeTimeMS = nowMS;

--- a/examples/platform/nxp/k32w/k32w0/util/include/LEDWidget.h
+++ b/examples/platform/nxp/k32w/k32w0/util/include/LEDWidget.h
@@ -31,7 +31,7 @@ public:
     void Animate();
 
 private:
-    uint64_t mLastChangeTimeUS;
+    uint64_t mLastChangeTimeMS;
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
     LED_t mGPIONum;

--- a/examples/platform/p6/LEDWidget.cpp
+++ b/examples/platform/p6/LEDWidget.cpp
@@ -25,7 +25,7 @@
 
 void LEDWidget::Init(int ledNum)
 {
-    mLastChangeTimeUS = 0;
+    mLastChangeTimeMS = 0;
     mBlinkOnTimeMS    = 0;
     mBlinkOffTimeMS   = 0;
     mLedNum           = ledNum;
@@ -41,7 +41,7 @@ void LEDWidget::Invert(void)
 
 void LEDWidget::Set(bool state)
 {
-    mLastChangeTimeUS = mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
+    mLastChangeTimeMS = mBlinkOnTimeMS = mBlinkOffTimeMS = 0;
     DoSet(state);
 }
 
@@ -61,14 +61,14 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        chip::System::Clock::MonotonicMicroseconds nowUS            = chip::System::SystemClock().GetMonotonicMicroseconds();
-        chip::System::Clock::MonotonicMicroseconds stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
-        chip::System::Clock::MonotonicMicroseconds nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
+        uint64_t nowMS            = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+        uint64_t stateDurMS       = mState ? mBlinkOnTimeMS : mBlinkOffTimeMS;
+        uint64_t nextChangeTimeMS = mLastChangeTimeMS + stateDurMS;
 
-        if (nextChangeTimeUS < nowUS)
+        if (nextChangeTimeMS < nowMS)
         {
             DoSet(!mState);
-            mLastChangeTimeUS = nowUS;
+            mLastChangeTimeMS = nowMS;
         }
     }
 }

--- a/examples/platform/p6/LEDWidget.h
+++ b/examples/platform/p6/LEDWidget.h
@@ -34,7 +34,7 @@ public:
     void Animate();
 
 private:
-    uint64_t mLastChangeTimeUS = 0;
+    uint64_t mLastChangeTimeMS = 0;
     uint32_t mBlinkOnTimeMS    = 0;
     uint32_t mBlinkOffTimeMS   = 0;
     int mLedNum                = 0;

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -50,7 +50,7 @@ public:
     {
         mMaxEchoCount       = 3;
         mEchoInterval       = 1000;
-        mLastEchoTime       = 0;
+        mLastEchoTime       = System::Clock::Zero;
         mEchoCount          = 0;
         mEchoRespCount      = 0;
         mPayloadSize        = 32;
@@ -62,8 +62,8 @@ public:
         mEchoPort = CHIP_PORT;
     }
 
-    uint64_t GetLastEchoTime() const { return mLastEchoTime; }
-    void SetLastEchoTime(uint64_t value) { mLastEchoTime = value; }
+    System::Clock::Timestamp GetLastEchoTime() const { return mLastEchoTime; }
+    void SetLastEchoTime(System::Clock::Timestamp value) { mLastEchoTime = value; }
 
     uint64_t GetEchoCount() const { return mEchoCount; }
     void SetEchoCount(uint64_t value) { mEchoCount = value; }
@@ -98,7 +98,7 @@ public:
 
 private:
     // The last time a echo request was attempted to be sent.
-    uint64_t mLastEchoTime;
+    System::Clock::Timestamp mLastEchoTime;
 
     // Count of the number of echo requests sent.
     uint64_t mEchoCount;
@@ -210,7 +210,7 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
         sendFlags.Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
     }
 
-    gPingArguments.SetLastEchoTime(System::SystemClock().GetMonotonicMilliseconds());
+    gPingArguments.SetLastEchoTime(System::SystemClock().GetMonotonicTimestamp());
     SuccessOrExit(chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(gPingArguments.GetEchoInterval()),
                                                               EchoTimerHandler, NULL));
 
@@ -256,7 +256,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Establish secure session failed, err: %s\n", ErrorStr(err));
-        gPingArguments.SetLastEchoTime(System::SystemClock().GetMonotonicMilliseconds());
+        gPingArguments.SetLastEchoTime(System::SystemClock().GetMonotonicTimestamp());
     }
     else
     {
@@ -268,17 +268,17 @@ exit:
 
 void HandleEchoResponseReceived(Messaging::ExchangeContext * ec, System::PacketBufferHandle && payload)
 {
-    uint64_t respTime    = System::SystemClock().GetMonotonicMilliseconds();
-    uint64_t transitTime = respTime - gPingArguments.GetLastEchoTime();
-    streamer_t * sout    = streamer_get();
+    System::Clock::Timestamp respTime         = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Milliseconds64 transitTime = respTime - gPingArguments.GetLastEchoTime();
+    streamer_t * sout                         = streamer_get();
 
     gPingArguments.SetWaitingForEchoResp(false);
     gPingArguments.IncrementEchoRespCount();
 
-    streamer_printf(sout, "Echo Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) len=%u time=%.3fms\n", gPingArguments.GetEchoRespCount(),
+    streamer_printf(sout, "Echo Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) len=%u time=%.3fs\n", gPingArguments.GetEchoRespCount(),
                     gPingArguments.GetEchoCount(),
                     static_cast<double>(gPingArguments.GetEchoRespCount()) * 100 / gPingArguments.GetEchoCount(),
-                    payload->DataLength(), static_cast<double>(transitTime) / 1000);
+                    payload->DataLength(), static_cast<double>(transitTime.count()) / 1000);
 }
 
 void StartPinging(streamer_t * stream, char * destination)

--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -117,14 +117,15 @@ struct Timestamp
     Timestamp() {}
     Timestamp(Type aType) : mType(aType) { mValue = 0; }
     Timestamp(Type aType, uint64_t aValue) : mType(aType), mValue(aValue) {}
+    Timestamp(System::Clock::Timestamp aValue) : mType(Type::kSystem), mValue(aValue.count()) {}
     static Timestamp UTC(uint64_t aValue)
     {
         Timestamp timestamp(Type::kUTC, aValue);
         return timestamp;
     }
-    static Timestamp System(uint64_t aValue)
+    static Timestamp System(System::Clock::Timestamp aValue)
     {
-        Timestamp timestamp(Type::kSystem, aValue);
+        Timestamp timestamp(Type::kSystem, aValue.count());
         return timestamp;
     }
 

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -87,7 +87,7 @@ struct EventEnvelopeContext
 
     uint16_t mFieldsToRead = 0;
     /* PriorityLevel and DeltaSystemTimestamp are there if that is not first event when putting events in report*/
-    Timestamp mDeltaSystemTime = Timestamp::System(0);
+    Timestamp mDeltaSystemTime = Timestamp::System(System::Clock::Zero);
     Timestamp mDeltaUtc        = Timestamp::UTC(0);
     PriorityLevel mPriority    = PriorityLevel::First;
     NodeId mNodeId             = 0;
@@ -496,7 +496,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, E
     CircularEventBuffer * buffer   = nullptr;
     EventLoadOutContext ctxt       = EventLoadOutContext(writer, aEventOptions.mpEventSchema->mPriority,
                                                    GetPriorityBuffer(aEventOptions.mpEventSchema->mPriority)->GetLastEventNumber());
-    Timestamp timestamp(Timestamp::Type::kSystem, System::SystemClock().GetMonotonicMilliseconds());
+    Timestamp timestamp(System::SystemClock().GetMonotonicTimestamp());
     EventOptions opts = EventOptions(timestamp);
     // Start the event container (anonymous structure) in the circular buffer
     writer.Init(*mpEventBuffer);
@@ -854,8 +854,8 @@ void CircularEventBuffer::Init(uint8_t * apBuffer, uint32_t aBufferLength, Circu
     mPriority                  = aPriorityLevel;
     mFirstEventNumber          = 1;
     mLastEventNumber           = 0;
-    mFirstEventSystemTimestamp = Timestamp::System(0);
-    mLastEventSystemTimestamp  = Timestamp::System(0);
+    mFirstEventSystemTimestamp = Timestamp::System(System::Clock::Zero);
+    mLastEventSystemTimestamp  = Timestamp::System(System::Clock::Zero);
     mpEventNumberCounter       = nullptr;
 }
 

--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -94,7 +94,7 @@ typedef struct
 {
     EndpointId endpoint;
     uint16_t status;
-    uint32_t eventTimeMs;
+    System::Clock::Timestamp eventTime;
 } IasZoneStatusQueueEntry;
 
 typedef struct
@@ -413,9 +413,9 @@ EmberStatus emberAfPluginIasZoneServerUpdateZoneStatus(EndpointId endpoint, uint
 {
 #if defined(EMBER_AF_PLUGIN_IAS_ZONE_SERVER_ENABLE_QUEUE)
     IasZoneStatusQueueEntry newBufferEntry;
-    newBufferEntry.endpoint    = endpoint;
-    newBufferEntry.status      = newStatus;
-    newBufferEntry.eventTimeMs = System::SystemClock().GetMonotonicMilliseconds();
+    newBufferEntry.endpoint  = endpoint;
+    newBufferEntry.status    = newStatus;
+    newBufferEntry.eventTime = System::SystemClock().GetMonotonicTimestamp();
 #endif
     EmberStatus sendStatus = EMBER_SUCCESS;
 
@@ -527,7 +527,7 @@ void emberAfPluginIasZoneServerManageQueueEventHandler(void)
         status = bufferStart->status;
         emberAfIasZoneClusterPrintln("Attempting to resend a queued zone status update (status: 0x%02X, "
                                      "event time (s): %d) with time of %d. Retry count: %d",
-                                     bufferStart->status, bufferStart->eventTimeMs / MILLISECOND_TICKS_PER_SECOND, elapsedTimeQs,
+                                     bufferStart->status, bufferStart->eventTime / MILLISECOND_TICKS_PER_SECOND, elapsedTimeQs,
                                      queueRetryParams.currentRetryCount);
         sendZoneUpdate(status, elapsedTimeQs, bufferStart->endpoint);
         emberEventControlSetInactive(&emberAfPluginIasZoneServerManageQueueEventControl);
@@ -749,7 +749,7 @@ void emberAfPluginIasZoneServerPrintQueue(void)
     for (int i = 0; i < messageQueue.entriesInQueue; i++)
     {
         emberAfIasZoneClusterPrintln("Entry %d: Endpoint: %d Status: %d EventTimeMs: %d", i, messageQueue.buffer[i].endpoint,
-                                     messageQueue.buffer[i].status, messageQueue.buffer[i].eventTimeMs);
+                                     messageQueue.buffer[i].status, messageQueue.buffer[i].eventTime);
     }
 }
 
@@ -877,9 +877,9 @@ static int16_t copyToBuffer(IasZoneStatusQueue * ring, const IasZoneStatusQueueE
         ring->lastIdx = 0;
     }
 
-    ring->buffer[ring->lastIdx].endpoint    = entry->endpoint;
-    ring->buffer[ring->lastIdx].status      = entry->status;
-    ring->buffer[ring->lastIdx].eventTimeMs = entry->eventTimeMs;
+    ring->buffer[ring->lastIdx].endpoint  = entry->endpoint;
+    ring->buffer[ring->lastIdx].status    = entry->status;
+    ring->buffer[ring->lastIdx].eventTime = entry->eventTime;
 
     ring->entriesInQueue++;
     return ring->lastIdx;
@@ -913,8 +913,8 @@ static int16_t popFromBuffer(IasZoneStatusQueue * ring, IasZoneStatusQueueEntry 
 
 uint16_t computeElapsedTimeQs(IasZoneStatusQueueEntry * entry)
 {
-    uint64_t currentTimeMs = System::SystemClock().GetMonotonicMilliseconds();
-    int64_t deltaTimeMs    = currentTimeMs - entry->eventTimeMs;
+    System::Clock::Milliseconds64 currentTimeMs = System::SystemClock().GetMonotonicMilliseconds64();
+    int64_t deltaTimeMs                         = currentTimeMs.count() - entry->eventTime.count();
 
     if (deltaTimeMs < 0)
     {

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -63,7 +63,7 @@ chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Command was attempted to be sent.
-uint64_t gLastMessageTime = 0;
+chip::System::Clock::Timestamp gLastMessageTime = chip::System::Clock::Zero;
 
 // Count of the number of CommandRequests sent.
 uint64_t gCommandCount = 0;
@@ -104,24 +104,26 @@ TestCommandResult gLastCommandResult = TestCommandResult::kUndefined;
 
 void HandleReadComplete()
 {
-    auto respTime    = chip::System::SystemClock().GetMonotonicMilliseconds();
-    auto transitTime = respTime - gLastMessageTime;
+    auto respTime                                   = chip::System::SystemClock().GetMonotonicTimestamp();
+    chip::System::Clock::Milliseconds64 transitTime = respTime - gLastMessageTime;
 
     gReadRespCount++;
 
-    printf("Read Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gReadRespCount, gReadCount,
-           static_cast<double>(gReadRespCount) * 100 / static_cast<double>(gReadCount), static_cast<double>(transitTime) / 1000);
+    printf("Read Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fs\n", gReadRespCount, gReadCount,
+           static_cast<double>(gReadRespCount) * 100 / static_cast<double>(gReadCount),
+           static_cast<double>(transitTime.count()) / 1000);
 }
 
 void HandleSubscribeReportComplete()
 {
-    auto respTime    = chip::System::SystemClock().GetMonotonicMilliseconds();
-    auto transitTime = respTime - gLastMessageTime;
+    auto respTime                                   = chip::System::SystemClock().GetMonotonicTimestamp();
+    chip::System::Clock::Milliseconds64 transitTime = respTime - gLastMessageTime;
 
     gSubRespCount++;
 
-    printf("Subscribe Complete: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gSubRespCount, gSubCount,
-           static_cast<double>(gSubRespCount) * 100 / static_cast<double>(gSubCount), static_cast<double>(transitTime) / 1000);
+    printf("Subscribe Complete: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fs\n", gSubRespCount, gSubCount,
+           static_cast<double>(gSubRespCount) * 100 / static_cast<double>(gSubCount),
+           static_cast<double>(transitTime.count()) / 1000);
 }
 
 class MockInteractionModelApp : public chip::app::InteractionModelDelegate,
@@ -168,15 +170,15 @@ public:
         printf("Command Response Success with EndpointId %d, ClusterId %d, CommandId %d", aPath.mEndpointId, aPath.mClusterId,
                aPath.mCommandId);
 
-        gLastCommandResult = TestCommandResult::kSuccess;
-        auto respTime      = chip::System::SystemClock().GetMonotonicMilliseconds();
-        auto transitTime   = respTime - gLastMessageTime;
+        gLastCommandResult                              = TestCommandResult::kSuccess;
+        auto respTime                                   = chip::System::SystemClock().GetMonotonicTimestamp();
+        chip::System::Clock::Milliseconds64 transitTime = respTime - gLastMessageTime;
 
         gCommandRespCount++;
 
-        printf("Command Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gCommandRespCount, gCommandCount,
+        printf("Command Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fs\n", gCommandRespCount, gCommandCount,
                static_cast<double>(gCommandRespCount) * 100 / static_cast<double>(gCommandCount),
-               static_cast<double>(transitTime) / 1000);
+               static_cast<double>(transitTime.count()) / 1000);
     }
     void OnError(const chip::app::CommandSender * apCommandSender, const chip::app::StatusIB & aStatus, CHIP_ERROR aError) override
     {
@@ -189,14 +191,14 @@ public:
     void OnResponse(const chip::app::WriteClient * apWriteClient, const chip::app::ConcreteAttributePath & path,
                     chip::app::StatusIB status) override
     {
-        auto respTime    = chip::System::SystemClock().GetMonotonicMilliseconds();
-        auto transitTime = respTime - gLastMessageTime;
+        auto respTime                                   = chip::System::SystemClock().GetMonotonicTimestamp();
+        chip::System::Clock::Milliseconds64 transitTime = respTime - gLastMessageTime;
 
         gWriteRespCount++;
 
-        printf("Write Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gWriteRespCount, gWriteCount,
+        printf("Write Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fs\n", gWriteRespCount, gWriteCount,
                static_cast<double>(gWriteRespCount) * 100 / static_cast<double>(gWriteCount),
-               static_cast<double>(transitTime) / 1000);
+               static_cast<double>(transitTime.count()) / 1000);
     }
     void OnError(const chip::app::WriteClient * apCommandSender, CHIP_ERROR aError) override
     {
@@ -219,7 +221,7 @@ CHIP_ERROR SendCommandRequest(std::unique_ptr<chip::app::CommandSender> && comma
 
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    gLastMessageTime = chip::System::SystemClock().GetMonotonicMilliseconds();
+    gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
@@ -267,7 +269,7 @@ CHIP_ERROR SendBadCommandRequest(std::unique_ptr<chip::app::CommandSender> && co
 
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    gLastMessageTime = chip::System::SystemClock().GetMonotonicMilliseconds();
+    gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
@@ -339,7 +341,7 @@ CHIP_ERROR SendWriteRequest(chip::app::WriteClientHandle & apWriteClient)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::TLV::TLVWriter * writer;
-    gLastMessageTime = chip::System::SystemClock().GetMonotonicMilliseconds();
+    gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
     chip::app::AttributePathParams attributePathParams;
 
     printf("\nSend write request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
@@ -373,7 +375,7 @@ exit:
 CHIP_ERROR SendSubscribeRequest()
 {
     CHIP_ERROR err   = CHIP_NO_ERROR;
-    gLastMessageTime = chip::System::SystemClock().GetMonotonicMilliseconds();
+    gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
     chip::app::ReadPrepareParams readPrepareParams(chip::SessionHandle(chip::kTestDeviceNodeId, 1, 1, gFabricIndex));
     chip::app::EventPathParams eventPathParams[2];
@@ -435,7 +437,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
-        gLastMessageTime = chip::System::SystemClock().GetMonotonicMilliseconds();
+        gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
     }
     else
     {

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -146,8 +146,8 @@ public:
     bool IsWiFiStationEnabled();
     bool IsWiFiStationApplicationControlled();
     bool IsWiFiStationConnected();
-    uint32_t GetWiFiStationReconnectIntervalMS();
-    CHIP_ERROR SetWiFiStationReconnectIntervalMS(uint32_t val);
+    System::Clock::Timeout GetWiFiStationReconnectInterval();
+    CHIP_ERROR SetWiFiStationReconnectInterval(System::Clock::Timeout val);
     bool IsWiFiStationProvisioned();
     void ClearWiFiStationProvision();
     CHIP_ERROR GetAndLogWifiStatsCounters();
@@ -160,8 +160,8 @@ public:
     void DemandStartWiFiAP();
     void StopOnDemandWiFiAP();
     void MaintainOnDemandWiFiAP();
-    uint32_t GetWiFiAPIdleTimeoutMS();
-    void SetWiFiAPIdleTimeoutMS(uint32_t val);
+    System::Clock::Timeout GetWiFiAPIdleTimeout();
+    void SetWiFiAPIdleTimeout(System::Clock::Timeout val);
 
     // Thread Methods
     ThreadMode GetThreadMode();
@@ -341,14 +341,14 @@ inline bool ConnectivityManager::IsWiFiStationConnected()
     return static_cast<ImplClass *>(this)->_IsWiFiStationConnected();
 }
 
-inline uint32_t ConnectivityManager::GetWiFiStationReconnectIntervalMS()
+inline System::Clock::Timeout ConnectivityManager::GetWiFiStationReconnectInterval()
 {
-    return static_cast<ImplClass *>(this)->_GetWiFiStationReconnectIntervalMS();
+    return static_cast<ImplClass *>(this)->_GetWiFiStationReconnectInterval();
 }
 
-inline CHIP_ERROR ConnectivityManager::SetWiFiStationReconnectIntervalMS(uint32_t val)
+inline CHIP_ERROR ConnectivityManager::SetWiFiStationReconnectInterval(System::Clock::Timeout val)
 {
-    return static_cast<ImplClass *>(this)->_SetWiFiStationReconnectIntervalMS(val);
+    return static_cast<ImplClass *>(this)->_SetWiFiStationReconnectInterval(val);
 }
 
 inline bool ConnectivityManager::IsWiFiStationProvisioned()
@@ -396,14 +396,14 @@ inline void ConnectivityManager::MaintainOnDemandWiFiAP()
     static_cast<ImplClass *>(this)->_MaintainOnDemandWiFiAP();
 }
 
-inline uint32_t ConnectivityManager::GetWiFiAPIdleTimeoutMS()
+inline System::Clock::Timeout ConnectivityManager::GetWiFiAPIdleTimeout()
 {
-    return static_cast<ImplClass *>(this)->_GetWiFiAPIdleTimeoutMS();
+    return static_cast<ImplClass *>(this)->_GetWiFiAPIdleTimeout();
 }
 
-inline void ConnectivityManager::SetWiFiAPIdleTimeoutMS(uint32_t val)
+inline void ConnectivityManager::SetWiFiAPIdleTimeout(System::Clock::Timeout val)
 {
-    static_cast<ImplClass *>(this)->_SetWiFiAPIdleTimeoutMS(val);
+    static_cast<ImplClass *>(this)->_SetWiFiAPIdleTimeout(val);
 }
 
 inline CHIP_ERROR ConnectivityManager::GetAndLogWifiStatsCounters()

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -57,8 +57,8 @@ public:
     bool _IsWiFiStationEnabled(void);
     bool _IsWiFiStationApplicationControlled(void);
     bool _IsWiFiStationConnected(void);
-    uint32_t _GetWiFiStationReconnectIntervalMS(void);
-    CHIP_ERROR _SetWiFiStationReconnectIntervalMS(uint32_t val);
+    System::Clock::Timeout _GetWiFiStationReconnectInterval(void);
+    CHIP_ERROR _SetWiFiStationReconnectInterval(System::Clock::Timeout val);
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     ConnectivityManager::WiFiAPMode _GetWiFiAPMode(void);
@@ -68,8 +68,8 @@ public:
     void _DemandStartWiFiAP(void);
     void _StopOnDemandWiFiAP(void);
     void _MaintainOnDemandWiFiAP(void);
-    uint32_t _GetWiFiAPIdleTimeoutMS(void);
-    void _SetWiFiAPIdleTimeoutMS(uint32_t val);
+    System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
+    void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
     CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR _GetWiFiVersion(uint8_t & wiFiVersion);
@@ -121,13 +121,13 @@ inline bool GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_IsWiFiStationConn
 }
 
 template <class ImplClass>
-inline uint32_t GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiStationReconnectIntervalMS(void)
+inline System::Clock::Timeout GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiStationReconnectInterval(void)
 {
-    return 0;
+    return System::Clock::Zero;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_SetWiFiStationReconnectIntervalMS(uint32_t val)
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_SetWiFiStationReconnectInterval(System::Clock::Timeout val)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
@@ -179,13 +179,13 @@ inline void GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_MaintainOnDemandW
 {}
 
 template <class ImplClass>
-inline uint32_t GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiAPIdleTimeoutMS(void)
+inline System::Clock::Timeout GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiAPIdleTimeout(void)
 {
-    return 0;
+    return System::Clock::Zero;
 }
 
 template <class ImplClass>
-inline void GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_SetWiFiAPIdleTimeoutMS(uint32_t val)
+inline void GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_SetWiFiAPIdleTimeout(System::Clock::Timeout val)
 {}
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -59,8 +59,8 @@ public:
     CHIP_ERROR _SetWiFiStationMode(ConnectivityManager::WiFiStationMode val);
     bool _IsWiFiStationEnabled();
     bool _IsWiFiStationApplicationControlled();
-    uint32_t _GetWiFiStationReconnectIntervalMS();
-    CHIP_ERROR _SetWiFiStationReconnectIntervalMS(uint32_t val);
+    System::Clock::Timeout _GetWiFiStationReconnectInterval();
+    CHIP_ERROR _SetWiFiStationReconnectInterval(System::Clock::Timeout val);
     bool _IsWiFiStationProvisioned();
     void _ClearWiFiStationProvision();
     ConnectivityManager::WiFiAPMode _GetWiFiAPMode();
@@ -70,8 +70,8 @@ public:
     void _DemandStartWiFiAP();
     void _StopOnDemandWiFiAP();
     void _MaintainOnDemandWiFiAP();
-    uint32_t _GetWiFiAPIdleTimeoutMS();
-    void _SetWiFiAPIdleTimeoutMS(uint32_t val);
+    System::Clock::Timeout _GetWiFiAPIdleTimeout();
+    void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters();
     CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR _GetWiFiVersion(uint8_t & wiFiVersion);
@@ -107,13 +107,13 @@ private:
 };
 
 template <class ImplClass>
-inline uint32_t GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiStationReconnectIntervalMS()
+inline System::Clock::Timeout GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiStationReconnectInterval()
 {
-    return 0;
+    return System::Clock::Zero;
 }
 
 template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_SetWiFiStationReconnectIntervalMS(uint32_t val)
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_SetWiFiStationReconnectInterval(System::Clock::Timeout val)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
@@ -165,13 +165,13 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_MaintainOnDemandWiF
 {}
 
 template <class ImplClass>
-inline uint32_t GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiAPIdleTimeoutMS()
+inline System::Clock::Timeout GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiAPIdleTimeout()
 {
-    return 0;
+    return System::Clock::Zero;
 }
 
 template <class ImplClass>
-inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_SetWiFiAPIdleTimeoutMS(uint32_t val)
+inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_SetWiFiAPIdleTimeout(System::Clock::Timeout val)
 {}
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -218,7 +218,7 @@ template <class ImplClass>
 void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent * event)
 {
 #if CHIP_PROGRESS_LOGGING
-    uint64_t startUS = System::SystemClock().GetMonotonicMicroseconds();
+    System::Clock::Timestamp start = System::SystemClock().GetMonotonicTimestamp();
 #endif // CHIP_PROGRESS_LOGGING
 
     switch (event->Type)
@@ -257,10 +257,10 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
 
     // TODO: make this configurable
 #if CHIP_PROGRESS_LOGGING
-    uint32_t delta = static_cast<uint32_t>((System::SystemClock().GetMonotonicMicroseconds() - startUS) / 1000);
-    if (delta > 100)
+    uint32_t deltaMs = System::Clock::Milliseconds32(System::SystemClock().GetMonotonicTimestamp() - start).count();
+    if (deltaMs > 100)
     {
-        ChipLogError(DeviceLayer, "Long dispatch time: %" PRIu32 " ms, for event type %d", delta, event->Type);
+        ChipLogError(DeviceLayer, "Long dispatch time: %" PRIu32 " ms, for event type %d", deltaMs, event->Type);
     }
 #endif // CHIP_PROGRESS_LOGGING
 }

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -29,8 +29,8 @@ namespace Minimal {
 /// Represents available data (replies) for mDNS queries.
 struct QueryResponderRecord
 {
-    Responder * responder = nullptr;                       // what response/data is available
-    bool reportService    = false;                         // report as a service when listing dnssd services
+    Responder * responder                            = nullptr;                   // what response/data is available
+    bool reportService                               = false;                     // report as a service when listing dnssd services
     chip::System::Clock::Timestamp lastMulticastTime = chip::System::Clock::Zero; // last time this record was multicast
 };
 
@@ -154,8 +154,8 @@ public:
     }
 
 private:
-    bool mIncludeAdditionalRepliesOnly = false;
-    ReplyFilter * mReplyFilter         = nullptr;
+    bool mIncludeAdditionalRepliesOnly                         = false;
+    ReplyFilter * mReplyFilter                                 = nullptr;
     chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore = chip::System::Clock::Zero;
 };
 

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -31,7 +31,7 @@ struct QueryResponderRecord
 {
     Responder * responder = nullptr;                       // what response/data is available
     bool reportService    = false;                         // report as a service when listing dnssd services
-    chip::System::Clock::Timestamp lastMulticastTime{ 0 }; // last time this record was multicast
+    chip::System::Clock::Timestamp lastMulticastTime = chip::System::Clock::Zero; // last time this record was multicast
 };
 
 namespace Internal {
@@ -156,7 +156,7 @@ public:
 private:
     bool mIncludeAdditionalRepliesOnly = false;
     ReplyFilter * mReplyFilter         = nullptr;
-    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore{ 0 };
+    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore = chip::System::Clock::Zero;
 };
 
 /// Iterates over an array of QueryResponderRecord items, providing only 'valid' ones, where

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -62,7 +62,7 @@ chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPen
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Echo was attempted to be sent.
-chip::System::Clock::Timestamp gLastEchoTime{ 0 };
+chip::System::Clock::Timestamp gLastEchoTime = chip::System::Clock::Zero;
 
 // Count of the number of EchoRequests sent.
 uint64_t gEchoCount = 0;

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -120,7 +120,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP(void)
 {
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        mLastAPDemandTime = System::SystemClock().GetMonotonicMilliseconds();
+        mLastAPDemandTime = System::SystemClock().GetMonotonicTimestamp();
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
@@ -129,7 +129,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void)
 {
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        mLastAPDemandTime = 0;
+        mLastAPDemandTime = System::Clock::Zero;
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
@@ -140,14 +140,14 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP(void)
     {
         if (mWiFiAPState == kWiFiAPState_Activating || mWiFiAPState == kWiFiAPState_Active)
         {
-            mLastAPDemandTime = System::SystemClock().GetMonotonicMilliseconds();
+            mLastAPDemandTime = System::SystemClock().GetMonotonicTimestamp();
         }
     }
 }
 
-void ConnectivityManagerImpl::_SetWiFiAPIdleTimeoutMS(uint32_t val)
+void ConnectivityManagerImpl::_SetWiFiAPIdleTimeout(System::Clock::Timeout val)
 {
-    mWiFiAPIdleTimeoutMS = val;
+    mWiFiAPIdleTimeout = val;
     DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
 }
 
@@ -334,14 +334,14 @@ CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWifiStatsCounters(void)
 
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
-    mLastStationConnectFailTime     = 0;
-    mLastAPDemandTime               = 0;
-    mWiFiStationMode                = kWiFiStationMode_Disabled;
-    mWiFiStationState               = kWiFiStationState_NotConnected;
-    mWiFiAPMode                     = kWiFiAPMode_Disabled;
-    mWiFiAPState                    = kWiFiAPState_NotActive;
-    mWiFiStationReconnectIntervalMS = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
-    mWiFiAPIdleTimeoutMS            = CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT;
+    mLastStationConnectFailTime   = System::Clock::Zero;
+    mLastAPDemandTime             = System::Clock::Zero;
+    mWiFiStationMode              = kWiFiStationMode_Disabled;
+    mWiFiStationState             = kWiFiStationState_NotConnected;
+    mWiFiAPMode                   = kWiFiAPMode_Disabled;
+    mWiFiAPState                  = kWiFiAPState_NotActive;
+    mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
+    mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
     mFlags.SetRaw(0);
 
     // Ensure that station mode is enabled.
@@ -462,7 +462,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             ChangeWiFiStationState(kWiFiStationState_Connected);
             ChipLogProgress(DeviceLayer, "WiFi station interface connected");
-            mLastStationConnectFailTime = 0;
+            mLastStationConnectFailTime = System::Clock::Zero;
             OnStationConnected();
         }
 
@@ -487,7 +487,7 @@ void ConnectivityManagerImpl::DriveStationState()
     // Otherwise the station interface is NOT connected to an AP, so...
     else
     {
-        uint64_t now = System::SystemClock().GetMonotonicMilliseconds();
+        System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
 
         // Advance the station state to NotConnected if it was previously Connected or Disconnecting,
         // or if a previous initiated connect attempt failed.
@@ -499,7 +499,7 @@ void ConnectivityManagerImpl::DriveStationState()
             if (prevState != kWiFiStationState_Connecting_Failed)
             {
                 ChipLogProgress(DeviceLayer, "WiFi station interface disconnected");
-                mLastStationConnectFailTime = 0;
+                mLastStationConnectFailTime = System::Clock::Zero;
                 OnStationDisconnected();
             }
             else
@@ -514,7 +514,8 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             // Initiate a connection to the AP if we haven't done so before, or if enough
             // time has passed since the last attempt.
-            if (mLastStationConnectFailTime == 0 || now >= mLastStationConnectFailTime + mWiFiStationReconnectIntervalMS)
+            if (mLastStationConnectFailTime == System::Clock::Zero ||
+                now >= mLastStationConnectFailTime + mWiFiStationReconnectInterval)
             {
                 ChipLogProgress(DeviceLayer, "Attempting to connect WiFi station interface");
                 rtw_wifi_setting_t wifi_info;
@@ -528,12 +529,12 @@ void ConnectivityManagerImpl::DriveStationState()
             // Otherwise arrange another connection attempt at a suitable point in the future.
             else
             {
-                uint32_t timeToNextConnect = (uint32_t)((mLastStationConnectFailTime + mWiFiStationReconnectIntervalMS) - now);
+                System::Clock::Timeout timeToNextConnect = (mLastStationConnectFailTime + mWiFiStationReconnectInterval) - now;
 
-                ChipLogProgress(DeviceLayer, "Next WiFi station reconnect in %" PRIu32 " ms", timeToNextConnect);
+                ChipLogProgress(DeviceLayer, "Next WiFi station reconnect in %" PRIu32 " ms",
+                                System::Clock::Milliseconds32(timeToNextConnect).count());
 
-                ReturnOnFailure(DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(timeToNextConnect),
-                                                                      DriveStationState, NULL));
+                ReturnOnFailure(DeviceLayer::SystemLayer().StartTimer(timeToNextConnect, DriveStationState, nullptr));
             }
         }
     }

--- a/src/platform/Ameba/ConnectivityManagerImpl.h
+++ b/src/platform/Ameba/ConnectivityManagerImpl.h
@@ -61,8 +61,8 @@ private:
     bool _IsWiFiStationEnabled(void);
     bool _IsWiFiStationApplicationControlled(void);
     bool _IsWiFiStationConnected(void);
-    uint32_t _GetWiFiStationReconnectIntervalMS(void);
-    CHIP_ERROR _SetWiFiStationReconnectIntervalMS(uint32_t val);
+    System::Clock::Timeout _GetWiFiStationReconnectInterval(void);
+    CHIP_ERROR _SetWiFiStationReconnectInterval(System::Clock::Timeout val);
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     WiFiAPMode _GetWiFiAPMode(void);
@@ -72,8 +72,8 @@ private:
     void _DemandStartWiFiAP(void);
     void _StopOnDemandWiFiAP(void);
     void _MaintainOnDemandWiFiAP(void);
-    uint32_t _GetWiFiAPIdleTimeoutMS(void);
-    void _SetWiFiAPIdleTimeoutMS(uint32_t val);
+    System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
+    void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
     CHIP_ERROR _Init(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
@@ -90,14 +90,14 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    uint64_t mLastStationConnectFailTime;
-    uint64_t mLastAPDemandTime;
+    System::Clock::Timestamp mLastStationConnectFailTime;
+    System::Clock::Timestamp mLastAPDemandTime;
     WiFiStationMode mWiFiStationMode;
     WiFiStationState mWiFiStationState;
     WiFiAPMode mWiFiAPMode;
     WiFiAPState mWiFiAPState;
-    uint32_t mWiFiStationReconnectIntervalMS;
-    uint32_t mWiFiAPIdleTimeoutMS;
+    System::Clock::Timeout mWiFiStationReconnectInterval;
+    System::Clock::Timeout mWiFiAPIdleTimeout;
     BitFlags<Flags> mFlags;
 
     void DriveStationState(void);
@@ -137,9 +137,9 @@ inline bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled(void)
     return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;
 }
 
-inline uint32_t ConnectivityManagerImpl::_GetWiFiStationReconnectIntervalMS(void)
+inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiStationReconnectInterval(void)
 {
-    return mWiFiStationReconnectIntervalMS;
+    return mWiFiStationReconnectInterval;
 }
 
 inline ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode(void)
@@ -152,9 +152,9 @@ inline bool ConnectivityManagerImpl::_IsWiFiAPActive(void)
     return mWiFiAPState == kWiFiAPState_Active;
 }
 
-inline uint32_t ConnectivityManagerImpl::_GetWiFiAPIdleTimeoutMS(void)
+inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout(void)
 {
-    return mWiFiAPIdleTimeoutMS;
+    return mWiFiAPIdleTimeout;
 }
 
 inline bool ConnectivityManagerImpl::_CanStartWiFiScan()

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
     esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
     esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
-    mStartTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
+    mStartTime = System::SystemClock().GetMonotonicTimestamp();
 
     // Initialize the ESP WiFi layer.
     cfg = WIFI_INIT_CONFIG_DEFAULT();
@@ -180,11 +180,11 @@ CHIP_ERROR PlatformManagerImpl::_GetRebootCount(uint16_t & rebootCount)
 
 CHIP_ERROR PlatformManagerImpl::_GetUpTime(uint64_t & upTime)
 {
-    uint64_t currentTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
+    System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
 
-    if (currentTimeMilliseconds >= mStartTimeMilliseconds)
+    if (currentTime >= mStartTime)
     {
-        upTime = (currentTimeMilliseconds - mStartTimeMilliseconds) / 1000;
+        upTime = std::chrono::duration_cast<System::Clock::Seconds64>(currentTime - mStartTime).count();
         return CHIP_NO_ERROR;
     }
 

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <platform/internal/GenericPlatformManagerImpl_FreeRTOS.h>
+#include <system/SystemClock.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -69,7 +70,7 @@ private:
     friend PlatformManager & PlatformMgr(void);
     friend PlatformManagerImpl & PlatformMgrImpl(void);
 
-    uint64_t mStartTimeMilliseconds = 0;
+    chip::System::Clock::Timestamp mStartTime = System::Clock::Zero;
 
     static PlatformManagerImpl sInstance;
 };

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -214,7 +214,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     err = Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_InitChipStack();
     SuccessOrExit(err);
 
-    mStartTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
+    mStartTime = System::SystemClock().GetMonotonicTimestamp();
 
 exit:
     return err;
@@ -300,11 +300,11 @@ CHIP_ERROR PlatformManagerImpl::_GetRebootCount(uint16_t & rebootCount)
 
 CHIP_ERROR PlatformManagerImpl::_GetUpTime(uint64_t & upTime)
 {
-    uint64_t currentTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
+    System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
 
-    if (currentTimeMilliseconds >= mStartTimeMilliseconds)
+    if (currentTime >= mStartTime)
     {
-        upTime = (currentTimeMilliseconds - mStartTimeMilliseconds) / 1000;
+        upTime = std::chrono::duration_cast<System::Clock::Seconds64>(currentTime - mStartTime).count();
         return CHIP_NO_ERROR;
     }
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -76,7 +76,7 @@ private:
     friend PlatformManagerImpl & PlatformMgrImpl();
     friend class Internal::BLEManagerImpl;
 
-    uint64_t mStartTimeMilliseconds = 0;
+    System::Clock::Timestamp mStartTime = System::Clock::Zero;
 
     static PlatformManagerImpl sInstance;
 

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -41,8 +41,8 @@ using namespace chip::Logging;
 using namespace chip::System;
 using namespace chip::System::Clock::Literals;
 
-constexpr Clock::Milliseconds64 kTestTimeMarginMs{ 2 };
-constexpr Clock::Microseconds64 kTestTimeMarginUs{ 500 };
+constexpr Clock::Milliseconds64 kTestTimeMarginMs = 2_ms64;
+constexpr Clock::Microseconds64 kTestTimeMarginUs = 500_us64;
 
 // =================================
 //      Unit tests

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -36,32 +36,13 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#define TEST_TIME_MARGIN_MS 2
-#define TEST_TIME_MARGIN_US 500
-
 using namespace chip;
 using namespace chip::Logging;
+using namespace chip::System;
+using namespace chip::System::Clock::Literals;
 
-// =================================
-//      Test Vectors
-// =================================
-
-struct time_test_vector
-{
-    uint64_t delay;
-};
-
-static const struct time_test_vector test_vector_system_time_ms[] = {
-    { .delay = 10 },
-    { .delay = 100 },
-    { .delay = 250 },
-};
-
-static const struct time_test_vector test_vector_system_time_us[] = {
-    { .delay = 600 },
-    { .delay = 900 },
-    { .delay = 1500 },
-};
+constexpr Clock::Milliseconds64 kTestTimeMarginMs{ 2 };
+constexpr Clock::Microseconds64 kTestTimeMarginUs{ 500 };
 
 // =================================
 //      Unit tests
@@ -69,26 +50,26 @@ static const struct time_test_vector test_vector_system_time_us[] = {
 
 static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * inContext)
 {
-    int numOfTestVectors = ArraySize(test_vector_system_time_us);
-    int numOfTestsRan    = 0;
-    const struct time_test_vector * test_params;
+    static const Clock::Microseconds64 kTestVectorSystemTimeUs[] = {
+        600_us64,
+        900_us64,
+        1500_us64,
+    };
+    int numOfTestsRan                      = 0;
+    constexpr Clock::Microseconds64 margin = kTestTimeMarginUs;
 
-    uint64_t margin = TEST_TIME_MARGIN_US;
-    uint64_t Tstart, Tend, Tdelta, Tdelay;
-
-    for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)
+    for (const Clock::Microseconds64 & Tdelay : kTestVectorSystemTimeUs)
     {
-        test_params = &test_vector_system_time_us[vectorIndex];
-        Tdelay      = test_params->delay;
-        Tstart      = System::SystemClock().GetMonotonicMicroseconds();
+        const Clock::Microseconds64 Tstart = System::SystemClock().GetMonotonicMicroseconds64();
 
-        chip::test_utils::SleepMicros(test_params->delay);
+        chip::test_utils::SleepMicros(Tdelay.count());
 
-        Tend   = System::SystemClock().GetMonotonicMicroseconds();
-        Tdelta = Tend - Tstart;
+        const Clock::Microseconds64 Tend   = System::SystemClock().GetMonotonicMicroseconds64();
+        const Clock::Microseconds64 Tdelta = Tend - Tstart;
 
-        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart, Tend, Tdelta,
-                        Tdelay);
+        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart.count(),
+                        Tend.count(), Tdelta.count(), Tdelay.count());
+
         // verify that timers don't fire early
         NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
         // verify they're not too late
@@ -100,26 +81,26 @@ static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * in
 
 static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * inContext)
 {
-    int numOfTestVectors = ArraySize(test_vector_system_time_ms);
-    int numOfTestsRan    = 0;
-    const struct time_test_vector * test_params;
+    static const System::Clock::Milliseconds64 kTestVectorSystemTimeMs[] = {
+        10_ms64,
+        100_ms64,
+        250_ms64,
+    };
+    int numOfTestsRan                      = 0;
+    constexpr Clock::Milliseconds64 margin = kTestTimeMarginMs;
 
-    uint64_t margin = TEST_TIME_MARGIN_MS;
-    uint64_t Tstart, Tend, Tdelta, Tdelay;
-
-    for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)
+    for (const Clock::Milliseconds64 & Tdelay : kTestVectorSystemTimeMs)
     {
-        test_params = &test_vector_system_time_ms[vectorIndex];
-        Tdelay      = test_params->delay;
-        Tstart      = System::SystemClock().GetMonotonicMilliseconds();
+        const Clock::Milliseconds64 Tstart = System::SystemClock().GetMonotonicMilliseconds64();
 
-        chip::test_utils::SleepMillis(test_params->delay);
+        chip::test_utils::SleepMillis(Tdelay.count());
 
-        Tend   = System::SystemClock().GetMonotonicMilliseconds();
-        Tdelta = Tend - Tstart;
+        const Clock::Milliseconds64 Tend   = System::SystemClock().GetMonotonicMilliseconds64();
+        const Clock::Milliseconds64 Tdelta = Tend - Tstart;
 
-        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart, Tend, Tdelta,
-                        Tdelay);
+        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart.count(),
+                        Tend.count(), Tdelta.count(), Tdelay.count());
+
         // verify that timers don't fire early
         NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
         // verify they're not too late

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -350,10 +350,10 @@ private:
     uint32_t mLastQueryNum = 0;
     uint32_t mNextQueryNum = 0;
 
-    System::Clock::Timeout mTimeout = System::Clock::Zero;
+    System::Clock::Timeout mTimeout            = System::Clock::Zero;
     System::Clock::Timestamp mTimeoutStartTime = System::Clock::Zero;
-    bool mShouldInitTimeoutStart = true;
-    bool mAwaitingResponse       = false;
+    bool mShouldInitTimeoutStart               = true;
+    bool mAwaitingResponse                     = false;
 };
 
 } // namespace bdx

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -350,8 +350,8 @@ private:
     uint32_t mLastQueryNum = 0;
     uint32_t mNextQueryNum = 0;
 
-    System::Clock::Timeout mTimeout{ 0 };
-    System::Clock::Timestamp mTimeoutStartTime{ 0 };
+    System::Clock::Timeout mTimeout = System::Clock::Zero;
+    System::Clock::Timestamp mTimeoutStartTime = System::Clock::Zero;
     bool mShouldInitTimeoutStart = true;
     bool mAwaitingResponse       = false;
 };

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -21,7 +21,7 @@ using namespace ::chip::Protocols;
 
 namespace {
 // Use this as a timestamp if not needing to test BDX timeouts.
-constexpr System::Clock::Timestamp kNoAdvanceTime{ 0 };
+constexpr System::Clock::Timestamp kNoAdvanceTime = System::Clock::Zero;
 
 const TLV::Tag tlvStrTag  = TLV::ContextTag(4);
 const TLV::Tag tlvListTag = TLV::ProfileTag(7777, 8888);

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -128,12 +128,6 @@ using Timeout = Milliseconds32;
 class ClockBase
 {
 public:
-    // Backwards compatibility types; avoid using in new code. These only provide documentation, not type safety.
-    using Tick = uint64_t;
-    static_assert(std::is_unsigned<Tick>::value, "Tick must be unsigned");
-    using MonotonicMicroseconds = Tick;
-    using MonotonicMilliseconds = Tick;
-
     virtual ~ClockBase() = default;
 
     /**
@@ -190,10 +184,6 @@ public:
      * @returns             Elapsed time in milliseconds since an arbitrary, platform-defined epoch.
      */
     virtual Milliseconds64 GetMonotonicMilliseconds64() = 0;
-
-    // Backwards compatibility methods; avoid using in new code. These only provide documentation, not type safety.
-    MonotonicMicroseconds GetMonotonicMicroseconds() { return GetMonotonicMicroseconds64().count(); }
-    MonotonicMilliseconds GetMonotonicMilliseconds() { return GetMonotonicMilliseconds64().count(); }
 };
 
 // Currently we have a single implementation class, ClockImpl, whose members are implemented in build-specific files.
@@ -216,10 +206,6 @@ inline void SetSystemClockForTesting(Clock::ClockBase * clock)
 }
 
 } // namespace Internal
-
-// Backwards compatibility types; avoid using in new code. These only provide documentation, not type safety.
-using MonotonicMicroseconds = ClockBase::MonotonicMicroseconds;
-using MonotonicMilliseconds = ClockBase::MonotonicMilliseconds;
 
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 Microseconds64 TimevalToMicroseconds(const timeval & in);

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR LayerImplLwIP::HandlePlatformTimer()
     if (!mTimerList.Empty())
     {
         // timers still exist so restart the platform timer.
-        Clock::Timeout delay{ 0 };
+        Clock::Timeout delay = System::Clock::Zero;
 
         Clock::Timestamp currentTime = SystemClock().GetMonotonicTimestamp();
 

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -38,7 +38,7 @@
 namespace chip {
 namespace System {
 
-constexpr Clock::Seconds64 kDefaultMinSleepPeriod{ 60 * 60 * 24 * 30 }; // Month [sec]
+constexpr Clock::Seconds64 kDefaultMinSleepPeriod = Clock::Seconds64( 60 * 60 * 24 * 30 ); // Month [sec]
 
 CHIP_ERROR LayerImplSelect::Init()
 {

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -38,7 +38,7 @@
 namespace chip {
 namespace System {
 
-constexpr Clock::Seconds64 kDefaultMinSleepPeriod = Clock::Seconds64( 60 * 60 * 24 * 30 ); // Month [sec]
+constexpr Clock::Seconds64 kDefaultMinSleepPeriod = Clock::Seconds64(60 * 60 * 24 * 30); // Month [sec]
 
 CHIP_ERROR LayerImplSelect::Init()
 {

--- a/src/system/TimeSource.h
+++ b/src/system/TimeSource.h
@@ -63,7 +63,7 @@ template <>
 class TimeSource<Source::kSystem>
 {
 public:
-    uint64_t GetCurrentMonotonicTimeMs() { return System::SystemClock().GetMonotonicMilliseconds(); }
+    uint64_t GetCurrentMonotonicTimeMs() { return System::SystemClock().GetMonotonicMilliseconds64().count(); }
 };
 
 /**

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -100,8 +100,8 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == Clock::Zero);
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == Clock::Zero);
 
-    constexpr Clock::Milliseconds64 k1234 = Clock::Milliseconds64( 1234 );
-    clock.mTime = k1234;
+    constexpr Clock::Milliseconds64 k1234 = Clock::Milliseconds64(1234);
+    clock.mTime                           = k1234;
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == k1234);
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == k1234);
 

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -90,7 +90,7 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     public:
         Clock::Microseconds64 GetMonotonicMicroseconds64() override { return mTime; }
         Clock::Milliseconds64 GetMonotonicMilliseconds64() override { return mTime; }
-        Clock::Milliseconds64 mTime{ 0 };
+        Clock::Milliseconds64 mTime = Clock::Zero;
     };
     MockClock clock;
 
@@ -100,7 +100,7 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == Clock::Zero);
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == Clock::Zero);
 
-    constexpr Clock::Milliseconds64 k1234{ 1234 };
+    constexpr Clock::Milliseconds64 k1234 = Clock::Milliseconds64( 1234 );
     clock.mTime = k1234;
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == k1234);
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == k1234);

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -122,8 +122,8 @@ void HandleTimer10Success(Layer * inetLayer, void * aState)
 
 static void CheckOverflow(nlTestSuite * inSuite, void * aContext)
 {
-    chip::System::Clock::Milliseconds32 timeout_overflow_0ms{ 652835029 };
-    chip::System::Clock::Milliseconds32 timeout_10ms{ 10 };
+    chip::System::Clock::Milliseconds32 timeout_overflow_0ms = chip::System::Clock::Milliseconds32( 652835029 );
+    chip::System::Clock::Milliseconds32 timeout_10ms = chip::System::Clock::Milliseconds32( 10 );
 
     TestContext & lContext = *static_cast<TestContext *>(aContext);
     Layer & lSys           = *lContext.mLayer;

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -122,8 +122,8 @@ void HandleTimer10Success(Layer * inetLayer, void * aState)
 
 static void CheckOverflow(nlTestSuite * inSuite, void * aContext)
 {
-    chip::System::Clock::Milliseconds32 timeout_overflow_0ms = chip::System::Clock::Milliseconds32( 652835029 );
-    chip::System::Clock::Milliseconds32 timeout_10ms = chip::System::Clock::Milliseconds32( 10 );
+    chip::System::Clock::Milliseconds32 timeout_overflow_0ms = chip::System::Clock::Milliseconds32(652835029);
+    chip::System::Clock::Milliseconds32 timeout_10ms         = chip::System::Clock::Milliseconds32(10);
 
     TestContext & lContext = *static_cast<TestContext *>(aContext);
     Layer & lSys           = *lContext.mLayer;


### PR DESCRIPTION
#### Problem

Previous PRs added strong types to `System::Clock` and converted many
uses, but a few remain.

#### Change overview

Convert the remaining uses of the weak types (`MonotonicMilliseconds`
and `MonotonicMicroseconds`), and remove them from `System::Clock`.

Fixes #10062 Some operations on System::Clock types are not safe

There are some remaining uses of `Clock`-derived values as plain
integers; these can be found for later cleanup by the use of `.count()`.

#### Testing

CI; no changes to functionality.
Converted `TestPlatformTime`.

